### PR TITLE
ST_AsText : adding optional argument 'precision' 

### DIFF
--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1023,7 +1023,17 @@ SELECT ST_GeoHash(ST_SetSRID(ST_MakePoint(-126,48),4326),5);
 			  </funcprototype>
 			  <funcprototype>
 				<funcdef>text <function>ST_AsText</function></funcdef>
+				<paramdef><type>geometry </type> <parameter>g1</parameter></paramdef>
+				<paramdef choice="opt"><type>integer </type> <parameter>precision=15</parameter></paramdef>
+			  </funcprototype>
+			  <funcprototype>
+				<funcdef>text <function>ST_AsText</function></funcdef>
 				<paramdef><type>geography </type> <parameter>g1</parameter></paramdef>
+			  </funcprototype>
+			  <funcprototype>
+				<funcdef>text <function>ST_AsText</function></funcdef>
+				<paramdef><type>geography </type> <parameter>g1</parameter></paramdef>
+				<paramdef choice="opt"><type>integer </type> <parameter>precision=15</parameter></paramdef>
 			  </funcprototype>
 			</funcsynopsis>
 		  </refsynopsisdiv>
@@ -1031,7 +1041,8 @@ SELECT ST_GeoHash(ST_SetSRID(ST_MakePoint(-126,48),4326),5);
 		  <refsection>
 			<title>Description</title>
 
-			<para>Returns the Well-Known Text representation of the geometry/geography.</para>
+			<para>Returns the Well-Known Text representation of the geometry/geography. The optional integer precision
+				parameter can specify the number of significant digits in the output doubles.</para>
 
 			<note>
 			  <para>The WKT spec does not include the SRID.  To get the SRID as part of the data, use the non-standard
@@ -1045,11 +1056,11 @@ SELECT ST_GeoHash(ST_SetSRID(ST_MakePoint(-126,48),4326),5);
 			</note>
 
 			<para>Availability: 1.5 - support for geography was introduced.</para>
+			<para>Enhanced: 2.3 - optional parameter precision introduced.</para>
 			<para>&sfs_compliant; s2.1.1.1</para>
 			<para>&sqlmm_compliant; SQL-MM 3: 5.1.25</para>
 			<para>&curve_support;</para>
 		  </refsection>
-
 
 		  <refsection>
 			<title>Examples</title>
@@ -1063,6 +1074,20 @@ F000000000000000000000000000000000000000000000000');
 --------------------------------
  POLYGON((0 0,0 1,1 1,1 0,0 0))
 (1 row)</programlisting>
+
+			<para>Providing the precision is optional.</para>
+
+			<programlisting>SELECT ST_AsText(GeomFromEWKT('SRID=4326;POINT(111.1111111 1.1111111)'))
+          st_astext
+------------------------------
+ POINT(111.1111111 1.1111111)
+(1 row)</programlisting>
+
+			<programlisting>SELECT ST_AsText(GeomFromEWKT('SRID=4326;POINT(111.1111111 1.1111111)'),2)
+st_astext
+--------------------
+POINT(1.1e+02 1.1)
+(1 row)</programlisting>
 		  </refsection>
 
 		  <!-- Optionally add a "See Also" section -->
@@ -1072,7 +1097,6 @@ F000000000000000000000000000000000000000000000000');
 			<para><xref linkend="ST_AsBinary" />, <xref linkend="ST_AsEWKB" />, <xref linkend="ST_AsEWKT" />, <xref linkend="ST_GeomFromText" /></para>
 		  </refsection>
 	</refentry>
-
 
 	<refentry id="ST_AsLatLonText">
 		  <refnamediv>

--- a/postgis/geography.sql.in
+++ b/postgis/geography.sql.in
@@ -104,6 +104,12 @@ CREATE OR REPLACE FUNCTION ST_AsText(geography)
 	AS 'MODULE_PATHNAME','LWGEOM_asText'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 	
+-- Availability: 2.3.0
+CREATE OR REPLACE FUNCTION ST_AsText(geography, int4)
+	RETURNS TEXT
+	AS 'MODULE_PATHNAME','LWGEOM_asText'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
 -- Availability: 1.5.0 - this is just a hack to prevent unknown from causing ambiguous name because of geography
 CREATE OR REPLACE FUNCTION ST_AsText(text)
 	RETURNS text AS
@@ -815,5 +821,3 @@ CREATE OR REPLACE FUNCTION ST_SetSRID(geog geography, srid int4)
 	LANGUAGE 'c' IMMUTABLE STRICT;
   
 -----------------------------------------------------------------------------
-
-

--- a/postgis/lwgeom_ogc.c
+++ b/postgis/lwgeom_ogc.c
@@ -848,14 +848,20 @@ Datum LWGEOM_asText(PG_FUNCTION_ARGS)
 	char *wkt;
 	size_t wkt_size;
 	text *result;
+	int dbl_dig_for_wkt = DBL_DIG;
 
 	POSTGIS_DEBUG(2, "Called.");
 
 	geom = PG_GETARG_GSERIALIZED_P(0);
 	lwgeom = lwgeom_from_gserialized(geom);
 
+	if (PG_NARGS() > 1)
+	{
+		dbl_dig_for_wkt = PG_GETARG_INT32(1);
+	}
+
 	/* Write to WKT and free the geometry */
