### PR TITLE
Fix issue with skipped tests not being cleaned up properly

### DIFF
--- a/regress/run_test.pl
+++ b/regress/run_test.pl
@@ -331,7 +331,8 @@ foreach $TEST (@ARGV)
 	{
 		print " skipped (can't read any ${TEST}.{sql,dbf,tif,dmp})\n";
 		$SKIP++;
-		next;
+		# Even though we skipped this test, we should still run the cleanup
+		# scripts
 	}
 
 	if ( -r "${TEST}-post.sql" )


### PR DESCRIPTION
This was what was causing the untracked file I noticed in #32.