### PR TITLE
add memcmp short-circuit to ST_Equals

### DIFF
--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -3097,6 +3097,14 @@ Datum ST_Equals(PG_FUNCTION_ARGS)
 		}
 	}
 
+	/*
+	 * short-circuit: if geom1 and geom2 are binary-equivalent, we can return
+	 * TRUE.  This is much faster than doing the comparison using GEOS.
+	 */
+	if (VARSIZE(geom1) == VARSIZE(geom2) && !memcmp(geom1, geom2, VARSIZE(geom1))) {
+	    PG_RETURN_BOOL(TRUE);
+	}
+
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 
 	g1 = (GEOSGeometry *)POSTGIS2GEOS(geom1);


### PR DESCRIPTION
This can be a huge benefit for certain types of queries, for example looking for duplicate geometries that have different IDs:

    SELECT count(*)
    FROM inputs a, inputs b
    WHERE a.id < b.id AND ST_Equals(a.geom, b.geom);

This patch reduces the runtime of the above from 13 seconds (trunk) to 500 ms.

(patch at https://github.com/postgis/postgis/pull/44.patch)