### PR TITLE
geohash_point_as_int: Fix undefined behaviour in shift operation

### DIFF
--- a/liblwgeom/lwalgorithm.c
+++ b/liblwgeom/lwalgorithm.c
@@ -680,7 +680,7 @@ unsigned int geohash_point_as_int(POINT2D *pt)
 			mid = (lon[0] + lon[1]) / 2;
 			if (longitude > mid)
 			{
-				ch |= 0x0001 << bit;
+				ch |= 0x0001u << bit;
 				lon[0] = mid;
 			}
 			else


### PR DESCRIPTION
Fixing undefined behaviour in test_geohash_point_as_int:
```
Running test 'test_geohash_point_as_int' in suite 'computational_geometry'.
lwalgorithm.c:669:18: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
```

0x0001 is a signed int so shifting it 31 bits is undefined. 0x00001u is unsigned so the bit shift is ok.