### PR TITLE
Drop cstring2text/text2cstring in favor of Postgresql functions

### DIFF
--- a/libpgcommon/lwgeom_pg.c
+++ b/libpgcommon/lwgeom_pg.c
@@ -31,40 +31,6 @@
 
 #define PGC_ERRMSG_MAXLEN 2048 //256
 
-/**
-* Utility to convert cstrings to textp pointers
-*/
-text*
-cstring2text(const char *cstring)
-{
-	text *output;
-	size_t sz;
-
-	/* Guard against null input */
-	if( !cstring )
-		return NULL;
-
-	sz = strlen(cstring);
-	output = palloc(sz + VARHDRSZ);
-	if ( ! output )
-		return NULL;
-	SET_VARSIZE(output, sz + VARHDRSZ);
-	if ( sz )
-		memcpy(VARDATA(output),cstring,sz);
-	return output;
-}
-
-char*
-text2cstring(const text *textptr)
-{
-	size_t size = VARSIZE(textptr) - VARHDRSZ;
-	char *str = lwalloc(size+1);
-	memcpy(str, VARDATA(textptr), size);
-	str[size]='\0';
-	return str;
-}
-
-
 /*
  * Error message parsing functions
  *

--- a/libpgcommon/lwgeom_pg.h
+++ b/libpgcommon/lwgeom_pg.h
@@ -124,18 +124,6 @@ GSERIALIZED* geography_serialize(LWGEOM *lwgeom);
 */
 int gserialized_datum_get_gbox_p(Datum gsdatum, GBOX *gbox);
 
-/**
-* Convert cstrings (null-terminated byte array) to textp pointers
-* (PgSQL varlena structure with VARSIZE header).
-*/
-text* cstring2text(const char *cstring);
-
-/**
-* Convert textp (PgSQL varlena structure with VARSIZE header) to
-* cstrings (null-terminated byte array).
-*/
-char* text2cstring(const text *textptr);
-
 /*
  * For PostgreSQL >= 8.5 redefine the STATRELATT macro to its
  * new value of STATRELATTINH

--- a/postgis/geography_inout.c
+++ b/postgis/geography_inout.c
@@ -336,7 +336,7 @@ Datum geography_as_gml(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	/* Turn string result into text for return */
-	result = cstring2text(gml);
+	result = cstring_to_text(gml);
 	lwfree(gml);
 
 	PG_RETURN_TEXT_P(result);
@@ -415,7 +415,7 @@ Datum geography_as_kml(PG_FUNCTION_ARGS)
 	if ( ! kml )
 		PG_RETURN_NULL();
 
-	result = cstring2text(kml);
+	result = cstring_to_text(kml);
 	lwfree(kml);
 
 	PG_RETURN_TEXT_P(result);
@@ -460,7 +460,7 @@ Datum geography_as_svg(PG_FUNCTION_ARGS)
     lwgeom_free(lwgeom);
 	PG_FREE_IF_COPY(g, 0);
 
-	result = cstring2text(svg);
+	result = cstring_to_text(svg);
 	lwfree(svg);
 
 	PG_RETURN_TEXT_P(result);
@@ -537,7 +537,7 @@ Datum geography_as_geojson(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(g, 1);
 	if (srs) pfree(srs);
 
-	result = cstring2text(geojson);
+	result = cstring_to_text(geojson);
 	lwfree(geojson);
 
 	PG_RETURN_TEXT_P(result);
@@ -557,7 +557,7 @@ Datum geography_from_text(PG_FUNCTION_ARGS)
 	text *wkt_text = PG_GETARG_TEXT_P(0);
 
 	/* Extract the cstring from the varlena */
-	char *wkt = text2cstring(wkt_text);
+	char *wkt = text_to_cstring(wkt_text);
 
 	/* Pass the cstring to the input parser, and magic occurs! */
 	if ( lwgeom_parse_wkt(&lwg_parser_result, wkt, LW_PARSER_CHECK_ALL) == LW_FAILURE )

--- a/postgis/gserialized_estimate.c
+++ b/postgis/gserialized_estimate.c
@@ -976,7 +976,7 @@ pg_get_nd_stats(const Oid table_oid, AttrNumber att_num, int mode, bool only_par
 static ND_STATS*
 pg_get_nd_stats_by_name(const Oid table_oid, const text *att_text, int mode, bool only_parent)
 {
-	const char *att_name = text2cstring(att_text);
+	const char *att_name = text_to_cstring(att_text);
 	AttrNumber att_num;
 
 	/* We know the name? Look up the num */
@@ -2052,11 +2052,11 @@ Datum _postgis_gserialized_stats(PG_FUNCTION_ARGS)
 	/* Retrieve the stats object */
 	nd_stats = pg_get_nd_stats_by_name(table_oid, att_text, mode, only_parent);
 	if ( ! nd_stats )
-		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid), text2cstring(att_text));
+		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid), text_to_cstring(att_text));
 
 	/* Convert to JSON */
 	str = nd_stats_to_json(nd_stats);
