### PR TITLE
Use verified schema name, not raw passed argument.

### DIFF
--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -2389,7 +2389,7 @@ BEGIN
 		END IF;
 	END IF;
 
-	IF postgis_constraint_srid(schema_name, table_name, column_name) IS NOT NULL THEN 
+	IF postgis_constraint_srid(real_schema, table_name, column_name) IS NOT NULL THEN 
 	-- srid was enforced with constraints before, keep it that way.
         -- Make up constraint name
         cname = 'enforce_srid_'  || column_name;


### PR DESCRIPTION
This should fix http://trac.osgeo.org/postgis/ticket/2708 where 

``` sql
SELECT updategeometrysrid('public', 'test','geom_utm', 32630);
```

would alter the `enforce_srid`-constraint, but

``` sql
SELECT updategeometrysrid('test','geom_utm', 32630);
```

wouldn't; even though

``` sql
SELECT current_schema()::text;
```

would yield `'public'`.

The changes are untested, but the use of the verified schema name seems to be the correct way to check for the `enforce_srid`-constraint.
