### PR TITLE
postgis/: Change TRUE and FALSE for true and false

### DIFF
--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -167,7 +167,7 @@ PROJ4SRSCacheIsEmpty(MemoryContext context)
 	 * Always return false since this call is mandatory according to tgl
 	 * (see postgis-devel archives July 2007)
 	 */
-	return FALSE;
+	return LW_FALSE;
 }
 
 static void

--- a/postgis/geography_btree.c
+++ b/postgis/geography_btree.c
@@ -52,9 +52,9 @@ Datum geography_lt(PG_FUNCTION_ARGS)
 	GSERIALIZED *g2 = PG_GETARG_GSERIALIZED_P(1);
 	int cmp = gserialized_cmp(g1, g2);
 	if (cmp < 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 /*
@@ -68,9 +68,9 @@ Datum geography_le(PG_FUNCTION_ARGS)
 	GSERIALIZED *g2 = PG_GETARG_GSERIALIZED_P(1);
 	int cmp = gserialized_cmp(g1, g2);
 	if (cmp <= 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 /*
@@ -84,9 +84,9 @@ Datum geography_gt(PG_FUNCTION_ARGS)
 	GSERIALIZED *g2 = PG_GETARG_GSERIALIZED_P(1);
 	int cmp = gserialized_cmp(g1, g2);
 	if (cmp > 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 /*
@@ -100,9 +100,9 @@ Datum geography_ge(PG_FUNCTION_ARGS)
 	GSERIALIZED *g2 = PG_GETARG_GSERIALIZED_P(1);
 	int cmp = gserialized_cmp(g1, g2);
 	if (cmp >= 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 /*
@@ -116,9 +116,9 @@ Datum geography_eq(PG_FUNCTION_ARGS)
 	GSERIALIZED *g2 = PG_GETARG_GSERIALIZED_P(1);
 	int cmp = gserialized_cmp(g1, g2);
 	if (cmp == 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 /*

--- a/postgis/geography_measurement.c
+++ b/postgis/geography_measurement.c
@@ -314,7 +314,7 @@ Datum geography_dwithin(PG_FUNCTION_ARGS)
 	{
 		PG_FREE_IF_COPY(g1, 0);
 		PG_FREE_IF_COPY(g2, 1);
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 	}
 
 	/* Do the brute force calculation if the cached calculation doesn't tick over */
@@ -436,7 +436,7 @@ Datum geography_dwithin_uncached(PG_FUNCTION_ARGS)
 	/* Return FALSE on empty arguments. */
 	if ( lwgeom_is_empty(lwgeom1) || lwgeom_is_empty(lwgeom2) )
 	{
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 	}
 
 	distance = lwgeom_distance_spheroid(lwgeom1, lwgeom2, &s, tolerance);
@@ -451,7 +451,7 @@ Datum geography_dwithin_uncached(PG_FUNCTION_ARGS)
 	if ( distance < 0.0 )
 	{
 		elog(ERROR, "lwgeom_distance_spheroid returned negative!");
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 	}
 
 	PG_RETURN_BOOL(distance <= tolerance);

--- a/postgis/gserialized_estimate.c
+++ b/postgis/gserialized_estimate.c
@@ -499,7 +499,7 @@ nd_box_merge(const ND_BOX *source, ND_BOX *target)
 		target->min[d] = Min(target->min[d], source->min[d]);
 		target->max[d] = Max(target->max[d], source->max[d]);
 	}
-	return TRUE;
+	return true;
 }
 
 /** Zero out an ND_BOX */
@@ -507,7 +507,7 @@ static int
 nd_box_init(ND_BOX *a)
 {
 	memset(a, 0, sizeof(ND_BOX));
-	return TRUE;
+	return true;
 }
 
 /**
@@ -524,7 +524,7 @@ nd_box_init_bounds(ND_BOX *a)
 		a->min[d] = FLT_MAX;
 		a->max[d] = -1 * FLT_MAX;
 	}
-	return TRUE;
+	return true;
 }
 
 /** Set the values of an #ND_BOX from a #GBOX */
@@ -563,7 +563,7 @@ nd_box_from_gbox(const GBOX *gbox, ND_BOX *nd_box)
 }
 
 /**
-* Return TRUE if #ND_BOX a overlaps b, false otherwise.
+* Return true if #ND_BOX a overlaps b, false otherwise.
 */
 static int
 nd_box_intersects(const ND_BOX *a, const ND_BOX *b, int ndims)
@@ -572,13 +572,13 @@ nd_box_intersects(const ND_BOX *a, const ND_BOX *b, int ndims)
 	for ( d = 0; d < ndims; d++ )
 	{
 		if ( (a->min[d] > b->max[d]) || (a->max[d] < b->min[d]) )
-			return FALSE;
+			return false;
 	}
-	return TRUE;
+	return true;
 }
 
 /**
-* Return TRUE if #ND_BOX a contains b, false otherwise.
+* Return true if #ND_BOX a contains b, false otherwise.
 */
 static int
 nd_box_contains(const ND_BOX *a, const ND_BOX *b, int ndims)
@@ -587,9 +587,9 @@ nd_box_contains(const ND_BOX *a, const ND_BOX *b, int ndims)
 	for ( d = 0; d < ndims; d++ )
 	{
 		if ( ! ((a->min[d] < b->min[d]) && (a->max[d] > b->max[d])) )
-			return FALSE;
+			return false;
 	}
-	return TRUE;
+	return true;
 }
 
 /**
@@ -608,7 +608,7 @@ nd_box_expand(ND_BOX *nd_box, double expansion_factor)
 		nd_box->min[d] -= size * expansion_factor / 2;
 		nd_box->max[d] += size * expansion_factor / 2;
 	}
-	return TRUE;
+	return true;
 }
 
 /**
@@ -644,7 +644,7 @@ nd_box_overlap(const ND_STATS *nd_stats, const ND_BOX *nd_box, ND_IBOX *nd_ibox)
 		nd_ibox->min[d] = Max(nd_ibox->min[d], 0);
 		nd_ibox->max[d] = Min(nd_ibox->max[d], size-1);
 	}
-	return TRUE;
+	return true;
 }
 
 /**
@@ -654,7 +654,7 @@ static inline double
 nd_box_ratio(const ND_BOX *b1, const ND_BOX *b2, int ndims)
 {
 	int d;
-	bool covered = TRUE;
+	bool covered = true;
 	double ivol = 1.0;
 	double vol2 = 1.0;
 	double vol1 = 1.0;
@@ -665,7 +665,7 @@ nd_box_ratio(const ND_BOX *b1, const ND_BOX *b2, int ndims)
 			return 0.0; /* Disjoint */
 
 		if ( b1->min[d] > b2->min[d] || b1->max[d] < b2->max[d] )