-	json = cstring2text(str);
+	json = cstring_to_text(str);
 	pfree(str);
 	pfree(nd_stats);
 	PG_RETURN_TEXT_P(json);
@@ -2086,7 +2086,7 @@ Datum _postgis_gserialized_sel(PG_FUNCTION_ARGS)
 	nd_stats = pg_get_nd_stats_by_name(table_oid, att_text, mode, false);
 
 	if ( ! nd_stats )
-		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid), text2cstring(att_text));
+		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid), text_to_cstring(att_text));
 
 	/* Calculate the gbox */
 	if ( ! gserialized_datum_get_gbox_p(geom_datum, &gbox) )
@@ -2123,16 +2123,16 @@ Datum _postgis_gserialized_joinsel(PG_FUNCTION_ARGS)
 	nd_stats2 = pg_get_nd_stats_by_name(table_oid2, att_text2, mode, false);
 
 	if ( ! nd_stats1 )
-		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid1), text2cstring(att_text1));
+		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid1), text_to_cstring(att_text1));
 
 	if ( ! nd_stats2 )
-		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid2), text2cstring(att_text2));
+		elog(ERROR, "stats for \"%s.%s\" do not exist", get_rel_name(table_oid2), text_to_cstring(att_text2));
 
 	/* Check if we've been asked to not use 2d mode */
 	if ( ! PG_ARGISNULL(4) )
 	{
 		text *modetxt = PG_GETARG_TEXT_P(4);
-		char *modestr = text2cstring(modetxt);
+		char *modestr = text_to_cstring(modetxt);
 		if ( modestr[0] == 'N' )
 			mode = 0;
 	}
@@ -2294,8 +2294,8 @@ Datum gserialized_estimated_extent(PG_FUNCTION_ARGS)
 
 	if ( PG_NARGS() == 4 )
 	{
-		nsp = text2cstring(PG_GETARG_TEXT_P(0));
-		tbl = text2cstring(PG_GETARG_TEXT_P(1));
+		nsp = text_to_cstring(PG_GETARG_TEXT_P(0));
+		tbl = text_to_cstring(PG_GETARG_TEXT_P(1));
 		col = PG_GETARG_TEXT_P(2);
 		only_parent = PG_GETARG_BOOL(3);
 		nsp_tbl = palloc(strlen(nsp) + strlen(tbl) + 6);
@@ -2305,8 +2305,8 @@ Datum gserialized_estimated_extent(PG_FUNCTION_ARGS)
 	}
 	else if ( PG_NARGS() == 3 )
 	{
-		nsp = text2cstring(PG_GETARG_TEXT_P(0));
-		tbl = text2cstring(PG_GETARG_TEXT_P(1));
+		nsp = text_to_cstring(PG_GETARG_TEXT_P(0));
+		tbl = text_to_cstring(PG_GETARG_TEXT_P(1));
 		col = PG_GETARG_TEXT_P(2);
 		nsp_tbl = palloc(strlen(nsp) + strlen(tbl) + 6);
 		sprintf(nsp_tbl, "\"%s\".\"%s\"", nsp, tbl);
@@ -2315,7 +2315,7 @@ Datum gserialized_estimated_extent(PG_FUNCTION_ARGS)
 	}
 	else if ( PG_NARGS() == 2 )
 	{
-		tbl = text2cstring(PG_GETARG_TEXT_P(0));
+		tbl = text_to_cstring(PG_GETARG_TEXT_P(0));
 		col = PG_GETARG_TEXT_P(1);
 		nsp_tbl = palloc(strlen(tbl) + 3);
 		sprintf(nsp_tbl, "\"%s\"", tbl);
@@ -2332,7 +2332,7 @@ Datum gserialized_estimated_extent(PG_FUNCTION_ARGS)
 	/* Read the extent from the head of the spatial index, if there is one */
 	idx_oid = table_get_spatial_index(tbl_oid, col, &key_type);
 	if (!idx_oid)
-		elog(DEBUG2, "index for \"%s.%s\" does not exist", tbl, text2cstring(col));
+		elog(DEBUG2, "index for \"%s.%s\" does not exist", tbl, text_to_cstring(col));
 	gbox = spatial_index_read_extent(idx_oid, key_type);
 #endif
 
@@ -2344,7 +2344,7 @@ Datum gserialized_estimated_extent(PG_FUNCTION_ARGS)
 
 		/* Error out on no stats */
 		if ( ! nd_stats ) {
-			elog(WARNING, "stats for \"%s.%s\" do not exist", tbl, text2cstring(col));
+			elog(WARNING, "stats for \"%s.%s\" do not exist", tbl, text_to_cstring(col));
 			PG_RETURN_NULL();
 		}
 
@@ -2411,7 +2411,7 @@ table_get_spatial_index(Oid tbl_oid, text *col, int *key_type)
 	ListCell *lc;
 	List *idx_list;
 	Oid result = InvalidOid;
-	char *colname = text2cstring(col);
+	char *colname = text_to_cstring(col);
 
 	/* Lookup our spatial index key types */
 	Oid b2d_oid = typname_to_oid(INDEX_KEY_2D);

--- a/postgis/gserialized_typmod.c
+++ b/postgis/gserialized_typmod.c
@@ -379,7 +379,7 @@ Datum postgis_typmod_type(PG_FUNCTION_ARGS)
 	if ( typmod >= 0 && TYPMOD_GET_M(typmod) )
 		ptr += sprintf(ptr, "%s", "M");
 
-	stext = cstring2text(s);
+	stext = cstring_to_text(s);
 	pfree(s);
 	PG_RETURN_TEXT_P(stext);
 }

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -31,6 +31,7 @@
 #include "float.h" /* for DBL_DIG */
 #include "postgres.h"
 #include "executor/spi.h"
