### PR TITLE
gbox_to_string: Address snprintf warning

### DIFF
--- a/liblwgeom/cunit/cu_geodetic.c
+++ b/liblwgeom/cunit/cu_geodetic.c
@@ -1569,6 +1569,28 @@ static void test_lwgeom_area_sphere(void)
 	/* end #3393 */
 }
 
+static void test_gbox_to_string_truncated(void)
+{
+	GBOX g = {
+		.flags = 0,
+		.xmin = -DBL_MAX,
+		.xmax = -DBL_MAX,
+		.ymin = -DBL_MAX,
+		.ymax = -DBL_MAX,
+		.zmin = -DBL_MAX,
+		.zmax = -DBL_MAX,
+		.mmin = -DBL_MAX,
+		.mmax = -DBL_MAX,
+	};
+	FLAGS_SET_Z(g.flags, 1);
+	FLAGS_SET_M(g.flags, 1);
+	char *c = gbox_to_string(&g);
+
+	ASSERT_STRING_EQUAL(c, "GBOX((-1.7976931e+308,-1.7976931e+308,-1.7976931e+308,-1.7976931e+308),(-1.7976931e+308,-1.7976931e+308,-1.7976931e+308,-1.7976931e+308))");
+
+	lwfree(c);
+}
+
 /*
 ** Used by test harness to register the tests in this file.
 */
@@ -1598,4 +1620,5 @@ void geodetic_suite_setup(void)
 	PG_ADD_TEST(suite, test_lwgeom_segmentize_sphere);
 	PG_ADD_TEST(suite, test_ptarray_contains_point_sphere);
 	PG_ADD_TEST(suite, test_ptarray_contains_point_sphere_iowa);
+	PG_ADD_TEST(suite, test_gbox_to_string_truncated);
 }

--- a/liblwgeom/g_box.c
+++ b/liblwgeom/g_box.c
@@ -403,7 +403,7 @@ GBOX* gbox_from_string(const char *str)
 
 char* gbox_to_string(const GBOX *gbox)
 {
-	static int sz = 128;
+	static int sz = 138;
 	char *str = NULL;
 
 	if ( ! gbox )


### PR DESCRIPTION
GCC 7.2 warning in gbox_to_string:
```
g_box.c: In function 'gbox_to_string'
g_box.c:421:21: warning: '))' directive output may be truncated writing 2 bytes into a region of size between 0 and 105 [-Wformat-truncation=]
   snprintf(str, sz, "GBOX((%.8g,%.8g,%.8g,%.8g),(%.8g,%.8g,%.8g,%.8g))", gbox->xmin, gbox->ymin, gbox->zmin, gbox->mmin, gbox->xmax, gbox->ymax, gbox->zmax, gbox->mmax);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from liblwgeom_internal.h:40,
                 from g_box.c:29:
/usr/include/bits/stdio2.h:64:10: note: '__builtin___snprintf_chk' output between 26 and 138 bytes into a destination of size 128
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The destination buffer was set too small to handle the max size of the string.