### PR TITLE
fix #2089: allow to use liblwgeom as standalone library.

### DIFF
--- a/doc/html/image_src/generator.c
+++ b/doc/html/image_src/generator.c
@@ -49,16 +49,6 @@ char *imageSize = "200x200";
 int getStyleName(char **styleName, char* line);
 
 /**
- * Set up liblwgeom to run in stand-alone mode using the
- * usual system memory handling functions.
- */
-void lwgeom_init_allocators(void)
-{
-	/* liblwgeom callback - install default handlers */
-	lwgeom_install_default_allocators();
-}
-
-/**
  * Writes the coordinates of a POINTARRAY to a char* where ordinates are
  * separated by a comma and coordinates by a space so that the coordinate
  * pairs can be interpreted by ImageMagick's SVG draw command.

--- a/liblwgeom/cunit/cu_tester.c
+++ b/liblwgeom/cunit/cu_tester.c
@@ -16,6 +16,10 @@
 #include "liblwgeom_internal.h"
 #include "cu_tester.h"
 
+/* Internal funcs */
+static void
+cu_errorreporter(const char *fmt, va_list ap);
+
 /* ADD YOUR SUITE HERE (1 of 2) */
 extern CU_SuiteInfo print_suite;
 extern CU_SuiteInfo algorithms_suite;
@@ -92,6 +96,9 @@ int main(int argc, char *argv[])
 	CU_pTestRegistry registry;
 	int num_run;
 	int num_failed;
+
+	/* install the custom error handler */
+	lwgeom_set_handlers(0, 0, 0, cu_errorreporter, 0);
 
 	/* initialize the CUnit test registry */
 	if (CUE_SUCCESS != CU_initialize_registry())
@@ -232,17 +239,3 @@ cu_error_msg_reset()
 {
 	memset(cu_error_msg, '\0', MAX_CUNIT_ERROR_LENGTH);
 }
-
-/*
-** Set up liblwgeom to run in stand-alone mode using the
-** usual system memory handling functions.
-*/
-void lwgeom_init_allocators(void)
-{
-	lwalloc_var = default_allocator;
-	lwrealloc_var = default_reallocator;
-	lwfree_var = default_freeor;
-	lwnotice_var = default_noticereporter;
-	lwerror_var = cu_errorreporter;
-}
-

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -32,10 +32,9 @@
 * units tests at cunit/cu_tester.c and the loader/dumper programs at
 * ../loader/shp2pgsql.c are examples of non-PostGIS applications using liblwgeom.
 *
-* Programs using this library should set up the default memory managers and error
-* handlers by implementing an lwgeom_init_allocators() function, which can be as
-* a wrapper around the lwgeom_install_default_allocators() function if you want
-* no special handling for memory management and error reporting.
+* Programs using this library can install their custom memory managers and error
+* handlers by calling the lwgeom_set_handlers() function, otherwise the default 
+* ones will be used.
 */
 
 /**
@@ -177,25 +176,21 @@ typedef void* (*lwallocator)(size_t size);
 typedef void* (*lwreallocator)(void *mem, size_t size);
 typedef void (*lwfreeor)(void* mem);
 typedef void (*lwreporter)(const char* fmt, va_list ap);
-extern lwreallocator lwrealloc_var;
-extern lwallocator lwalloc_var;
-extern lwfreeor lwfree_var;
-extern lwreporter lwerror_var;
-extern lwreporter lwnotice_var;
 
 /**
-* Supply the memory management and error handling functions you want your
+* Install custom memory management and error handling functions you want your
 * application to use.
 * @ingroup system
 */
-extern void lwgeom_init_allocators(void);
+extern void lwgeom_set_handlers(lwallocator allocator, 
+        lwreallocator reallocator, lwfreeor freeor, lwreporter errorreporter,
+        lwreporter noticereporter);
 
 /**
 * Apply the default memory management (malloc() and free()) and error handlers.
-* Called inside lwgeom_init_allocators() generally.
 * @ingroup system
 */