+#include "utils/builtins.h"
 
 #include "../postgis_config.h"
 #include "lwgeom_pg.h"
@@ -304,7 +305,7 @@ Datum LWGEOM_asGML(PG_FUNCTION_ARGS)
 	if ( ! gml )
 		PG_RETURN_NULL();
 
-	result = cstring2text(gml);
+	result = cstring_to_text(gml);
 	lwfree(gml);
 	PG_RETURN_TEXT_P(result);
 }
@@ -379,7 +380,7 @@ Datum LWGEOM_asKML(PG_FUNCTION_ARGS)
 	if( ! kml )
 		PG_RETURN_NULL();
 
-	result = cstring2text(kml);
+	result = cstring_to_text(kml);
 	lwfree(kml);
 
 	PG_RETURN_POINTER(result);
@@ -480,7 +481,7 @@ Datum LWGEOM_asGeoJson(PG_FUNCTION_ARGS)
 
 	if (srs) pfree(srs);
 
-	result = cstring2text(geojson);
+	result = cstring_to_text(geojson);
 	lwfree(geojson);
 
 	PG_FREE_IF_COPY(geom, 0);
@@ -520,7 +521,7 @@ Datum LWGEOM_asSVG(PG_FUNCTION_ARGS)
 
 	lwgeom = lwgeom_from_gserialized(geom);
 	svg = lwgeom_to_svg(lwgeom, precision, relative);
-	result = cstring2text(svg);
+	result = cstring_to_text(svg);
 	lwgeom_free(lwgeom);
 	pfree(svg);
 	PG_FREE_IF_COPY(geom, 0);
