### PR TITLE
Add note to ST_Equals about not supporting geometry collections

### DIFF
--- a/doc/reference_measure.xml
+++ b/doc/reference_measure.xml
@@ -2501,7 +2501,11 @@ SELECT s.gid, s.school_name
 			points are the same).</para>
 
 		<important>
-		  <para>This function will return false if either geometry is invalid even if they are binary equal.</para>
+	        <para>This function will return false if either geometry is invalid even if they are binary equal.</para>
+		</important>
+
+		<important>
+          <para>Do not call with a GEOMETRYCOLLECTION as an argument.</para>
 		</important>
 
 		<para>&sfs_compliant; s2.1.1.2</para>


### PR DESCRIPTION
Closing the loop on an old fork of postgis. We never did the PR about our docs change.

Since the current docs https://postgis.net/docs/ST_Equals.html don't mention this limitation i open a PR about it. If this has been addressed otherwise without my knowledge, please feel free to reject and close.