-extern void lwgeom_install_default_allocators(void);
+void lwgeom_install_default_allocators(void);
 
 /**
  * Write a notice out to the notice handler.

--- a/liblwgeom/lwutil.c
+++ b/liblwgeom/lwutil.c
@@ -87,7 +87,7 @@ lwerror(const char *fmt, ...)
 void *
 init_allocator(size_t size)
 {
-	lwgeom_init_allocators();
+	lwgeom_install_default_allocators();
 
 	return lwalloc_var(size);
 }
@@ -95,7 +95,7 @@ init_allocator(size_t size)
 void
 init_freeor(void *mem)
 {
-	lwgeom_init_allocators();
+	lwgeom_install_default_allocators();
 
 	lwfree_var(mem);
 }
@@ -103,7 +103,7 @@ init_freeor(void *mem)
 void *
 init_reallocator(void *mem, size_t size)
 {
-	lwgeom_init_allocators();
+	lwgeom_install_default_allocators();
 
 	return lwrealloc_var(mem, size);
 }
@@ -111,7 +111,7 @@ init_reallocator(void *mem, size_t size)
 void
 init_noticereporter(const char *fmt, va_list ap)
 {
-	lwgeom_init_allocators();
+	lwgeom_install_default_allocators();
 
 	(*lwnotice_var)(fmt, ap);
 }
@@ -119,7 +119,7 @@ init_noticereporter(const char *fmt, va_list ap)
 void
 init_errorreporter(const char *fmt, va_list ap)
 {
-	lwgeom_init_allocators();
+	lwgeom_install_default_allocators();
 
 	(*lwerror_var)(fmt, ap);
 }
@@ -192,8 +192,8 @@ default_errorreporter(const char *fmt, va_list ap)
 
 
 /*
- * This function should be called from lwgeom_init_allocators() by programs
- * which wish to use the default allocators above
+ * This function set up default which wish to use the default memory managers
+ * and error handlers
  */
 
 void lwgeom_install_default_allocators(void)
@@ -205,6 +205,22 @@ void lwgeom_install_default_allocators(void)
 	lwnotice_var = default_noticereporter;
 }
 
+/**
+ * This function is called by programs which want to set up custom handling 
+ * for memory management and error reporting
+ */
+void
+lwgeom_set_handlers(lwallocator allocator, lwreallocator reallocator,
+	        lwfreeor freeor, lwreporter errorreporter,
+	        lwreporter noticereporter) {
+
+	lwalloc_var = allocator ? allocator : default_allocator;
+	lwrealloc_var = reallocator ? reallocator : default_reallocator;
+	lwfree_var = freeor ? freeor : default_freeor;
+
+	lwerror_var = errorreporter ? errorreporter : default_errorreporter;
+	lwnotice_var = noticereporter ? noticereporter : default_noticereporter;
+}
 
 const char* 
 lwtype_name(uint8_t type)

--- a/libpgcommon/lwgeom_pg.c
+++ b/libpgcommon/lwgeom_pg.c
@@ -181,14 +181,10 @@ pg_notice(const char *fmt, va_list ap)
 }
 
 void