-			covered = FALSE;
+			covered = false;
 	}
 
 	if ( covered )
@@ -793,7 +793,7 @@ nd_box_array_distribution(const ND_BOX **nd_boxes, int num_boxes, const ND_BOX *
 		distribution[d] = range;
 	}
 
-	return TRUE;
+	return true;
 }
 
 /**
@@ -818,10 +818,10 @@ nd_increment(ND_IBOX *ibox, int ndims, int *counter)
 	}
 	/* That's it, cannot increment any more! */
 	if ( d == ndims )
-		return FALSE;
+		return false;
 
 	/* Increment complete! */
-	return TRUE;
+	return true;
 }
 
 static ND_STATS*
@@ -889,7 +889,7 @@ pg_get_nd_stats(const Oid table_oid, AttrNumber att_num, int mode, bool only_par
 	if ( ! only_parent )
 	{
 		POSTGIS_DEBUGF(2, "searching whole tree stats for \"%s\"", get_rel_name(table_oid)? get_rel_name(table_oid) : "NULL");
-		stats_tuple = SearchSysCache3(STATRELATT, table_oid, att_num, TRUE);
+		stats_tuple = SearchSysCache3(STATRELATT, table_oid, att_num, true);
 		if ( stats_tuple )
 			POSTGIS_DEBUGF(2, "found whole tree stats for \"%s\"", get_rel_name(table_oid)? get_rel_name(table_oid) : "NULL");
 	}
@@ -924,7 +924,7 @@ pg_get_nd_stats(const Oid table_oid, AttrNumber att_num, int mode, bool only_par
 * debugging functions are taking human input (table names)
 * and columns, so we have to look those up first.
 * In case of parent tables whith INHERITS, when "only_parent"
-* is TRUE this function only searchs for stats in the parent
+* is true this function only searchs for stats in the parent
 * table ignoring any statistic collected from the children.
 */
 static ND_STATS*
@@ -1249,8 +1249,8 @@ Datum gserialized_gist_joinsel(PG_FUNCTION_ARGS)
 	                 get_rel_name(relid1) ? get_rel_name(relid1) : "NULL", relid1, get_rel_name(relid2) ? get_rel_name(relid2) : "NULL", relid2);
 
 	/* Pull the stats from the stats system. */
-	stats1 = pg_get_nd_stats(relid1, var1->varattno, mode, FALSE);
-	stats2 = pg_get_nd_stats(relid2, var2->varattno, mode, FALSE);
+	stats1 = pg_get_nd_stats(relid1, var1->varattno, mode, false);
+	stats2 = pg_get_nd_stats(relid2, var2->varattno, mode, false);
 
 	/* If we can't get stats, we have to stop here! */
 	if ( ! stats1 )
@@ -1803,7 +1803,7 @@ compute_gserialized_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
 * It will need to return a stats builder function reference
 * and a "minimum" sample rows to feed it.
 * If we want analisys to be completely skipped we can return
-* FALSE and leave output vals untouched.
+* false and leave output vals untouched.
 *
 * What we know from this call is:
 *
@@ -1992,7 +1992,7 @@ Datum _postgis_gserialized_stats(PG_FUNCTION_ARGS)
 	char *str;
 	text *json;
 	int mode = 2; /* default to 2D mode */
-	bool only_parent = FALSE; /* default to whole tree stats */
+	bool only_parent = false; /* default to whole tree stats */
 
 	/* Check if we've been asked to not use 2d mode */
 	if ( ! PG_ARGISNULL(2) )
@@ -2036,7 +2036,7 @@ Datum _postgis_gserialized_sel(PG_FUNCTION_ARGS)
 		mode = text_p_get_mode(PG_GETARG_TEXT_P(3));
 
 	/* Retrieve the stats object */
-	nd_stats = pg_get_nd_stats_by_name(table_oid, att_text, mode, FALSE);
+	nd_stats = pg_get_nd_stats_by_name(table_oid, att_text, mode, false);
 
 	if ( ! nd_stats )
 		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid), text2cstring(att_text));
@@ -2072,8 +2072,8 @@ Datum _postgis_gserialized_joinsel(PG_FUNCTION_ARGS)
 
 
 	/* Retrieve the stats object */
-	nd_stats1 = pg_get_nd_stats_by_name(table_oid1, att_text1, mode, FALSE);
-	nd_stats2 = pg_get_nd_stats_by_name(table_oid2, att_text2, mode, FALSE);
+	nd_stats1 = pg_get_nd_stats_by_name(table_oid1, att_text1, mode, false);
+	nd_stats2 = pg_get_nd_stats_by_name(table_oid2, att_text2, mode, false);
 
 	if ( ! nd_stats1 )
 		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid1), text2cstring(att_text1));
@@ -2242,7 +2242,7 @@ Datum gserialized_estimated_extent(PG_FUNCTION_ARGS)
 	Oid tbl_oid;
 	ND_STATS *nd_stats;
 	GBOX *gbox;
-	bool only_parent = FALSE;
+	bool only_parent = false;
 
 	if ( PG_NARGS() == 4 )
 	{

--- a/postgis/gserialized_gist_2d.c
+++ b/postgis/gserialized_gist_2d.c
@@ -182,7 +182,7 @@ static bool box2df_intersection(const BOX2DF *a, const BOX2DF *b, BOX2DF *n)
 	POSTGIS_DEBUGF(5, "calculating intersection of %s with %s", box2df_to_string(a), box2df_to_string(b));
 
 	if( a == NULL || b == NULL || n == NULL )
-		return FALSE;
+		return false;
 
 	n->xmax = Min(a->xmax, b->xmax);
 	n->ymax = Min(a->ymax, b->ymax);
@@ -192,9 +192,9 @@ static bool box2df_intersection(const BOX2DF *a, const BOX2DF *b, BOX2DF *n)
 	POSTGIS_DEBUGF(5, "intersection is %s", box2df_to_string(n));
 
 	if ( (n->xmax < n->xmin) || (n->ymax < n->ymin) )
-		return FALSE;
+		return false;
 
-	return TRUE;
+	return true;
 }
 #endif
 
