### PR TITLE
Recursive subdivide fixes

### DIFF
--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -1979,11 +1979,11 @@ lwgeom_subdivide_recursive(const LWGEOM *geom, int maxvertices, int depth, LWCOL
 		return n;
 	}
 	
-	/* But don't go too far. 2^25 = 33M, that's enough subdivision */
-	/* Signal callers above that we depth'ed out with a negative */
-	/* return value */
+	/* But don't go too far. 2^50 ~= 10^15, that's enough subdivision */
+	/* Just add what's left */
 	if ( depth > maxdepth )
 	{
+		lwcollection_add_lwgeom(col, lwgeom_clone_deep(geom));
 		return 0;
 	}
 	
@@ -2030,15 +2030,17 @@ lwgeom_subdivide_recursive(const LWGEOM *geom, int maxvertices, int depth, LWCOL
 	clipped1 = lwgeom_clip_by_rect(geom, subbox1.xmin, subbox1.ymin, subbox1.xmax, subbox1.ymax);
 	clipped2 = lwgeom_clip_by_rect(geom, subbox2.xmin, subbox2.ymin, subbox2.xmax, subbox2.ymax);
 	
+	++depth;
+	
 	if ( clipped1 )
 	{
-		n += lwgeom_subdivide_recursive(clipped1, maxvertices, ++depth, col, &subbox1);
+		n += lwgeom_subdivide_recursive(clipped1, maxvertices, depth, col, &subbox1);
 		lwgeom_free(clipped1);
 	}
 
 	if ( clipped2 )
 	{
-		n += lwgeom_subdivide_recursive(clipped2, maxvertices, ++depth, col, &subbox2);
+		n += lwgeom_subdivide_recursive(clipped2, maxvertices, depth, col, &subbox2);
 		lwgeom_free(clipped2);
 	}
 	

--- a/regress/subdivide.sql
+++ b/regress/subdivide.sql
@@ -24,3 +24,20 @@ FROM gs
 GROUP BY gs.full_area;
 
 SELECT '#3522', ST_AsText(ST_Subdivide(ST_GeomFromText('POINT(1 1)',4326),10));
+
+
+with inverted_geom as (
+    select ST_Difference(
+               ST_Expand('SRID=3857;POINT(0 0)' :: geometry, 20000000),
+               ST_Buffer(
+                   'SRID=3857;POINT(0 0)' :: geometry,
+                   1,
+                   1000
+               )
+           ) as geom
+)
+select 'https://github.com/postgis/postgis/pull/127', ST_Area(ST_Simplify(ST_Union(geom), 2))
+from (
+         select ST_Subdivide(geom) geom
+         from inverted_geom
+     ) z;

--- a/regress/subdivide_expected
+++ b/regress/subdivide_expected
@@ -2,3 +2,4 @@
 2|t|6|7
 3|t|15|9
 #3522|POINT(1 1)
+https://github.com/postgis/postgis/pull/127|1600000000000000


### PR DESCRIPTION
 - don't lose geometry on deep subdivision;
 - don't increment depth twice if we need to subdivide both left and right sides.