### PR TITLE
Do not have postgis module export library symbols (#3281)

### DIFF
--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -70,7 +70,7 @@ OBJS=$(PG_OBJS)
 # older version of PostGIS, rather than with the static liblwgeom.a 
 # supplied with newer versions of PostGIS
 PG_CPPFLAGS+=@CPPFLAGS@ -I../liblwgeom
-SHLIB_LINK+=@SHLIB_LINK@ ../liblwgeom/liblwgeom.a
+SHLIB_LINK+=@SHLIB_LINK@ -Wl,--exclude-libs,ALL ../liblwgeom/liblwgeom.a
 
 # Extra files to remove during 'make clean'
 EXTRA_CLEAN=$(SQL_OBJS)


### PR DESCRIPTION
Allows other modules to use a dynamically linked liblwgeom