@@ -315,33 +315,33 @@ static inline void box2df_validate(BOX2DF *b)
 
 static bool box2df_overlaps(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	if ( (a->xmin > b->xmax) || (b->xmin > a->xmax) ||
 	     (a->ymin > b->ymax) || (b->ymin > a->ymax) )
 	{
-		return FALSE;
+		return false;
 	}
 
-	return TRUE;
+	return true;
 }
 
 bool box2df_contains(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	if ( (a->xmin > b->xmin) || (a->xmax < b->xmax) ||
 	     (a->ymin > b->ymin) || (a->ymax < b->ymax) )
 	{
-		return FALSE;
+		return false;
 	}
 
-	return TRUE;
+	return true;
 }
 
 static bool box2df_within(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	POSTGIS_DEBUG(5, "entered function");
 	return box2df_contains(b,a);
@@ -353,21 +353,21 @@ static bool box2df_equals(const BOX2DF *a, const BOX2DF *b)
 		if ( (a->xmin != b->xmin) || (a->xmax != b->xmax) ||
 		     (a->ymin != b->ymin) || (a->ymax != b->ymax) )
 		{
-			return FALSE;
+			return false;
 		}
-		return TRUE;
+		return true;
 	} else if ( a || b ) {
 		/* one empty, one not */
-		return FALSE;
+		return false;
 	} else {
 		/* both empty */
-		return TRUE;
+		return true;
 	}
 }
 
 static bool box2df_overleft(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.xmax <= b.xmax */
 	return a->xmax <= b->xmax;
@@ -375,7 +375,7 @@ static bool box2df_overleft(const BOX2DF *a, const BOX2DF *b)
 
 static bool box2df_left(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.xmax < b.xmin */
 	return a->xmax < b->xmin;
@@ -383,7 +383,7 @@ static bool box2df_left(const BOX2DF *a, const BOX2DF *b)
 
 static bool box2df_right(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.xmin > b.xmax */
 	return a->xmin > b->xmax;
@@ -391,7 +391,7 @@ static bool box2df_right(const BOX2DF *a, const BOX2DF *b)
 
 static bool box2df_overright(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.xmin >= b.xmin */
 	return a->xmin >= b->xmin;
@@ -399,7 +399,7 @@ static bool box2df_overright(const BOX2DF *a, const BOX2DF *b)
 
 static bool box2df_overbelow(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.ymax <= b.ymax */
 	return a->ymax <= b->ymax;
@@ -407,7 +407,7 @@ static bool box2df_overbelow(const BOX2DF *a, const BOX2DF *b)
 
 static bool box2df_below(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.ymax < b.ymin */
 	return a->ymax < b->ymin;
@@ -415,7 +415,7 @@ static bool box2df_below(const BOX2DF *a, const BOX2DF *b)
 
 static bool box2df_above(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.ymin > b.ymax */
 	return a->ymin > b->ymax;
@@ -423,7 +423,7 @@ static bool box2df_above(const BOX2DF *a, const BOX2DF *b)
 
 static bool box2df_overabove(const BOX2DF *a, const BOX2DF *b)
 {
-	if ( ! a || ! b ) return FALSE; /* TODO: might be smarter for EMPTY */
+	if ( ! a || ! b ) return false; /* TODO: might be smarter for EMPTY */
 
 	/* a.ymin >= b.ymin */
 	return a->ymin >= b->ymin;
@@ -685,18 +685,18 @@ Datum gserialized_contains_box2df_geom_2d(PG_FUNCTION_ARGS)
 {
 	POSTGIS_DEBUG(3, "entered function");
         if ( gserialized_datum_predicate_box2df_geom_2d((BOX2DF*)PG_GETARG_POINTER(0), PG_GETARG_DATUM(1), box2df_contains) == LW_TRUE )
-                PG_RETURN_BOOL(TRUE);
+                PG_RETURN_BOOL(true);
 
-        PG_RETURN_BOOL(FALSE);
+        PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_contains_box2df_box2df_2d);
 Datum gserialized_contains_box2df_box2df_2d(PG_FUNCTION_ARGS)
 {
 	if ( box2df_contains((BOX2DF *)PG_GETARG_POINTER(0), (BOX2DF *)PG_GETARG_POINTER(1)))
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_within_box2df_geom_2d);
@@ -704,18 +704,18 @@ Datum gserialized_within_box2df_geom_2d(PG_FUNCTION_ARGS)
 {
 	POSTGIS_DEBUG(3, "entered function");
         if ( gserialized_datum_predicate_box2df_geom_2d((BOX2DF*)PG_GETARG_POINTER(0), PG_GETARG_DATUM(1), box2df_within) == LW_TRUE )
-                PG_RETURN_BOOL(TRUE);
+                PG_RETURN_BOOL(true);
 
-        PG_RETURN_BOOL(FALSE);
+        PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_within_box2df_box2df_2d);
 Datum gserialized_within_box2df_box2df_2d(PG_FUNCTION_ARGS)
 {
         if ( box2df_within((BOX2DF *)PG_GETARG_POINTER(0), (BOX2DF *)PG_GETARG_POINTER(1)))
-                PG_RETURN_BOOL(TRUE);
+                PG_RETURN_BOOL(true);
 
-        PG_RETURN_BOOL(FALSE);
+        PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_overlaps_box2df_geom_2d);
@@ -723,18 +723,18 @@ Datum gserialized_overlaps_box2df_geom_2d(PG_FUNCTION_ARGS)
 {
         POSTGIS_DEBUG(3, "entered function");
         if ( gserialized_datum_predicate_box2df_geom_2d((BOX2DF*)PG_GETARG_POINTER(0), PG_GETARG_DATUM(1), box2df_overlaps) == LW_TRUE )
-                PG_RETURN_BOOL(TRUE);
+                PG_RETURN_BOOL(true);
 
-        PG_RETURN_BOOL(FALSE);
+        PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_overlaps_box2df_box2df_2d);
 Datum gserialized_overlaps_box2df_box2df_2d(PG_FUNCTION_ARGS)
 {
         if ( box2df_overlaps((BOX2DF *)PG_GETARG_POINTER(0), (BOX2DF *)PG_GETARG_POINTER(1)))
-                PG_RETURN_BOOL(TRUE);
+                PG_RETURN_BOOL(true);
 
-        PG_RETURN_BOOL(FALSE);
+        PG_RETURN_BOOL(false);
 }
 #endif
 
@@ -786,9 +786,9 @@ PG_FUNCTION_INFO_V1(gserialized_same_2d);
 Datum gserialized_same_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_equals) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_within_2d);
@@ -796,9 +796,9 @@ Datum gserialized_within_2d(PG_FUNCTION_ARGS)
 {
 	POSTGIS_DEBUG(3, "entered function");
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_within) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_contains_2d);
@@ -806,90 +806,90 @@ Datum gserialized_contains_2d(PG_FUNCTION_ARGS)
 {
 	POSTGIS_DEBUG(3, "entered function");
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_contains) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_overlaps_2d);
 Datum gserialized_overlaps_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_overlaps) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_left_2d);
 Datum gserialized_left_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_left) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_right_2d);
 Datum gserialized_right_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_right) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_above_2d);
 Datum gserialized_above_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_above) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_below_2d);
 Datum gserialized_below_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_below) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_overleft_2d);
 Datum gserialized_overleft_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_overleft) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_overright_2d);
 Datum gserialized_overright_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_overright) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_overabove_2d);
 Datum gserialized_overabove_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_overabove) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_overbelow_2d);
 Datum gserialized_overbelow_2d(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate_2d(PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), box2df_overbelow) == LW_TRUE )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 
