### PR TITLE
fix po2xml error in doc/po/ko_KR/reference_raster.xml.po. https://tra…

### DIFF
--- a/doc/po/ko_KR/reference_raster.xml.po
+++ b/doc/po/ko_KR/reference_raster.xml.po
@@ -15812,8 +15812,8 @@ msgid ""
 "representing the shared portion of two rasters or the geometrical "
 "intersection of a vectorization of the raster and a geometry.</refpurpose>"
 msgstr ""
-"두 래스터의 공유 부분을 표현하는, 또는 벡터화된 래스터와 도형의 기하학적 교차"
-"를 표현하는 래스터 또는 도형-픽셀값 쌍의 집합을 반환합니다."
+"<refpurpose>두 래스터의 공유 부분을 표현하는, 또는 벡터화된 래스터와 도형의 기하학적 교차"
+"를 표현하는 래스터 또는 도형-픽셀값 쌍의 집합을 반환합니다.</refpurpose>"
 
 #. Tag: funcsynopsis
 #: reference_raster.xml:6399


### PR DESCRIPTION
The doc/po/ko_KR/refrence_raster.xml.po was modified for fix error in po2xml.
It was issued at  https://trac.osgeo.org/postgis/ticket/3574#comment:2.

It is looks good in transifex.com like below.
![image](https://cloud.githubusercontent.com/assets/1990833/17478323/f388c8fc-5da5-11e6-9ce9-82e8d9ec86cd.png)
But in Github <refpurpose> tag is missing.

And some other problems issued in https://trac.osgeo.org/postgis/ticket/3574#comment:3 was fixed in transifex.com's reference_accessor.xml file.

Please 'tx pull' and retry make command, and send FULL error message to me.
Then I will fix each problems.
