### PR TITLE
Avoid undefined behaviour in pointarray_to_encoded_polyline

### DIFF
--- a/liblwgeom/lwout_encoded_polyline.c
+++ b/liblwgeom/lwout_encoded_polyline.c
@@ -73,7 +73,7 @@ char * pointarray_to_encoded_polyline(const POINTARRAY *pa, int precision)
 	stringbuffer_t *sb;
 	double scale = pow(10,precision);
 
-	/* Take the double value and multiply it by 1x10^percision, rounding the result */
+	/* Take the double value and multiply it by 1x10^precision, rounding the result */
 	prevPoint = getPoint2d_cp(pa, 0);
 	delta[0] = round(prevPoint->y*scale);
 	delta[1] = round(prevPoint->x*scale);
@@ -90,8 +90,8 @@ char * pointarray_to_encoded_polyline(const POINTARRAY *pa, int precision)
 	/* value to binary: a negative value must be calculated using its two's complement */
 	for (i=0; i<pa->npoints*2; i++)
 	{
-		/* Left-shift the binary value one bit */
-		delta[i] <<= 1;
+		/* Multiply by 2 for a signed left shift */
+		delta[i] *= 2;
 		/* if value is negative, invert this encoding */
 		if (delta[i] < 0) {
 			delta[i] = ~(delta[i]);


### PR DESCRIPTION
Shifting a negative value is undefined, so I was getting the following warning:
```
$ LD_LIBRARY_PATH=../.libs/  ./.libs/cu_tester out_encoded_polyline_test_precision

Running test 'out_encoded_polyline_test_precision' in suite 'encoded_polyline_output'.
lwout_encoded_polyline.c:94:12: runtime error: left shift of negative value -250691

    PASSED - asserts -   2 passed,   0 failed,   2 total.
```