@@ -934,7 +934,7 @@ Datum gserialized_gist_compress_2d(PG_FUNCTION_ARGS)
 	{
 		POSTGIS_DEBUG(4, "[GIST] leafkey is null");
 		gistentryinit(*entry_out, (Datum) 0, entry_in->rel,
-		              entry_in->page, entry_in->offset, FALSE);
+		              entry_in->page, entry_in->offset, false);
 		POSTGIS_DEBUG(4, "[GIST] returning copy of input");
 		PG_RETURN_POINTER(entry_out);
 	}
@@ -964,7 +964,7 @@ Datum gserialized_gist_compress_2d(PG_FUNCTION_ARGS)
 
 	/* Prepare GISTENTRY for return. */
 	gistentryinit(*entry_out, PointerGetDatum(box2df_copy(&bbox_out)),
-	              entry_in->rel, entry_in->page, entry_in->offset, FALSE);
+	              entry_in->rel, entry_in->page, entry_in->offset, false);
 
 	/* Return GISTENTRY. */
 	POSTGIS_DEBUG(4, "[GIST] 'compress' function complete");
@@ -1044,7 +1044,7 @@ static inline bool gserialized_gist_consistent_leaf_2d(BOX2DF *key, BOX2DF *quer
 		break;
 
 	default:
-		retval = FALSE;
+		retval = false;
 	}
 
 	return (retval);
@@ -1106,7 +1106,7 @@ static inline bool gserialized_gist_consistent_internal_2d(BOX2DF *key, BOX2DF *
 		break;
 
 	default:
-		retval = FALSE;
+		retval = false;
 	}
 
 	return (retval);
@@ -1139,21 +1139,21 @@ Datum gserialized_gist_consistent_2d(PG_FUNCTION_ARGS)
 	if ( DatumGetPointer(PG_GETARG_DATUM(1)) == NULL )
 	{
 		POSTGIS_DEBUG(4, "[GIST] null query pointer (!?!), returning false");
-		PG_RETURN_BOOL(FALSE); /* NULL query! This is screwy! */
+		PG_RETURN_BOOL(false); /* NULL query! This is screwy! */
 	}
 
 	/* Quick sanity check on entry key. */
 	if ( DatumGetPointer(entry->key) == NULL )
 	{
 		POSTGIS_DEBUG(4, "[GIST] null index entry, returning false");
-		PG_RETURN_BOOL(FALSE); /* NULL entry! */
+		PG_RETURN_BOOL(false); /* NULL entry! */
 	}
 
 	/* Null box should never make this far. */
 	if ( gserialized_datum_get_box2df_p(PG_GETARG_DATUM(1), &query_gbox_index) == LW_FAILURE )
 	{
 		POSTGIS_DEBUG(4, "[GIST] null query_gbox_index!");
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 	}
 
 	/* Treat leaf node tests different from internal nodes */
@@ -2351,12 +2351,12 @@ Datum gserialized_gist_picksplit_2d(PG_FUNCTION_ARGS)
 		float sizeLR, sizeBT;
 		BOX2DF interLR, interBT;
 
-		if ( box2df_intersection(unionL, unionR, &interLR) == FALSE )
+		if ( box2df_intersection(unionL, unionR, &interLR) == false )
 			sizeLR = 0.0;
 		else
 			sizeLR = box2df_size(&interLR);
 
-		if ( box2df_intersection(unionB, unionT, &interBT) == FALSE )
+		if ( box2df_intersection(unionB, unionT, &interBT) == false )
 			sizeBT = 0.0;
 		else
 			sizeBT = box2df_size(&interBT);

--- a/postgis/gserialized_gist_nd.c
+++ b/postgis/gserialized_gist_nd.c
@@ -159,8 +159,8 @@ static inline bool gidx_is_unknown(const GIDX *a)
 	size_t size = VARSIZE(a) - VARHDRSZ;
 	/* "unknown" gidx objects have a too-small size of one float */
 	if ( size <= 0.0 )
-		return TRUE;
-	return FALSE;
+		return true;
+	return false;
 }
 
 static inline void gidx_set_unknown(GIDX *a)
@@ -420,10 +420,10 @@ static bool gidx_overlaps(GIDX *a, GIDX *b)
 	int ndims_b;
 	POSTGIS_DEBUG(5, "entered function");
 