-lwgeom_init_allocators(void)
+pg_install_handlers(void)
 {
-	/* liblwgeom callback - install PostgreSQL handlers */
-	lwalloc_var = pg_alloc;
-	lwrealloc_var = pg_realloc;
-	lwfree_var = pg_free;
-	lwerror_var = pg_error;
-	lwnotice_var = pg_notice;
+	/* install PostgreSQL handlers */
+	lwgeom_set_handlers(pg_alloc, pg_realloc, pg_free, pg_error, pg_notice);
 }
 
 /**

--- a/loader/shpcommon.c
+++ b/loader/shpcommon.c
@@ -14,14 +14,6 @@
 
 #include <stdlib.h>
 #include "shpcommon.h"
-#include "../liblwgeom/liblwgeom.h" /* for lwgeom_install_default_allocators */
-
-
-/* liblwgeom allocator callback - install the defaults (malloc/free/stdout/stderr) */
-void lwgeom_init_allocators()
-{
-	lwgeom_install_default_allocators();
-}
 
 
 /**

--- a/postgis/postgis_module.c
+++ b/postgis/postgis_module.c
@@ -92,6 +92,8 @@ _PG_init(void)
    );
 #endif
 
+    /* install PostgreSQL handlers */
+    pg_install_handlers();
 }
 
 /*

--- a/raster/loader/raster2pgsql.c
+++ b/raster/loader/raster2pgsql.c
@@ -31,11 +31,6 @@
 #include "ogr_srs_api.h"
 #include <assert.h>
 
-/* This is needed by liblwgeom */
-void lwgeom_init_allocators(void) {
-	lwgeom_install_default_allocators();
-}
-
 static void
 loader_rt_error_handler(const char *fmt, va_list ap) {
 	static const char *label = "ERROR: ";

--- a/raster/rt_pg/Makefile.in
+++ b/raster/rt_pg/Makefile.in
@@ -24,7 +24,9 @@ SQLPP = @SQLPP@
 SQL_OBJS=rtpostgis.sql.in rtpostgis_drop.sql.in rtpostgis_upgrade_cleanup.sql.in rtpostgis_legacy.sql.in
 
 # Objects to build using PGXS
-OBJS=rt_pg.o
+OBJS= \
+	rt_module.o \
+	rt_pg.o
 
 # Libraries to link into the module (proj, geos)
 #

--- a/raster/rt_pg/rt_module.c
+++ b/raster/rt_pg/rt_module.c
@@ -1,0 +1,36 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.refractions.net
+ *
+ * Copyright (C) 2011  OpenGeo.org 
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU General Public Licence. See the COPYING file.
+ *
+ **********************************************************************/
+
+#include "postgres.h"
+#include "fmgr.h"
+
+#include "../../postgis_config.h"
+
+#include "liblwgeom.h"
+#include "rt_pg.h"
+
+/*
+ * This is required for builds against pgsql
+ */
+PG_MODULE_MAGIC;
+
+/*
+ * Module load callback
+ */
+void _PG_init(void);
+void
+_PG_init(void)
+{
+    /* Install raster handlers */
+    lwgeom_set_handlers(rt_pg_alloc, rt_pg_realloc, rt_pg_free,
+            rt_pg_error, rt_pg_notice);
+}

--- a/raster/rt_pg/rt_pg.c
+++ b/raster/rt_pg/rt_pg.c
@@ -60,11 +60,6 @@
 #define MAX_DBL_CHARLEN (3 + DBL_MANT_DIG - DBL_MIN_EXP)
 #define MAX_INT_CHARLEN 32
 
-/*
- * This is required for builds against pgsql 
- */
-PG_MODULE_MAGIC;
-
 /***************************************************************
  * Internal functions must be prefixed with rtpg_.  This is
  * keeping inline with the use of pgis_ for ./postgis C utility
@@ -17204,7 +17199,7 @@ Datum RASTER_clip(PG_FUNCTION_ARGS)
 /*  Memory allocation / error reporting hooks                       */
 /* ---------------------------------------------------------------- */
 
-static void *
+void *
 rt_pg_alloc(size_t size)
 {
     void * result;
@@ -17216,7 +17211,7 @@ rt_pg_alloc(size_t size)
     return result;
 }
 
-static void *
+void *
 rt_pg_realloc(void *mem, size_t size)
 {
     void * result;
@@ -17232,14 +17227,14 @@ rt_pg_realloc(void *mem, size_t size)
     return result;
 }
 
-static void
+void
 rt_pg_free(void *ptr)
 {
     POSTGIS_RT_DEBUG(5, "rt_pfree called");
     pfree(ptr);
 }
 
-static void
+void
 rt_pg_error(const char *fmt, va_list ap)
 {
 #define ERRMSG_MAXLEN 256
@@ -17252,7 +17247,7 @@ rt_pg_error(const char *fmt, va_list ap)
     ereport(ERROR, (errmsg_internal("%s", errmsg)));
 }
 
-static void
+void
 rt_pg_notice(const char *fmt, va_list ap)
 {
     char *msg;
@@ -17269,7 +17264,6 @@ rt_pg_notice(const char *fmt, va_list ap)
     ereport(NOTICE, (errmsg_internal("%s", msg)));
     free(msg);
 }
-
 
 void
 rt_init_allocators(void)

--- a/raster/rt_pg/rt_pg.h
+++ b/raster/rt_pg/rt_pg.h
@@ -35,6 +35,12 @@
 #include "../../postgis_config.h"
 #include "../raster_config.h"
 
+void *rt_pg_alloc(size_t size);
+void *rt_pg_realloc(void *ptr, size_t size);
+void rt_pg_free(void *ptr);
+void rt_pg_error(const char *msg, va_list vp);
+void rt_pg_notice(const char *msg, va_list vp);
+
 /* Debugging macros */
 #if POSTGIS_DEBUG_LEVEL > 0
 

--- a/raster/test/core/testapi.c
+++ b/raster/test/core/testapi.c
@@ -8675,13 +8675,6 @@ main()
     return EXIT_SUCCESS;
 }
 