@@ -619,7 +620,7 @@ Datum LWGEOM_asX3D(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 	PG_FREE_IF_COPY(geom, 1);
 
-	result = cstring2text(x3d);
+	result = cstring_to_text(x3d);
 	lwfree(x3d);
 
 	PG_RETURN_TEXT_P(result);
@@ -657,7 +658,7 @@ Datum LWGEOM_asEncodedPolyline(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 	PG_FREE_IF_COPY(geom, 0);
 
-	result = cstring2text(encodedpolyline);
+	result = cstring_to_text(encodedpolyline);
 	lwfree(encodedpolyline);
 
 	PG_RETURN_TEXT_P(result);

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -25,8 +25,9 @@
 
 #include "postgres.h"
 #include "fmgr.h"
-#include "utils/elog.h"
 #include "utils/array.h"
+#include "utils/builtins.h"
+#include "utils/elog.h"
 #include "utils/geo_decls.h"
 
 #include "../postgis_config.h"
@@ -140,7 +141,7 @@ Datum LWGEOM_summary(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 
 	/* create a text obj to return */
-	mytext = cstring2text(result);
+	mytext = cstring_to_text(result);
 	pfree(result);
 
 	PG_FREE_IF_COPY(geom,0);
@@ -151,7 +152,7 @@ PG_FUNCTION_INFO_V1(postgis_version);
 Datum postgis_version(PG_FUNCTION_ARGS)
 {
 	char *ver = POSTGIS_VERSION;
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_TEXT_P(result);
 }
 
@@ -159,7 +160,7 @@ PG_FUNCTION_INFO_V1(postgis_liblwgeom_version);
 Datum postgis_liblwgeom_version(PG_FUNCTION_ARGS)
 {
 	const char *ver = lwgeom_version();
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_TEXT_P(result);
 }
 
@@ -167,7 +168,7 @@ PG_FUNCTION_INFO_V1(postgis_lib_version);
 Datum postgis_lib_version(PG_FUNCTION_ARGS)
 {
 	char *ver = POSTGIS_LIB_VERSION;
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_TEXT_P(result);
 }
 
@@ -179,7 +180,7 @@ Datum postgis_svn_version(PG_FUNCTION_ARGS)
 	if ( rev > 0 )
 	{
 		snprintf(ver, 32, "%d", rev);
-		PG_RETURN_TEXT_P(cstring2text(ver));
+		PG_RETURN_TEXT_P(cstring_to_text(ver));
 	}
 	else
 		PG_RETURN_NULL();
@@ -189,7 +190,7 @@ PG_FUNCTION_INFO_V1(postgis_lib_build_date);
 Datum postgis_lib_build_date(PG_FUNCTION_ARGS)
 {
 	char *ver = POSTGIS_BUILD_DATE;
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_TEXT_P(result);
 }
 
@@ -202,7 +203,7 @@ Datum postgis_scripts_released(PG_FUNCTION_ARGS)
 	snprintf(ver, 64, "%s r%d", POSTGIS_LIB_VERSION, POSTGIS_SVN_REVISION);
 	ver[63] = '\0';
 
-	result = cstring2text(ver);
+	result = cstring_to_text(ver);
 	PG_RETURN_TEXT_P(result);
 }
 
@@ -227,7 +228,7 @@ PG_FUNCTION_INFO_V1(postgis_libxml_version);
 Datum postgis_libxml_version(PG_FUNCTION_ARGS)
 {
 	char *ver = POSTGIS_LIBXML2_VERSION;
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_TEXT_P(result);
 }
 
@@ -2345,7 +2346,7 @@ Datum LWGEOM_asEWKT(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 
 	/* Write to text and free the WKT */
-	result = cstring2text(wkt);
+	result = cstring_to_text(wkt);
 	pfree(wkt);
 
 	/* Return the text */
@@ -2676,7 +2677,7 @@ Datum ST_GeoHash(PG_FUNCTION_ARGS)
 	if ( ! geohash )
 		PG_RETURN_NULL();
 
-	result = cstring2text(geohash);
+	result = cstring_to_text(geohash);
 	pfree(geohash);
 
 	PG_RETURN_TEXT_P(result);

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -113,7 +113,7 @@ PG_FUNCTION_INFO_V1(postgis_geos_version);
 Datum postgis_geos_version(PG_FUNCTION_ARGS)
 {
 	const char *ver = lwgeom_geos_version();
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_POINTER(result);
 }
 
@@ -1140,7 +1140,7 @@ Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
 	if ( nargs > 2 )
 	{
 		text *wkttext = PG_GETARG_TEXT_P(2);
-		paramstr = text2cstring(wkttext);
+		paramstr = text_to_cstring(wkttext);
 
 		POSTGIS_DEBUGF(3, "paramstr: %s", paramstr);
 
@@ -1204,7 +1204,7 @@ Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
 			}
 		}
 		POSTGIS_DEBUGF(3, "joinStyle:%d mitreLimit:%g", joinStyle, mitreLimit);
-		pfree(paramstr); /* alloc'ed in text2cstring */
+		pfree(paramstr); /* alloc'ed in text_to_cstring */
 	}
 
 	lwgeom_result = lwgeom_offsetcurve(lwgeom_as_lwline(lwgeom_input), size, quadsegs, joinStyle, mitreLimit);
@@ -1600,12 +1600,12 @@ Datum isvalidreason(PG_FUNCTION_ARGS)
 		reason_str = GEOSisValidReason(g1);
 		GEOSGeom_destroy((GEOSGeometry *)g1);
 		if (!reason_str) HANDLE_GEOS_ERROR("GEOSisValidReason");
-		result = cstring2text(reason_str);
+		result = cstring_to_text(reason_str);
 		GEOSFree(reason_str);
 	}
 	else
 	{
-		result = cstring2text(lwgeom_geos_errmsg);
+		result = cstring_to_text(lwgeom_geos_errmsg);
 	}
 
 	PG_FREE_IF_COPY(geom, 0);
@@ -2677,7 +2677,7 @@ Datum relate_full(PG_FUNCTION_ARGS)
 
 	if (!relate_str) HANDLE_GEOS_ERROR("GEOSRelate");
 
-	result = cstring2text(relate_str);
+	result = cstring_to_text(relate_str);
 	GEOSFree(relate_str);
 
 	PG_FREE_IF_COPY(geom1, 0);

--- a/postgis/lwgeom_geos_relatematch.c
+++ b/postgis/lwgeom_geos_relatematch.c
@@ -26,6 +26,7 @@
 #include "postgres.h"
 #include "fmgr.h"
 #include "funcapi.h"
+#include "utils/builtins.h"
 
 #include "../postgis_config.h"
 #include "lwgeom_geos.h"
@@ -49,8 +50,8 @@ Datum ST_RelateMatch(PG_FUNCTION_ARGS)
         pat_text = (PG_GETARG_TEXT_P(1));
 
         /* Convert from text to cstring */
-        mat = text2cstring(mat_text);
-        pat = text2cstring(pat_text);
+        mat = text_to_cstring(mat_text);
+        pat = text_to_cstring(pat_text);
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 

--- a/postgis/lwgeom_in_encoded_polyline.c
+++ b/postgis/lwgeom_in_encoded_polyline.c
@@ -26,6 +26,7 @@
 #include <assert.h>
 
 #include "postgres.h"