-	if ( (a == NULL) || (b == NULL) ) return FALSE;
+	if ( (a == NULL) || (b == NULL) ) return false;
 
 	if ( gidx_is_unknown(a) || gidx_is_unknown(b) )
-		return FALSE;
+		return false;
 
 	/* Ensure 'a' has the most dimensions. */
 	gidx_dimensionality_check(&a, &b);
@@ -434,12 +434,12 @@ static bool gidx_overlaps(GIDX *a, GIDX *b)
 	for ( i = 0; i < ndims_b; i++ )
 	{
 		if ( GIDX_GET_MIN(a,i) > GIDX_GET_MAX(b,i) )
-			return FALSE;
+			return false;
 		if ( GIDX_GET_MIN(b,i) > GIDX_GET_MAX(a,i) )
-			return FALSE;
+			return false;
 	}
 
-	return TRUE;
+	return true;
 }
 
 /*
@@ -453,10 +453,10 @@ bool gidx_contains(GIDX *a, GIDX *b)
 
 	POSTGIS_DEBUG(5, "entered function");
 
-	if ( (a == NULL) || (b == NULL) ) return FALSE;
+	if ( (a == NULL) || (b == NULL) ) return false;
 
 	if ( gidx_is_unknown(a) || gidx_is_unknown(b) )
-		return FALSE;
+		return false;
 
 	dims_a = GIDX_NDIMS(a);
 	dims_b = GIDX_NDIMS(b);
@@ -470,9 +470,9 @@ bool gidx_contains(GIDX *a, GIDX *b)
 		for (i = dims_a; i < dims_b; i++)
 		{
 			if ( GIDX_GET_MIN(b,i) != 0 )
-				return FALSE;
+				return false;
 			if ( GIDX_GET_MAX(b,i) != 0 )
-				return FALSE;
+				return false;
 		}
 	}
 
@@ -480,12 +480,12 @@ bool gidx_contains(GIDX *a, GIDX *b)
 	for (i = 0; i < Min(dims_a, dims_b); i++)
 	{
 		if ( GIDX_GET_MIN(a,i) > GIDX_GET_MIN(b,i) )
-			return FALSE;
+			return false;
 		if ( GIDX_GET_MAX(a,i) < GIDX_GET_MAX(b,i) )
-			return FALSE;
+			return false;
 	}
 
-	return TRUE;
+	return true;
 }
 
 /*
@@ -499,14 +499,14 @@ static bool gidx_equals(GIDX *a, GIDX *b)
 
 	POSTGIS_DEBUG(5, "entered function");
 
-	if ( (a == NULL) && (b == NULL) ) return TRUE;
-	if ( (a == NULL) || (b == NULL) ) return FALSE;
+	if ( (a == NULL) && (b == NULL) ) return true;
+	if ( (a == NULL) || (b == NULL) ) return false;
 
 	if ( gidx_is_unknown(a) && gidx_is_unknown(b) )
-		return TRUE;
+		return true;
 
 	if ( gidx_is_unknown(a) || gidx_is_unknown(b) )
-		return FALSE;
+		return false;
 
 	/* Ensure 'a' has the most dimensions. */
 	gidx_dimensionality_check(&a, &b);
@@ -515,19 +515,19 @@ static bool gidx_equals(GIDX *a, GIDX *b)
 	for (i = 0; i < GIDX_NDIMS(b); i++)
 	{
 		if ( GIDX_GET_MIN(a,i) != GIDX_GET_MIN(b,i) )
-			return FALSE;
+			return false;
 		if ( GIDX_GET_MAX(a,i) != GIDX_GET_MAX(b,i) )
-			return FALSE;
+			return false;
 	}
 	/* For all unshared dimensions min(a) == 0.0, max(a) == 0.0 */
 	for (i = GIDX_NDIMS(b); i < GIDX_NDIMS(a); i++)
 	{
 		if ( GIDX_GET_MIN(a,i) != 0.0 )
-			return FALSE;
+			return false;
 		if ( GIDX_GET_MAX(a,i) != 0.0 )
-			return FALSE;
+			return false;
 	}
