### PR TITLE
Add note to ST_Equals that the function does not support geometry collections

### DIFF
--- a/doc/reference_measure.xml
+++ b/doc/reference_measure.xml
@@ -2501,7 +2501,11 @@ SELECT s.gid, s.school_name
 			points are the same).</para>
 
 		<important>
-		  <para>This function will return false if either geometry is invalid even if they are binary equal.</para>
+	        <para>This function will return false if either geometry is invalid even if they are binary equal.</para>
+		</important>
+
+		<important>
+          <para>Do not call with a GEOMETRYCOLLECTION as an argument.</para>
 		</important>
 
 		<para>&sfs_compliant; s2.1.1.2</para>


### PR DESCRIPTION
I just had a situation where ST_Equals failed to compare GeometryCollections. Looking add the source this is normal behavior, but there is no mention of it in the docs of ST_Equals.

This pull request adds a section to the documentation.