+#include "utils/builtins.h"
 
 #include "../postgis_config.h"
 #include "lwgeom_pg.h"
@@ -45,7 +46,7 @@ Datum line_from_encoded_polyline(PG_FUNCTION_ARGS)
   if (PG_ARGISNULL(0)) PG_RETURN_NULL();
 
   encodedpolyline_input = PG_GETARG_TEXT_P(0);
-  encodedpolyline = text2cstring(encodedpolyline_input);
+  encodedpolyline = text_to_cstring(encodedpolyline_input);
 
   if (PG_NARGS() > 1 && !PG_ARGISNULL(1))
   {

--- a/postgis/lwgeom_in_geohash.c
+++ b/postgis/lwgeom_in_geohash.c
@@ -26,6 +26,7 @@
 #include <assert.h>
 
 #include "postgres.h"
+#include "utils/builtins.h"
 
 #include "../postgis_config.h"
 #include "lwgeom_pg.h"
@@ -92,7 +93,7 @@ Datum box2d_from_geohash(PG_FUNCTION_ARGS)
 	}
 
 	geohash_input = PG_GETARG_TEXT_P(0);
-	geohash = text2cstring(geohash_input);
+	geohash = text_to_cstring(geohash_input);
 
 	box = parse_geohash(geohash, precision);
 
@@ -121,7 +122,7 @@ Datum point_from_geohash(PG_FUNCTION_ARGS)
 	}
 
 	geohash_input = PG_GETARG_TEXT_P(0);
-	geohash = text2cstring(geohash_input);
+	geohash = text_to_cstring(geohash_input);
 
 	box = parse_geohash(geohash, precision);
 

--- a/postgis/lwgeom_in_geojson.c
+++ b/postgis/lwgeom_in_geojson.c
@@ -38,6 +38,28 @@
 # else
 #  include <json/json.h>
 # endif
+
+/* We don't include <utils/builtins.h> to avoid collisions with json-c/json.h */
+static text*
+cstring2text(const char *cstring)
+{
+	size_t len = strlen(cstring);
+	text *result = (text *) palloc(len + VARHDRSZ);
+	SET_VARSIZE(result, len + VARHDRSZ);
+	memcpy(VARDATA(result), cstring, len);
+
+	return result;
+}
+
+static char*
+text2cstring(const text *textptr)
+{
+	size_t size = VARSIZE(textptr) - VARHDRSZ;
+	char *str = lwalloc(size+1);
+	memcpy(str, VARDATA(textptr), size);
+	str[size]='\0';
+	return str;
+}
 #endif
 
 Datum geom_from_geojson(PG_FUNCTION_ARGS);

--- a/postgis/lwgeom_in_gml.c
+++ b/postgis/lwgeom_in_gml.c
@@ -54,6 +54,7 @@
 
 #include "postgres.h"
 #include "executor/spi.h"
+#include "utils/builtins.h"
 
 #include "../postgis_config.h"
 #include "lwgeom_pg.h"
@@ -106,7 +107,7 @@ Datum geom_from_gml(PG_FUNCTION_ARGS)
 	/* Get the GML stream */
 	if (PG_ARGISNULL(0)) PG_RETURN_NULL();
 	xml_input = PG_GETARG_TEXT_P(0);
-	xml = text2cstring(xml_input);
+	xml = text_to_cstring(xml_input);
 
 	/* Zero for undefined */
 	root_srid = PG_GETARG_INT32(1);

--- a/postgis/lwgeom_in_kml.c
+++ b/postgis/lwgeom_in_kml.c
@@ -45,6 +45,7 @@
 #include <string.h>
 
 #include "postgres.h"
+#include "utils/builtins.h"
 
 #include "../postgis_config.h"
 #include "lwgeom_pg.h"
@@ -86,7 +87,7 @@ Datum geom_from_kml(PG_FUNCTION_ARGS)
 	/* Get the KML stream */
 	if (PG_ARGISNULL(0)) PG_RETURN_NULL();
 	xml_input = PG_GETARG_TEXT_P(0);
-	xml = text2cstring(xml_input);
+	xml = text_to_cstring(xml_input);
 	xml_size = VARSIZE(xml_input) - VARHDRSZ;
 
 	/* Begin to Parse XML doc */

--- a/postgis/lwgeom_inout.c
+++ b/postgis/lwgeom_inout.c
@@ -39,8 +39,9 @@
 #include "fmgr.h"
 #include "utils/elog.h"
 #include "mb/pg_wchar.h"
-# include "lib/stringinfo.h" /* for binary input */
+#include "lib/stringinfo.h" /* for binary input */
 #include "utils/array.h"
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "funcapi.h"
 
@@ -222,7 +223,7 @@ Datum LWGEOM_to_latlon(PG_FUNCTION_ARGS)
     PG_RETURN_NULL();
   }
 
