### PR TITLE
Fix division by zero in lw_dist2d_pt_arc

### DIFF
--- a/liblwgeom/cunit/cu_measures.c
+++ b/liblwgeom/cunit/cu_measures.c
@@ -534,6 +534,13 @@ test_lw_dist2d_pt_arc(void)
 	CU_ASSERT_EQUAL( rv, LW_SUCCESS );
 	CU_ASSERT_DOUBLE_EQUAL(dl.distance, 0, 0.000001);
 
+	/* Point on semicircle center */
+	P.x  = 0 ; P.y  = 0;
+	lw_dist2d_distpts_init(&dl, DIST_MIN);
+	rv = lw_dist2d_pt_arc(&P, &A1, &A2, &A3, &dl);
+	CU_ASSERT_EQUAL( rv, LW_SUCCESS );
+	CU_ASSERT_DOUBLE_EQUAL(dl.distance, 1, 0.000001);
+
 	/* Point inside closed circle */
 	P.x  = 0 ; P.y  = 0.5;
 	A2.x = 1; A2.y = 0;

--- a/liblwgeom/measures.c
+++ b/liblwgeom/measures.c
@@ -1455,6 +1455,15 @@ lw_dist2d_pt_arc(const POINT2D* P, const POINT2D* A1, const POINT2D* A2, const P
 	/* Distance from point to center */
 	d = distance2d_pt_pt(&C, P);
 
+	/* P is the center of the circle */
+	if ( FP_EQUALS(d, 0.0) )
+	{
+		dl->distance = radius_A;
+		dl->p1 = *A1;
+		dl->p2 = *P;
+		return LW_TRUE;
+	}
+
 	/* X is the point on the circle where the line from P to C crosses */
 	X.x = C.x + (P->x - C.x) * radius_A / d;
 	X.y = C.y + (P->y - C.y) * radius_A / d;


### PR DESCRIPTION
In `lw_dist2d_pt_arc`, if the point is in the center of the arc a division by zero happens which leads to undefined behaviour.

The PR solves this by retuning the radius as distance an setting the first point (A1) as the closest (all the points in the arc are at the same distance from P). 