### PR TITLE
BTree sorting logic fix

### DIFF
--- a/liblwgeom/g_serialized.c
+++ b/liblwgeom/g_serialized.c
@@ -401,7 +401,7 @@ int gserialized_cmp(const GSERIALIZED *g1, const GSERIALIZED *g2)
 		else if (bsz1 > bsz2)
  			return 1;
 	}
-	return cmp == 0 ? 0 : (cmp > 0 ? 1 : -1);	
+	return cmp == 0 ? 0 : (cmp > 0 ? 1 : -1);
 }
 
 int gserialized_read_gbox_p(const GSERIALIZED *g, GBOX *gbox)

--- a/liblwgeom/g_serialized.c
+++ b/liblwgeom/g_serialized.c
@@ -393,8 +393,15 @@ int gserialized_cmp(const GSERIALIZED *g1, const GSERIALIZED *g2)
 			return 1;
 	}
 
-	/* OK fine, we'll sort on the memcmp just to be done with this */
-	return cmp == 0 ? 0 : (cmp > 0 ? 1 : -1);
+	/* Prefix comes before longer one. */
+	if (bsz1 != bsz2 && cmp == 0)
+	{
+		if (bsz1 < bsz2)
+ 			return -1;
+		else if (bsz1 > bsz2)
+ 			return 1;
+	}
+	return cmp == 0 ? 0 : (cmp > 0 ? 1 : -1);	
 }
 
 int gserialized_read_gbox_p(const GSERIALIZED *g, GBOX *gbox)


### PR DESCRIPTION
Patch by Darafei Praliaskouski <me@komzpa.net>

 - allow fast path for geography points;
 - fix gcc warnings;
 - compare EMPTY geometries as normal memcmp path.