-	format_str = text2cstring(format_text);
+	format_str = text_to_cstring(format_text);
   assert(format_str != NULL);
 
   /* The input string supposedly will be in the database encoding,
@@ -251,7 +252,7 @@ Datum LWGEOM_to_latlon(PG_FUNCTION_ARGS)
   }
 
 	/* Convert to the postgres output string type. */
-	formatted_text = cstring2text(formatted_str);
+	formatted_text = cstring_to_text(formatted_str);
   pfree(formatted_str);
 
 	PG_RETURN_POINTER(formatted_text);
@@ -350,7 +351,7 @@ Datum LWGEOM_to_text(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 
 	/* Copy into text obect */
-	result = cstring2text(hexwkb);
+	result = cstring_to_text(hexwkb);
 	pfree(hexwkb);
 
 	/* Clean up and return */
@@ -731,7 +732,7 @@ Datum parse_WKT_lwgeom(PG_FUNCTION_ARGS)
 	Datum result;
 
 	/* Unwrap the PgSQL text type into a cstring */
-	wkt = text2cstring(wkt_text);
+	wkt = text_to_cstring(wkt_text);
 
 	/* Now we call over to the geometry_in function */
 	result = DirectFunctionCall1(LWGEOM_in, CStringGetDatum(wkt));

--- a/postgis/lwgeom_ogc.c
+++ b/postgis/lwgeom_ogc.c
@@ -35,6 +35,7 @@
 #include "access/itup.h"
 
 #include "fmgr.h"
+#include "utils/builtins.h"
 #include "utils/elog.h"
 
 #include "../postgis_config.h"
@@ -191,7 +192,7 @@ Datum geometry_geometrytype(PG_FUNCTION_ARGS)
 	strncat(type_str, lwtype_name(gserialized_get_type(gser)), type_str_len - 3);
 
 	/* Build a text type to store things in */
-	type_text = cstring2text(type_str);
+	type_text = cstring_to_text(type_str);
 
 	PG_FREE_IF_COPY(gser, 0);
 	PG_RETURN_TEXT_P(type_text);
@@ -784,7 +785,7 @@ PG_FUNCTION_INFO_V1(LWGEOM_from_text);
 Datum LWGEOM_from_text(PG_FUNCTION_ARGS)
 {
 	text *wkttext = PG_GETARG_TEXT_P(0);
-	char *wkt = text2cstring(wkttext);
+	char *wkt = text_to_cstring(wkttext);
 	LWGEOM_PARSER_RESULT lwg_parser_result;
 	GSERIALIZED *geom_result = NULL;
 	LWGEOM *lwgeom;
@@ -878,7 +879,7 @@ Datum LWGEOM_asText(PG_FUNCTION_ARGS)
 	POSTGIS_DEBUGF(3, "WKT size = %u, WKT length = %u", (unsigned int)wkt_size, (unsigned int)strlen(wkt));
 
 	/* Write to text and free the WKT */
-	result = cstring2text(wkt);
+	result = cstring_to_text(wkt);
 	pfree(wkt);
 
 	/* Return the text */

--- a/postgis/lwgeom_sfcgal.c
+++ b/postgis/lwgeom_sfcgal.c
@@ -25,6 +25,7 @@
 
 #include "postgres.h"
 #include "fmgr.h"
+#include "utils/builtins.h"
 #include "../liblwgeom/liblwgeom.h"
 
 #include "lwgeom_pg.h"
@@ -62,7 +63,7 @@ Datum sfcgal_is_solid(PG_FUNCTION_ARGS);
 
 
 GSERIALIZED *geometry_serialize(LWGEOM *lwgeom);
-char* text2cstring(const text *textptr);
+char* text_to_cstring(const text *textptr);
 
 static int __sfcgal_init = 0;
 
@@ -143,7 +144,7 @@ Datum sfcgal_from_ewkt(PG_FUNCTION_ARGS)
 	GSERIALIZED* result;
 	sfcgal_prepared_geometry_t* g;
 	text *wkttext = PG_GETARG_TEXT_P(0);
-	char *cstring = text2cstring(wkttext);
+	char *cstring = text_to_cstring(wkttext);
 
 	sfcgal_postgis_init();
 
@@ -721,7 +722,7 @@ PG_FUNCTION_INFO_V1(postgis_sfcgal_version);
 Datum postgis_sfcgal_version(PG_FUNCTION_ARGS)
 {
         const char *ver = lwgeom_sfcgal_version();
-        text *result = cstring2text(ver);
+        text *result = cstring_to_text(ver);
         PG_RETURN_POINTER(result);
 }
 

--- a/postgis/lwgeom_transform.c
+++ b/postgis/lwgeom_transform.c
@@ -25,6 +25,7 @@
 
 #include "postgres.h"
 #include "fmgr.h"
+#include "utils/builtins.h"
 
 #include "../postgis_config.h"
 #include "liblwgeom.h"
@@ -130,8 +131,8 @@ Datum transform_geom(PG_FUNCTION_ARGS)
 	output_proj4_text = (PG_GETARG_TEXT_P(2));
 
 	/* Convert from text to cstring for libproj */
-	input_proj4 = text2cstring(input_proj4_text);
-	output_proj4 = text2cstring(output_proj4_text);
+	input_proj4 = text_to_cstring(input_proj4_text);
+	output_proj4 = text_to_cstring(output_proj4_text);
 
 	/* make input and output projection objects */
 	input_pj = lwproj_from_string(input_proj4);
@@ -199,6 +200,6 @@ PG_FUNCTION_INFO_V1(postgis_proj_version);
 Datum postgis_proj_version(PG_FUNCTION_ARGS)
 {
 	const char *ver = pj_get_release();
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_POINTER(result);
 }

--- a/postgis/postgis_libprotobuf.c
+++ b/postgis/postgis_libprotobuf.c
@@ -14,7 +14,7 @@ Datum postgis_libprotobuf_version(PG_FUNCTION_ARGS)
 	PG_RETURN_NULL();
 #else /* HAVE_LIBPROTOBUF  */
 	const char *ver = protobuf_c_version();
-	text *result = cstring2text(ver);
+	text *result = cstring_to_text(ver);
 	PG_RETURN_POINTER(result);
 #endif
 }

--- a/raster/rt_pg/rtpg_spatial_relationship.c
+++ b/raster/rt_pg/rtpg_spatial_relationship.c
@@ -29,6 +29,7 @@
 
 #include <postgres.h> /* for palloc */
 #include <fmgr.h>
+#include <utils/builtins.h>
 
 #include "../../postgis_config.h"
 
@@ -1309,6 +1310,6 @@ Datum RASTER_notSameAlignmentReason(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 	}
 
-	result = cstring2text(reason);
+	result = cstring_to_text(reason);
 	PG_RETURN_TEXT_P(result);
 }

