### PR TITLE
Have ./configure fail if LEX or YACC are missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,16 @@ AC_PROG_YACC
 AC_SUBST([LEX])
 AC_SUBST([YACC])
 
+if test "x$YACC" = "x"; then
+	dnl YACC was not found
+	AC_MSG_ERROR([Liblwgeom parsers require bison, byacc or yacc, which was not found within the current path])
+fi
+
+if test "x$LEX" = "x"; then
+	dnl LEX was not found
+	AC_MSG_ERROR([Liblwgeom parsers require flex or lex, which were not found within the current path])
+fi
+
 dnl
 dnl Search for OS-specific headers
 dnl


### PR DESCRIPTION
After writing the patch I realized we're shipping generated parser files with tarballs, so ./configure should NOT fail if lex/yacc are not found. So here's my patch, probably to remain here forever (ops).

Alternatively, someone might tweak the patch to check for the existance of the generated lexer files and avoid failing if the files are already there ?

\cc @pramsey @robe2 