### PR TITLE
[sketch] add skip for empty collection elements in LWGEOM2GEOS

### DIFF
--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -332,7 +332,7 @@ LWGEOM2GEOS(const LWGEOM *lwgeom, int autofix)
 	/*
 	LWGEOM *tmp;
 	*/
-	uint32_t ngeoms, i;
+	uint32_t ngeoms, i, j;
 	int geostype;
 #if LWDEBUG_LEVEL >= 4
 	char *wkt;
@@ -443,9 +443,11 @@ LWGEOM2GEOS(const LWGEOM *lwgeom, int autofix)
 		ngeoms = lwc->ngeoms;
 		if ( ngeoms > 0 )
 			geoms = malloc(sizeof(GEOSGeom)*ngeoms);
-
+		j = 0;
+		// i is index of lwgeom geometry, j is index of geos geometry - skip empty collection entries
 		for (i=0; i<ngeoms; ++i)
 		{
+			if (lwgeom_is_empty(lwgeom)) continue; // skip empty
 			GEOSGeometry* g = LWGEOM2GEOS(lwc->geoms[i], 0);
 			if ( ! g )
 			{
@@ -453,9 +455,9 @@ LWGEOM2GEOS(const LWGEOM *lwgeom, int autofix)
 				free(geoms);
 				return NULL;
 			}
-			geoms[i] = g;
+			geoms[++j] = g;
 		}
-		g = GEOSGeom_createCollection(geostype, geoms, ngeoms);
+		g = GEOSGeom_createCollection(geostype, geoms, j);
 		if ( geoms ) free(geoms);
 		if ( ! g ) return NULL;
 		break;

--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -447,7 +447,7 @@ LWGEOM2GEOS(const LWGEOM *lwgeom, int autofix)
 		// i is index of lwgeom geometry, j is index of geos geometry - skip empty collection entries
 		for (i=0; i<ngeoms; ++i)
 		{
-			if (lwgeom_is_empty(lwgeom)) continue; // skip empty
+			if (lwgeom_is_empty(lwc->geoms[i])) continue; // skip empty
 			GEOSGeometry* g = LWGEOM2GEOS(lwc->geoms[i], 0);
 			if ( ! g )
 			{
@@ -455,7 +455,7 @@ LWGEOM2GEOS(const LWGEOM *lwgeom, int autofix)
 				free(geoms);
 				return NULL;
 			}
-			geoms[++j] = g;
+			geoms[j++] = g;
 		}
 		g = GEOSGeom_createCollection(geostype, geoms, j);
 		if ( geoms ) free(geoms);


### PR DESCRIPTION
we can easily crash postgis with this query, this pullrequest sketches the solution:

```
with
        params as (
        select
            11 :: float as sidewalk_offset,
            1 :: float  as epsilon
    ),
        road as (
-- L-shaped road, 10 m
        select 'SRID=3857;LINESTRING(10 0, 0 0, 0 10)' :: geometry as geom
    ),
        sidewalks as (
        select ST_Collect(
                   ST_OffsetCurve(geom, sidewalk_offset),
                   ST_OffsetCurve(geom, -sidewalk_offset)
               ) geom
        from road, params
    )
select
    ST_Intersects(road.geom, sidewalks.geom),
-- should be false
    ST_Intersects(ST_Buffer(road.geom, sidewalk_offset + epsilon), sidewalks.geom) -- should be true
from road, sidewalks, params;
```