### PR TITLE
return 1 in ST_Subdivide

### DIFF
--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -1991,7 +1991,7 @@ lwgeom_subdivide_recursive(const LWGEOM *geom, int maxvertices, int depth, LWCOL
 	if ( depth > maxdepth )
 	{
 		lwcollection_add_lwgeom(col, lwgeom_clone_deep(geom));
-		return 0;
+		return 1;
 	}
 
 	nvertices = lwgeom_count_vertices(geom);


### PR DESCRIPTION
We have a large geometry in which ST_Subdivide loses a box.
Re-reading the code found this issue: we add into collection but return length as 0, but not 1.