### PR TITLE
Re-enable all scan types by the end of test

### DIFF
--- a/regress/knn.sql
+++ b/regress/knn.sql
@@ -25,6 +25,8 @@ CREATE INDEX on test using gist (the_geom);
 
 -- Index-supported KNN query
 
+set enable_seqscan = on;
+
 SELECT '<-> idx', qnodes('select * from test order by the_geom <-> ST_MakePoint(0,0)');
 SELECT '<-> res1',num,
   (the_geom <-> 'LINESTRING(0 0,5 5)'::geometry)::numeric(10,2),

--- a/regress/regress_index.sql
+++ b/regress/regress_index.sql
@@ -108,3 +108,6 @@ DROP FUNCTION estimate_error(text, int);
 
 DROP FUNCTION qnodes(text);
 
+set enable_indexscan = on;
+set enable_bitmapscan = on;
+set enable_seqscan = on;


### PR DESCRIPTION
There seem to be a bug in the test itself, as, 9.4 should be doing a SEQUENCIAL scan in absence of LIMIT for the ORDER BY, as found by travis here:
https://travis-ci.org/postgis/postgis/builds/51970185