### PR TITLE
Fix bug in iterate_4d

### DIFF
--- a/liblwgeom/lwgeom_median.c
+++ b/liblwgeom/lwgeom_median.c
@@ -101,7 +101,7 @@ iterate_4d(POINT3D* curr, const POINT4D* points, uint32_t npoints, double* dista
 				{
 					dx += (points[i].x - curr->x) / distances[i];
 					dy += (points[i].y - curr->y) / distances[i];
-					dz += (points[i].y - curr->z) / distances[i];
+					dz += (points[i].z - curr->z) / distances[i];
 				}
 			}
 


### PR DESCRIPTION
Appeared with:
do_median_test("MULTIPOINT ZM ((0 -1 0 1), (0 0 0 1), (0 1 0 0.5), (0 1 0 0.5))", "POINT (0 0 0)", LW_TRUE, 1000);

```lwgeom_median.c:111:17: runtime error: division by zero```

Introduced in https://github.com/postgis/postgis/pull/176