### PR TITLE
Double // in default tiger import for sh.

### DIFF
--- a/extras/tiger_geocoder/tiger_loader_2015.sql
+++ b/extras/tiger_geocoder/tiger_loader_2015.sql
@@ -191,7 +191,7 @@ VALUES('sh', 'wget', '',
 E'TMPDIR="${staging_fold}/temp/"
 UNZIPTOOL=unzip
 WGETTOOL="/usr/bin/wget"
-export PGBIN=/usr/lib/postgresql/9.4/bin/
+export PGBIN=/usr/lib/postgresql/9.4/bin
 export PGPORT=5432
 export PGHOST=localhost
 export PGUSER=postgres


### PR DESCRIPTION
export PGBIN=/usr/lib/postgresql/9.4/bin/
PSQL=${PGBIN}/psql
SHP2PGSQL=${PGBIN}/shp2pgsql

results in double // for the PSQL and SHP2PGSQL variables which throws an error.

Also the GitHub web edit added a newline to end of file automatically so ignore that if it's not necessary.