### PR TITLE
lwprint_double: Avoid undefined behaviour with infinity

### DIFF
--- a/liblwgeom/lwprint.c
+++ b/liblwgeom/lwprint.c
@@ -488,7 +488,7 @@ int
 lwprint_double(double d, int maxdd, char* buf, size_t bufsize)
 {
 	double ad = fabs(d);
-	int ndd = ad < 1 ? 0 : floor(log10(ad)) + 1; /* non-decimal digits */
+	int ndd;
 	int length = 0;
 	if (ad <= FP_TOLERANCE)
 	{
@@ -497,6 +497,7 @@ lwprint_double(double d, int maxdd, char* buf, size_t bufsize)
 	}
 	if (ad < OUT_MAX_DOUBLE)
 	{
+		ndd = ad < 1 ? 0 : floor(log10(ad)) + 1; /* non-decimal digits */
 		if (maxdd > (OUT_MAX_DOUBLE_PRECISION - ndd)) maxdd -= ndd;
 		length = snprintf(buf, bufsize, "%.*f", maxdd, d);
 	}


### PR DESCRIPTION
lwprint.c:491:12: runtime error: inf is outside the range of representable values of type 'int'

Detected in test_wkt_in_point with "POINT(1e700 0)"