### PR TITLE
Fix memory leak when lwgeom_simplify returns an empty geom

### DIFF
--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -1824,7 +1824,11 @@ LWGEOM* lwgeom_simplify(const LWGEOM *igeom, double dist, int preserve_collapsed
 {
 	LWGEOM *lwgeom_out = lwgeom_clone_deep(igeom);
 	lwgeom_simplify_in_place(lwgeom_out, dist, preserve_collapsed);
-	if (lwgeom_is_empty(lwgeom_out)) return NULL;
+	if (lwgeom_is_empty(lwgeom_out))
+	{
+		lwgeom_free(lwgeom_out);
+		return NULL;
+	}
 	return lwgeom_out;
 }
 


### PR DESCRIPTION
Detected with asan:

Before:
```
$ ./cu_tester test_lwgeom_simplify

Running test 'test_lwgeom_simplify' in suite 'algorithm'.

    PASSED - asserts -   6 passed,   0 failed,   6 total.




=================================================================
==22750==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7f67953bbae9 in __interceptor_malloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7f6794fd8d8e in lwpoly_clone_deep /home/raul/dev/public/postgis/liblwgeom/lwpoly.c:231
    #2 0x7f6794fd1298 in lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/lwgeom.c:1825
    #3 0x55cc92159ea1 in test_lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/cunit/cu_algorithm.c:1072
    #4 0x7f6794b40087 in run_single_test /tmp/yaourt-tmp-raul/aur-cunit/src/CUnit-2.1-3/CUnit/Sources/Framework/TestRun.c:991

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f67953bbae9 in __interceptor_malloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7f6794fd53b4 in lwline_clone_deep /home/raul/dev/public/postgis/liblwgeom/lwline.c:120
    #2 0x7f6794fd1298 in lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/lwgeom.c:1825
    #3 0x55cc92159e37 in test_lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/cunit/cu_algorithm.c:1065
    #4 0x7f6794b40087 in run_single_test /tmp/yaourt-tmp-raul/aur-cunit/src/CUnit-2.1-3/CUnit/Sources/Framework/TestRun.c:991

Indirect leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f67953bbae9 in __interceptor_malloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7f6794fc26bc in ptarray_clone_deep /home/raul/dev/public/postgis/liblwgeom/ptarray.c:645
    #2 0x7f6794fd542e in lwline_clone_deep /home/raul/dev/public/postgis/liblwgeom/lwline.c:126
    #3 0x7f6794fd1298 in lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/lwgeom.c:1825
    #4 0x55cc92159e37 in test_lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/cunit/cu_algorithm.c:1065
    #5 0x7f6794b40087 in run_single_test /tmp/yaourt-tmp-raul/aur-cunit/src/CUnit-2.1-3/CUnit/Sources/Framework/TestRun.c:991

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f67953bbae9 in __interceptor_malloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7f6794fc25ca in ptarray_clone_deep /home/raul/dev/public/postgis/liblwgeom/ptarray.c:633
    #2 0x7f6794fd542e in lwline_clone_deep /home/raul/dev/public/postgis/liblwgeom/lwline.c:126
    #3 0x7f6794fd1298 in lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/lwgeom.c:1825
    #4 0x55cc92159e37 in test_lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/cunit/cu_algorithm.c:1065
    #5 0x7f6794b40087 in run_single_test /tmp/yaourt-tmp-raul/aur-cunit/src/CUnit-2.1-3/CUnit/Sources/Framework/TestRun.c:991

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f67953bbae9 in __interceptor_malloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7f6794fd8e21 in lwpoly_clone_deep /home/raul/dev/public/postgis/liblwgeom/lwpoly.c:234
    #2 0x7f6794fd1298 in lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/lwgeom.c:1825
    #3 0x55cc92159ea1 in test_lwgeom_simplify /home/raul/dev/public/postgis/liblwgeom/cunit/cu_algorithm.c:1072
    #4 0x7f6794b40087 in run_single_test /tmp/yaourt-tmp-raul/aur-cunit/src/CUnit-2.1-3/CUnit/Sources/Framework/TestRun.c:991

SUMMARY: AddressSanitizer: 184 byte(s) leaked in 5 allocation(s).
```

After:
```
١(º_º)١┳━┳[raul cunit]$ ./cu_tester test_lwgeom_simplify

Running test 'test_lwgeom_simplify' in suite 'algorithm'.

    PASSED - asserts -   6 passed,   0 failed,   6 total.
```