--- a/raster/rt_pg/rtpg_utility.c
+++ b/raster/rt_pg/rtpg_utility.c
@@ -50,7 +50,7 @@ Datum RASTER_lib_version(PG_FUNCTION_ARGS)
     snprintf(ver, 64, "%s r%d", POSTGIS_LIB_VERSION, POSTGIS_SVN_REVISION);
     ver[63] = '\0';
 
-    result = cstring2text(ver);
+    result = cstring_to_text(ver);
     PG_RETURN_TEXT_P(result);
 }
 
@@ -76,15 +76,15 @@ Datum RASTER_gdal_version(PG_FUNCTION_ARGS)
 		char *rtn = NULL;
 		rtn = palloc(strlen(ver) + strlen(" GDAL_DATA not found") + 1);
 		if (!rtn)
-			result = cstring2text(ver);
+			result = cstring_to_text(ver);
 		else {
 			sprintf(rtn, "%s GDAL_DATA not found", ver);
-			result = cstring2text(rtn);
+			result = cstring_to_text(rtn);
 			pfree(rtn);
 		}
 	}
 	else
-		result = cstring2text(ver);
+		result = cstring_to_text(ver);
 
 	PG_RETURN_POINTER(result);
 }

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -13,6 +13,7 @@
 #include "postgres.h"
 #include "fmgr.h"
 #include "c.h" /* for UINT64_FORMAT and uint64 */
+#include "utils/builtins.h"
 #include "utils/elog.h"
 #include "utils/memutils.h" /* for TopMemoryContext */
 #include "utils/array.h" /* for ArrayType */
