### PR TITLE
liblwgeom: Avoid implicit type conversions

### DIFF
--- a/liblwgeom/bytebuffer.c
+++ b/liblwgeom/bytebuffer.c
@@ -140,7 +140,7 @@ static inline void
 bytebuffer_makeroom(bytebuffer_t *s, size_t size_to_add)
 {
 	LWDEBUGF(2,"Entered bytebuffer_makeroom with space need of %d", size_to_add);
-	size_t current_write_size = (s->writecursor - s->buf_start);
+	size_t current_write_size = (size_t) (s->writecursor - s->buf_start);
 	size_t capacity = s->capacity;
 	size_t required_size = current_write_size + size_to_add;
 
@@ -150,7 +150,7 @@ bytebuffer_makeroom(bytebuffer_t *s, size_t size_to_add)
 
 	if ( capacity > s->capacity )
 	{
-		size_t current_read_size = (s->readcursor - s->buf_start);
+		size_t current_read_size = (size_t) (s->readcursor - s->buf_start);
 		LWDEBUGF(4,"We need to realloc more memory. New capacity is %d", capacity);
 		if ( s->buf_start == s->buf_static )
 		{
@@ -279,7 +279,7 @@ bytebuffer_append_int(bytebuffer_t *buf, const int val, int swap)
 		LWDEBUG(4,"Ok, let's do the swaping thing");
 		for ( i = 0; i < WKB_INT_SIZE; i++ )
 		{
-			*(buf->writecursor) = iptr[WKB_INT_SIZE - 1 - i];
+			*(buf->writecursor) = (uint8_t) iptr[WKB_INT_SIZE - 1 - i];
 			buf->writecursor += 1;
 		}
 	}
@@ -325,7 +325,7 @@ bytebuffer_append_double(bytebuffer_t *buf, const double val, int swap)
 		LWDEBUG(4,"Ok, let's do the swapping thing");
 		for ( i = 0; i < WKB_DOUBLE_SIZE; i++ )
 		{
-			*(buf->writecursor) = dptr[WKB_DOUBLE_SIZE - 1 - i];
+			*(buf->writecursor) = (uint8_t) dptr[WKB_DOUBLE_SIZE - 1 - i];
 			buf->writecursor += 1;
 		}
 	}

--- a/liblwgeom/cunit/cu_algorithm.c
+++ b/liblwgeom/cunit/cu_algorithm.c
@@ -1357,7 +1357,7 @@ static void test_lwpoly_construct_circle(void)
 {
 	LWPOLY* p;
 	const GBOX* g;
-	const int srid = 4326;
+	const int32_t srid = 4326;
 	const int segments_per_quad = 17;
 	const int x = 10;
 	const int y = 20;

--- a/liblwgeom/cunit/cu_libgeom.c
+++ b/liblwgeom/cunit/cu_libgeom.c
@@ -21,7 +21,7 @@
 static void test_typmod_macros(void)
 {
 	int32_t typmod = 0;
-	int srid = 4326;
+	int32_t srid = 4326;
 	int type = 6;
 	int z = 1;
 	int rv;
@@ -1008,7 +1008,7 @@ static void test_lwline_from_lwmpoint(void)
 	LWMPOINT *mpoint;
 
 //	LWLINE *
-//	lwline_from_lwmpoint(int srid, LWMPOINT *mpoint)
+//	lwline_from_lwmpoint(int32_t srid, LWMPOINT *mpoint)
 
 	mpoint = (LWMPOINT*)lwgeom_from_wkt("MULTIPOINT(0 0, 0 1, 1 1, 1 2, 2 2)", LW_PARSER_CHECK_NONE);
 	line = lwline_from_lwmpoint(SRID_DEFAULT, mpoint);

--- a/liblwgeom/g_box.c
+++ b/liblwgeom/g_box.c
@@ -398,7 +398,7 @@ GBOX* gbox_from_string(const char *str)
 
 char* gbox_to_string(const GBOX *gbox)
 {
-	static int sz = 138;
+	static size_t sz = 138;
 	char *str = NULL;
 
 	if ( ! gbox )
@@ -443,12 +443,12 @@ void gbox_duplicate(const GBOX *original, GBOX *duplicate)
 	memcpy(duplicate, original, sizeof(GBOX));
 }
 
-size_t gbox_serialized_size(uint8_t flags)
+uint32_t gbox_serialized_size(uint8_t flags)
 {
 	if ( FLAGS_GET_GEODETIC(flags) )
 		return 6 * sizeof(float);
 	else
-		return 2 * FLAGS_NDIMS(flags) * sizeof(float);
+		return 2 * (uint32_t) FLAGS_NDIMS(flags) * (uint32_t) sizeof(float);
 }
 
 

--- a/liblwgeom/g_serialized.c
+++ b/liblwgeom/g_serialized.c
@@ -804,7 +804,7 @@ static size_t gserialized_from_any_size(const LWGEOM *geom)
 
 /* Public function */
 
-size_t gserialized_from_lwgeom_size(const LWGEOM *geom)
+uint32_t gserialized_from_lwgeom_size(const LWGEOM *geom)
 {
 	size_t size = 8; /* Header overhead. */
 	assert(geom);

--- a/liblwgeom/g_util.c
+++ b/liblwgeom/g_util.c
@@ -31,9 +31,9 @@
 struct geomtype_struct
 {
 	char *typename;
-	int type;
-	int z;
-	int m;
+	uint8_t type;
+	uint8_t z;
+	uint8_t m;
 };
 
 /* Type array. Note that the order of this array is important in
@@ -142,7 +142,7 @@ static char dump_toupper(int in)
 	return dumb_upper_map[in];
 }
 
-uint8_t gflags(int hasz, int hasm, int geodetic)
+uint8_t gflags(char hasz, char hasm, int geodetic)
 {
 	uint8_t flags = 0;
 	if ( hasz )

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -169,7 +169,7 @@ typedef enum LWORD_T {
 #define TYPMOD_SET_Z(typmod) ((typmod) = typmod | 0x00000002)
 #define TYPMOD_GET_M(typmod) (typmod & 0x00000001)
 #define TYPMOD_SET_M(typmod) ((typmod) = typmod | 0x00000001)
-#define TYPMOD_GET_NDIMS(typmod) (2+TYPMOD_GET_Z(typmod)+TYPMOD_GET_M(typmod))
+#define TYPMOD_GET_NDIMS(typmod) (uint32_t)(2+TYPMOD_GET_Z(typmod)+TYPMOD_GET_M(typmod))
 
 /**
 * Maximum allowed SRID value in serialized geometry.
@@ -206,10 +206,10 @@ typedef enum LWORD_T {
 * what went in.
 * Raises an error if SRID value is out of bounds.
 */
-extern int clamp_srid(int srid);
+extern int32_t clamp_srid(int32_t srid);
 
 /* Raise an lwerror if srids do not match */
-void error_if_srid_mismatch(int srid1, int srid2);
+void error_if_srid_mismatch(int32_t srid1, int32_t srid2);
 
 /**
  * Global functions for memory/logging handlers.
@@ -639,7 +639,7 @@ extern LWTIN* lwtin_add_lwtriangle(LWTIN *mobj, const LWTRIANGLE *obj);
 /**
 * Construct a new flags char.
 */
-extern uint8_t gflags(int hasz, int hasm, int geodetic);
+extern uint8_t gflags(char hasz, char hasm, int geodetic);
 
 /**
 * Extract the geometry type from the serialized form (it hides in
@@ -771,7 +771,7 @@ extern int lwtype_is_collection(uint8_t type);
 /**
 * Given an lwtype number, what homogeneous collection can hold it?
 */
-extern uint32_t lwtype_get_collectiontype(uint8_t type);
+extern uint8_t lwtype_get_collectiontype(uint8_t type);
 
 /**
 * Return the type name string associated with a type number
@@ -875,10 +875,10 @@ extern void ptarray_set_point4d(POINTARRAY *pa, uint32_t n, const POINT4D *p4d);
 extern uint8_t *getPoint_internal(const POINTARRAY *pa, uint32_t n);
 
 /*
- * size of point represeneted in the POINTARRAY
+ * size of point represented in the POINTARRAY
  * 16 for 2d, 24 for 3d, 32 for 4d
  */
-extern size_t ptarray_point_size(const POINTARRAY *pa);
+extern uint32_t ptarray_point_size(const POINTARRAY *pa);
 
 
 /**
@@ -1064,7 +1064,7 @@ extern LWCURVEPOLY* lwcurvepoly_construct_from_lwpoly(LWPOLY *lwpoly);
  * LWGEOM functions
  ******************************************************************/
 
-extern int lwcollection_ngeoms(const LWCOLLECTION *col);
+extern uint32_t lwcollection_ngeoms(const LWCOLLECTION *col);
 
 /* Given a generic geometry/collection, return the "simplest" form.
  * The elements of the homogenized collection are references to the
@@ -1079,11 +1079,11 @@ extern LWGEOM *lwgeom_homogenize(const LWGEOM *geom);
  * LWMULTIx and LWCOLLECTION functions
  ******************************************************************/
 
-LWGEOM *lwcollection_getsubgeom(LWCOLLECTION *col, int gnum);
+LWGEOM *lwcollection_getsubgeom(LWCOLLECTION *col, uint32_t gnum);
 
 /* WARNING: the output will contain references to geometries in the input, */
 /* so the result must be carefully released, not freed. */
-LWCOLLECTION* lwcollection_extract(LWCOLLECTION *col, int type);
+LWCOLLECTION* lwcollection_extract(LWCOLLECTION *col, uint8_t type);
 
 
 /******************************************************************
@@ -1095,7 +1095,7 @@ LWCOLLECTION* lwcollection_extract(LWCOLLECTION *col, int type);
 * For collections, only the parent gets an SRID, all
 * the children get SRID_UNKNOWN.
 */
-extern void lwgeom_set_srid(LWGEOM *geom, int srid);
+extern void lwgeom_set_srid(LWGEOM *geom, int32_t srid);
 
 /*------------------------------------------------------
  * other stuff
@@ -1342,47 +1342,47 @@ extern POINTARRAY *ptarray_clone_deep(const POINTARRAY *ptarray);
 * passed to them, they just take references, so do not free them out
 * from underneath the geometries.
 */
-extern LWPOINT* lwpoint_construct(int srid, GBOX *bbox, POINTARRAY *point);
-extern LWMPOINT *lwmpoint_construct(int srid, const POINTARRAY *pa);
-extern LWLINE* lwline_construct(int srid, GBOX *bbox, POINTARRAY *points);
-extern LWCIRCSTRING* lwcircstring_construct(int srid, GBOX *bbox, POINTARRAY *points);
-extern LWPOLY* lwpoly_construct(int srid, GBOX *bbox, uint32_t nrings, POINTARRAY **points);
-extern LWCURVEPOLY* lwcurvepoly_construct(int srid, GBOX *bbox, uint32_t nrings, LWGEOM **geoms);
-extern LWTRIANGLE* lwtriangle_construct(int srid, GBOX *bbox, POINTARRAY *points);
-extern LWCOLLECTION* lwcollection_construct(uint8_t type, int srid, GBOX *bbox, uint32_t ngeoms, LWGEOM **geoms);
+extern LWPOINT* lwpoint_construct(int32_t srid, GBOX *bbox, POINTARRAY *point);
+extern LWMPOINT *lwmpoint_construct(int32_t srid, const POINTARRAY *pa);
+extern LWLINE* lwline_construct(int32_t srid, GBOX *bbox, POINTARRAY *points);
+extern LWCIRCSTRING* lwcircstring_construct(int32_t srid, GBOX *bbox, POINTARRAY *points);
+extern LWPOLY* lwpoly_construct(int32_t srid, GBOX *bbox, uint32_t nrings, POINTARRAY **points);
+extern LWCURVEPOLY* lwcurvepoly_construct(int32_t srid, GBOX *bbox, uint32_t nrings, LWGEOM **geoms);
+extern LWTRIANGLE* lwtriangle_construct(int32_t srid, GBOX *bbox, POINTARRAY *points);
+extern LWCOLLECTION* lwcollection_construct(uint8_t type, int32_t srid, GBOX *bbox, uint32_t ngeoms, LWGEOM **geoms);
 /*
 * Empty geometry constructors.
 */
-extern LWGEOM* lwgeom_construct_empty(uint8_t type, int srid, char hasz, char hasm);
-extern LWPOINT* lwpoint_construct_empty(int srid, char hasz, char hasm);
-extern LWLINE* lwline_construct_empty(int srid, char hasz, char hasm);
-extern LWPOLY* lwpoly_construct_empty(int srid, char hasz, char hasm);
-extern LWCURVEPOLY* lwcurvepoly_construct_empty(int srid, char hasz, char hasm);
-extern LWCIRCSTRING* lwcircstring_construct_empty(int srid, char hasz, char hasm);
-extern LWCOMPOUND* lwcompound_construct_empty(int srid, char hasz, char hasm);
-extern LWTRIANGLE* lwtriangle_construct_empty(int srid, char hasz, char hasm);
-extern LWMPOINT* lwmpoint_construct_empty(int srid, char hasz, char hasm);
-extern LWMLINE* lwmline_construct_empty(int srid, char hasz, char hasm);
-extern LWMPOLY* lwmpoly_construct_empty(int srid, char hasz, char hasm);
-extern LWCOLLECTION* lwcollection_construct_empty(uint8_t type, int srid, char hasz, char hasm);
+extern LWGEOM* lwgeom_construct_empty(uint8_t type, int32_t srid, char hasz, char hasm);
+extern LWPOINT* lwpoint_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWLINE* lwline_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWPOLY* lwpoly_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWCURVEPOLY* lwcurvepoly_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWCIRCSTRING* lwcircstring_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWCOMPOUND* lwcompound_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWTRIANGLE* lwtriangle_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWMPOINT* lwmpoint_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWMLINE* lwmline_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWMPOLY* lwmpoly_construct_empty(int32_t srid, char hasz, char hasm);
+extern LWCOLLECTION* lwcollection_construct_empty(uint8_t type, int32_t srid, char hasz, char hasm);
 
 
 /* Other constructors */
-extern LWPOINT *lwpoint_make2d(int srid, double x, double y);
-extern LWPOINT *lwpoint_make3dz(int srid, double x, double y, double z);
-extern LWPOINT *lwpoint_make3dm(int srid, double x, double y, double m);
-extern LWPOINT *lwpoint_make4d(int srid, double x, double y, double z, double m);
-extern LWPOINT *lwpoint_make(int srid, int hasz, int hasm, const POINT4D *p);
-extern LWLINE *lwline_from_lwgeom_array(int srid, uint32_t ngeoms, LWGEOM **geoms);
-extern LWLINE *lwline_from_ptarray(int srid, uint32_t npoints, LWPOINT **points); /* TODO: deprecate */
-extern LWLINE *lwline_from_lwmpoint(int srid, const LWMPOINT *mpoint);
+extern LWPOINT *lwpoint_make2d(int32_t srid, double x, double y);
+extern LWPOINT *lwpoint_make3dz(int32_t srid, double x, double y, double z);
+extern LWPOINT *lwpoint_make3dm(int32_t srid, double x, double y, double m);
+extern LWPOINT *lwpoint_make4d(int32_t srid, double x, double y, double z, double m);
+extern LWPOINT *lwpoint_make(int32_t srid, char hasz, char hasm, const POINT4D *p);
+extern LWLINE *lwline_from_lwgeom_array(int32_t srid, uint32_t ngeoms, LWGEOM **geoms);
+extern LWLINE *lwline_from_ptarray(int32_t srid, uint32_t npoints, LWPOINT **points); /* TODO: deprecate */
+extern LWLINE *lwline_from_lwmpoint(int32_t srid, const LWMPOINT *mpoint);
 extern LWLINE *lwline_addpoint(LWLINE *line, LWPOINT *point, uint32_t where);
 extern LWLINE *lwline_removepoint(LWLINE *line, uint32_t which);
 extern void lwline_setPoint4d(LWLINE *line, uint32_t which, POINT4D *newpoint);
 extern LWPOLY *lwpoly_from_lwlines(const LWLINE *shell, uint32_t nholes, const LWLINE **holes);
 extern LWPOLY *lwpoly_construct_rectangle(char hasz, char hasm, POINT4D *p1, POINT4D *p2, POINT4D *p3, POINT4D *p4);
-extern LWPOLY *lwpoly_construct_envelope(int srid, double x1, double y1, double x2, double y2);
-extern LWPOLY *lwpoly_construct_circle(int srid, double x, double y, double radius, uint32_t segments_per_quarter, char exterior);
+extern LWPOLY *lwpoly_construct_envelope(int32_t srid, double x1, double y1, double x2, double y2);
+extern LWPOLY *lwpoly_construct_circle(int32_t srid, double x, double y, double radius, uint32_t segments_per_quarter, char exterior);
 extern LWTRIANGLE *lwtriangle_from_lwline(const LWLINE *shell);
 extern LWMPOINT *lwmpoint_from_lwgeom(const LWGEOM *g); /* Extract the coordinates of an LWGEOM into an LWMPOINT */
 
@@ -1503,7 +1503,7 @@ extern LWPOINT* lwmpoint_median(const LWMPOINT *g, double tol, uint32_t maxiter,
 /**
 * Calculate the GeoHash (http://geohash.org) string for a geometry. Caller must free.
 */
-char *lwgeom_geohash(const LWGEOM *lwgeom, int precision);
+char *lwgeom_geohash(const LWGEOM *lwgeom, int32_t precision);
 unsigned int geohash_point_as_int(POINT2D *pt);
 
 
@@ -1559,18 +1559,18 @@ LWCOLLECTION* lwgeom_clip_to_ordinate_range(const LWGEOM *lwin, char ordinate, d
 
 
 
-extern char* lwgeom_to_gml2(const LWGEOM *geom, const char *srs, int precision, const char *prefix);
-extern char* lwgeom_extent_to_gml2(const LWGEOM *geom, const char *srs, int precision, const char *prefix);
+extern char* lwgeom_to_gml2(const LWGEOM *geom, const char *srs, int32_t precision, const char *prefix);
+extern char* lwgeom_extent_to_gml2(const LWGEOM *geom, const char *srs, int32_t precision, const char *prefix);
 /**
  * @param opts output options bitfield, see LW_GML macros for meaning
  */
-extern char* lwgeom_extent_to_gml3(const LWGEOM *geom, const char *srs, int precision, int opts, const char *prefix);
-extern char* lwgeom_to_gml3(const LWGEOM *geom, const char *srs, int precision, int opts, const char *prefix, const char *id);
-extern char* lwgeom_to_kml2(const LWGEOM *geom, int precision, const char *prefix);
-extern char* lwgeom_to_geojson(const LWGEOM *geo, char *srs, int precision, int has_bbox);
-extern char* lwgeom_to_svg(const LWGEOM *geom, int precision, int relative);
-extern char* lwgeom_to_x3d3(const LWGEOM *geom, char *srs, int precision, int opts, const char *defid);
-extern char* lwgeom_to_encoded_polyline(const LWGEOM *geom, int precision);
+extern char* lwgeom_extent_to_gml3(const LWGEOM *geom, const char *srs, int32_t precision, int opts, const char *prefix);
+extern char* lwgeom_to_gml3(const LWGEOM *geom, const char *srs, int32_t precision, int opts, const char *prefix, const char *id);
+extern char* lwgeom_to_kml2(const LWGEOM *geom, int32_t precision, const char *prefix);
+extern char* lwgeom_to_geojson(const LWGEOM *geo, char *srs, int32_t precision, int has_bbox);
+extern char* lwgeom_to_svg(const LWGEOM *geom, int32_t precision, int relative);
+extern char* lwgeom_to_x3d3(const LWGEOM *geom, char *srs, int32_t precision, int opts, const char *defid);
+extern char* lwgeom_to_encoded_polyline(const LWGEOM *geom, int32_t precision);
 
 /**
  * Create an LWGEOM object from a GeoJSON representation
@@ -1588,7 +1588,7 @@ extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
  *
  * @param encodedpolyline the Encoded Polyline input
  */
-extern LWGEOM* lwgeom_from_encoded_polyline(const char *encodedpolyline, int precision);
+extern LWGEOM* lwgeom_from_encoded_polyline(const char *encodedpolyline, int32_t precision);
 
 /**
 * Initialize a spheroid object for use in geodetic functions.
@@ -1913,7 +1913,7 @@ extern void gbox_duplicate(const GBOX *original, GBOX *duplicate);
 * Return the number of bytes necessary to hold a #GBOX of this dimension in
 * serialized form.
 */
-extern size_t gbox_serialized_size(uint8_t flags);
+extern uint32_t gbox_serialized_size(uint8_t flags);
 
 /**
 * Check if 2 given Gbox are the same
@@ -1961,7 +1961,7 @@ extern int geometry_type_from_string(const char *str, uint8_t *type, int *z, int
 * Primarily used internally by the serialization code. Exposed to allow the cunit
 * tests to exercise it.
 */
-extern size_t gserialized_from_lwgeom_size(const LWGEOM *geom);
+extern uint32_t gserialized_from_lwgeom_size(const LWGEOM *geom);
 
 /**
 * Allocate a new #GSERIALIZED from an #LWGEOM. For all non-point types, a bounding
@@ -2091,7 +2091,7 @@ LWGEOM_UNPARSER_RESULT;
 * @param lwgeom geometry to convert to WKT
 * @param variant output format to use (WKT_ISO, WKT_SFSQL, WKT_EXTENDED)
 */
-extern char*   lwgeom_to_wkt(const LWGEOM *geom, uint8_t variant, int precision, size_t *size_out);
+extern char*   lwgeom_to_wkt(const LWGEOM *geom, uint8_t variant, int32_t precision, size_t *size_out);
 
 /**
 * @param lwgeom geometry to convert to WKT
@@ -2148,7 +2148,7 @@ extern void *lwrealloc(void *mem, size_t size);
 extern void lwfree(void *mem);
 
 /* Utilities */
-extern char *lwmessage_truncate(char *str, int startpos, int endpos, int maxlength, int truncdirection);
+extern char *lwmessage_truncate(char *str, size_t startpos, size_t endpos, size_t maxlength, int truncdirection);
 
 /*
 * TWKB functions
@@ -2158,7 +2158,7 @@ extern char *lwmessage_truncate(char *str, int startpos, int endpos, int maxleng
  * @param check parser check flags, see LW_PARSER_CHECK_* macros
  * @param size parser check flags, see LW_PARSER_CHECK_* macros
  */
-extern LWGEOM* lwgeom_from_twkb(const uint8_t *twkb, size_t twkb_size, char check);
+extern LWGEOM* lwgeom_from_twkb(const uint8_t *twkb, size_t twkb_size, uint32_t check);
 
 /**
  * @param geom input geometry

--- a/liblwgeom/liblwgeom_internal.h
+++ b/liblwgeom/liblwgeom_internal.h
@@ -258,8 +258,8 @@ LWCOLLECTION *lwpoint_clip_to_ordinate_range(const LWPOINT *mpoint, char ordinat
 * Geohash
 */
 int lwgeom_geohash_precision(GBOX bbox, GBOX *bounds);
-char *geohash_point(double longitude, double latitude, int precision);
-void decode_geohash_bbox(char *geohash, double *lat, double *lon, int precision);
+char *geohash_point(double longitude, double latitude, int32_t precision);
+void decode_geohash_bbox(char *geohash, double *lat, double *lon, int32_t precision);
 
 /*
 * Point comparisons
@@ -473,7 +473,7 @@ int lwline_split_by_point_to(const LWLINE* ln, const LWPOINT* pt, LWMLINE* to);
 void lwcollection_reserve(LWCOLLECTION *col, uint32_t ngeoms);
 
 /** Check if subtype is allowed in collectiontype */
-int lwcollection_allows_subtype(int collectiontype, int subtype);
+int lwcollection_allows_subtype(uint8_t collectiontype, uint8_t subtype);
 
 /** GBOX utility functions to figure out coverage/location on the globe */
 double gbox_angular_height(const GBOX* gbox);

--- a/liblwgeom/liblwgeom_topo.h
+++ b/liblwgeom/liblwgeom_topo.h
@@ -158,7 +158,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    */
   LWT_BE_TOPOLOGY* (*createTopology) (
     const LWT_BE_DATA* be,
-    const char* name, int srid, double precision, int hasZ
+    const char* name, int32_t srid, double precision, int hasZ
   );
 
   /**
@@ -949,7 +949,7 @@ typedef struct LWT_TOPOLOGY_T LWT_TOPOLOGY;
  *         (liblwgeom error handler will be invoked with error message)
  */
 LWT_TOPOLOGY *lwt_CreateTopology(LWT_BE_IFACE *iface, const char *name,
-                        int srid, double prec, int hasz);
+                        int32_t srid, double prec, int hasz);
 
 /**
  * Loads an existing topology by name from the database

--- a/liblwgeom/liblwgeom_topo_internal.h
+++ b/liblwgeom/liblwgeom_topo_internal.h
@@ -86,7 +86,7 @@ struct LWT_TOPOLOGY_T
 {
   const LWT_BE_IFACE *be_iface;
   LWT_BE_TOPOLOGY *be_topo;
-  int srid;
+  int32_t srid;
   double precision;
   int hasZ;
 };

--- a/liblwgeom/lwcircstring.c
+++ b/liblwgeom/lwcircstring.c
@@ -34,8 +34,8 @@
 void printLWCIRCSTRING(LWCIRCSTRING *curve);
 void lwcircstring_release(LWCIRCSTRING *lwcirc);
 char lwcircstring_same(const LWCIRCSTRING *me, const LWCIRCSTRING *you);
-LWCIRCSTRING *lwcircstring_from_lwpointarray(int srid, uint32_t npoints, LWPOINT **points);
-LWCIRCSTRING *lwcircstring_from_lwmpoint(int srid, LWMPOINT *mpoint);
+LWCIRCSTRING *lwcircstring_from_lwpointarray(int32_t srid, uint32_t npoints, LWPOINT **points);
+LWCIRCSTRING *lwcircstring_from_lwmpoint(int32_t srid, LWMPOINT *mpoint);
 LWCIRCSTRING *lwcircstring_addpoint(LWCIRCSTRING *curve, LWPOINT *point, uint32_t where);
 LWCIRCSTRING *lwcircstring_removepoint(LWCIRCSTRING *curve, uint32_t index);
 void lwcircstring_setPoint4d(LWCIRCSTRING *curve, uint32_t index, POINT4D *newpoint);
@@ -47,7 +47,7 @@ void lwcircstring_setPoint4d(LWCIRCSTRING *curve, uint32_t index, POINT4D *newpo
  * use SRID=SRID_UNKNOWN for unknown SRID (will have 8bit type's S = 0)
  */
 LWCIRCSTRING *
-lwcircstring_construct(int srid, GBOX *bbox, POINTARRAY *points)
+lwcircstring_construct(int32_t srid, GBOX *bbox, POINTARRAY *points)
 {
 	LWCIRCSTRING *result;
 
@@ -76,7 +76,7 @@ lwcircstring_construct(int srid, GBOX *bbox, POINTARRAY *points)
 }
 
 LWCIRCSTRING *
-lwcircstring_construct_empty(int srid, char hasz, char hasm)
+lwcircstring_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWCIRCSTRING *result = lwalloc(sizeof(LWCIRCSTRING));
 	result->type = CIRCSTRINGTYPE;
@@ -138,7 +138,7 @@ lwcircstring_same(const LWCIRCSTRING *me, const LWCIRCSTRING *you)
  * LWCIRCSTRING dimensions are large enough to host all input dimensions.
  */
 LWCIRCSTRING *
-lwcircstring_from_lwpointarray(int srid, uint32_t npoints, LWPOINT **points)
+lwcircstring_from_lwpointarray(int32_t srid, uint32_t npoints, LWPOINT **points)
 {
 	int zmflag=0;
 	uint32_t i;
@@ -189,11 +189,11 @@ lwcircstring_from_lwpointarray(int srid, uint32_t npoints, LWPOINT **points)
  * Construct a LWCIRCSTRING from a LWMPOINT
  */
 LWCIRCSTRING *
-lwcircstring_from_lwmpoint(int srid, LWMPOINT *mpoint)
+lwcircstring_from_lwmpoint(int32_t srid, LWMPOINT *mpoint)
 {
 	uint32_t i;
 	POINTARRAY *pa;
-	char zmflag = FLAGS_GET_ZM(mpoint->flags);
+	int zmflag = FLAGS_GET_ZM(mpoint->flags);
 	size_t ptsize, size;
 	uint8_t *newpoints, *ptr;
 
@@ -230,7 +230,7 @@ lwcircstring_addpoint(LWCIRCSTRING *curve, LWPOINT *point, uint32_t where)
 
 	newpa = ptarray_addPoint(curve->points,
 	                         getPoint_internal(point->point, 0),
-	                         FLAGS_NDIMS(point->flags), where);
+	                         (size_t) FLAGS_NDIMS(point->flags), where);
 	ret = lwcircstring_construct(curve->srid, NULL, newpa);
 
 	return ret;

--- a/liblwgeom/lwcollection.c
+++ b/liblwgeom/lwcollection.c
@@ -40,13 +40,13 @@ lwcollection_release(LWCOLLECTION *lwcollection)
 
 
 LWCOLLECTION *
-lwcollection_construct(uint8_t type, int srid, GBOX *bbox,
+lwcollection_construct(uint8_t type, int32_t srid, GBOX *bbox,
                        uint32_t ngeoms, LWGEOM **geoms)
 {
 	LWCOLLECTION *ret;
 	int hasz, hasm;
 #ifdef CHECK_LWGEOM_ZM
-	char zm;
+	int zm;
 	uint32_t i;
 #endif
 
@@ -91,7 +91,7 @@ lwcollection_construct(uint8_t type, int srid, GBOX *bbox,
 }
 
 LWCOLLECTION *
-lwcollection_construct_empty(uint8_t type, int srid, char hasz, char hasm)
+lwcollection_construct_empty(uint8_t type, int32_t srid, char hasz, char hasm)
 {
 	LWCOLLECTION *ret;
 	if( ! lwtype_is_collection(type) )
@@ -110,7 +110,7 @@ lwcollection_construct_empty(uint8_t type, int srid, char hasz, char hasm)
 }
 
 LWGEOM *
-lwcollection_getsubgeom(LWCOLLECTION *col, int gnum)
+lwcollection_getsubgeom(LWCOLLECTION *col, uint32_t gnum)
 {
 	return (LWGEOM *)col->geoms[gnum];
 }
@@ -301,10 +301,10 @@ lwcollection_same(const LWCOLLECTION *c1, const LWCOLLECTION *c2)
 	return LW_TRUE;
 }
 
-int lwcollection_ngeoms(const LWCOLLECTION *col)
+uint32_t lwcollection_ngeoms(const LWCOLLECTION *col)
 {
 	uint32_t i;
-	int ngeoms = 0;
+	uint32_t ngeoms = 0;
 
 	if ( ! col )
 	{
@@ -369,13 +369,13 @@ void lwcollection_free(LWCOLLECTION *col)
 * so the result must be carefully released, not freed.
 */
 LWCOLLECTION*
-lwcollection_extract(LWCOLLECTION* col, int type)
+lwcollection_extract(LWCOLLECTION* col, uint8_t type)
 {
 	uint32_t i = 0;
 	LWGEOM** geomlist;
 	LWCOLLECTION* outcol;
-	int geomlistsize = 16;
-	int geomlistlen = 0;
+	uint32_t geomlistsize = 16;
+	uint32_t geomlistlen = 0;
 	uint8_t outtype;
 
 	if (!col) return NULL;
@@ -404,7 +404,7 @@ lwcollection_extract(LWCOLLECTION* col, int type)
 	/* Process each sub-geometry */
 	for (i = 0; i < col->ngeoms; i++)
 	{
-		int subtype = col->geoms[i]->type;
+		uint8_t subtype = col->geoms[i]->type;
 		/* Don't bother adding empty sub-geometries */
 		if (lwgeom_is_empty(col->geoms[i])) continue;
 		/* Copy our sub-types into the output list */
@@ -517,7 +517,7 @@ uint32_t lwcollection_count_vertices(LWCOLLECTION *col)
 }
 
 
-int lwcollection_allows_subtype(int collectiontype, int subtype)
+int lwcollection_allows_subtype(uint8_t collectiontype, uint8_t subtype)
 {
 	if ( collectiontype == COLLECTIONTYPE )
 		return LW_TRUE;

--- a/liblwgeom/lwcompound.c
+++ b/liblwgeom/lwcompound.c
@@ -35,7 +35,7 @@ int
 lwcompound_is_closed(const LWCOMPOUND *compound)
 {
 	size_t size;
-	int npoints=0;
+	uint32_t npoints=0;
 
 	if ( lwgeom_has_z((LWGEOM*)compound) )
 	{
@@ -120,7 +120,7 @@ int lwcompound_add_lwgeom(LWCOMPOUND *comp, LWGEOM *geom)
 }
 
 LWCOMPOUND *
-lwcompound_construct_empty(int srid, char hasz, char hasm)
+lwcompound_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWCOMPOUND *ret = (LWCOMPOUND*)lwcollection_construct_empty(COMPOUNDTYPE, srid, hasz, hasm);
 	return ret;

--- a/liblwgeom/lwcurvepoly.c
+++ b/liblwgeom/lwcurvepoly.c
@@ -33,7 +33,7 @@
 
 
 LWCURVEPOLY *
-lwcurvepoly_construct_empty(int srid, char hasz, char hasm)
+lwcurvepoly_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWCURVEPOLY *ret;
 

--- a/liblwgeom/lwgeodetic.c
+++ b/liblwgeom/lwgeodetic.c
@@ -2321,7 +2321,7 @@ double lwgeom_distance_spheroid(const LWGEOM *lwgeom1, const LWGEOM *lwgeom2, co
 
 int lwgeom_covers_lwgeom_sphere(const LWGEOM *lwgeom1, const LWGEOM *lwgeom2)
 {
-	int type1, type2;
+	uint8_t type1, type2;
 	GBOX gbox1, gbox2;
 	gbox1.flags = gbox2.flags = 0;
 
@@ -2636,7 +2636,7 @@ int lwpoly_intersects_line(const LWPOLY* lwpoly, const POINTARRAY* line)
 				ll2cart(b1, &pb1);
 				ll2cart(b2, &pb2);
 
-				int inter = edge_intersects(&pa1, &pa2, &pb1, &pb2);
+				uint32_t inter = edge_intersects(&pa1, &pa2, &pb1, &pb2);
 
 				/* ignore same edges */
 				if (inter & PIR_INTERSECTS
@@ -3195,7 +3195,7 @@ double ptarray_length_spheroid(const POINTARRAY *pa, const SPHEROID *s)
 
 double lwgeom_length_spheroid(const LWGEOM *geom, const SPHEROID *s)
 {
-	int type;
+	uint8_t type;
 	uint32_t i = 0;
 	double length = 0.0;
 
@@ -3302,7 +3302,7 @@ ptarray_nudge_geodetic(POINTARRAY *pa)
 int
 lwgeom_nudge_geodetic(LWGEOM *geom)
 {
-	int type;
+	uint8_t type;
 	uint32_t i = 0;
 	int rv = LW_FALSE;
 
@@ -3413,7 +3413,7 @@ edge_intersects(const POINT3D *A1, const POINT3D *A2, const POINT3D *B1, const P
 	POINT3D AN, BN, VN;  /* Normals to plane A and plane B */
 	double ab_dot;
 	int a1_side, a2_side, b1_side, b2_side;
-	int rv = PIR_NO_INTERACT;
+	uint32_t rv = PIR_NO_INTERACT;
 
 	/* Normals to the A-plane and B-plane */
 	unit_normal(A1, A2, &AN);

--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -359,7 +359,7 @@ uint8_t MULTITYPE[NUMTYPES] =
 
 uint8_t lwtype_multitype(uint8_t type)
 {
-	if (type > 15 || type < 0) return 0;
+	if (type > 15) return 0;
 	return MULTITYPE[type];
 }
 
@@ -411,11 +411,6 @@ lwgeom_as_curve(const LWGEOM *lwgeom)
 {
 	LWGEOM *ogeom;
 	int type = lwgeom->type;
-	/*
-	int hasz = FLAGS_GET_Z(lwgeom->flags);
-	int hasm = FLAGS_GET_M(lwgeom->flags);
-	int srid = lwgeom->srid;
-	*/
 
 	switch(type)
 	{
@@ -1115,7 +1110,7 @@ lwtype_is_collection(uint8_t type)
 /**
 * Given an lwtype number, what homogeneous collection can hold it?
 */
-uint32_t
+uint8_t
 lwtype_get_collectiontype(uint8_t type)
 {
 	switch (type)
@@ -1233,7 +1228,7 @@ int lwgeom_needs_bbox(const LWGEOM *geom)
 */
 uint32_t lwgeom_count_vertices(const LWGEOM *geom)
 {
-	int result = 0;
+	uint32_t result = 0;
 
 	/* Null? Zero. */
 	if( ! geom ) return 0;
@@ -1343,7 +1338,7 @@ int lwgeom_dimension(const LWGEOM *geom)
 */
 uint32_t lwgeom_count_rings(const LWGEOM *geom)
 {
-	int result = 0;
+	uint32_t result = 0;
 
 	/* Null? Empty? Zero. */
 	if( ! geom || lwgeom_is_empty(geom) )
@@ -1627,7 +1622,7 @@ lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 			for (i = 0; i < g->nrings; i++)
 			{
 				POINTARRAY *pa = g->rings[i];
-				int minpoints = 4;
+				uint32_t minpoints = 4;
 				/* Skip zero'ed out rings */
 				if(!pa)
 					continue;
@@ -1787,7 +1782,7 @@ lwgeom_simplify_in_place(LWGEOM *geom, double epsilon, int preserve_collapsed)
 			{
 				POINTARRAY *pa = g->rings[i];
 				/* Only stop collapse on first ring */
-				int minpoints = (preserve_collapsed && i == 0) ? 4 : 0;
+				uint32_t minpoints = (preserve_collapsed && i == 0) ? 4 : 0;
 				/* Skip zero'ed out rings */
 				if(!pa)
 					continue;
@@ -1967,7 +1962,7 @@ double lwgeom_length_2d(const LWGEOM *geom)
 void
 lwgeom_affine(LWGEOM *geom, const AFFINE *affine)
 {
-	int type = geom->type;
+	uint8_t type = geom->type;
 	uint32_t i;
 
 	switch(type)
@@ -2018,7 +2013,7 @@ lwgeom_affine(LWGEOM *geom, const AFFINE *affine)
 void
 lwgeom_scale(LWGEOM *geom, const POINT4D *factor)
 {
-	int type = geom->type;
+	uint8_t type = geom->type;
 	uint32_t i;
 
 	switch(type)
@@ -2256,7 +2251,8 @@ lwgeom_subdivide_recursive(const LWGEOM *geom, uint32_t maxvertices, uint32_t de
 {
 	const uint32_t maxdepth = 50;
 	uint32_t nvertices = 0;
-	uint32_t i, n = 0;
+	uint32_t i;
+	int n = 0;
 	double width = clip->xmax - clip->xmin;
 	double height = clip->ymax - clip->ymin;
 	GBOX subbox1, subbox2;

--- a/liblwgeom/lwgeom_api.c
+++ b/liblwgeom/lwgeom_api.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <assert.h>
+#include <math.h>
 #include "../postgis_svn_revision.h"
 
 const char *
@@ -51,7 +52,7 @@ lwgeom_version()
 inline float
 next_float_down(double d)
 {
-	float result  = d;
+	float result  = (float) d;
 
 	if ( ((double)result) <=d )
 		return result;
@@ -67,7 +68,7 @@ next_float_down(double d)
 inline float
 next_float_up(double d)
 {
-	float result  = d;
+	float result  = (float) d;
 
 	if ( ((double)result) >=d )
 		return result;

--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -1250,7 +1250,7 @@ lwpoly_to_points(const LWPOLY* lwpoly, uint32_t npoints)
 	GEOSGeometry* gpt;
 	GEOSCoordSequence* gseq;
 	LWMPOINT* mpt;
-	int srid = lwgeom_get_srid(lwgeom);
+	int32_t srid = lwgeom_get_srid(lwgeom);
 	int done = 0;
 	int* cells;
 	const size_t size = 2 * sizeof(int);
@@ -1631,7 +1631,7 @@ lwgeom_voronoi_diagram(const LWGEOM* g, const GBOX* env, double tolerance, int o
 	uint32_t num_points = lwgeom_count_vertices(g);
 	LWGEOM* lwgeom_result;
 	char is_3d = LW_FALSE;
-	int srid = lwgeom_get_srid(g);
+	int32_t srid = lwgeom_get_srid(g);
 	GEOSCoordSequence* coords;
 	GEOSGeometry* geos_geom;
 	GEOSGeometry* geos_env = NULL;

--- a/liblwgeom/lwgeom_sfcgal.c
+++ b/liblwgeom/lwgeom_sfcgal.c
@@ -275,7 +275,7 @@ ptarray_to_SFCGAL(const POINTARRAY* pa, int type)
  * Throws an error on unsupported type
  */
 LWGEOM*
-SFCGAL2LWGEOM(const sfcgal_geometry_t* geom, int force3D, int srid)
+SFCGAL2LWGEOM(const sfcgal_geometry_t* geom, int force3D, int32_t srid)
 {
 	uint32_t ngeoms, nshells, nsolids;
 	uint32_t i, j, k;

--- a/liblwgeom/lwgeom_sfcgal.h
+++ b/liblwgeom/lwgeom_sfcgal.h
@@ -34,7 +34,7 @@ lwgeom_sfcgal_version(void);
 
 /* Convert SFCGAL structure to lwgeom PostGIS */
 LWGEOM*
-SFCGAL2LWGEOM(const sfcgal_geometry_t* geom, int force3D, int SRID);
+SFCGAL2LWGEOM(const sfcgal_geometry_t* geom, int force3D, int32_t SRID);
 
 /* Convert lwgeom PostGIS to SFCGAL structure */
 sfcgal_geometry_t*

--- a/liblwgeom/lwin_encoded_polyline.c
+++ b/liblwgeom/lwin_encoded_polyline.c
@@ -29,51 +29,56 @@
 #include "../postgis_config.h"
 
 LWGEOM*
-lwgeom_from_encoded_polyline(const char *encodedpolyline, int precision)
+lwgeom_from_encoded_polyline(const char *encodedpolyline, int32_t precision)
 {
-  LWGEOM *geom = NULL;
-  POINTARRAY *pa = NULL;
-  int length = strlen(encodedpolyline);
-  int idx = 0;
+	LWGEOM *geom = NULL;
+	POINTARRAY *pa = NULL;
+	size_t length = strlen(encodedpolyline);
+	size_t idx = 0;
 	double scale = pow(10,precision);
 
-  float latitude = 0.0f;
-  float longitude = 0.0f;
+	double latitude = 0.0;
+	double longitude = 0.0;
 
-  pa = ptarray_construct_empty(LW_FALSE, LW_FALSE, 1);
+	pa = ptarray_construct_empty(LW_FALSE, LW_FALSE, 1);
 
-  while (idx < length) {
-    POINT4D pt;
-    char byte = 0;
+	while (idx < length)
+	{
+		POINT4D pt;
+		char byte = 0;
 
-    int res = 0;
-    char shift = 0;
-    do {
-      byte = encodedpolyline[idx++] - 63;
-      res |= (byte & 0x1F) << shift;
-      shift += 5;
-    } while (byte >= 0x20);
-    float deltaLat = ((res & 1) ? ~(res >> 1) : (res >> 1));
-    latitude += deltaLat;
+		int res = 0;
+		int shift = 0;
+		do
+		{
+			byte = (char) (encodedpolyline[idx++] - 63);
+			res |= (byte & 0x1F) << shift;
+			shift += 5;
+		} while (byte >= 0x20);
 
-    shift = 0;
-    res = 0;
-    do {
-      byte = encodedpolyline[idx++] - 63;
-      res |= (byte & 0x1F) << shift;
-      shift += 5;
-    } while (byte >= 0x20);
-    float deltaLon = ((res & 1) ? ~(res >> 1) : (res >> 1));
-    longitude += deltaLon;
+		double deltaLat = ((res & 1) ? ~(res >> 1) : (res >> 1));
+		latitude += deltaLat;
 
-    pt.x = longitude/scale;
-    pt.y = latitude/scale;
-	pt.m = pt.z = 0.0;
-    ptarray_append_point(pa, &pt, LW_FALSE);
-  }
+		shift = 0;
+		res = 0;
+		do
+		{
+			byte = (char) (encodedpolyline[idx++] - 63);
+			res |= (byte & 0x1F) << shift;
+			shift += 5;
+		} while (byte >= 0x20);
 
-  geom = (LWGEOM *)lwline_construct(4326, NULL, pa);
-  lwgeom_add_bbox(geom);
+		double deltaLon = ((res & 1) ? ~(res >> 1) : (res >> 1));
+		longitude += deltaLon;
 
-  return geom;
+		pt.x = longitude/scale;
+		pt.y = latitude/scale;
+		pt.m = pt.z = 0.0;
+		ptarray_append_point(pa, &pt, LW_FALSE);
+	}
+
+	geom = (LWGEOM *)lwline_construct(4326, NULL, pa);
+	lwgeom_add_bbox(geom);
+
+	return geom;
 }

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -110,7 +110,7 @@ parse_geojson_coord(json_object *poObj, int *hasz, POINTARRAY *pa)
 	{
 
 		json_object* poObjCoord = NULL;
-		const int nSize = json_object_array_length( poObj );
+		const size_t nSize = json_object_array_length( poObj );
 		LWDEBUGF(3, "parse_geojson_coord called for array size %d.", nSize );
 
 		if ( nSize < 2 )
@@ -192,7 +192,7 @@ parse_geojson_linestring(json_object *geojson, int *hasz, int root_srid)
 	LWGEOM *geom;
 	POINTARRAY *pa;
 	json_object* points = NULL;
-	int i = 0;
+	size_t i = 0;
 
 	LWDEBUG(2, "parse_geojson_linestring called.");
 
@@ -207,7 +207,7 @@ parse_geojson_linestring(json_object *geojson, int *hasz, int root_srid)
 
 	if( json_type_array == json_object_get_type( points ) )
 	{
-		const int nPoints = json_object_array_length( points );
+		const size_t nPoints = json_object_array_length( points );
 		for(i = 0; i < nPoints; ++i)
 		{
 			json_object* coords = NULL;
@@ -228,8 +228,8 @@ parse_geojson_polygon(json_object *geojson, int *hasz, int root_srid)
 	POINTARRAY **ppa = NULL;
 	json_object* rings = NULL;
 	json_object* points = NULL;
-	int i = 0, j = 0;
-	int nRings = 0, nPoints = 0;
+	size_t i = 0, j = 0;
+	size_t nRings = 0, nPoints = 0;
 
 	rings = findMemberByName( geojson, "coordinates" );
 	if ( ! rings )
@@ -281,14 +281,13 @@ parse_geojson_polygon(json_object *geojson, int *hasz, int root_srid)
 	if ( ! ppa )
 		return (LWGEOM *)lwpoly_construct_empty(root_srid, 0, 0);
 
-	return (LWGEOM *) lwpoly_construct(root_srid, NULL, nRings, ppa);
+	return (LWGEOM *) lwpoly_construct(root_srid, NULL, (uint32_t) nRings, ppa);
 }
 
 static LWGEOM*
 parse_geojson_multipoint(json_object *geojson, int *hasz, int root_srid)
 {
 	LWGEOM *geom;
-	int i = 0;
 	json_object* poObjPoints = NULL;
 
 	if (!root_srid)
@@ -309,7 +308,8 @@ parse_geojson_multipoint(json_object *geojson, int *hasz, int root_srid)
 
 	if( json_type_array == json_object_get_type( poObjPoints ) )
 	{
-		const int nPoints = json_object_array_length( poObjPoints );
+		const size_t nPoints = json_object_array_length( poObjPoints );
+		size_t i;
 		for( i = 0; i < nPoints; ++i)
 		{
 			POINTARRAY *pa;
@@ -331,7 +331,6 @@ static LWGEOM*
 parse_geojson_multilinestring(json_object *geojson, int *hasz, int root_srid)
 {
 	LWGEOM *geom = NULL;
-	int i, j;
 	json_object* poObjLines = NULL;
 
 	if (!root_srid)
@@ -352,7 +351,8 @@ parse_geojson_multilinestring(json_object *geojson, int *hasz, int root_srid)
 
 	if( json_type_array == json_object_get_type( poObjLines ) )
 	{
-		const int nLines = json_object_array_length( poObjLines );
+		const size_t nLines = json_object_array_length( poObjLines );
+		size_t i, j;
 		for( i = 0; i < nLines; ++i)
 		{
 			POINTARRAY *pa = NULL;
@@ -362,7 +362,7 @@ parse_geojson_multilinestring(json_object *geojson, int *hasz, int root_srid)
 
 			if( json_type_array == json_object_get_type( poObjLine ) )
 			{
-				const int nPoints = json_object_array_length( poObjLine );
+				const size_t nPoints = json_object_array_length( poObjLine );
 				for(j = 0; j < nPoints; ++j)
 				{
 					json_object* coords = NULL;
@@ -383,7 +383,6 @@ static LWGEOM*
 parse_geojson_multipolygon(json_object *geojson, int *hasz, int root_srid)
 {
 	LWGEOM *geom = NULL;
-	int i, j, k;
 	json_object* poObjPolys = NULL;
 
 	if (!root_srid)
@@ -404,8 +403,8 @@ parse_geojson_multipolygon(json_object *geojson, int *hasz, int root_srid)
 
 	if( json_type_array == json_object_get_type( poObjPolys ) )
 	{
-		const int nPolys = json_object_array_length( poObjPolys );
-
+		const size_t nPolys = json_object_array_length( poObjPolys );
+		size_t i, j, k;
 		for(i = 0; i < nPolys; ++i)
 		{
 			json_object* poObjPoly = json_object_array_get_idx( poObjPolys, i );
@@ -413,7 +412,7 @@ parse_geojson_multipolygon(json_object *geojson, int *hasz, int root_srid)
 			if( json_type_array == json_object_get_type( poObjPoly ) )
 			{
 				LWPOLY *lwpoly = lwpoly_construct_empty(geom->srid, lwgeom_has_z(geom), lwgeom_has_m(geom));
-				int nRings = json_object_array_length( poObjPoly );
+				size_t nRings = json_object_array_length( poObjPoly );
 
 				for(j = 0; j < nRings; ++j)
 				{
@@ -424,7 +423,7 @@ parse_geojson_multipolygon(json_object *geojson, int *hasz, int root_srid)
 
 						POINTARRAY *pa = ptarray_construct_empty(1, 0, 1);
 
-						int nPoints = json_object_array_length( points );
+						size_t nPoints = json_object_array_length( points );
 						for ( k=0; k < nPoints; k++ )
 						{
 							json_object* coords = json_object_array_get_idx( points, k );
@@ -446,7 +445,6 @@ static LWGEOM*
 parse_geojson_geometrycollection(json_object *geojson, int *hasz, int root_srid)
 {
 	LWGEOM *geom = NULL;
-	int i;
 	json_object* poObjGeoms = NULL;
 
 	if (!root_srid)
@@ -467,8 +465,9 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz, int root_srid)
 
 	if( json_type_array == json_object_get_type( poObjGeoms ) )
 	{
-		const int nGeoms = json_object_array_length( poObjGeoms );
+		const size_t nGeoms = json_object_array_length( poObjGeoms );
 		json_object* poObjGeom = NULL;
+		size_t i;
 		for(i = 0; i < nGeoms; ++i )
 		{
 			poObjGeom = json_object_array_get_idx( poObjGeoms, i );

--- a/liblwgeom/lwin_wkt.c
+++ b/liblwgeom/lwin_wkt.c
@@ -58,16 +58,16 @@ const char *parser_error_messages[] =
 /**
 * Read the SRID number from an SRID=<> string
 */
-int wkt_lexer_read_srid(char *str)
+int32_t wkt_lexer_read_srid(char *str)
 {
 	char *c = str;
 	long i = 0;
-	int srid;
+	int32_t srid;
 
 	if( ! str ) return SRID_UNKNOWN;
 	c += 5; /* Advance past "SRID=" */
 	i = strtol(c, NULL, 10);
-	srid = clamp_srid((int)i);
+	srid = clamp_srid(i);
 	/* TODO: warn on explicit UNKNOWN srid ? */
 	return srid;
 }
@@ -699,7 +699,7 @@ LWGEOM* wkt_parser_collection_new(LWGEOM *geom)
 {
 	LWCOLLECTION *col;
 	LWGEOM **geoms;
-	static int ngeoms = 1;
+	static uint32_t ngeoms = 1;
 	LWDEBUG(4,"entered");
 
 	/* Toss error on null geometry input */
@@ -725,7 +725,7 @@ LWGEOM* wkt_parser_compound_new(LWGEOM *geom)
 {
 	LWCOLLECTION *col;
 	LWGEOM **geoms;
-	static int ngeoms = 1;
+	static uint32_t ngeoms = 1;
 	LWDEBUG(4,"entered");
 
 	/* Toss error on null geometry input */
@@ -802,7 +802,7 @@ LWGEOM* wkt_parser_collection_add_geom(LWGEOM *col, LWGEOM *geom)
 	return lwcollection_as_lwgeom(lwcollection_add_lwgeom(lwgeom_as_lwcollection(col), geom));
 }
 
-LWGEOM* wkt_parser_collection_finalize(int lwtype, LWGEOM *geom, char *dimensionality)
+LWGEOM* wkt_parser_collection_finalize(uint8_t lwtype, LWGEOM *geom, char *dimensionality)
 {
 	uint8_t flags = wkt_dimensionality(dimensionality);
 	int flagdims = FLAGS_NDIMS(flags);
@@ -856,7 +856,7 @@ LWGEOM* wkt_parser_collection_finalize(int lwtype, LWGEOM *geom, char *dimension
 	return geom;
 }
 
-void wkt_parser_geometry_new(LWGEOM *geom, int srid)
+void wkt_parser_geometry_new(LWGEOM *geom, int32_t srid)
 {
 	LWDEBUG(4,"entered");
 	LWDEBUGF(4,"geom %p",geom);

--- a/liblwgeom/lwin_wkt.h
+++ b/liblwgeom/lwin_wkt.h
@@ -76,6 +76,6 @@ LWGEOM* wkt_parser_compound_new(LWGEOM *element);
 LWGEOM* wkt_parser_compound_add_geom(LWGEOM *col, LWGEOM *geom);
 LWGEOM* wkt_parser_collection_new(LWGEOM *geom);
 LWGEOM* wkt_parser_collection_add_geom(LWGEOM *col, LWGEOM *geom);
-LWGEOM* wkt_parser_collection_finalize(int lwtype, LWGEOM *col, char *dimensionality);
-void    wkt_parser_geometry_new(LWGEOM *geom, int srid);
+LWGEOM* wkt_parser_collection_finalize(uint8_t lwtype, LWGEOM *col, char *dimensionality);
+void    wkt_parser_geometry_new(LWGEOM *geom, int32_t srid);
 

--- a/liblwgeom/lwin_wkt_parse.c
+++ b/liblwgeom/lwin_wkt_parse.c
@@ -1,27 +1,4 @@
-/**********************************************************************
- *
- * PostGIS - Spatial Types for PostgreSQL
- * http://postgis.net
- *
- * PostGIS is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * PostGIS is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
- *
- **********************************************************************
- *
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
- *
- **********************************************************************/
-
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -118,16 +95,16 @@ LWGEOM_PARSER_RESULT global_parser_result;
 /* Turn on/off verbose parsing (turn off for production) */
 int wkt_yydebug = 0;
 
-/*
-* Error handler called by the bison parser. Mostly we will be
+/* 
+* Error handler called by the bison parser. Mostly we will be 
 * catching our own errors and filling out the message and errlocation
-* from WKT_ERROR in the grammar, but we keep this one
+* from WKT_ERROR in the grammar, but we keep this one 
 * around just in case.
 */
 void wkt_yyerror(__attribute__((__unused__)) const char *str)
 {
 	/* If we haven't already set a message and location, let's set one now. */
-	if ( ! global_parser_result.message )
+	if ( ! global_parser_result.message ) 
 	{
 		global_parser_result.message = parser_error_messages[PARSER_ERROR_OTHER];
 		global_parser_result.errcode = PARSER_ERROR_OTHER;
@@ -160,14 +137,14 @@ int lwgeom_parse_wkt(LWGEOM_PARSER_RESULT *parser_result, char *wktstr, int pars
 	/* Set the input text string, and parse checks. */
 	global_parser_result.wkinput = wktstr;
 	global_parser_result.parser_check_flags = parser_check_flags;
-
+		
 	wkt_lexer_init(wktstr); /* Lexer ready */
 	parse_rv = wkt_yyparse(); /* Run the parse */
 	LWDEBUGF(4,"wkt_yyparse returned %d", parse_rv);
 	wkt_lexer_close(); /* Clean up lexer */
-
+	
 	/* A non-zero parser return is an error. */
-	if ( parse_rv != 0 )
+	if ( parse_rv != 0 ) 
 	{
 		if( ! global_parser_result.errcode )
 		{
@@ -176,17 +153,17 @@ int lwgeom_parse_wkt(LWGEOM_PARSER_RESULT *parser_result, char *wktstr, int pars
 			global_parser_result.errlocation = wkt_yylloc.last_column;
 		}
 
-		LWDEBUGF(5, "error returned by wkt_yyparse() @ %d: [%d] '%s'",
-		            global_parser_result.errlocation,
-		            global_parser_result.errcode,
+		LWDEBUGF(5, "error returned by wkt_yyparse() @ %d: [%d] '%s'", 
+		            global_parser_result.errlocation, 
+		            global_parser_result.errcode, 
 		            global_parser_result.message);
-
+		
 		/* Copy the global values into the return pointer */
 		*parser_result = global_parser_result;
                 wkt_yylex_destroy();
 		return LW_FAILURE;
 	}
-
+	
 	/* Copy the global value into the return pointer */
 	*parser_result = global_parser_result;
         wkt_yylex_destroy();
@@ -287,7 +264,7 @@ extern int wkt_yydebug;
 
 union YYSTYPE
 {
-#line 108 "lwin_wkt_parse.y" /* yacc.c:355  */
+#line 107 "lwin_wkt_parse.y" /* yacc.c:355  */
 
 	int integervalue;
 	double doublevalue;
@@ -629,20 +606,20 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   212,   212,   214,   218,   219,   220,   221,   222,   223,
-     224,   225,   226,   227,   228,   229,   230,   231,   232,   235,
-     237,   239,   241,   245,   247,   251,   253,   255,   257,   261,
-     263,   265,   267,   269,   271,   275,   277,   279,   281,   285,
-     287,   289,   291,   295,   297,   299,   301,   305,   307,   311,
-     313,   317,   319,   321,   323,   327,   329,   333,   336,   338,
-     340,   342,   346,   348,   352,   353,   354,   355,   358,   360,
-     364,   366,   370,   373,   376,   378,   380,   382,   386,   388,
-     390,   392,   394,   396,   400,   402,   404,   406,   410,   412,
-     414,   416,   418,   420,   422,   424,   428,   430,   432,   434,
-     438,   440,   444,   446,   448,   450,   454,   456,   458,   460,
-     464,   466,   470,   472,   476,   478,   480,   482,   486,   490,
-     492,   494,   496,   500,   502,   506,   508,   510,   514,   516,
-     518,   520,   524,   526,   530,   532,   534
+       0,   211,   211,   213,   217,   218,   219,   220,   221,   222,
+     223,   224,   225,   226,   227,   228,   229,   230,   231,   234,
+     236,   238,   240,   244,   246,   250,   252,   254,   256,   260,
+     262,   264,   266,   268,   270,   274,   276,   278,   280,   284,
+     286,   288,   290,   294,   296,   298,   300,   304,   306,   310,
+     312,   316,   318,   320,   322,   326,   328,   332,   335,   337,
+     339,   341,   345,   347,   351,   352,   353,   354,   357,   359,
+     363,   365,   369,   372,   375,   377,   379,   381,   385,   387,
+     389,   391,   393,   395,   399,   401,   403,   405,   409,   411,
+     413,   415,   417,   419,   421,   423,   427,   429,   431,   433,
+     437,   439,   443,   445,   447,   449,   453,   455,   457,   459,
+     463,   465,   469,   471,   475,   477,   479,   481,   485,   489,
+     491,   493,   495,   499,   501,   505,   507,   509,   513,   515,
+     517,   519,   523,   525,   529,   531,   533
 };
 #endif
 
@@ -1408,217 +1385,217 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 28: /* geometry_no_srid  */
-#line 190 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 189 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1391 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 29: /* geometrycollection  */
-#line 191 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 190 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1397 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 31: /* multisurface  */
-#line 198 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 197 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1403 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 32: /* surface_list  */
-#line 177 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 176 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1409 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 33: /* tin  */
-#line 205 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 204 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1415 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 34: /* polyhedralsurface  */
-#line 204 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 203 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1421 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 35: /* multipolygon  */
-#line 197 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 196 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1427 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 36: /* polygon_list  */
-#line 178 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 177 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1433 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 37: /* patch_list  */
-#line 179 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 178 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1439 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 38: /* polygon  */
-#line 201 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 200 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1445 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 39: /* polygon_untagged  */
-#line 203 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 202 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1451 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 40: /* patch  */
-#line 202 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 201 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1457 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 41: /* curvepolygon  */
-#line 188 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 187 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1463 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 42: /* curvering_list  */
-#line 175 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 174 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1469 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 43: /* curvering  */
-#line 189 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 188 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1475 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 44: /* patchring_list  */
-#line 185 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 184 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1481 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 45: /* ring_list  */
-#line 184 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 183 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1487 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 46: /* patchring  */
-#line 174 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 173 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { ptarray_free(((*yyvaluep).ptarrayvalue)); }
 #line 1493 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 47: /* ring  */
-#line 173 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 172 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { ptarray_free(((*yyvaluep).ptarrayvalue)); }
 #line 1499 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 48: /* compoundcurve  */
-#line 187 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 186 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1505 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 49: /* compound_list  */
-#line 183 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 182 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1511 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 50: /* multicurve  */
-#line 194 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 193 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1517 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 51: /* curve_list  */
-#line 182 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 181 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1523 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 52: /* multilinestring  */
-#line 195 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 194 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1529 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 53: /* linestring_list  */
-#line 181 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 180 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1535 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 54: /* circularstring  */
-#line 186 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 185 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1541 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 55: /* linestring  */
-#line 192 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 191 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1547 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 56: /* linestring_untagged  */
-#line 193 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 192 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1553 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 57: /* triangle_list  */
-#line 176 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 175 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1559 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 58: /* triangle  */
-#line 206 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 205 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1565 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 59: /* triangle_untagged  */
-#line 207 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 206 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1571 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 60: /* multipoint  */
-#line 196 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 195 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1577 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 61: /* point_list  */
-#line 180 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 179 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1583 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 62: /* point_untagged  */
-#line 200 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 199 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1589 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 63: /* point  */
-#line 199 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 198 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { lwgeom_free(((*yyvaluep).geometryvalue)); }
 #line 1595 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
 
     case 64: /* ptarray  */
-#line 172 "lwin_wkt_parse.y" /* yacc.c:1257  */
+#line 171 "lwin_wkt_parse.y" /* yacc.c:1257  */
       { ptarray_free(((*yyvaluep).ptarrayvalue)); }
 #line 1601 "lwin_wkt_parse.c" /* yacc.c:1257  */
         break;
@@ -1906,811 +1883,811 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 213 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 212 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { wkt_parser_geometry_new((yyvsp[0].geometryvalue), SRID_UNKNOWN); WKT_ERROR(); }
 #line 1889 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 215 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 214 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { wkt_parser_geometry_new((yyvsp[0].geometryvalue), (yyvsp[-2].integervalue)); WKT_ERROR(); }
 #line 1895 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 218 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 217 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1901 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 219 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 218 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1907 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 220 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 219 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1913 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 221 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 220 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1919 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 222 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 221 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1925 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 223 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 222 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1931 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 224 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 223 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1937 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 225 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 224 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1943 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 226 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 225 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1949 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 227 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 226 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1955 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 228 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 227 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1961 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 229 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 228 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1967 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 230 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 229 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1973 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 231 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 230 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1979 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 232 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 231 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 1985 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 236 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 235 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COLLECTIONTYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 1991 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 238 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 237 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COLLECTIONTYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 1997 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 240 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 239 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COLLECTIONTYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2003 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 242 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 241 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COLLECTIONTYPE, NULL, NULL); WKT_ERROR(); }
 #line 2009 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 246 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 245 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2015 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 248 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 247 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2021 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 252 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 251 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTISURFACETYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2027 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 254 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 253 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTISURFACETYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2033 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 256 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 255 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTISURFACETYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2039 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 258 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 257 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTISURFACETYPE, NULL, NULL); WKT_ERROR(); }
 #line 2045 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 262 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 261 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2051 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 264 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 263 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2057 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 266 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 265 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2063 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 268 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 267 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2069 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 270 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 269 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2075 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 272 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 271 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2081 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 276 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 275 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(TINTYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2087 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 278 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 277 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(TINTYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2093 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 280 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 279 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(TINTYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2099 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 282 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 281 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(TINTYPE, NULL, NULL); WKT_ERROR(); }
 #line 2105 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 286 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 285 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(POLYHEDRALSURFACETYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2111 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 288 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 287 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(POLYHEDRALSURFACETYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2117 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 290 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 289 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(POLYHEDRALSURFACETYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2123 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 292 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 291 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(POLYHEDRALSURFACETYPE, NULL, NULL); WKT_ERROR(); }
 #line 2129 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 296 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 295 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOLYGONTYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2135 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 298 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 297 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOLYGONTYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2141 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 300 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 299 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOLYGONTYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2147 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 302 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 301 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOLYGONTYPE, NULL, NULL); WKT_ERROR(); }
 #line 2153 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 306 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 305 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2159 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 308 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 307 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2165 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 312 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 311 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2171 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 314 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 313 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2177 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 318 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 317 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_finalize((yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2183 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 320 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 319 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_finalize((yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2189 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 322 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 321 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_finalize(NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2195 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 324 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 323 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_finalize(NULL, NULL); WKT_ERROR(); }
 #line 2201 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 328 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 327 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[-1].geometryvalue); }
 #line 2207 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 330 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 329 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_finalize(NULL, NULL); WKT_ERROR(); }
 #line 2213 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 333 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 332 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[-1].geometryvalue); }
 #line 2219 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 337 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 336 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_curvepolygon_finalize((yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2225 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 339 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 338 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_curvepolygon_finalize((yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2231 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 341 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 340 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_curvepolygon_finalize(NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2237 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 343 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 342 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_curvepolygon_finalize(NULL, NULL); WKT_ERROR(); }
 #line 2243 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 347 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 346 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_curvepolygon_add_ring((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2249 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 349 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 348 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_curvepolygon_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2255 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 352 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 351 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 2261 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 353 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 352 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 2267 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 354 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 353 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 2273 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 355 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 354 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = (yyvsp[0].geometryvalue); }
 #line 2279 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 359 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 358 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_add_ring((yyvsp[-2].geometryvalue),(yyvsp[0].ptarrayvalue),'Z'); WKT_ERROR(); }
 #line 2285 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 361 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 360 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_new((yyvsp[0].ptarrayvalue),'Z'); WKT_ERROR(); }
 #line 2291 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 365 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 364 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_add_ring((yyvsp[-2].geometryvalue),(yyvsp[0].ptarrayvalue),'2'); WKT_ERROR(); }
 #line 2297 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 367 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 366 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_polygon_new((yyvsp[0].ptarrayvalue),'2'); WKT_ERROR(); }
 #line 2303 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 370 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 369 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.ptarrayvalue) = (yyvsp[-1].ptarrayvalue); }
 #line 2309 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 373 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 372 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.ptarrayvalue) = (yyvsp[-1].ptarrayvalue); }
 #line 2315 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 377 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 376 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COMPOUNDTYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2321 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 379 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 378 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COMPOUNDTYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2327 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 381 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 380 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COMPOUNDTYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2333 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 383 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 382 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(COMPOUNDTYPE, NULL, NULL); WKT_ERROR(); }
 #line 2339 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 387 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 386 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_compound_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2345 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 389 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 388 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_compound_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2351 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 391 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 390 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_compound_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2357 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 393 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 392 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_compound_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2363 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 395 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 394 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_compound_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2369 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 397 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 396 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_compound_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2375 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 401 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 400 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTICURVETYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2381 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 403 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 402 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTICURVETYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2387 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 405 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 404 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTICURVETYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2393 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 407 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 406 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTICURVETYPE, NULL, NULL); WKT_ERROR(); }
 #line 2399 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 411 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 410 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2405 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 413 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 412 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2411 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 415 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 414 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2417 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 417 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 416 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2423 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 419 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 418 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2429 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 421 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 420 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2435 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 423 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 422 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2441 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 425 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 424 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2447 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 429 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 428 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTILINETYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2453 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 431 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 430 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTILINETYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2459 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 433 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 432 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTILINETYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2465 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 435 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 434 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTILINETYPE, NULL, NULL); WKT_ERROR(); }
 #line 2471 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 439 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 438 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2477 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 441 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 440 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2483 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 445 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 444 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_circularstring_new((yyvsp[-1].ptarrayvalue), NULL); WKT_ERROR(); }
 #line 2489 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 447 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 446 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_circularstring_new((yyvsp[-1].ptarrayvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2495 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 449 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 448 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_circularstring_new(NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2501 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 451 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 450 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_circularstring_new(NULL, NULL); WKT_ERROR(); }
 #line 2507 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 455 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 454 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_linestring_new((yyvsp[-1].ptarrayvalue), NULL); WKT_ERROR(); }
 #line 2513 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 457 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 456 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_linestring_new((yyvsp[-1].ptarrayvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2519 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 459 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 458 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_linestring_new(NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2525 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 461 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 460 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_linestring_new(NULL, NULL); WKT_ERROR(); }
 #line 2531 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 465 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 464 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_linestring_new((yyvsp[-1].ptarrayvalue), NULL); WKT_ERROR(); }
 #line 2537 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 467 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 466 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_linestring_new(NULL, NULL); WKT_ERROR(); }
 #line 2543 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 471 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 470 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2549 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 473 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 472 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2555 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 477 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 476 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_triangle_new((yyvsp[-2].ptarrayvalue), NULL); WKT_ERROR(); }
 #line 2561 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 479 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 478 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_triangle_new((yyvsp[-2].ptarrayvalue), (yyvsp[-5].stringvalue)); WKT_ERROR(); }
 #line 2567 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 481 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 480 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_triangle_new(NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2573 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 483 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 482 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_triangle_new(NULL, NULL); WKT_ERROR(); }
 #line 2579 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 487 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 486 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_triangle_new((yyvsp[-2].ptarrayvalue), NULL); WKT_ERROR(); }
 #line 2585 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 491 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 490 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOINTTYPE, (yyvsp[-1].geometryvalue), NULL); WKT_ERROR(); }
 #line 2591 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 493 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 492 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOINTTYPE, (yyvsp[-1].geometryvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2597 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 495 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 494 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOINTTYPE, NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2603 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 497 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 496 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_finalize(MULTIPOINTTYPE, NULL, NULL); WKT_ERROR(); }
 #line 2609 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 501 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 500 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_add_geom((yyvsp[-2].geometryvalue),(yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2615 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 503 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 502 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_collection_new((yyvsp[0].geometryvalue)); WKT_ERROR(); }
 #line 2621 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 507 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 506 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_point_new(wkt_parser_ptarray_new((yyvsp[0].coordinatevalue)),NULL); WKT_ERROR(); }
 #line 2627 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 126:
-#line 509 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 508 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_point_new(wkt_parser_ptarray_new((yyvsp[-1].coordinatevalue)),NULL); WKT_ERROR(); }
 #line 2633 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 127:
-#line 511 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 510 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_point_new(NULL, NULL); WKT_ERROR(); }
 #line 2639 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 515 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 514 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_point_new((yyvsp[-1].ptarrayvalue), NULL); WKT_ERROR(); }
 #line 2645 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 129:
-#line 517 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 516 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_point_new((yyvsp[-1].ptarrayvalue), (yyvsp[-3].stringvalue)); WKT_ERROR(); }
 #line 2651 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 130:
-#line 519 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 518 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_point_new(NULL, (yyvsp[-1].stringvalue)); WKT_ERROR(); }
 #line 2657 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 131:
-#line 521 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 520 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.geometryvalue) = wkt_parser_point_new(NULL,NULL); WKT_ERROR(); }
 #line 2663 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 525 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 524 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.ptarrayvalue) = wkt_parser_ptarray_add_coord((yyvsp[-2].ptarrayvalue), (yyvsp[0].coordinatevalue)); WKT_ERROR(); }
 #line 2669 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 527 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 526 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.ptarrayvalue) = wkt_parser_ptarray_new((yyvsp[0].coordinatevalue)); WKT_ERROR(); }
 #line 2675 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 531 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 530 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.coordinatevalue) = wkt_parser_coord_2((yyvsp[-1].doublevalue), (yyvsp[0].doublevalue)); WKT_ERROR(); }
 #line 2681 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 135:
-#line 533 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 532 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.coordinatevalue) = wkt_parser_coord_3((yyvsp[-2].doublevalue), (yyvsp[-1].doublevalue), (yyvsp[0].doublevalue)); WKT_ERROR(); }
 #line 2687 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
 
   case 136:
-#line 535 "lwin_wkt_parse.y" /* yacc.c:1646  */
+#line 534 "lwin_wkt_parse.y" /* yacc.c:1646  */
     { (yyval.coordinatevalue) = wkt_parser_coord_4((yyvsp[-3].doublevalue), (yyvsp[-2].doublevalue), (yyvsp[-1].doublevalue), (yyvsp[0].doublevalue)); WKT_ERROR(); }
 #line 2693 "lwin_wkt_parse.c" /* yacc.c:1646  */
     break;
@@ -2951,6 +2928,6 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 537 "lwin_wkt_parse.y" /* yacc.c:1906  */
+#line 536 "lwin_wkt_parse.y" /* yacc.c:1906  */
 
 

--- a/liblwgeom/lwin_wkt_parse.h
+++ b/liblwgeom/lwin_wkt_parse.h
@@ -1,27 +1,4 @@
-/**********************************************************************
- *
- * PostGIS - Spatial Types for PostgreSQL
- * http://postgis.net
- *
- * PostGIS is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * PostGIS is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
- *
- **********************************************************************
- *
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
- *
- **********************************************************************/
-
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison interface for Yacc-like parsers in C
 
@@ -123,7 +100,7 @@ extern int wkt_yydebug;
 
 union YYSTYPE
 {
-#line 108 "lwin_wkt_parse.y" /* yacc.c:1909  */
+#line 107 "lwin_wkt_parse.y" /* yacc.c:1909  */
 
 	int integervalue;
 	double doublevalue;

--- a/liblwgeom/lwiterator.c
+++ b/liblwgeom/lwiterator.c
@@ -98,10 +98,10 @@ extract_pointarrays_from_lwgeom(LWGEOM* g)
 		LISTNODE* n = NULL;
 
 		LWPOLY* p = lwgeom_as_lwpoly(g);
-		int i;
-		for (i = p->nrings - 1; i >= 0; i--)
+		uint32_t i;
+		for (i = 0; i < p->nrings; i++)
 		{
-			n = prepend_node(p->rings[i], n);
+			n = prepend_node(p->rings[p->nrings - i - 1], n);
 		}
 
 		return n;
@@ -119,7 +119,7 @@ extract_pointarrays_from_lwgeom(LWGEOM* g)
 static void
 unroll_collection(LWPOINTITERATOR* s)
 {
-	int i;
+	uint32_t i;
 	LWCOLLECTION* c;
 
 	if (!s->geoms)
@@ -130,9 +130,9 @@ unroll_collection(LWPOINTITERATOR* s)
 	c = (LWCOLLECTION*) s->geoms->item;
 	s->geoms = pop_node(s->geoms);
 
-	for (i = c->ngeoms - 1; i >= 0; i--)
+	for (i = 0; i < c->ngeoms; i++)
 	{
-		LWGEOM* g = lwcollection_getsubgeom(c, i);
+		LWGEOM* g = lwcollection_getsubgeom(c, c->ngeoms - i -1);
 
 		add_lwgeom_to_stack(s, g);
 	}

--- a/liblwgeom/lwline.c
+++ b/liblwgeom/lwline.c
@@ -39,7 +39,7 @@
  * use SRID=SRID_UNKNOWN for unknown SRID (will have 8bit type's S = 0)
  */
 LWLINE *
-lwline_construct(int srid, GBOX *bbox, POINTARRAY *points)
+lwline_construct(int32_t srid, GBOX *bbox, POINTARRAY *points)
 {
 	LWLINE *result;
 	result = (LWLINE*) lwalloc(sizeof(LWLINE));
@@ -61,7 +61,7 @@ lwline_construct(int srid, GBOX *bbox, POINTARRAY *points)
 }
 
 LWLINE *
-lwline_construct_empty(int srid, char hasz, char hasm)
+lwline_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWLINE *result = lwalloc(sizeof(LWLINE));
 	result->type = LINETYPE;
@@ -157,7 +157,7 @@ lwline_same(const LWLINE *l1, const LWLINE *l2)
  * LWLINE dimensions are large enough to host all input dimensions.
  */
 LWLINE *
-lwline_from_lwgeom_array(int srid, uint32_t ngeoms, LWGEOM **geoms)
+lwline_from_lwgeom_array(int32_t srid, uint32_t ngeoms, LWGEOM **geoms)
 {
 	uint32_t i;
 	int hasz = LW_FALSE;
@@ -234,7 +234,7 @@ lwline_from_lwgeom_array(int srid, uint32_t ngeoms, LWGEOM **geoms)
  * LWLINE dimensions are large enough to host all input dimensions.
  */
 LWLINE *
-lwline_from_ptarray(int srid, uint32_t npoints, LWPOINT **points)
+lwline_from_ptarray(int32_t srid, uint32_t npoints, LWPOINT **points)
 {
  	uint32_t i;
 	int hasz = LW_FALSE;
@@ -281,15 +281,15 @@ lwline_from_ptarray(int srid, uint32_t npoints, LWPOINT **points)
  * Construct a LWLINE from a LWMPOINT
  */
 LWLINE *
-lwline_from_lwmpoint(int srid, const LWMPOINT *mpoint)
+lwline_from_lwmpoint(int32_t srid, const LWMPOINT *mpoint)
 {
 	uint32_t i;
 	POINTARRAY *pa = NULL;
 	LWGEOM *lwgeom = (LWGEOM*)mpoint;
 	POINT4D pt;
 
-	char hasz = lwgeom_has_z(lwgeom);
-	char hasm = lwgeom_has_m(lwgeom);
+	int hasz = lwgeom_has_z(lwgeom);
+	int hasm = lwgeom_has_m(lwgeom);
 	uint32_t npoints = mpoint->ngeoms;
 
 	if ( lwgeom_is_empty(lwgeom) )
@@ -387,9 +387,9 @@ lwline_setPoint4d(LWLINE *line, uint32_t index, POINT4D *newpoint)
 LWLINE*
 lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end)
 {
-	int i = 0;
+	uint32_t i = 0;
 	int hasm = 0, hasz = 0;
-	int npoints = 0;
+	uint32_t npoints = 0;
 	double length = 0.0;
 	double length_so_far = 0.0;
 	double m_range = m_end - m_start;
@@ -463,7 +463,7 @@ int
 lwline_is_trajectory(const LWLINE *line)
 {
   POINT3DM p;
-  int i, n;
+  uint32_t i, n;
   double m = -1 * FLT_MAX;
 
   if ( ! FLAGS_GET_M(line->flags) ) {

--- a/liblwgeom/lwmline.c
+++ b/liblwgeom/lwmline.c
@@ -35,7 +35,7 @@ lwmline_release(LWMLINE *lwmline)
 }
 
 LWMLINE *
-lwmline_construct_empty(int srid, char hasz, char hasm)
+lwmline_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWMLINE *ret = (LWMLINE*)lwcollection_construct_empty(MULTILINETYPE, srid, hasz, hasm);
 	return ret;

--- a/liblwgeom/lwmpoint.c
+++ b/liblwgeom/lwmpoint.c
@@ -36,7 +36,7 @@ lwmpoint_release(LWMPOINT *lwmpoint)
 }
 
 LWMPOINT *
-lwmpoint_construct_empty(int srid, char hasz, char hasm)
+lwmpoint_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWMPOINT *ret = (LWMPOINT*)lwcollection_construct_empty(MULTIPOINTTYPE, srid, hasz, hasm);
 	return ret;
@@ -49,7 +49,7 @@ LWMPOINT* lwmpoint_add_lwpoint(LWMPOINT *mobj, const LWPOINT *obj)
 }
 
 LWMPOINT *
-lwmpoint_construct(int srid, const POINTARRAY *pa)
+lwmpoint_construct(int32_t srid, const POINTARRAY *pa)
 {
 	uint32_t i;
 	int hasz = ptarray_has_z(pa);

--- a/liblwgeom/lwmpoly.c
+++ b/liblwgeom/lwmpoly.c
@@ -37,7 +37,7 @@ lwmpoly_release(LWMPOLY *lwmpoly)
 }
 
 LWMPOLY *
-lwmpoly_construct_empty(int srid, char hasz, char hasm)
+lwmpoly_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWMPOLY *ret = (LWMPOLY*)lwcollection_construct_empty(MULTIPOLYGONTYPE, srid, hasz, hasm);
 	return ret;

--- a/liblwgeom/lwout_twkb.c
+++ b/liblwgeom/lwout_twkb.c
@@ -24,6 +24,7 @@
 
 
 #include "lwout_twkb.h"
+#include <stddef.h>
 
 /*
 * GeometryType, and dimensions
@@ -105,13 +106,13 @@ static void write_bbox(TWKB_STATE *ts, int ndims)
 */
 static int ptarray_to_twkb_buf(const POINTARRAY *pa, TWKB_GLOBALS *globals, TWKB_STATE *ts, int register_npoints, uint32_t minpoints)
 {
-	uint32_t ndims = FLAGS_NDIMS(pa->flags);
+	uint32_t ndims = (uint32_t) FLAGS_NDIMS(pa->flags);
 	uint32_t i, j;
 	bytebuffer_t b;
 	bytebuffer_t *b_p;
 	int64_t nextdelta[MAX_N_DIMS];
-	int npoints = 0;
-	size_t npoints_offset = 0;
+	uint32_t npoints = 0;
+	ptrdiff_t npoints_offset = 0;
 
 	LWDEBUGF(2, "Entered %s", __func__);
 
@@ -156,7 +157,7 @@ static int ptarray_to_twkb_buf(const POINTARRAY *pa, TWKB_GLOBALS *globals, TWKB
 	for ( i = 0; i < pa->npoints; i++ )
 	{
 		double *dbl_ptr = (double*)getPoint_internal(pa, i);
-		int diff = 0;
+		long long int diff = 0;
 
 		/* Write this coordinate to the buffer as a varint */
 		for ( j = 0; j < ndims; j++ )
@@ -279,7 +280,7 @@ static int lwpoly_to_twkb_buf(const LWPOLY *poly, TWKB_GLOBALS *globals, TWKB_ST
 static int lwmulti_to_twkb_buf(const LWCOLLECTION *col, TWKB_GLOBALS *globals, TWKB_STATE *ts)
 {
 	uint32_t i;
-	int nempty = 0;
+	uint32_t nempty = 0;
 
 	LWDEBUGF(2, "Entered %s", __func__);
 	LWDEBUGF(4, "Number of geometries in multi is %d", col->ngeoms);
@@ -293,7 +294,7 @@ static int lwmulti_to_twkb_buf(const LWCOLLECTION *col, TWKB_GLOBALS *globals, T
 	}
 
 	/* Set the number of geometries */
-	bytebuffer_append_uvarint(ts->geom_buf, (uint64_t) (col->ngeoms - nempty));
+	bytebuffer_append_uvarint(ts->geom_buf, (col->ngeoms - nempty));
 
 	/* We've been handed an idlist, so write it in */
 	if ( ts->idlist )

--- a/liblwgeom/lwout_twkb.h
+++ b/liblwgeom/lwout_twkb.h
@@ -50,27 +50,27 @@
 * Header true/false flags
 */
 
-#define FIRST_BYTE_SET_BBOXES(flag, bool)   ((flag) = ((bool) ? (flag) | 0x01 : (flag) & (~0x01)))
-#define FIRST_BYTE_SET_SIZES(flag, bool)    ((flag) = ((bool) ? (flag) | 0x02 : (flag) & (~0x02)))
-#define FIRST_BYTE_SET_IDLIST(flag, bool)   ((flag) = ((bool) ? (flag) | 0x04 : (flag) & (~0x04)))
-#define FIRST_BYTE_SET_EXTENDED(flag, bool) ((flag) = ((bool) ? (flag) | 0x08 : (flag) & (~0x08)))
-#define FIRST_BYTE_SET_EMPTY(flag, bool)    ((flag) = ((bool) ? (flag) | 0x10 : (flag) & (~0x10)))
+#define FIRST_BYTE_SET_BBOXES(flag, bool)   ((flag) = ((bool) ? (flag) | 0x01 : (flag) & (uint8_t) (~0x01)))
+#define FIRST_BYTE_SET_SIZES(flag, bool)    ((flag) = ((bool) ? (flag) | 0x02 : (flag) & (uint8_t) (~0x02)))
+#define FIRST_BYTE_SET_IDLIST(flag, bool)   ((flag) = ((bool) ? (flag) | 0x04 : (flag) & (uint8_t) (~0x04)))
+#define FIRST_BYTE_SET_EXTENDED(flag, bool) ((flag) = ((bool) ? (flag) | 0x08 : (flag) & (uint8_t) (~0x08)))
+#define FIRST_BYTE_SET_EMPTY(flag, bool)    ((flag) = ((bool) ? (flag) | 0x10 : (flag) & (uint8_t) (~0x10)))
 
 
 /**
-* Macros for manipulating the 'type_precision' int. An int8_t used as follows:
+* Macros for manipulating the 'type_precision' int. An uint8_t used as follows:
 * Type 4 bits
 * Precision 4 bits
 */
 
-#define TYPE_PREC_SET_TYPE(flag, type) ((flag) = ((flag) & 0xF0) | (((type) & 0x0F)))
-#define TYPE_PREC_SET_PREC(flag, prec) ((flag) = ((flag) & 0x0F) | (((prec) & 0x0F) << 4))
+#define TYPE_PREC_SET_TYPE(flag, type) ((flag) = (uint8_t) (((flag) & (uint8_t) 0xF0) | (((type) & 0x0F))))
+#define TYPE_PREC_SET_PREC(flag, prec) ((flag) = (uint8_t) (((flag) & (uint8_t) 0x0F) | (((prec) & 0x0F) << 4)))
 
-#define HIGHER_DIM_SET_HASZ(flag, bool) ((flag) = ((bool) ? (flag) | 0x01 : (flag) & (~0x01)))
-#define HIGHER_DIM_SET_HASM(flag, bool) ((flag) = ((bool) ? (flag) | 0x02 : (flag) & (~0x02)))
+#define HIGHER_DIM_SET_HASZ(flag, bool) ((flag) = ((bool) ? (flag) | 0x01 : (flag) & (uint8_t) (~0x01)))
+#define HIGHER_DIM_SET_HASM(flag, bool) ((flag) = ((bool) ? (flag) | 0x02 : (flag) & (uint8_t) (~0x02)))
 
-#define HIGHER_DIM_SET_PRECZ(flag, prec) ((flag) = ((flag) & 0xE3) | (((prec) & 0x07) << 2))
-#define HIGHER_DIM_SET_PRECM(flag, prec) ((flag) = ((flag) & 0x1F) | (((prec) & 0x07) << 5))
+#define HIGHER_DIM_SET_PRECZ(flag, prec) ((flag) = (uint8_t) (((flag) & 0xE3) | (((prec) & 0x07) << 2)))
+#define HIGHER_DIM_SET_PRECM(flag, prec) ((flag) = (uint8_t) (((flag) & 0x1F) | (((prec) & 0x07) << 5)))
 
 typedef struct
 {
@@ -79,7 +79,7 @@ typedef struct
 	int8_t prec_xy;
 	int8_t prec_z;
 	int8_t prec_m;
-	float factor[4]; /*What factor to multiply the coordiinates with to get the requested precision*/
+	double factor[4]; /*What factor to multiply the coordinates with to get the requested precision*/
 } TWKB_GLOBALS;
 
 typedef struct

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -210,11 +210,11 @@ static uint8_t* integer_to_wkb_buf(const int ival, uint8_t *buf, uint8_t variant
 		for ( i = 0; i < WKB_INT_SIZE; i++ )
 		{
 			int j = (swap ? WKB_INT_SIZE - 1 - i : i);
-			uint8_t b = iptr[j];
+			uint8_t b = (uint8_t) iptr[j];
 			/* Top four bits to 0-F */
-			buf[2*i] = hexchr[b >> 4];
+			buf[2*i] = (uint8_t) hexchr[b >> 4];
 			/* Bottom four bits to 0-F */
-			buf[2*i+1] = hexchr[b & 0x0F];
+			buf[2*i+1] = (uint8_t) hexchr[b & 0x0F];
 		}
 		return buf + (2 * WKB_INT_SIZE);
 	}
@@ -225,7 +225,7 @@ static uint8_t* integer_to_wkb_buf(const int ival, uint8_t *buf, uint8_t variant
 		{
 			for ( i = 0; i < WKB_INT_SIZE; i++ )
 			{
-				buf[i] = iptr[WKB_INT_SIZE - 1 - i];
+				buf[i] = (uint8_t) iptr[WKB_INT_SIZE - 1 - i];
 			}
 		}
 		/* If machine arch and requested arch match, don't flip byte order */
@@ -257,11 +257,11 @@ static uint8_t* double_to_wkb_buf(const double d, uint8_t *buf, uint8_t variant)
 		for ( i = 0; i < WKB_DOUBLE_SIZE; i++ )
 		{
 			int j = (swap ? WKB_DOUBLE_SIZE - 1 - i : i);
-			uint8_t b = dptr[j];
+			uint8_t b = (uint8_t) dptr[j];
 			/* Top four bits to 0-F */
-			buf[2*i] = hexchr[b >> 4];
+			buf[2*i] = (uint8_t) hexchr[b >> 4];
 			/* Bottom four bits to 0-F */
-			buf[2*i+1] = hexchr[b & 0x0F];
+			buf[2*i+1] = (uint8_t) hexchr[b & 0x0F];
 		}
 		return buf + (2 * WKB_DOUBLE_SIZE);
 	}
@@ -272,7 +272,7 @@ static uint8_t* double_to_wkb_buf(const double d, uint8_t *buf, uint8_t variant)
 		{
 			for ( i = 0; i < WKB_DOUBLE_SIZE; i++ )
 			{
-				buf[i] = dptr[WKB_DOUBLE_SIZE - 1 - i];
+				buf[i] = (uint8_t) dptr[WKB_DOUBLE_SIZE - 1 - i];
 			}
 		}
 		/* If machine arch and requested arch match, don't flip byte order */
@@ -301,7 +301,7 @@ static size_t empty_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 	if ( geom->type == POINTTYPE )
 	{
 		const LWPOINT *pt = (LWPOINT*)geom;
-		size += WKB_DOUBLE_SIZE * FLAGS_NDIMS(pt->point->flags);
+		size += WKB_DOUBLE_SIZE * (size_t) FLAGS_NDIMS(pt->point->flags);
 	}
 	/* num-elements */
 	else
@@ -320,7 +320,7 @@ static uint8_t* empty_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t varia
 	buf = endian_to_wkb_buf(buf, variant);
 
 	/* Set the geometry type */
-	buf = integer_to_wkb_buf(wkb_type, buf, variant);
+	buf = integer_to_wkb_buf((int)wkb_type, buf, variant);
 
 	/* Set the SRID if necessary */
 	if ( lwgeom_wkb_needs_srid(geom, variant) )
@@ -352,11 +352,11 @@ static uint8_t* empty_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t varia
 */
 static size_t ptarray_to_wkb_size(const POINTARRAY *pa, uint8_t variant)
 {
-	int dims = 2;
+	size_t dims = 2;
 	size_t size = 0;
 
 	if ( variant & (WKB_ISO | WKB_EXTENDED) )
-		dims = FLAGS_NDIMS(pa->flags);
+		dims = (size_t) FLAGS_NDIMS(pa->flags);
 
 	/* Include the npoints if it's not a POINT type) */
 	if ( ! ( variant & WKB_NO_NPOINTS ) )
@@ -371,7 +371,7 @@ static size_t ptarray_to_wkb_size(const POINTARRAY *pa, uint8_t variant)
 static uint8_t* ptarray_to_wkb_buf(const POINTARRAY *pa, uint8_t *buf, uint8_t variant)
 {
 	uint32_t dims = 2;
-	uint32_t pa_dims = FLAGS_NDIMS(pa->flags);
+	uint32_t pa_dims = (uint32_t) FLAGS_NDIMS(pa->flags);
 	uint32_t i, j;
 	double *dbl_ptr;
 
@@ -381,7 +381,7 @@ static uint8_t* ptarray_to_wkb_buf(const POINTARRAY *pa, uint8_t *buf, uint8_t v
 
 	/* Set the number of points (if it's not a POINT type) */
 	if ( ! ( variant & WKB_NO_NPOINTS ) )
-		buf = integer_to_wkb_buf(pa->npoints, buf, variant);
+		buf = integer_to_wkb_buf((int)pa->npoints, buf, variant);
 
 	/* Bulk copy the coordinates when: dimensionality matches, output format */
 	/* is not hex, and output endian matches internal endian. */
@@ -441,7 +441,7 @@ static uint8_t* lwpoint_to_wkb_buf(const LWPOINT *pt, uint8_t *buf, uint8_t vari
 	buf = endian_to_wkb_buf(buf, variant);
 	LWDEBUGF(4, "Endian set, buf = %p", buf);
 	/* Set the geometry type */
-	buf = integer_to_wkb_buf(lwgeom_wkb_type((LWGEOM*)pt, variant), buf, variant);
+	buf = integer_to_wkb_buf((int)lwgeom_wkb_type((LWGEOM*)pt, variant), buf, variant);
 	LWDEBUGF(4, "Type set, buf = %p", buf);
 	/* Set the optional SRID for extended variant */
 	if ( lwgeom_wkb_needs_srid((LWGEOM*)pt, variant) )
@@ -485,7 +485,7 @@ static uint8_t* lwline_to_wkb_buf(const LWLINE *line, uint8_t *buf, uint8_t vari
 	/* Set the endian flag */
 	buf = endian_to_wkb_buf(buf, variant);
 	/* Set the geometry type */
-	buf = integer_to_wkb_buf(lwgeom_wkb_type((LWGEOM*)line, variant), buf, variant);
+	buf = integer_to_wkb_buf((int)lwgeom_wkb_type((LWGEOM*)line, variant), buf, variant);
 	/* Set the optional SRID for extended variant */
 	if ( lwgeom_wkb_needs_srid((LWGEOM*)line, variant) )
 		buf = integer_to_wkb_buf(line->srid, buf, variant);
@@ -526,7 +526,7 @@ static uint8_t* lwtriangle_to_wkb_buf(const LWTRIANGLE *tri, uint8_t *buf, uint8
 	buf = endian_to_wkb_buf(buf, variant);
 
 	/* Set the geometry type */
-	buf = integer_to_wkb_buf(lwgeom_wkb_type((LWGEOM*)tri, variant), buf, variant);
+	buf = integer_to_wkb_buf((int)lwgeom_wkb_type((LWGEOM*)tri, variant), buf, variant);
 
 	/* Set the optional SRID for extended variant */
 	if ( lwgeom_wkb_needs_srid((LWGEOM*)tri, variant) )
@@ -578,12 +578,12 @@ static uint8_t* lwpoly_to_wkb_buf(const LWPOLY *poly, uint8_t *buf, uint8_t vari
 	/* Set the endian flag */
 	buf = endian_to_wkb_buf(buf, variant);
 	/* Set the geometry type */
-	buf = integer_to_wkb_buf(lwgeom_wkb_type((LWGEOM*)poly, variant), buf, variant);
+	buf = integer_to_wkb_buf((int)lwgeom_wkb_type((LWGEOM*)poly, variant), buf, variant);
 	/* Set the optional SRID for extended variant */
 	if ( lwgeom_wkb_needs_srid((LWGEOM*)poly, variant) )
 		buf = integer_to_wkb_buf(poly->srid, buf, variant);
 	/* Set the number of rings */
-	buf = integer_to_wkb_buf(poly->nrings, buf, variant);
+	buf = integer_to_wkb_buf((int)poly->nrings, buf, variant);
 
 	for ( i = 0; i < poly->nrings; i++ )
 	{
@@ -625,12 +625,12 @@ static uint8_t* lwcollection_to_wkb_buf(const LWCOLLECTION *col, uint8_t *buf, u
 	/* Set the endian flag */
 	buf = endian_to_wkb_buf(buf, variant);
 	/* Set the geometry type */
-	buf = integer_to_wkb_buf(lwgeom_wkb_type((LWGEOM*)col, variant), buf, variant);
+	buf = integer_to_wkb_buf((int)lwgeom_wkb_type((LWGEOM*)col, variant), buf, variant);
 	/* Set the optional SRID for extended variant */
 	if ( lwgeom_wkb_needs_srid((LWGEOM*)col, variant) )
 		buf = integer_to_wkb_buf(col->srid, buf, variant);
 	/* Set the number of sub-geometries */
-	buf = integer_to_wkb_buf(col->ngeoms, buf, variant);
+	buf = integer_to_wkb_buf((int)col->ngeoms, buf, variant);
 
 	/* Write the sub-geometries. Sub-geometries do not get SRIDs, they
 	   inherit from their parents. */

--- a/liblwgeom/lwout_wkt.c
+++ b/liblwgeom/lwout_wkt.c
@@ -89,7 +89,7 @@ static void ptarray_to_wkt_sb(const POINTARRAY *ptarray, stringbuffer_t *sb, int
 
 	/* ISO and extended formats include all dimensions */
 	if ( variant & ( WKT_ISO | WKT_EXTENDED ) )
-		dimensions = FLAGS_NDIMS(ptarray->flags);
+		dimensions = (uint32_t) FLAGS_NDIMS(ptarray->flags);
 
 	/* Opening paren? */
 	if ( ! (variant & WKT_NO_PARENS) )
@@ -327,7 +327,7 @@ static void lwcompound_to_wkt_sb(const LWCOMPOUND *comp, stringbuffer_t *sb, int
 	variant = variant | WKT_IS_CHILD; /* Inform the sub-geometries they are childre */
 	for ( i = 0; i < comp->ngeoms; i++ )
 	{
-		int type = comp->geoms[i]->type;
+		uint8_t type = comp->geoms[i]->type;
 		if ( i > 0 )
 			stringbuffer_append(sb, ",");
 		/* Linestring subgeoms don't get type identifiers */
@@ -371,7 +371,7 @@ static void lwcurvepoly_to_wkt_sb(const LWCURVEPOLY *cpoly, stringbuffer_t *sb, 
 	variant = variant | WKT_IS_CHILD; /* Inform the sub-geometries they are childre */
 	for ( i = 0; i < cpoly->nrings; i++ )
 	{
-		int type = cpoly->rings[i]->type;
+		uint8_t type = cpoly->rings[i]->type;
 		if ( i > 0 )
 			stringbuffer_append(sb, ",");
 		switch (type)
@@ -419,7 +419,7 @@ static void lwmcurve_to_wkt_sb(const LWMCURVE *mcurv, stringbuffer_t *sb, int pr
 	variant = variant | WKT_IS_CHILD; /* Inform the sub-geometries they are childre */
 	for ( i = 0; i < mcurv->ngeoms; i++ )
 	{
-		int type = mcurv->geoms[i]->type;
+		uint8_t type = mcurv->geoms[i]->type;
 		if ( i > 0 )
 			stringbuffer_append(sb, ",");
 		switch (type)
@@ -467,7 +467,7 @@ static void lwmsurface_to_wkt_sb(const LWMSURFACE *msurf, stringbuffer_t *sb, in
 	variant = variant | WKT_IS_CHILD; /* Inform the sub-geometries they are childre */
 	for ( i = 0; i < msurf->ngeoms; i++ )
 	{
-		int type = msurf->geoms[i]->type;
+		uint8_t type = msurf->geoms[i]->type;
 		if ( i > 0 )
 			stringbuffer_append(sb, ",");
 		switch (type)
@@ -672,7 +672,7 @@ static void lwgeom_to_wkt_sb(const LWGEOM *geom, stringbuffer_t *sb, int precisi
  * @param size_out If supplied, will return the size of the returned string,
  * including the null terminator.
  */
-char* lwgeom_to_wkt(const LWGEOM *geom, uint8_t variant, int precision, size_t *size_out)
+char* lwgeom_to_wkt(const LWGEOM *geom, uint8_t variant, int32_t precision, size_t *size_out)
 {
 	stringbuffer_t *sb;
 	char *str = NULL;

--- a/liblwgeom/lwpoint.c
+++ b/liblwgeom/lwpoint.c
@@ -126,7 +126,7 @@ lwpoint_get_m(const LWPOINT *point)
  * use SRID=SRID_UNKNOWN for unknown SRID (will have 8bit type's S = 0)
  */
 LWPOINT *
-lwpoint_construct(int srid, GBOX *bbox, POINTARRAY *point)
+lwpoint_construct(int32_t srid, GBOX *bbox, POINTARRAY *point)
 {
 	LWPOINT *result;
 	uint8_t flags = 0;
@@ -148,7 +148,7 @@ lwpoint_construct(int srid, GBOX *bbox, POINTARRAY *point)
 }
 
 LWPOINT *
-lwpoint_construct_empty(int srid, char hasz, char hasm)
+lwpoint_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWPOINT *result = lwalloc(sizeof(LWPOINT));
 	result->type = POINTTYPE;
@@ -160,7 +160,7 @@ lwpoint_construct_empty(int srid, char hasz, char hasm)
 }
 
 LWPOINT *
-lwpoint_make2d(int srid, double x, double y)
+lwpoint_make2d(int32_t srid, double x, double y)
 {
 	POINT4D p = {x, y, 0.0, 0.0};
 	POINTARRAY *pa = ptarray_construct_empty(0, 0, 1);
@@ -170,7 +170,7 @@ lwpoint_make2d(int srid, double x, double y)
 }
 
 LWPOINT *
-lwpoint_make3dz(int srid, double x, double y, double z)
+lwpoint_make3dz(int32_t srid, double x, double y, double z)
 {
 	POINT4D p = {x, y, z, 0.0};
 	POINTARRAY *pa = ptarray_construct_empty(1, 0, 1);
@@ -181,7 +181,7 @@ lwpoint_make3dz(int srid, double x, double y, double z)
 }
 
 LWPOINT *
-lwpoint_make3dm(int srid, double x, double y, double m)
+lwpoint_make3dm(int32_t srid, double x, double y, double m)
 {
 	POINT4D p = {x, y, 0.0, m};
 	POINTARRAY *pa = ptarray_construct_empty(0, 1, 1);
@@ -192,7 +192,7 @@ lwpoint_make3dm(int srid, double x, double y, double m)
 }
 
 LWPOINT *
-lwpoint_make4d(int srid, double x, double y, double z, double m)
+lwpoint_make4d(int32_t srid, double x, double y, double z, double m)
 {
 	POINT4D p = {x, y, z, m};
 	POINTARRAY *pa = ptarray_construct_empty(1, 1, 1);
@@ -203,7 +203,7 @@ lwpoint_make4d(int srid, double x, double y, double z, double m)
 }
 
 LWPOINT *
-lwpoint_make(int srid, int hasz, int hasm, const POINT4D *p)
+lwpoint_make(int32_t srid, char hasz, char hasm, const POINT4D *p)
 {
 	POINTARRAY *pa = ptarray_construct_empty(hasz, hasm, 1);
 	ptarray_append_point(pa, p, LW_TRUE);

--- a/liblwgeom/lwpoly.c
+++ b/liblwgeom/lwpoly.c
@@ -40,12 +40,12 @@
  * use SRID=SRID_UNKNOWN for unknown SRID (will have 8bit type's S = 0)
  */
 LWPOLY*
-lwpoly_construct(int srid, GBOX *bbox, uint32_t nrings, POINTARRAY **points)
+lwpoly_construct(int32_t srid, GBOX *bbox, uint32_t nrings, POINTARRAY **points)
 {
 	LWPOLY *result;
 	int hasz, hasm;
 #ifdef CHECK_POLY_RINGS_ZM
-	char zm;
+	int zm;
 	uint32_t i;
 #endif
 
@@ -95,7 +95,7 @@ lwpoly_construct_rectangle(char hasz, char hasm, POINT4D *p1, POINT4D *p2,
 }
 
 LWPOLY *
-lwpoly_construct_envelope(int srid, double x1, double y1, double x2, double y2)
+lwpoly_construct_envelope(int32_t srid, double x1, double y1, double x2, double y2)
 {
 	POINT4D p1, p2, p3, p4;
 	LWPOLY *poly;
@@ -117,7 +117,7 @@ lwpoly_construct_envelope(int srid, double x1, double y1, double x2, double y2)
 }
 
 LWPOLY*
-lwpoly_construct_circle(int srid, double x, double y, double radius, uint32_t segments_per_quarter, char exterior)
+lwpoly_construct_circle(int32_t srid, double x, double y, double radius, uint32_t segments_per_quarter, char exterior)
 {
 	const uint32_t segments = 4*segments_per_quarter;
 	double theta;
@@ -158,7 +158,7 @@ lwpoly_construct_circle(int srid, double x, double y, double radius, uint32_t se
 }
 
 LWPOLY*
-lwpoly_construct_empty(int srid, char hasz, char hasm)
+lwpoly_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWPOLY *result = lwalloc(sizeof(LWPOLY));
 	result->type = POLYGONTYPE;
@@ -252,7 +252,7 @@ lwpoly_add_ring(LWPOLY *poly, POINTARRAY *pa)
 	/* We have used up our storage, add some more. */
 	if( poly->nrings >= poly->maxrings )
 	{
-		int new_maxrings = 2 * (poly->nrings + 1);
+		uint32_t new_maxrings = 2 * (poly->nrings + 1);
 		poly->rings = lwrealloc(poly->rings, new_maxrings * sizeof(POINTARRAY*));
 		poly->maxrings = new_maxrings;
 	}
@@ -362,7 +362,7 @@ lwpoly_from_lwlines(const LWLINE *shell,
 {
 	uint32_t nrings;
 	POINTARRAY **rings = lwalloc((nholes+1)*sizeof(POINTARRAY *));
-	int srid = shell->srid;
+	int32_t srid = shell->srid;
 	LWPOLY *ret;
 
 	if ( shell->points->npoints < 4 )

--- a/liblwgeom/lwprint.c
+++ b/liblwgeom/lwprint.c
@@ -106,14 +106,12 @@ static char * lwdouble_to_dms(double val, const char *pos_dir_symbol, const char
 	int sec_dec_digits = 0;
 	int sec_piece = -1;
 
-	int round_pow = 0;
-
-	int format_length = ((NULL == format) ? 0 : strlen(format));
+	size_t format_length = ((NULL == format) ? 0 : strlen(format));
 
 	char * result;
 
-	int index, following_byte_index;
-	int multibyte_char_width = 1;
+	size_t index, following_byte_index;
+	size_t multibyte_char_width = 1;
 
 	/* Initialize the working strs to blank.  We may not populate all of them, and
 	 * this allows us to concat them all at the end without worrying about how many
@@ -324,12 +322,12 @@ static char * lwdouble_to_dms(double val, const char *pos_dir_symbol, const char
 		{
 			lwerror("Bad format, cannot include seconds (SS.SSS) without including minutes (MM.MMM).");
 		}
-		seconds = modf(minutes, &minutes) * 60;
+		seconds = modf(minutes, &minutes) * 60.0;
 		if (sec_piece >= 0)
 		{
 			/* See if the formatted seconds round up to 60. If so, increment minutes and reset seconds. */
-			round_pow = pow(10, sec_dec_digits);
-			if (floorf(seconds * round_pow) / round_pow >= 60)
+			double round_pow = pow(10, sec_dec_digits);
+			if ((round(seconds * round_pow) / round_pow) >= 60.0)
 			{
 				minutes += 1;
 				seconds = 0;
@@ -444,8 +442,7 @@ static void
 trim_trailing_zeros(char* str)
 {
 	char *ptr, *totrim = NULL;
-	int len;
-	int i;
+	size_t len, i;
 
 	LWDEBUGF(3, "input: %s", str);
 
@@ -497,7 +494,7 @@ lwprint_double(double d, int maxdd, char* buf, size_t bufsize)
 	}
 	if (ad < OUT_MAX_DOUBLE)
 	{
-		ndd = ad < 1 ? 0 : floor(log10(ad)) + 1; /* non-decimal digits */
+		ndd = ad < 1 ? 0 : (int) floor(log10(ad)) + 1; /* non-decimal digits */
 		if (maxdd > (OUT_MAX_DOUBLE_PRECISION - ndd)) maxdd -= ndd;
 		length = snprintf(buf, bufsize, "%.*f", maxdd, d);
 	}

--- a/liblwgeom/lwtriangle.c
+++ b/liblwgeom/lwtriangle.c
@@ -37,7 +37,7 @@
  * use SRID=SRID_UNKNOWN for unknown SRID (will have 8bit type's S = 0)
  */
 LWTRIANGLE*
-lwtriangle_construct(int srid, GBOX *bbox, POINTARRAY *points)
+lwtriangle_construct(int32_t srid, GBOX *bbox, POINTARRAY *points)
 {
 	LWTRIANGLE *result;
 
@@ -55,7 +55,7 @@ lwtriangle_construct(int srid, GBOX *bbox, POINTARRAY *points)
 }
 
 LWTRIANGLE*
-lwtriangle_construct_empty(int srid, char hasz, char hasm)
+lwtriangle_construct_empty(int32_t srid, char hasz, char hasm)
 {
 	LWTRIANGLE *result = lwalloc(sizeof(LWTRIANGLE));
 	result->type = TRIANGLETYPE;

--- a/liblwgeom/lwutil.c
+++ b/liblwgeom/lwutil.c
@@ -129,8 +129,8 @@ default_debuglogger(int level, const char *fmt, va_list ap)
 	if ( POSTGIS_DEBUG_LEVEL >= level )
 	{
 		/* Space pad the debug output */
-		int i;
-		for ( i = 0; i < level; i++ )
+		size_t i;
+		for ( i = 0; i < (size_t) level; i++ )
 			msg[i] = ' ';
 		vsnprintf(msg+i, LW_MSG_MAXLEN-i, fmt, ap);
 		msg[LW_MSG_MAXLEN]='\0';
@@ -258,7 +258,7 @@ lwfree(void *mem)
  *    1 - end trunctation (i.e. characters are removed from the end)
  */
 
-char *lwmessage_truncate(char *str, int startpos, int endpos, int maxlength, int truncdirection)
+char *lwmessage_truncate(char *str, size_t startpos, size_t endpos, size_t maxlength, int truncdirection)
 {
 	char *output;
 	char *outstart;
@@ -335,7 +335,7 @@ getMachineEndian(void)
 
 
 void
-error_if_srid_mismatch(int srid1, int srid2)
+error_if_srid_mismatch(int32_t srid1, int32_t srid2)
 {
 	if ( srid1 != srid2 )
 	{
@@ -343,21 +343,25 @@ error_if_srid_mismatch(int srid1, int srid2)
 	}
 }
 
-int
-clamp_srid(int srid)
+int32_t
+clamp_srid(int32_t srid)
 {
 	int newsrid = srid;
 
-	if ( newsrid <= 0 ) {
-		if ( newsrid != SRID_UNKNOWN ) {
+	if ( newsrid <= 0 )
+	{
+		if ( newsrid != SRID_UNKNOWN )
+		{
 			newsrid = SRID_UNKNOWN;
 			lwnotice("SRID value %d converted to the officially unknown SRID value %d", srid, newsrid);
 		}
-	} else if ( srid > SRID_MAXIMUM ) {
-    newsrid = SRID_USER_MAXIMUM + 1 +
-      /* -1 is to reduce likelyhood of clashes */
-      /* NOTE: must match implementation in postgis_restore.pl */
-      ( srid % ( SRID_MAXIMUM - SRID_USER_MAXIMUM - 1 ) );
+	}
+	else if ( srid > SRID_MAXIMUM )
+	{
+		newsrid = SRID_USER_MAXIMUM + 1 +
+			/* -1 is to reduce likelyhood of clashes */
+			/* NOTE: must match implementation in postgis_restore.pl */
+			( srid % ( SRID_MAXIMUM - SRID_USER_MAXIMUM - 1 ) );
 		lwnotice("SRID value %d > SRID_MAXIMUM converted to %d", srid, newsrid);
 	}
 

--- a/liblwgeom/measures.c
+++ b/liblwgeom/measures.c
@@ -81,7 +81,7 @@ lw_dist2d_distpts_init(DISTPTS *dl, int mode)
 Function initializing shortestline and longestline calculations.
 */
 LWGEOM *
-lw_dist2d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode)
+lw_dist2d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int32_t srid, int mode)
 {
 	double x1,x2,y1,y2;
 
@@ -128,7 +128,7 @@ lw_dist2d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode)
 Function initializing closestpoint calculations.
 */
 LWGEOM *
-lw_dist2d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2,int srid,int mode)
+lw_dist2d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2,int32_t srid,int mode)
 {
 	double x,y;
 	DISTPTS thedl;
@@ -276,9 +276,9 @@ This is a recursive function delivering every possible combinatin of subgeometri
 */
 int lw_dist2d_recursive(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl)
 {
-	int i, j;
-	int n1=1;
-	int n2=1;
+	uint32_t i, j;
+	uint32_t n1=1;
+	uint32_t n2=1;
 	LWGEOM *g1 = NULL;
 	LWGEOM *g2 = NULL;
 	LWCOLLECTION *c1 = NULL;
@@ -370,8 +370,8 @@ int
 lw_dist2d_distribute_bruteforce(const LWGEOM *lwg1,const LWGEOM *lwg2, DISTPTS *dl)
 {
 
-	int	t1 = lwg1->type;
-	int	t2 = lwg2->type;
+	uint8_t	t1 = lwg1->type;
+	uint8_t	t2 = lwg2->type;
 
 	switch ( t1 )
 	{
@@ -526,8 +526,8 @@ int
 lw_dist2d_distribute_fast(LWGEOM *lwg1, LWGEOM *lwg2, DISTPTS *dl)
 {
 	POINTARRAY *pa1, *pa2;
-	int	type1 = lwg1->type;
-	int	type2 = lwg2->type;
+	uint8_t	type1 = lwg1->type;
+	uint8_t	type2 = lwg2->type;
 
 	LWDEBUGF(2, "lw_dist2d_distribute_fast is called with typ1=%d, type2=%d", lwg1->type, lwg2->type);
 
@@ -1945,13 +1945,13 @@ lw_dist2d_fast_ptarray_ptarray(POINTARRAY *l1, POINTARRAY *l2,DISTPTS *dl, GBOX 
 	/*here we define two lists to hold our calculated "z"-values and the order number in the geometry*/
 
 	double k, thevalue;
-	float	deltaX, deltaY, c1m, c2m;
+	double	deltaX, deltaY, c1m, c2m;
 	POINT2D	c1, c2;
 	const POINT2D *theP;
-	float min1X, max1X, max1Y, min1Y,min2X, max2X, max2Y, min2Y;
-	int t;
-	int n1 = l1->npoints;
-	int n2 = l2->npoints;
+	double min1X, max1X, max1Y, min1Y,min2X, max2X, max2Y, min2Y;
+	uint32_t t;
+	uint32_t n1 = l1->npoints;
+	uint32_t n2 = l2->npoints;
 
 	LISTSTRUCT *list1, *list2;
 	list1 = (LISTSTRUCT*)lwalloc(sizeof(LISTSTRUCT)*n1);
@@ -2071,10 +2071,12 @@ int
 lw_dist2d_pre_seg_seg(POINTARRAY *l1, POINTARRAY *l2,LISTSTRUCT *list1, LISTSTRUCT *list2,double k, DISTPTS *dl)
 {
 	const POINT2D *p1, *p2, *p3, *p4, *p01, *p02;
-	int pnr1,pnr2,pnr3,pnr4, n1, n2, i, u, r, twist;
+	uint32_t pnr1,pnr2,pnr3,pnr4, u;
+	int twist;
 	double maxmeasure;
-	n1=	l1->npoints;
-	n2 = l2->npoints;
+	uint32_t n1 = l1->npoints;
+	uint32_t n2 = l2->npoints;
+	int64_t i, r;
 
 	LWDEBUG(2, "lw_dist2d_pre_seg_seg is called");
 
@@ -2106,7 +2108,7 @@ lw_dist2d_pre_seg_seg(POINTARRAY *l1, POINTARRAY *l2,LISTSTRUCT *list1, LISTSTRU
 				if (( p1->x == p01->x) && (p1->y == p01->y)) pnr2 = 0;
 				else pnr2 = pnr1; /* if it is a line and the last and first point is not the same we avoid the edge between start and end this way*/
 			}
-			else pnr2 = pnr1+r;
+			else pnr2 = (uint32_t) ((int64_t) pnr1 + r);
 
 
 			p2 = getPoint2d_cp(l1, pnr2);

--- a/liblwgeom/measures.h
+++ b/liblwgeom/measures.h
@@ -56,7 +56,7 @@ typedef struct
 typedef struct
 {
 	double themeasure;	/*a value calculated to compare distances*/
-	int pnr;	/*pointnumber. the ordernumber of the point*/
+	uint32_t pnr;		/*pointnumber. the ordernumber of the point*/
 } LISTSTRUCT;
 
 
@@ -121,7 +121,7 @@ double lw_arc_length(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3);
 /*
 * Geometry returning functions
 */
-LWGEOM* lw_dist2d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode);
-LWGEOM* lw_dist2d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode);
+LWGEOM* lw_dist2d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2, int32_t srid, int mode);
+LWGEOM* lw_dist2d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int32_t srid, int mode);
 
 

--- a/liblwgeom/measures3d.c
+++ b/liblwgeom/measures3d.c
@@ -68,7 +68,7 @@ geometries lacks z-values. The vertical line crosses the 2d point that is closes
 and the z-range is from maxz to minz in the geoemtrie that has z values.
 */
 static
-LWGEOM* create_v_line(const LWGEOM *lwgeom,double x, double y, int srid)
+LWGEOM* create_v_line(const LWGEOM *lwgeom,double x, double y, int32_t srid)
 {
 
 	LWPOINT *lwpoints[2];
@@ -107,7 +107,7 @@ lwgeom_closest_point_3d(const LWGEOM *lw1, const LWGEOM *lw2)
 Function initializing 3dshortestline and 3dlongestline calculations.
 */
 LWGEOM *
-lw_dist3d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode)
+lw_dist3d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int32_t srid, int mode)
 {
 	LWDEBUG(2, "lw_dist3d_distanceline is called");
 	double x1,x2,y1,y2, z1, z2, x, y;
@@ -211,7 +211,7 @@ lw_dist3d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode)
 Function initializing 3dclosestpoint calculations.
 */
 LWGEOM *
-lw_dist3d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode)
+lw_dist3d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2, int32_t srid, int mode)
 {
 
 	double x,y,z;
@@ -398,9 +398,9 @@ This is a recursive function delivering every possible combination of subgeometr
 */
 int lw_dist3d_recursive(const LWGEOM *lwg1,const LWGEOM *lwg2, DISTPTS3D *dl)
 {
-	int i, j;
-	int n1=1;
-	int n2=1;
+	uint32_t i, j;
+	uint32_t n1=1;
+	uint32_t n2=1;
 	LWGEOM *g1 = NULL;
 	LWGEOM *g2 = NULL;
 	LWCOLLECTION *c1 = NULL;
@@ -480,8 +480,8 @@ int
 lw_dist3d_distribute_bruteforce(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS3D *dl)
 {
 
-	int	t1 = lwg1->type;
-	int	t2 = lwg2->type;
+	uint8_t	t1 = lwg1->type;
+	uint8_t	t2 = lwg2->type;
 
 	LWDEBUGF(2, "lw_dist3d_distribute_bruteforce is called with typ1=%d, type2=%d", lwg1->type, lwg2->type);
 
@@ -1167,7 +1167,7 @@ define_plane(POINTARRAY *pa, PLANE3D *pl)
 	sumx=0;
 	sumy=0;
 	sumz=0;
-	numberofvectors= floor((pa->npoints-1)/pointsinslice); /*the number of vectors we try can be 3, 4 or 5*/
+	numberofvectors= (pa->npoints-1)/pointsinslice; /*the number of vectors we try can be 3, 4 or 5*/
 
 	getPoint3dz_p(pa, 0, &p1);
 	for (j=pointsinslice;j<pa->npoints;j+=pointsinslice)

--- a/liblwgeom/measures3d.h
+++ b/liblwgeom/measures3d.h
@@ -63,8 +63,8 @@ PLANE3D;
 /*
 Geometry returning functions
 */
-LWGEOM * lw_dist3d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2,int srid,int mode);
-LWGEOM * lw_dist3d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2,int srid,int mode);
+LWGEOM * lw_dist3d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2,int32_t srid,int mode);
+LWGEOM * lw_dist3d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2,int32_t srid,int mode);
 
 /*
 Preprocessing functions

--- a/liblwgeom/stringbuffer.h
+++ b/liblwgeom/stringbuffer.h
@@ -54,9 +54,9 @@ extern void stringbuffer_append(stringbuffer_t *sb, const char *s);
 extern int stringbuffer_aprintf(stringbuffer_t *sb, const char *fmt, ...);
 extern const char *stringbuffer_getstring(stringbuffer_t *sb);
 extern char *stringbuffer_getstringcopy(stringbuffer_t *sb);
-extern int stringbuffer_getlength(stringbuffer_t *sb);
+extern size_t stringbuffer_getlength(stringbuffer_t *sb);
 extern char stringbuffer_lastchar(stringbuffer_t *s);
-extern int stringbuffer_trim_trailing_white(stringbuffer_t *s);
-extern int stringbuffer_trim_trailing_zeroes(stringbuffer_t *s);
+extern size_t stringbuffer_trim_trailing_white(stringbuffer_t *s);
+extern size_t stringbuffer_trim_trailing_zeroes(stringbuffer_t *s);
 
 #endif /* _STRINGBUFFER_H */

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -63,7 +63,7 @@ typedef struct {
 /* An entry in the PROJ4 SRS cache */
 typedef struct struct_PROJ4SRSCacheItem
 {
-	int srid;
+	int32_t srid;
 	projPJ projection;
 	MemoryContext projection_mcxt;
 }

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -87,10 +87,10 @@ static void DeletePJHashEntry(MemoryContext mcxt);
 
 /* Internal Cache API */
 /* static PROJ4PortalCache *GetPROJ4SRSCache(FunctionCallInfo fcinfo) ; */
-static bool IsInPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid);
-static projPJ GetProjectionFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid);
-static void AddToPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid, int other_srid);
-static void DeleteFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid);
+static bool IsInPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid);
+static projPJ GetProjectionFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid);
+static void AddToPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid, int other_srid);
+static void DeleteFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid);
 
 /* Search path for PROJ.4 library */
 static bool IsPROJ4LibPathSet = false;
@@ -280,7 +280,7 @@ static void DeletePJHashEntry(MemoryContext mcxt)
 }
 
 bool
-IsInPROJ4Cache(Proj4Cache PROJ4Cache, int srid) {
+IsInPROJ4Cache(Proj4Cache PROJ4Cache, int32_t srid) {
 	return IsInPROJ4SRSCache((PROJ4PortalCache *)PROJ4Cache, srid) ;
 }
 
@@ -289,7 +289,7 @@ IsInPROJ4Cache(Proj4Cache PROJ4Cache, int srid) {
  */
 
 static bool
-IsInPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid)
+IsInPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid)
 {
 	/*
 	 * Return true/false depending upon whether the item
@@ -308,7 +308,7 @@ IsInPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid)
 	return 0;
 }
 
-projPJ GetProjectionFromPROJ4Cache(Proj4Cache cache, int srid)
+projPJ GetProjectionFromPROJ4Cache(Proj4Cache cache, int32_t srid)
 {
 	return GetProjectionFromPROJ4SRSCache((PROJ4PortalCache *)cache, srid) ;
 }
@@ -318,7 +318,7 @@ projPJ GetProjectionFromPROJ4Cache(Proj4Cache cache, int srid)
  * already have checked it exists using IsInPROJ4SRSCache first)
  */
 static projPJ
-GetProjectionFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid)
+GetProjectionFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid)
 {
 	int i;
 
@@ -331,7 +331,7 @@ GetProjectionFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid)
 	return NULL;
 }
 
-char* GetProj4StringSPI(int srid)
+char* GetProj4StringSPI(int32_t srid)
 {
 	static int maxproj4len = 512;
 	int spi_result;
@@ -405,7 +405,7 @@ char* GetProj4StringSPI(int srid)
  *  (WGS84 UTM N/S, Polar Stereographic N/S - see SRID_* macros),
  *  return the proj4text for those.
  */
-static char* GetProj4String(int srid)
+static char* GetProj4String(int32_t srid)
 {
 	static int maxproj4len = 512;
 
@@ -490,7 +490,7 @@ static char* GetProj4String(int srid)
 	}
 }
 
-void AddToPROJ4Cache(Proj4Cache cache, int srid, int other_srid) {
+void AddToPROJ4Cache(Proj4Cache cache, int32_t srid, int other_srid) {
 	AddToPROJ4SRSCache((PROJ4PortalCache *)cache, srid, other_srid) ;
 }
 
@@ -501,7 +501,7 @@ void AddToPROJ4Cache(Proj4Cache cache, int srid, int other_srid) {
  * which is the definition for the other half of the transformation.
  */
 static void
-AddToPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid, int other_srid)
+AddToPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid, int other_srid)
 {
 	MemoryContext PJMemoryContext;
 	projPJ projection = NULL;
@@ -600,12 +600,12 @@ AddToPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid, int other_srid)
 
 }
 
-void DeleteFromPROJ4Cache(Proj4Cache cache, int srid) {
+void DeleteFromPROJ4Cache(Proj4Cache cache, int32_t srid) {
 	DeleteFromPROJ4SRSCache((PROJ4PortalCache *)cache, srid) ;
 }
 
 
-static void DeleteFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int srid)
+static void DeleteFromPROJ4SRSCache(PROJ4PortalCache *PROJ4Cache, int32_t srid)
 {
 	/*
 	 * Delete the SRID entry from the cache
@@ -702,7 +702,7 @@ SetSpatialRefSysSchema(FunctionCallInfo fcinfo)
 }
 
 int
-GetProjectionsUsingFCInfo(FunctionCallInfo fcinfo, int srid1, int srid2, projPJ *pj1, projPJ *pj2)
+GetProjectionsUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid1, int32_t srid2, projPJ *pj1, projPJ *pj2)
 {
 	Proj4Cache *proj_cache = NULL;
 
@@ -733,7 +733,7 @@ GetProjectionsUsingFCInfo(FunctionCallInfo fcinfo, int srid1, int srid2, projPJ 
 }
 
 int
-spheroid_init_from_srid(FunctionCallInfo fcinfo, int srid, SPHEROID *s)
+spheroid_init_from_srid(FunctionCallInfo fcinfo, int32_t srid, SPHEROID *s)
 {
 	projPJ pj1, pj2;
 #if POSTGIS_PROJ_VERSION >= 48
@@ -761,7 +761,7 @@ spheroid_init_from_srid(FunctionCallInfo fcinfo, int srid, SPHEROID *s)
 	return LW_SUCCESS;
 }
 
-void srid_is_latlong(FunctionCallInfo fcinfo, int srid)
+void srid_is_latlong(FunctionCallInfo fcinfo, int32_t srid)
 {
 	projPJ pj1;
 	projPJ pj2;
@@ -781,7 +781,7 @@ void srid_is_latlong(FunctionCallInfo fcinfo, int srid)
 }
 
 
-srs_precision srid_axis_precision(FunctionCallInfo fcinfo, int srid, int precision)
+srs_precision srid_axis_precision(FunctionCallInfo fcinfo, int32_t srid, int precision)
 {
 	projPJ pj1;
 	projPJ pj2;

--- a/libpgcommon/lwgeom_transform.h
+++ b/libpgcommon/lwgeom_transform.h
@@ -20,7 +20,7 @@ typedef struct srs_precision
 	int precision_m;
 } srs_precision;
 
-char* GetProj4StringSPI(int srid);
+char* GetProj4StringSPI(int32_t srid);
 void SetPROJ4LibPath(void) ;
 
 /**
@@ -30,14 +30,14 @@ typedef void *Proj4Cache ;
 
 void SetPROJ4LibPath(void);
 Proj4Cache GetPROJ4Cache(FunctionCallInfo fcinfo) ;
-bool IsInPROJ4Cache(Proj4Cache cache, int srid) ;
-void AddToPROJ4Cache(Proj4Cache cache, int srid, int other_srid);
-void DeleteFromPROJ4Cache(Proj4Cache cache, int srid) ;
-projPJ GetProjectionFromPROJ4Cache(Proj4Cache cache, int srid);
-int GetProjectionsUsingFCInfo(FunctionCallInfo fcinfo, int srid1, int srid2, projPJ *pj1, projPJ *pj2);
-int spheroid_init_from_srid(FunctionCallInfo fcinfo, int srid, SPHEROID *s);
-void srid_is_latlong(FunctionCallInfo fcinfo, int srid);
-srs_precision srid_axis_precision(FunctionCallInfo fcinfo, int srid, int precision);
+bool IsInPROJ4Cache(Proj4Cache cache, int32_t srid) ;
+void AddToPROJ4Cache(Proj4Cache cache, int32_t srid, int other_srid);
+void DeleteFromPROJ4Cache(Proj4Cache cache, int32_t srid) ;
+projPJ GetProjectionFromPROJ4Cache(Proj4Cache cache, int32_t srid);
+int GetProjectionsUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid1, int32_t srid2, projPJ *pj1, projPJ *pj2);
+int spheroid_init_from_srid(FunctionCallInfo fcinfo, int32_t srid, SPHEROID *s);
+void srid_is_latlong(FunctionCallInfo fcinfo, int32_t srid);
+srs_precision srid_axis_precision(FunctionCallInfo fcinfo, int32_t srid, int precision);
 
 /**
  * Builtin SRID values

--- a/regress/tickets.sql
+++ b/regress/tickets.sql
@@ -1033,11 +1033,11 @@ WITH RECURSIVE path (id, g) AS (
     WHERE ST_Y(path.g) = ST_X(rec.g)
 )
 SELECT '#1014c', id, st_astext(g) FROM path;
-SELECT '#1014d', ST_AsEWKT(g) FROM (
+SELECT '#1014d', ST_AsEWKT(g) as t FROM (
 	SELECT 'SRID=1;POINT(0 1)'::geometry AS g
 	UNION
 	SELECT 'SRID=2;POINT(0 1)'::geometry AS g
-) a;
+) a ORDER BY t;
 DROP TABLE IF EXISTS rec;
 
 -- #3930

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -2257,7 +2257,7 @@ cb_checkTopoGeomRemEdge ( const LWT_BE_TOPOLOGY* topo,
       " AND r.element_id = ANY (ARRAY[%" LWTFMT_ELEMID ",%" LWTFMT_ELEMID
       "]::int4[]) group by r.topogeo_id, r.layer_id, l.schema_name, "
       "l.table_name, l.feature_column ) t WHERE NOT t.elems @> ARRAY[%"
-      LWTFMT_ELEMID ",%" LWTFMT_ELEMID "]::int4[]",
+      LWTFMT_ELEMID ",%" LWTFMT_ELEMID "]::int4[] ORDER BY 1",
 
       topo->name, topo->id,
       face_left, face_right, face_left, face_right );


### PR DESCRIPTION
WIP to avoid implicit type conversions (`-Wconversion`)

Continues with the spirit of https://github.com/postgis/postgis/pull/183:
- Standarizes `int32_t` as the type to store `srid`.
- Standarizes `uint32_t` as the type to manage `sizes` (some places used size_t, some int, some uint32_t).
- Changes pending `int` geometry iterators to `uint32_t` (missing from #183).
- [WIP] Use `int8_t` for boolean (currently mostly using `int`, `char`)