### PR TITLE
Migrate Travis CI builds to container-based architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - ./configure
   - make
   - make check
-  - sudo make install
+  - make install
   - make installcheck
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,6 @@ notifications:
     on_success: change
     on_failure: always
     use_notice: false
+
+after_failure:
+  - cat /tmp/pgis_reg/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 env:
   global:
     - RUNTESTFLAGS=-v
@@ -5,21 +7,31 @@ env:
 addons:
   postgresql: "9.4"
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y
-      postgresql-9.4 postgresql-server-dev-9.4
-      build-essential autoconf libtool libcunit1-dev
-      xsltproc docbook-xsl docbook-mathml dblatex
-      libproj-dev libgdal-dev libgeos-dev libjson0-dev
-  - dpkg -l | grep postgresql
-  - ./autogen.sh
+ addons:
+   postgresql: "9.4"
+   apt:
+    packages:
+    - autoconf
+    - build-essential
+    - dblatex
+    - docbook-mathml
+    - docbook-xsl
+    - libcunit1-dev
+    - libgdal-dev
+    - libgeos-dev
+    - libjson0-dev
+    - libproj-dev
+    - libtool
+    - postgresql-9.4
+    - postgresql-server-dev-9.4
+    - xsltproc
 
 language: c
 
 compiler: gcc
 
 script:
+  - ./autogen.sh
   - ./configure
   - make
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ env:
 
 addons:
   postgresql: "9.4"
-
- addons:
-   postgresql: "9.4"
-   apt:
+  apt:
     packages:
     - autoconf
     - build-essential


### PR DESCRIPTION
The `.travis.yml` update is sound.

## Status
Build is failing at the `installcheck` step due to issue:
* build generates `postgis-2.2`
* installcheck loads `postgis-2.1`
```
ERROR:  could not access file "$libdir/postgis-2.1": No such file or directory
```
* See detailed log at https://travis-ci.org/mloskot/postgis/builds/74320589

## Problem
[Pre-installed PostGIS](http://docs.travis-ci.com/user/using-postgresql/#Using-PostGIS) version conflicts with the build:
> All available versions of PostgreSQL come with PostGIS 2.1 packages preinstalled.

## Solution
* Install PostgreSQL from sources into `--prefix=$HOME/postgresql`, which does not require `sudo`.
* Alternatively, it may be possible to use sudo as per this message from the top of the build log:
> If you require sudo, add 'sudo: required' to your .travis.yml
> See http://docs.travis-ci.com/user/workers/container-based-infrastructure/ for details.

However, `sudo: required` means switch back to old non-container architecture.

