### PR TITLE
geojson: Do not include private header for json-c >= 0.13

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,7 @@ PostGIS 2.5.0
   - #3234, Do not accept EMPTY points as topology nodes (Sandro Santilli)
   - #1014, Hashable geometry, allowing direct use in CTE signatures (Paul Ramsey)
   - #3097, Really allow MULTILINESTRING blades in ST_Split() (Paul Ramsey)
+  - #3942, geojson: Do not include private header for json-c >= 0.13 (Björn Esser)
 
 
 PostGIS 2.4.0

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -31,12 +31,18 @@
 
 #if defined(HAVE_LIBJSON) || defined(HAVE_LIBJSON_C) /* --{ */
 
+#define JSON_C_VERSION_013 (13 << 8)
+
 #ifdef HAVE_LIBJSON_C
 #include <json-c/json.h>
+#if !defined(JSON_C_VERSION_NUM) || JSON_C_VERSION_NUM < JSON_C_VERSION_013
 #include <json-c/json_object_private.h>
+#endif
 #else
 #include <json/json.h>
+#if !defined(JSON_C_VERSION_NUM) || JSON_C_VERSION_NUM < JSON_C_VERSION_013
 #include <json/json_object_private.h>
+#endif
 #endif
 
 #ifndef JSON_C_VERSION


### PR DESCRIPTION
`json_object_private.h` is gone with json-c >= 0.13 and will not be needed anymore.