-/* This is needed by liblwgeom */
-void
-lwgeom_init_allocators(void)
-{
-    lwgeom_install_default_allocators();
-}
-
 
 void rt_init_allocators(void)
 {

--- a/raster/test/core/testwkb.c
+++ b/raster/test/core/testwkb.c
@@ -803,13 +803,6 @@ main()
     return EXIT_SUCCESS;
 }
 
-/* This is needed by liblwgeom */
-void
-lwgeom_init_allocators(void)
-{
-    lwgeom_install_default_allocators();
-}
-
 void rt_init_allocators(void)
 {
     rt_install_default_allocators();

--- a/raster/test/cunit/cu_tester.c
+++ b/raster/test/cunit/cu_tester.c
@@ -15,6 +15,10 @@
 #include "CUnit/Basic.h"
 #include "cu_tester.h"
 
+/* Internal funcs */
+static void 
+cu_error_reporter(const char *fmt, va_list ap);
+
 /* ADD YOUR SUITE HERE (1 of 2) */
 extern CU_SuiteInfo pixtype_suite;
 extern CU_SuiteInfo raster_basics_suite;
@@ -61,6 +65,9 @@ int main(int argc, char *argv[])
 	CU_pTestRegistry registry;
 	int num_run;
 	int num_failed;
+
+	/* install the custom error handler */
+	lwgeom_set_handlers(0, 0, 0, cu_error_reporter, 0);
 
 	/* initialize the CUnit test registry */
 	if (CUE_SUCCESS != CU_initialize_registry())
@@ -238,14 +245,6 @@ rt_band cu_add_band(rt_raster raster, rt_pixtype pixtype, int hasnodata, double 
 	CU_ASSERT(bandNum >= 0);
 
 	return band;
-}
-
-void lwgeom_init_allocators(void) {
-	lwalloc_var = default_allocator;
-	lwrealloc_var = default_reallocator;
-	lwfree_var = default_freeor;
-	lwnotice_var = default_noticereporter;
-	lwerror_var = cu_error_reporter;
 }
 
 void rt_init_allocators(void) {


### PR DESCRIPTION
It replaces the "lwgeom_init_allocators" function with the "lwgeom_set_handlers" one which allows to set custom handlers for both memory ma
    This helps in using the liblwgeom functionalities outside postgis by dlopen (e.g. through python ctypes).
    Now the postgis and pgraster libs call the new function to install those routines from their initialization code.

Replace the pull request #4 
