### PR TITLE
Fix documentation of centroid examples.

### DIFF
--- a/doc/po/de_DE/reference_measure.xml.po
+++ b/doc/po/de_DE/reference_measure.xml.po
@@ -1264,7 +1264,7 @@ msgstr ""
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr ""
 

--- a/doc/po/es/reference_measure.xml.po
+++ b/doc/po/es/reference_measure.xml.po
@@ -1264,7 +1264,7 @@ msgstr ""
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr ""
 

--- a/doc/po/fr/reference_measure.xml.po
+++ b/doc/po/fr/reference_measure.xml.po
@@ -1479,7 +1479,7 @@ msgstr ""
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr ""
 

--- a/doc/po/it_IT/reference_measure.xml.po
+++ b/doc/po/it_IT/reference_measure.xml.po
@@ -1468,7 +1468,7 @@ msgstr "&sqlmm_compliant; SQL-MM 3: 8.1.4, 9.5.5"
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr ""
 

--- a/doc/po/ja/reference_measure.xml.po
+++ b/doc/po/ja/reference_measure.xml.po
@@ -1694,7 +1694,7 @@ msgstr "&sqlmm_compliant; SQL-MM 3: 8.1.4, 9.5.5"
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr "次に示す図では、青点が入力ジオメトリの重心です。"
 

--- a/doc/po/ko_KR/reference_measure.xml.po
+++ b/doc/po/ko_KR/reference_measure.xml.po
@@ -1699,7 +1699,7 @@ msgstr "&sqlmm_compliant; SQL-MM 3: 8.1.4, 9.5.5"
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr "다음 그림들 각각에서, 파란색 점이 입력 도형의 중심점을 나타냅니다."
 

--- a/doc/po/pl/reference_measure.xml.po
+++ b/doc/po/pl/reference_measure.xml.po
@@ -1265,7 +1265,7 @@ msgstr ""
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr ""
 

--- a/doc/po/pt_BR/reference_measure.xml.po
+++ b/doc/po/pt_BR/reference_measure.xml.po
@@ -1712,7 +1712,7 @@ msgstr "&sqlmm_compliant; SQL-MM 3: 8.1.4, 9.5.5"
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr ""
 "Em cada uma das ilustrações seguintes, o ponto azul representa o centroide "

--- a/doc/po/templates/reference_measure.xml.pot
+++ b/doc/po/templates/reference_measure.xml.pot
@@ -1262,7 +1262,7 @@ msgstr ""
 #: reference_measure.xml:665
 #, no-c-format
 msgid ""
-"In each of the following illustrations, the blue dot represents the centroid "
+"In each of the following illustrations, the green dot represents the centroid "
 "of the source geometry."
 msgstr ""
 

--- a/doc/reference_measure.xml
+++ b/doc/reference_measure.xml
@@ -870,7 +870,7 @@ SELECT degrees(ST_Azimuth(ST_Point(25, 45), ST_Point(75, 100))) AS degA_B,
 	<refsection>
 	  <title>Examples</title>
 
-	  <para>In each of the following illustrations, the blue dot represents
+	  <para>In each of the following illustrations, the green dot represents
 	  the centroid of the source geometry.</para>
 
 	  <informaltable>


### PR DESCRIPTION
I've noticed that in the ST_centroid example images (http://postgis.net/docs/ST_Centroid.html) the centroid dot is green instead of blue. I've fixed the documentation so it now says green. I hope this helps.