-	return TRUE;
+	return true;
 }
 
 /**
@@ -924,10 +924,10 @@ Datum gserialized_within(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate(PG_GETARG_DATUM(1), PG_GETARG_DATUM(0), gidx_contains) == LW_TRUE )
 	{
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	}
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 #if POSTGIS_PGSQL_VERSION > 94
@@ -941,9 +941,9 @@ Datum gserialized_gidx_geom_within(PG_FUNCTION_ARGS)
    GIDX *gidx = (GIDX *)PG_GETARG_POINTER(0);
 
    if ( gserialized_datum_predicate_geom_gidx(PG_GETARG_DATUM(1), gidx, gidx_contains) == LW_TRUE )
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 
 /*
@@ -954,9 +954,9 @@ PG_FUNCTION_INFO_V1(gserialized_gidx_gidx_within);
 Datum gserialized_gidx_gidx_within(PG_FUNCTION_ARGS)
 {
    if ( gidx_contains((GIDX *)PG_GETARG_POINTER(1), (GIDX *)PG_GETARG_POINTER(0)))
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 #endif
 
@@ -969,10 +969,10 @@ Datum gserialized_contains(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate(PG_GETARG_DATUM(0),PG_GETARG_DATUM(1), gidx_contains) == LW_TRUE )
 	{
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	}
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 #if POSTGIS_PGSQL_VERSION > 94
@@ -986,9 +986,9 @@ Datum gserialized_gidx_geom_contains(PG_FUNCTION_ARGS)
    GIDX *gidx = (GIDX *)PG_GETARG_POINTER(0);
 
    if ( gserialized_datum_predicate_gidx_geom(gidx, PG_GETARG_DATUM(1), gidx_contains) == LW_TRUE )
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 
 /*
@@ -999,9 +999,9 @@ PG_FUNCTION_INFO_V1(gserialized_gidx_gidx_contains);
 Datum gserialized_gidx_gidx_contains(PG_FUNCTION_ARGS)
 {
    if ( gidx_contains((GIDX *)PG_GETARG_POINTER(0), (GIDX *)PG_GETARG_POINTER(1)))
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_gidx_geom_same);
@@ -1010,18 +1010,18 @@ Datum gserialized_gidx_geom_same(PG_FUNCTION_ARGS)
    GIDX *gidx = (GIDX *)PG_GETARG_POINTER(0);
 
    if ( gserialized_datum_predicate_gidx_geom(gidx, PG_GETARG_DATUM(1), gidx_equals) == LW_TRUE )
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_gidx_gidx_same);
 Datum gserialized_gidx_gidx_same(PG_FUNCTION_ARGS)
 {
    if ( gidx_equals((GIDX *)PG_GETARG_POINTER(0), (GIDX *)PG_GETARG_POINTER(1)) )
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 #endif
 
@@ -1034,10 +1034,10 @@ Datum gserialized_overlaps(PG_FUNCTION_ARGS)
 {
 	if ( gserialized_datum_predicate(PG_GETARG_DATUM(0),PG_GETARG_DATUM(1), gidx_overlaps) == LW_TRUE )
 	{
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	}
 
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 #if POSTGIS_PGSQL_VERSION > 94
@@ -1050,9 +1050,9 @@ Datum gserialized_gidx_geog_overlaps(PG_FUNCTION_ARGS)
    GIDX *gidx = (GIDX *)PG_GETARG_POINTER(0);
 
    if ( gserialized_datum_predicate_gidx_geom(gidx, PG_GETARG_DATUM(1), gidx_overlaps) == LW_TRUE )
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_gidx_geom_overlaps);
@@ -1061,18 +1061,18 @@ Datum gserialized_gidx_geom_overlaps(PG_FUNCTION_ARGS)
    GIDX *gidx = (GIDX *)PG_GETARG_POINTER(0);
 
    if ( gserialized_datum_predicate_gidx_geom(gidx, PG_GETARG_DATUM(1), gidx_overlaps) == LW_TRUE )
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(gserialized_gidx_gidx_overlaps);
 Datum gserialized_gidx_gidx_overlaps(PG_FUNCTION_ARGS)
 {
    if ( gidx_overlaps((GIDX *)PG_GETARG_POINTER(0), (GIDX *)PG_GETARG_POINTER(1)) )
-       PG_RETURN_BOOL(TRUE);
+       PG_RETURN_BOOL(true);
 
-   PG_RETURN_BOOL(FALSE);
+   PG_RETURN_BOOL(false);
 }
 #endif
 
@@ -1119,7 +1119,7 @@ Datum gserialized_gist_compress(PG_FUNCTION_ARGS)
 	{
 		POSTGIS_DEBUG(4, "[GIST] leafkey is null");
 		gistentryinit(*entry_out, (Datum) 0, entry_in->rel,
-		              entry_in->page, entry_in->offset, FALSE);
+		              entry_in->page, entry_in->offset, false);
 		POSTGIS_DEBUG(4, "[GIST] returning copy of input");
 		PG_RETURN_POINTER(entry_out);
 	}
@@ -1135,7 +1135,7 @@ Datum gserialized_gist_compress(PG_FUNCTION_ARGS)
 		gidx_set_unknown(bbox_out);
 		gistentryinit(*entry_out, PointerGetDatum(gidx_copy(bbox_out)),
 		              entry_in->rel, entry_in->page,
-		              entry_in->offset, FALSE);
+		              entry_in->offset, false);
 		PG_RETURN_POINTER(entry_out);
 	}
 
@@ -1152,7 +1152,7 @@ Datum gserialized_gist_compress(PG_FUNCTION_ARGS)
 			gistentryinit(*entry_out,
 			              PointerGetDatum(gidx_copy(bbox_out)),
 			              entry_in->rel, entry_in->page,
-			              entry_in->offset, FALSE);
+			              entry_in->offset, false);
 			PG_RETURN_POINTER(entry_out);
 		}
 	}
@@ -1162,7 +1162,7 @@ Datum gserialized_gist_compress(PG_FUNCTION_ARGS)
 
 	/* Prepare GISTENTRY for return. */
 	gistentryinit(*entry_out, PointerGetDatum(gidx_copy(bbox_out)),
-	              entry_in->rel, entry_in->page, entry_in->offset, FALSE);
+	              entry_in->rel, entry_in->page, entry_in->offset, false);
 
 	/* Return GISTENTRY. */
 	POSTGIS_DEBUG(4, "[GIST] 'compress' function complete");
@@ -1208,7 +1208,7 @@ static inline bool gserialized_gist_consistent_leaf(GIDX *key, GIDX *query, Stra
 		retval = (bool) gidx_contains(query, key);
 		break;
 	default:
-		retval = FALSE;
+		retval = false;
 	}
 
 	return (retval);
@@ -1239,7 +1239,7 @@ static inline bool gserialized_gist_consistent_internal(GIDX *key, GIDX *query, 
 		retval = (bool) gidx_overlaps(key, query);
 		break;
 	default:
-		retval = FALSE;
+		retval = false;
 	}
 
 	return (retval);
@@ -1273,21 +1273,21 @@ Datum gserialized_gist_consistent(PG_FUNCTION_ARGS)
 	if ( DatumGetPointer(PG_GETARG_DATUM(1)) == NULL )
 	{
 		POSTGIS_DEBUG(4, "[GIST] null query pointer (!?!), returning false");
-		PG_RETURN_BOOL(FALSE); /* NULL query! This is screwy! */
+		PG_RETURN_BOOL(false); /* NULL query! This is screwy! */
 	}
 
 	/* Quick sanity check on entry key. */
 	if ( DatumGetPointer(entry->key) == NULL )
 	{
 		POSTGIS_DEBUG(4, "[GIST] null index entry, returning false");
-		PG_RETURN_BOOL(FALSE); /* NULL entry! */
+		PG_RETURN_BOOL(false); /* NULL entry! */
 	}
 
 	/* Null box should never make this far. */
 	if ( gserialized_datum_get_gidx_p(PG_GETARG_DATUM(1), query_gbox_index) == LW_FAILURE )
 	{
 		POSTGIS_DEBUG(4, "[GIST] null query_gbox_index!");
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 	}
 
 	/* Treat leaf node tests different from internal nodes */