@@ -3011,7 +3012,7 @@ Datum ST_ModEdgeSplit(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   edge_id = PG_GETARG_INT32(1) ;
@@ -3076,7 +3077,7 @@ Datum ST_NewEdgesSplit(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   edge_id = PG_GETARG_INT32(1) ;
@@ -3141,7 +3142,7 @@ Datum ST_AddIsoNode(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   if ( PG_ARGISNULL(1) ) containing_face = -1;
@@ -3221,7 +3222,7 @@ Datum ST_AddIsoEdge(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   start_node = PG_GETARG_INT32(1);
@@ -3292,7 +3293,7 @@ Datum ST_AddEdgeModFace(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   startnode_id = PG_GETARG_INT32(1) ;
@@ -3358,7 +3359,7 @@ Datum ST_AddEdgeNewFaces(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   startnode_id = PG_GETARG_INT32(1) ;
@@ -3423,7 +3424,7 @@ Datum ST_GetFaceGeometry(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   face_id = PG_GETARG_INT32(1) ;
@@ -3508,7 +3509,7 @@ Datum ST_GetFaceEdges(PG_FUNCTION_ARGS)
     }
 
     toponame_text = PG_GETARG_TEXT_P(0);
-    toponame = text2cstring(toponame_text);
+    toponame = text_to_cstring(toponame_text);
     PG_FREE_IF_COPY(toponame_text, 0);
 
     face_id = PG_GETARG_INT32(1) ;
@@ -3618,7 +3619,7 @@ Datum ST_ChangeEdgeGeom(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   edge_id = PG_GETARG_INT32(1) ;
@@ -3665,7 +3666,7 @@ Datum ST_ChangeEdgeGeom(PG_FUNCTION_ARGS)
   {
     buf[63] = '\0';
   }
-  PG_RETURN_TEXT_P(cstring2text(buf));
+  PG_RETURN_TEXT_P(cstring_to_text(buf));
 }
 
 /*  ST_RemoveIsoNode(atopology, anode) */
@@ -3686,7 +3687,7 @@ Datum ST_RemoveIsoNode(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   node_id = PG_GETARG_INT32(1) ;
@@ -3725,7 +3726,7 @@ Datum ST_RemoveIsoNode(PG_FUNCTION_ARGS)
   {
     buf[63] = '\0';
   }
-  PG_RETURN_TEXT_P(cstring2text(buf));
+  PG_RETURN_TEXT_P(cstring_to_text(buf));
 }
 
 /*  ST_RemIsoEdge(atopology, anedge) */
@@ -3746,7 +3747,7 @@ Datum ST_RemIsoEdge(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   node_id = PG_GETARG_INT32(1) ;
@@ -3785,7 +3786,7 @@ Datum ST_RemIsoEdge(PG_FUNCTION_ARGS)
   {
     buf[63] = '\0';
   }
-  PG_RETURN_TEXT_P(cstring2text(buf));
+  PG_RETURN_TEXT_P(cstring_to_text(buf));
 }
 
 /*  ST_MoveIsoNode(atopology, anode, apoint) */
@@ -3810,7 +3811,7 @@ Datum ST_MoveIsoNode(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   node_id = PG_GETARG_INT32(1) ;
@@ -3869,7 +3870,7 @@ Datum ST_MoveIsoNode(PG_FUNCTION_ARGS)
   {
     buf[63] = '\0';
   }
-  PG_RETURN_TEXT_P(cstring2text(buf));
+  PG_RETURN_TEXT_P(cstring_to_text(buf));
 }
 
 /*  ST_RemEdgeModFace(atopology, anedge) */
@@ -3889,7 +3890,7 @@ Datum ST_RemEdgeModFace(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   node_id = PG_GETARG_INT32(1) ;
@@ -3940,7 +3941,7 @@ Datum ST_RemEdgeNewFace(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   node_id = PG_GETARG_INT32(1) ;
@@ -3989,7 +3990,7 @@ Datum ST_ModEdgeHeal(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   eid1 = PG_GETARG_INT32(1) ;
@@ -4039,7 +4040,7 @@ Datum ST_NewEdgeHeal(PG_FUNCTION_ARGS)
   }
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   eid1 = PG_GETARG_INT32(1) ;
@@ -4087,7 +4088,7 @@ Datum GetNodeByPoint(PG_FUNCTION_ARGS)
   LWT_TOPOLOGY *topo;
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   geom = PG_GETARG_GSERIALIZED_P(1);
@@ -4153,7 +4154,7 @@ Datum GetEdgeByPoint(PG_FUNCTION_ARGS)
   LWT_TOPOLOGY *topo;
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   geom = PG_GETARG_GSERIALIZED_P(1);
@@ -4219,7 +4220,7 @@ Datum GetFaceByPoint(PG_FUNCTION_ARGS)
   LWT_TOPOLOGY *topo;
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   geom = PG_GETARG_GSERIALIZED_P(1);
@@ -4285,7 +4286,7 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   LWT_TOPOLOGY *topo;
 
   toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text2cstring(toponame_text);
+  toponame = text_to_cstring(toponame_text);
 	PG_FREE_IF_COPY(toponame_text, 0);
 
   geom = PG_GETARG_GSERIALIZED_P(1);
@@ -4376,7 +4377,7 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     }
 
     toponame_text = PG_GETARG_TEXT_P(0);
-    toponame = text2cstring(toponame_text);
+    toponame = text_to_cstring(toponame_text);
     PG_FREE_IF_COPY(toponame_text, 0);
 
     geom = PG_GETARG_GSERIALIZED_P(1);
@@ -4500,7 +4501,7 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
     }
 
     toponame_text = PG_GETARG_TEXT_P(0);
-    toponame = text2cstring(toponame_text);
+    toponame = text_to_cstring(toponame_text);
     PG_FREE_IF_COPY(toponame_text, 0);
 
     geom = PG_GETARG_GSERIALIZED_P(1);


### PR DESCRIPTION
To avoid future issues (as discussed in #211) I've changed all calls of `cstring2text` / `text2cstring` for cstring_to_text / `text_to_cstring` from `utils/builtins.h`.

As `lwgeom_in_geojson.c` can't include both `json-c/json.h` and `utils/builtins.h` I've moved the old declarations there and left a warning since I'm pretty sure that error will come up in the future.