-	wkt = lwgeom_to_wkt(lwgeom, WKT_ISO, DBL_DIG, &wkt_size);
+	wkt = lwgeom_to_wkt(lwgeom, WKT_ISO, dbl_dig_for_wkt, &wkt_size);
 	lwgeom_free(lwgeom);
 	POSTGIS_DEBUGF(3, "WKT size = %u, WKT length = %u", (unsigned int)wkt_size, (unsigned int)strlen(wkt));
 

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -4352,6 +4352,13 @@ CREATE OR REPLACE FUNCTION ST_AsText(geometry)
 	AS 'MODULE_PATHNAME','LWGEOM_asText'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
+-- Availability: 2.3.0
+-- PostGIS equivalent function: AsText(geometry, int4)
+CREATE OR REPLACE FUNCTION ST_AsText(geometry, int4)
+    RETURNS TEXT
+    AS 'MODULE_PATHNAME','LWGEOM_asText'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -- Availability: 1.2.2
 CREATE OR REPLACE FUNCTION ST_GeometryFromText(text)
 	RETURNS geometry

--- a/regress/out_geography.sql
+++ b/regress/out_geography.sql
@@ -66,7 +66,7 @@ SELECT 'kml_version_03', ST_AsKML(-4, geography(GeomFromEWKT('SRID=4326;POINT(1 
 SELECT 'kml_prefix_01', ST_AsKML(2, geography(GeomFromEWKT('SRID=4326;POINT(1 2)')), 0, '');
 SELECT 'kml_prefix_02', ST_AsKML(2, geography(GeomFromEWKT('SRID=4326;POINT(1 2)')), 0, 'kml');
 
--- Projected 
+-- Projected
 -- National Astronomical Observatory of Colombia - Bogota, Colombia (Placemark)
 SELECT 'kml_projection_01', ST_AsKML(geography(GeomFromEWKT('SRID=102189;POINT(1000000 1000000)')), 3);
 
@@ -136,6 +136,15 @@ SELECT 'geojson_options_13', ST_AsGeoJson(geography(GeomFromEWKT('LINESTRING(1 1
 SELECT 'geojson_options_14', ST_AsGeoJson(geography(GeomFromEWKT('SRID=4326;LINESTRING(1 1, 2 2, 3 3, 4 4)')), 0, 6);
 SELECT 'geojson_options_15', ST_AsGeoJson(geography(GeomFromEWKT('LINESTRING(1 1, 2 2, 3 3, 4 4)')), 0, 7);
 SELECT 'geojson_options_16', ST_AsGeoJson(geography(GeomFromEWKT('SRID=4326;LINESTRING(1 1, 2 2, 3 3, 4 4)')), 0, 7);
+
+
+--
+-- Text
+--
+
+-- Precision
+SELECT 'text_precision_01', ST_AsText(geography(GeomFromEWKT('SRID=4326;POINT(111.1111111 1.1111111)')));
+SELECT 'text_precision_02', ST_AsText(geography(GeomFromEWKT('SRID=4326;POINT(111.1111111 1.1111111)')),2);
 
 
 --

--- a/regress/out_geography_expected
+++ b/regress/out_geography_expected
@@ -66,3 +66,5 @@ geojson_options_13|{"type":"LineString","crs":{"type":"name","properties":{"name
 geojson_options_14|{"type":"LineString","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[[1,1],[2,2],[3,3],[4,4]]}
 geojson_options_15|{"type":"LineString","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"bbox":[1,1,4,4],"coordinates":[[1,1],[2,2],[3,3],[4,4]]}
 geojson_options_16|{"type":"LineString","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"bbox":[1,1,4,4],"coordinates":[[1,1],[2,2],[3,3],[4,4]]}
+text_precision_01|POINT(111.1111111 1.1111111)
+text_precision_02|POINT(1.1e+2 1.1)

--- a/regress/out_geometry.sql
+++ b/regress/out_geometry.sql
@@ -171,6 +171,16 @@ SELECT 'pgcast_04','LINESTRING EMPTY'::geometry::path IS NULL;
 SELECT 'pgcast_05','POINT EMPTY'::geometry::point IS NULL;
 SELECT 'pgcast_06',ST_AsText('((0,0),(0,1),(1,1),(1,0))'::polygon::geometry);
 
+
+--
+-- Text
+--
+
+-- Precision
+SELECT 'text_precision_01', ST_AsText(GeomFromEWKT('SRID=4326;POINT(111.1111111 1.1111111)'));
+SELECT 'text_precision_02', ST_AsText(GeomFromEWKT('SRID=4326;POINT(111.1111111 1.1111111)'),2);
+
+
 --
 -- Delete inserted spatial data
 --

--- a/regress/out_geometry_expected
+++ b/regress/out_geometry_expected
@@ -88,3 +88,5 @@ pgcast_03|t
 pgcast_04|t
 pgcast_05|t
 pgcast_06|POLYGON((0 0,0 1,1 1,1 0,0 0))
+text_precision_01|POINT(111.1111111 1.1111111)
+text_precision_02|POINT(1.1e+2 1.1)


### PR DESCRIPTION
The optional argument 'precision' is used for specifying the number of significant digits in the output doubles