@@ -1612,9 +1612,9 @@ static int gserialized_gist_picksplit_badratio(int x, int y)
 	POSTGIS_DEBUGF(4, "[GIST] checking split ratio (%d, %d)", x, y);
 	if ( (y == 0) || (((float)x / (float)y) < LIMIT_RATIO) ||
 	     (x == 0) || (((float)y / (float)x) < LIMIT_RATIO) )
-		return TRUE;
+		return true;
 
-	return FALSE;
+	return false;
 }
 
 static bool gserialized_gist_picksplit_badratios(int *pos, int dims)
@@ -1622,10 +1622,10 @@ static bool gserialized_gist_picksplit_badratios(int *pos, int dims)
 	int i;
 	for ( i = 0; i < dims; i++ )
 	{
-		if ( gserialized_gist_picksplit_badratio(pos[2*i],pos[2*i+1]) == FALSE )
-			return FALSE;
+		if ( gserialized_gist_picksplit_badratio(pos[2*i],pos[2*i+1]) == false )
+			return false;
 	}
-	return TRUE;
+	return true;
 }
 
 
@@ -1731,11 +1731,11 @@ static void gserialized_gist_picksplit_constructsplit(GIST_SPLITVEC *v, OffsetNu
 			GISTENTRY oldUnion,	addon;
 
 			gistentryinit(oldUnion, (v->spl_ldatum_exists) ? v->spl_ldatum : v->spl_rdatum,
-			              NULL, NULL, InvalidOffsetNumber, FALSE);
+			              NULL, NULL, InvalidOffsetNumber, false);
 
-			gistentryinit(addon, PointerGetDatum(*union1), NULL, NULL, InvalidOffsetNumber, FALSE);
+			gistentryinit(addon, PointerGetDatum(*union1), NULL, NULL, InvalidOffsetNumber, false);
 			DirectFunctionCall3(gserialized_gist_penalty, PointerGetDatum(&oldUnion), PointerGetDatum(&addon), PointerGetDatum(&p1));
-			gistentryinit(addon, PointerGetDatum(*union2), NULL, NULL, InvalidOffsetNumber, FALSE);
+			gistentryinit(addon, PointerGetDatum(*union2), NULL, NULL, InvalidOffsetNumber, false);
 			DirectFunctionCall3(gserialized_gist_penalty, PointerGetDatum(&oldUnion), PointerGetDatum(&addon), PointerGetDatum(&p2));
 
 			POSTGIS_DEBUGF(4, "[GIST] p1 / p2 == %.12g / %.12g", p1, p2);
@@ -1890,7 +1890,7 @@ Datum gserialized_gist_picksplit(PG_FUNCTION_ARGS)
 	** sides of the page union box can occasionally all end up in one place, leading
 	** to this condition.
 	*/
