### PR TITLE
Fix spelling errors in st_makevalid documentation

### DIFF
--- a/doc/reference_processing.xml
+++ b/doc/reference_processing.xml
@@ -1728,7 +1728,7 @@ SELECT ST_AsEWKT(ST_LineToCurve(ST_GeomFromEWKT('LINESTRING(1 2 3, 3 4 8, 5 6 4,
     <refentry id="ST_MakeValid">
       <refnamediv>
         <refname>ST_MakeValid</refname>
-        <refpurpose>Attempts to make an invalid geometry valid w/out loosing vertices.</refpurpose>
+        <refpurpose>Attempts to make an invalid geometry valid without losing vertices.</refpurpose>
       </refnamediv>
     
       <refsynopsisdiv>
@@ -1744,8 +1744,8 @@ SELECT ST_AsEWKT(ST_LineToCurve(ST_GeomFromEWKT('LINESTRING(1 2 3, 3 4 8, 5 6 4,
         <title>Description</title>
     <para>
     The function attempts to create a valid representation of a given invalid
-    geometry without loosing any of the input vertices. 
-    Already-valid geometries are returned w/out further intervention.
+    geometry without losing any of the input vertices. 
+    Already-valid geometries are returned without further intervention.
     </para>
 
     <para>
@@ -1765,7 +1765,7 @@ SELECT ST_AsEWKT(ST_LineToCurve(ST_GeomFromEWKT('LINESTRING(1 2 3, 3 4 8, 5 6 4,
     </para>
     
     <para>Availability: 2.0.0, requires GEOS-3.3.0</para>
-    <para>Enahnced: 2.0.1, speed improvements requires GEOS-3.3.4</para>
+    <para>Enhanced: 2.0.1, speed improvements requires GEOS-3.3.4</para>
     <para>Enhanced: 2.1.0 added support for GEOMETRYCOLLECTION and MULTIPOINT.</para>
     
     <para>&Z_support;</para>


### PR DESCRIPTION
Fixes a couple of spelling errors, and use the full word 'without' instead of the contraction 'w/out'.
