### PR TITLE
Fix memory leak in lwgeom_remove_repeated_points_in_place with MULTIPOINTTYPE

### DIFF
--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -1667,7 +1667,11 @@ lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 						break;
 					}
 				}
-				if (seen) continue;
+				if (seen)
+				{
+					lwpoint_free(p1);
+					continue;
+				}
 				out[n++] = p1;
 			}
 


### PR DESCRIPTION
Leak due to removed points memory not being free'd.

Example:
```
Indirect leak of 1472 byte(s) in 23 object(s) allocated from:
    #0 0x7f07c9071ae9 in __interceptor_malloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7f07c8c7799e in ptarray_construct_empty /home/raul/dev/public/postgis/liblwgeom/ptarray.c:84
    #2 0x7f07c8cbeced in wkt_parser_ptarray_new /home/raul/dev/public/postgis/liblwgeom/lwin_wkt.c:306
    #3 0x7f07c8cb6209 in wkt_yyparse /home/raul/dev/public/postgis/liblwgeom/lwin_wkt_parse.y:507
    #4 0x7f07c8cb80e3 in lwgeom_parse_wkt /home/raul/dev/public/postgis/liblwgeom/lwin_wkt_parse.y:68
    #5 0x7f07c8cc1934 in lwgeom_from_wkt /home/raul/dev/public/postgis/liblwgeom/lwin_wkt.c:908
    #6 0x55f62e8385a3 in test_lwgeom_remove_repeated_points /home/raul/dev/public/postgis/liblwgeom/cunit/cu_algorithm.c:1028
    #7 0x7f07c87f6087 in run_single_test /tmp/yaourt-tmp-raul/aur-cunit/src/CUnit-2.1-3/CUnit/Sources/Framework/TestRun.c:991
```