### PR TITLE
Fixed county level file download match pattern when stateid = 20

### DIFF
--- a/extras/tiger_geocoder/tiger_2011/tiger_loader_2014.sql
+++ b/extras/tiger_geocoder/tiger_2011/tiger_loader_2014.sql
@@ -334,7 +334,7 @@ SELECT
 	-- County Level files
 	|| E'\n' ||
 		array_to_string( ARRAY(SELECT 'cd ' || replace(variables.staging_fold,'/', platform.path_sep) || '
-' || platform.wget || ' ' || COALESCE(lu.website_root_override,variables.website_root || '/' || upper(table_name)  ) || '/*_' || s.state_fips || '* --no-parent --relative --recursive --level=2 --accept=zip --mirror --reject=html 
+' || platform.wget || ' ' || COALESCE(lu.website_root_override,variables.website_root || '/' || upper(table_name)  ) || '/tl_*_' || s.state_fips || '* --no-parent --relative --recursive --level=2 --accept=zip --mirror --reject=html 
 '
 || 'cd ' ||  replace(variables.staging_fold,'/', platform.path_sep) || '/' || replace(replace(COALESCE(lu.website_root_override,variables.website_root || '/' || upper(table_name)  || '/'), 'http://', ''),'ftp://','')  || '
 ' || replace(platform.unzip_command, '*.zip', 'tl_*_' || s.state_fips || '*_' || table_name || '.zip ') || '


### PR DESCRIPTION
2014 TIGER lines file naming format is tl_YYYY_state_fips*_tablename.zip. The current County level file match download pulls ALL zipfiles for all states when statecode is 20 as it matches /*_ to tl_2014_* when it should in fact match only tl_2014_20*.