-	if ( gserialized_gist_picksplit_badratios(pos,ndims_pageunion) == TRUE )
+	if ( gserialized_gist_picksplit_badratios(pos,ndims_pageunion) == true )
 	{
 		/*
 		** Instead we split on center points and see if we do better.
@@ -1943,7 +1943,7 @@ Datum gserialized_gist_picksplit(PG_FUNCTION_ARGS)
 		}
 
 		/* Do we have a good disposition now? If not, screw it, just cut the node in half. */
-		if ( gserialized_gist_picksplit_badratios(pos,ndims_pageunion) == TRUE )
+		if ( gserialized_gist_picksplit_badratios(pos,ndims_pageunion) == true )
 		{
 			POSTGIS_DEBUG(4, "[GIST] picksplit still cannot find a good split! just cutting the node in half");
 			gserialized_gist_picksplit_fallback(entryvec, v);

--- a/postgis/lwgeom_btree.c
+++ b/postgis/lwgeom_btree.c
@@ -56,9 +56,9 @@ Datum lwgeom_lt(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
 	if (cmp < 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(lwgeom_le);
@@ -70,9 +70,9 @@ Datum lwgeom_le(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
 	if (cmp == 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(lwgeom_eq);
@@ -84,9 +84,9 @@ Datum lwgeom_eq(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
 	if (cmp == 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(lwgeom_ge);
@@ -98,9 +98,9 @@ Datum lwgeom_ge(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
 	if (cmp >= 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(lwgeom_gt);
@@ -112,9 +112,9 @@ Datum lwgeom_gt(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
 	if (cmp > 0)
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	else
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(lwgeom_cmp);

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -209,16 +209,16 @@ Datum postgis_scripts_released(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(postgis_uses_stats);
 Datum postgis_uses_stats(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_BOOL(TRUE);
+	PG_RETURN_BOOL(true);
 }
 
 PG_FUNCTION_INFO_V1(postgis_autocache_bbox);
 Datum postgis_autocache_bbox(PG_FUNCTION_ARGS)
 {
 #ifdef POSTGIS_AUTOCACHE_BBOX
-	PG_RETURN_BOOL(TRUE);
+	PG_RETURN_BOOL(true);
 #else
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 #endif
 }
 
@@ -2030,14 +2030,14 @@ Datum LWGEOM_same(PG_FUNCTION_ARGS)
 	{
 		PG_FREE_IF_COPY(g1, 0);
 		PG_FREE_IF_COPY(g2, 1);
-		PG_RETURN_BOOL(FALSE); /* different types */
+		PG_RETURN_BOOL(false); /* different types */
 	}
 
 	if ( gserialized_get_zm(g1) != gserialized_get_zm(g2) )
 	{
 		PG_FREE_IF_COPY(g1, 0);
 		PG_FREE_IF_COPY(g2, 1);
-		PG_RETURN_BOOL(FALSE); /* different dimensions */
+		PG_RETURN_BOOL(false); /* different dimensions */
 	}
 
 	/* ok, deserialize. */
@@ -2590,7 +2590,7 @@ Datum optimistic_overlap(PG_FUNCTION_ARGS)
 	     (g1_bvol.ymin > geom2->bbox->ymax) ||
 	     (g1_bvol.ymax < geom2->bbox->ymin) )
 	{
-		PG_RETURN_BOOL(FALSE);  /*bbox not overlap */
+		PG_RETURN_BOOL(false);  /*bbox not overlap */
 	}
 
 	/*

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -1565,7 +1565,7 @@ Datum isvalid(PG_FUNCTION_ARGS)
 		 * notice now that we have ST_isValidReason ?
 		 */
 		lwpgnotice("%s", lwgeom_geos_errmsg);
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 	}
 
 	result = GEOSisValid(g1);
@@ -1749,7 +1749,7 @@ Datum overlaps(PG_FUNCTION_ARGS)
 	{
 		if ( ! gbox_overlaps_2d(&box1, &box2) )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 	}
 
@@ -1819,7 +1819,7 @@ Datum contains(PG_FUNCTION_ARGS)
 	{
 		if ( ! gbox_contains_2d(&box1, &box2) )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 	}
 
@@ -1964,7 +1964,7 @@ Datum containsproperly(PG_FUNCTION_ARGS)
 	        gserialized_get_gbox_p(geom2, &box2) )
 	{
 		if ( ! gbox_contains_2d(&box1, &box2) )
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -2049,7 +2049,7 @@ Datum covers(PG_FUNCTION_ARGS)
 	{
 		if ( ! gbox_contains_2d(&box1, &box2) )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 	}
 	/*
@@ -2198,7 +2198,7 @@ Datum coveredby(PG_FUNCTION_ARGS)
 	{
 		if ( ! gbox_contains_2d(&box2, &box1) )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 
 		POSTGIS_DEBUG(3, "bounding box short-circuit missed.");
@@ -2323,7 +2323,7 @@ Datum crosses(PG_FUNCTION_ARGS)
 	{
 		if ( gbox_overlaps_2d(&box1, &box2) == LW_FALSE )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 	}
 
@@ -2389,7 +2389,7 @@ Datum geos_intersects(PG_FUNCTION_ARGS)
 	{
 		if ( gbox_overlaps_2d(&box1, &box2) == LW_FALSE )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 	}
 
@@ -2534,7 +2534,7 @@ Datum touches(PG_FUNCTION_ARGS)
 	{
 		if ( gbox_overlaps_2d(&box1, &box2) == LW_FALSE )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 	}
 
@@ -2601,7 +2601,7 @@ Datum disjoint(PG_FUNCTION_ARGS)
 	{
 		if ( gbox_overlaps_2d(&box1, &box2) == LW_FALSE )
 		{
-			PG_RETURN_BOOL(TRUE);
+			PG_RETURN_BOOL(true);
 		}
 	}
 
@@ -2793,7 +2793,7 @@ Datum ST_Equals(PG_FUNCTION_ARGS)
 
 	/* Empty == Empty */
 	if ( gserialized_is_empty(geom1) && gserialized_is_empty(geom2) )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
 	/*
 	 * short-circuit: If geom1 and geom2 do not have the same bounding box
@@ -2804,7 +2804,7 @@ Datum ST_Equals(PG_FUNCTION_ARGS)
 	{
 		if ( gbox_same_2d_float(&box1, &box2) == LW_FALSE )
 		{
-			PG_RETURN_BOOL(FALSE);
+			PG_RETURN_BOOL(false);
 		}
 	}
 
@@ -2813,7 +2813,7 @@ Datum ST_Equals(PG_FUNCTION_ARGS)
 	 * TRUE.  This is much faster than doing the comparison using GEOS.
 	 */
 	if (VARSIZE(geom1) == VARSIZE(geom2) && !memcmp(geom1, geom2, VARSIZE(geom1))) {
-	    PG_RETURN_BOOL(TRUE);
+	    PG_RETURN_BOOL(true);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -2864,7 +2864,7 @@ Datum issimple(PG_FUNCTION_ARGS)
 	geom = PG_GETARG_GSERIALIZED_P(0);
 
 	if ( gserialized_is_empty(geom) )
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 
 	lwgeom_in = lwgeom_from_gserialized(geom);
 	result = lwgeom_is_simple(lwgeom_in);
@@ -2889,7 +2889,7 @@ Datum isring(PG_FUNCTION_ARGS)
 
 	/* Empty things can't close */
 	if ( gserialized_is_empty(geom) )
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 

--- a/postgis/lwgeom_geos_prepared.c
+++ b/postgis/lwgeom_geos_prepared.c
@@ -174,7 +174,7 @@ PreparedCacheIsEmpty(MemoryContext context)
 	 * Always return false since this call is mandatory according to tgl
 	 * (see postgis-devel archives July 2007)
 	 */
-	return FALSE;
+	return LW_FALSE;
 }
 
 static void

--- a/postgis/lwgeom_spheroid.c
+++ b/postgis/lwgeom_spheroid.c
@@ -534,7 +534,7 @@ PG_FUNCTION_INFO_V1(LWGEOM_distance_ellipsoid);
 Datum LWGEOM_distance_ellipsoid(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_DATUM(DirectFunctionCall4(geometry_distance_spheroid,
-	                                    PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), PG_GETARG_DATUM(2), BoolGetDatum(TRUE)));
+	                                    PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), PG_GETARG_DATUM(2), BoolGetDatum(true)));
 }
 
 PG_FUNCTION_INFO_V1(LWGEOM_distance_sphere);
@@ -547,6 +547,6 @@ Datum LWGEOM_distance_sphere(PG_FUNCTION_ARGS)
 	s.a = s.b = s.radius;
 
 	PG_RETURN_DATUM(DirectFunctionCall4(geometry_distance_spheroid,
-	                                    PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), PointerGetDatum(&s), BoolGetDatum(FALSE)));
+	                                    PG_GETARG_DATUM(0), PG_GETARG_DATUM(1), PointerGetDatum(&s), BoolGetDatum(false)));
 }
 


### PR DESCRIPTION
Required after changes in PostgreSQL:
From http://www.postgresql-archive.org/PostgreSQL-Weekly-News-November-19-2017-td5992809.html
    - Remove TRUE and FALSE.  Code should be using true and false.  Existing code
    can be changed to those in a backward compatible way.  The definitions in the
    ecpg header files are left around to avoid upsetting those users
    unnecessarily.  Reviewed-by: Michael Paquier <[hidden email]>
    https://git.postgresql.org/pg/commitdiff/6337865f36da34e9c89aaa292f976bde6df0b065

Patch by Raul Marin (Algunenano), Carto