### PR TITLE
fix ST_Equals compiler warning

### DIFF
--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1849,6 +1849,12 @@ extern GSERIALIZED* gserialized_from_lwgeom(LWGEOM *geom, int is_geodetic, size_
 extern LWGEOM* lwgeom_from_gserialized(const GSERIALIZED *g);
 
 /**
+ * Pull a #GBOX from the header of a #GSERIALIZED, if one is available.  If
+ * it is not, return LW_FAILURE.
+ */
+extern int gserialized_read_gbox_p(const GSERIALIZED *g, GBOX *gbox);
+
+/**
 * Pull a #GBOX from the header of a #GSERIALIZED, if one is available. If
 * it is not, calculate it from the geometry. If that doesn't work (null
 * or empty) return LW_FAILURE.


### PR DESCRIPTION
Looks like I introduced this one earlier when switching from `gserialized_get_gbox_p` to `gserialized_read_gbox_p`.  Alternative is to revert `ST_Equals` to use `gserialized_read_gbox_p`.  It seemed, though, that the intent of a short-circuit test was to use the box if it's available, not to force one to be constructed as the `get` variety does.  If this logic is sound, might want to change the other uses of `get` to `read`.