### PR TITLE
Allocate memory for encoding argument, so that it can be freed later.

### DIFF
--- a/loader/shp2pgsql-cli.c
+++ b/loader/shp2pgsql-cli.c
@@ -176,7 +176,7 @@ main (int argc, char **argv)
 			break;
 
 		case 'W':
-			config->encoding = pgis_optarg;
+			config->encoding = strdup(pgis_optarg);
 			break;
 
 		case 'N':


### PR DESCRIPTION
When an encoding is specified for `shp2pgsql` with the `-W` argument, the pointer is copied rather than the string being reallocated. If the `-W` argument is `UTF-8`, then it is assumed to be the default (which is `strdup`ed) and, if the shapefile contains a code page, the pointer is `free`d and the program crashes. For example:

```
$ for i in shp shx dbf prj; do \
    wget https://raw.githubusercontent.com/tilezen/vector-datasource/7dcf316a7badd392b8bfc88c1f1ee7468b84c93e/integration-test/fixtures/land_polygons/399-earth-fixture.${i}; \
    done
...
$ loader/shp2pgsql -W UTF-8 399-earth-fixture.shp
*** Error in `/home/matt/Programming/OSM/postgis/loader/.libs/lt-shp2pgsql': munmap_chunk(): invalid pointer: 0x00007ffdd3eda138 ***
Aborted (core dumped)
```

I don't think there's anything special about the code page in the shapefile from the repository above, it just happened to be one I had lying around.

This patch fixes the crash by `strdup`ing the command line argument. However, there might be a second issue: if the argument has been specified by the user, should the block of code which [replaces it with the encoding from the code page](https://github.com/postgis/postgis/blob/5737faa03138c5f3a02268343ef6590be369bc7e/loader/shp2pgsql-core.c#L871-L882) even be run? Would it be better to keep the default as NULL and replace NULL with the encoding from the file's code page (or `strdup(DEFAULT_ENCODING)`) if it wasn't set to a non-null value by the option parser? The only reason that I've not included that in the patch is that I thought it might have bad interactions with the GUI code.
