### PR TITLE
Fix undefined behaviour with negative input in TYPMOD_GET_SRID

### DIFF
--- a/liblwgeom/cunit/cu_libgeom.c
+++ b/liblwgeom/cunit/cu_libgeom.c
@@ -35,6 +35,16 @@ static void test_typmod_macros(void)
 	rv = TYPMOD_GET_SRID(typmod);
 	CU_ASSERT_EQUAL(rv, srid);
 
+        srid = 999999;
+        TYPMOD_SET_SRID(typmod,srid);
+        rv = TYPMOD_GET_SRID(typmod);
+        CU_ASSERT_EQUAL(rv, srid);
+
+        srid = -999999;
+        TYPMOD_SET_SRID(typmod,srid);
+        rv = TYPMOD_GET_SRID(typmod);
+        CU_ASSERT_EQUAL(rv, srid);
+
 	srid = SRID_UNKNOWN;
 	TYPMOD_SET_SRID(typmod,srid);
 	rv = TYPMOD_GET_SRID(typmod);

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -161,7 +161,7 @@ typedef enum LWORD_T {
 * ZM Flags = Bottom 2 bits.
 */
 
-#define TYPMOD_GET_SRID(typmod) ((((typmod) & 0x1FFFFF00)<<3)>>11)
+#define TYPMOD_GET_SRID(typmod) ((((typmod) & 0x0FFFFF00) - ((typmod) & 0x10000000)) >> 8)
 #define TYPMOD_SET_SRID(typmod, srid) ((typmod) = (((typmod) & 0xE00000FF) | ((srid & 0x001FFFFF)<<8)))
 #define TYPMOD_GET_TYPE(typmod) ((typmod & 0x000000FC)>>2)
 #define TYPMOD_SET_TYPE(typmod, type) ((typmod) = (typmod & 0xFFFFFF03) | ((type & 0x0000003F)<<2))


### PR DESCRIPTION
Fixes an undefined behaviour when the SRID is negative.

Some output example using undefined behaviour sanitizer:
```
Running test 'test_typmod_macros' in suite 'serialization/deserialization'.
cu_libgeom.c:35:7: runtime error: left shift of 535589632 by 3 places cannot be represented in type 'int'
cu_libgeom.c:45:14: runtime error: left shift of 280871168 by 3 places cannot be represented in type 'int'
```