### PR TITLE
EncodedPolylines: precision is second parameter... not third !

### DIFF
--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -637,9 +637,9 @@ Datum LWGEOM_asEncodedPolyline(PG_FUNCTION_ARGS)
 	lwgeom = lwgeom_from_gserialized(geom);
 	PG_FREE_IF_COPY(geom, 0);
 	
-	if (PG_NARGS() >2 && !PG_ARGISNULL(2))
+	if (PG_NARGS() >1 && !PG_ARGISNULL(1))
 	{
-		precision = PG_GETARG_INT32(2);
+		precision = PG_GETARG_INT32(1);
 		if ( precision < 0 ) precision = 5;
 	}
 

--- a/postgis/lwgeom_in_encoded_polyline.c
+++ b/postgis/lwgeom_in_encoded_polyline.c
@@ -47,9 +47,9 @@ Datum line_from_encoded_polyline(PG_FUNCTION_ARGS)
   encodedpolyline_input = PG_GETARG_TEXT_P(0);
   encodedpolyline = text2cstring(encodedpolyline_input);
 
-  if (PG_NARGS() >2 && !PG_ARGISNULL(2))
+  if (PG_NARGS() >1 && !PG_ARGISNULL(1))
   {
-    precision = PG_GETARG_INT32(2);
+    precision = PG_GETARG_INT32(1);
     if ( precision < 0 ) precision = 5;
   }
 


### PR DESCRIPTION
precision parameter had no effect on ST_AsEncodedPolyline and st_linefromencodedpolyline as code was looking for it as the third parameter instead of the second.

regress tests need to be updated... (not enough familiar with that, sorry)
