### PR TITLE
check_gdal: Don't assume failure when the datapath is invalid

### DIFF
--- a/raster/test/regress/check_gdal.sql
+++ b/raster/test/regress/check_gdal.sql
@@ -5,13 +5,8 @@ SELECT
 			THEN false
 		ELSE NULL
 	END;
-SET postgis.gdal_datapath = '';
-SELECT
-	CASE
-		WHEN strpos(postgis_gdal_version(), 'GDAL_DATA') <> 0
-			THEN NULL
-		ELSE TRUE
-	END;
+SET postgis.gdal_datapath = 'invalid_path';
+SHOW postgis.gdal_datapath;
 SET postgis.gdal_datapath = default;
 SELECT
 	CASE

--- a/raster/test/regress/check_gdal_expected
+++ b/raster/test/regress/check_gdal_expected
@@ -1,3 +1,4 @@
+invalid_path
 t
 DISABLE_ALL
 ENABLE_ALL


### PR DESCRIPTION
From gdal cpl_findfile.cpp (https://git.io/vAebm) if GDAL_DATA is not found some system folders can be used to look for resources, so the check might not fail due to unsetting it.

Trac issue: https://trac.osgeo.org/postgis/ticket/4013