### PR TITLE
Handle invalid topology names

### DIFF
--- a/topology/test/regress/addtopogeometrycolumn.sql
+++ b/topology/test/regress/addtopogeometrycolumn.sql
@@ -1,6 +1,7 @@
 set client_min_messages to WARNING;
 \set VERBOSITY terse
 
+select addtopogeometrycolumn('tt','public','feature','tg','POINT'); -- fail
 select createtopology('tt') > 0;
 select addtopogeometrycolumn('tt','public','feature','tg','POINT'); -- fail
 create table feature(id integer);

--- a/topology/test/regress/addtopogeometrycolumn_expected
+++ b/topology/test/regress/addtopogeometrycolumn_expected
@@ -1,3 +1,4 @@
+ERROR:  Topology 'tt' does not exist
 t
 ERROR:  relation "public.feature" does not exist
 ERROR:  Layer type must be one of POINT,LINE,POLYGON,COLLECTION

--- a/topology/test/regress/createtopology.sql
+++ b/topology/test/regress/createtopology.sql
@@ -26,3 +26,7 @@ SELECT topology.AddNode('2d', 'POINT(2 2)');
 SELECT topology.DropTopology('2d');
 SELECT topology.DropTopology('2dAgain');
 SELECT topology.DropTopology('3d');
+
+-- Exceptions
+SELECT topology.CreateTopology('public');
+SELECT topology.CreateTopology('topology');

--- a/topology/test/regress/createtopology_expected
+++ b/topology/test/regress/createtopology_expected
@@ -14,3 +14,5 @@ ERROR:  Geometry has Z dimension but column does not
 Topology '2d' dropped
 Topology '2dAgain' dropped
 Topology '3d' dropped
+ERROR:  schema "public" already exists
+ERROR:  schema "topology" already exists

--- a/topology/test/regress/droptopology.sql
+++ b/topology/test/regress/droptopology.sql
@@ -13,3 +13,7 @@ SELECT topology.DropTopology('t1');
 SELECT topology.DropTopology('t2');
 DROP TABLE t2f;
 DROP TABLE t1f;
+
+-- Exceptions
+SELECT topology.DropTopology('topology');
+SELECT topology.DropTopology('doesnotexist');

--- a/topology/test/regress/droptopology_expected
+++ b/topology/test/regress/droptopology_expected
@@ -4,3 +4,5 @@ t
 t
 Topology 't1' dropped
 Topology 't2' dropped
+ERROR:  Topology 'topology' does not exist
+ERROR:  Topology 'doesnotexist' does not exist

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -560,12 +560,12 @@ DECLARE
   query text;
 BEGIN
 
-        -- Get topology id
-        SELECT id FROM topology.topology into topoid
-                WHERE name = toponame;
+  -- Get topology id
+  SELECT id INTO topoid
+    FROM topology.topology WHERE name = toponame;
 
-  IF topoid IS NULL THEN
-    RAISE EXCEPTION 'Topology % does not exist', toponame;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Topology % does not exist', quote_literal(toponame);
   END IF;
 
   IF ltype ILIKE '%POINT%' OR ltype ILIKE 'PUNTAL' THEN
@@ -861,8 +861,12 @@ BEGIN
   END IF;
 
   -- Get topology id into return TopoGeometry
-  SELECT id FROM topology.topology into ret.topology_id
-    WHERE name = toponame;
+  SELECT id INTO ret.topology_id
+    FROM topology.topology WHERE name = toponame;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Topology % does not exist', quote_literal(toponame);
+  END IF;
 
   --
   -- Get layer info
@@ -995,8 +999,13 @@ $$
 DECLARE
   ret integer;
 BEGIN
-        SELECT id FROM topology.topology into ret
-                WHERE name = toponame;
+  SELECT id INTO ret
+    FROM topology.topology WHERE name = toponame;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Topology % does not exist', quote_literal(toponame);
+  END IF;
+
   RETURN ret;
 END
 $$
@@ -1920,37 +1929,34 @@ DECLARE
   topoid integer;
   rec RECORD;
 BEGIN
-
   -- Get topology id
-        SELECT id FROM topology.topology into topoid
-                WHERE name = atopology;
+  SELECT id INTO topoid
+    FROM topology.topology WHERE name = atopology;
 
-
-  IF topoid IS NOT NULL THEN
-
-    RAISE NOTICE 'Dropping all layers from topology % (%)',
-      atopology, topoid;
-
-    -- Drop all layers in the topology
-    FOR rec IN EXECUTE 'SELECT * FROM topology.layer WHERE '
-         ' topology_id = ' || topoid
-    LOOP
-
-      EXECUTE 'SELECT topology.DropTopoGeometryColumn('
-        || quote_literal(rec.schema_name)
-        || ','
-        || quote_literal(rec.table_name)
-        || ','
-        || quote_literal(rec.feature_column)
-        || ')';
-    END LOOP;
-
-    -- Delete record from topology.topology
-    EXECUTE 'DELETE FROM topology.topology WHERE id = '
-      || topoid;
-
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Topology % does not exist', quote_literal(atopology);
   END IF;
 
+  RAISE NOTICE 'Dropping all layers from topology % (%)',
+    quote_literal(atopology), topoid;
+
+  -- Drop all layers in the topology
+  FOR rec IN EXECUTE 'SELECT * FROM topology.layer WHERE '
+    || ' topology_id = ' || topoid
+  LOOP
+
+    EXECUTE 'SELECT topology.DropTopoGeometryColumn('
+      || quote_literal(rec.schema_name)
+      || ','
+      || quote_literal(rec.table_name)
+      || ','
+      || quote_literal(rec.feature_column)
+      || ')';
+  END LOOP;
+
+  -- Delete record from topology.topology
+  EXECUTE 'DELETE FROM topology.topology WHERE id = '
+    || topoid;
 
   -- Drop the schema (if it exists)
   FOR rec IN SELECT * FROM pg_namespace WHERE text(nspname) = atopology


### PR DESCRIPTION
Fixes https://trac.osgeo.org/postgis/ticket/3196

Changed functions:
* `topology.AddTopoGeometryColumn`
* `topology.GetTopologyId`
* `topology.DropTopology`
