### PR TITLE
Add bit-setting function to optimize geometries for compression

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ PostGIS 2.5.0
   - #3913, Upgrade when creating extension from unpackaged (Sandro Santilli)
   - #2256, _postgis_index_extent() for extent from index (Paul Ramsey)
   - #3176, Add ST_OrientedEnvelope (Dan Baston)
+  - #4029, Add postgis_optimize_geometry (Dan Baston)
 
 * Breaking Changes *
   - #3885, version number removed from address_standardize lib file

--- a/liblwgeom/cunit/cu_algorithm.c
+++ b/liblwgeom/cunit/cu_algorithm.c
@@ -1461,7 +1461,7 @@ static void test_trim_bits(void)
 	for (sigfigs = 1; sigfigs <= 15; sigfigs++)
 	{
 		LWLINE *line2 = (LWLINE*) lwgeom_clone_deep((LWGEOM*) line);
-		lwgeom_trim_bits_in_place((LWGEOM*) line2, sigfigs); 
+		lwgeom_trim_bits_in_place((LWGEOM*) line2, sigfigs);
 
 		for (i = 0; i < line->points->npoints; i++)
 		{

--- a/liblwgeom/cunit/cu_algorithm.c
+++ b/liblwgeom/cunit/cu_algorithm.c
@@ -1434,6 +1434,52 @@ static void test_kmeans(void)
 	return;
 }
 
+static void test_trim_bits(void)
+{
+	POINTARRAY *pta = ptarray_construct_empty(LW_TRUE, LW_TRUE, 2);
+	POINT4D pt;
+	LWLINE *line;
+	uint8_t sigfigs;
+	uint32_t i;
+
+	pt.x = 1.2345678901234;
+	pt.y = 2.3456789012345;
+	pt.z = 3.4567890123456;
+	pt.m = 4.5678901234567;
+
+	ptarray_insert_point(pta, &pt, 0);
+
+	pt.x *= 3;
+	pt.y *= 3;
+	pt.y *= 3;
+	pt.z *= 3;
+
+	ptarray_insert_point(pta, &pt, 1);
+
+	line = lwline_construct(0, NULL, pta);
+
+	for (sigfigs = 1; sigfigs <= 15; sigfigs++)
+	{
+		LWLINE *line2 = (LWLINE*) lwgeom_clone_deep((LWGEOM*) line);
+		lwgeom_trim_bits_in_place((LWGEOM*) line2, sigfigs); 
+
+		for (i = 0; i < line->points->npoints; i++)
+		{
+			POINT4D pt1 = getPoint4d(line->points, i);
+			POINT4D pt2 = getPoint4d(line2->points, i);
+
+			CU_ASSERT_DOUBLE_EQUAL(pt1.x, pt2.x, fabs(pt1.x*pow(10, -1*sigfigs)));
+			CU_ASSERT_DOUBLE_EQUAL(pt1.y, pt2.y, fabs(pt1.y*pow(10, -1*sigfigs)));
+			CU_ASSERT_DOUBLE_EQUAL(pt1.z, pt2.z, fabs(pt1.z*pow(10, -1*sigfigs)));
+			CU_ASSERT_DOUBLE_EQUAL(pt1.m, pt2.m, fabs(pt1.m*pow(10, -1*sigfigs)));
+		}
+
+		lwline_free(line2);
+	}
+
+	lwline_free(line);
+}
+
 /*
 ** Used by test harness to register the tests in this file.
 */
@@ -1465,5 +1511,6 @@ void algorithms_suite_setup(void)
 	PG_ADD_TEST(suite,test_median_handles_3d_correctly);
 	PG_ADD_TEST(suite,test_median_robustness);
 	PG_ADD_TEST(suite,test_lwpoly_construct_circle);
+	PG_ADD_TEST(suite,test_trim_bits);
 	PG_ADD_TEST(suite,test_lwgeom_remove_repeated_points);
 }

--- a/liblwgeom/cunit/cu_algorithm.c
+++ b/liblwgeom/cunit/cu_algorithm.c
@@ -1461,7 +1461,7 @@ static void test_trim_bits(void)
 	for (sigfigs = 1; sigfigs <= 15; sigfigs++)
 	{
 		LWLINE *line2 = (LWLINE*) lwgeom_clone_deep((LWGEOM*) line);
-		lwgeom_trim_bits_in_place((LWGEOM*) line2, sigfigs);
+		lwgeom_trim_bits_in_place((LWGEOM*) line2, sigfigs, sigfigs, sigfigs, sigfigs);
 
 		for (i = 0; i < line->points->npoints; i++)
 		{

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -2166,6 +2166,8 @@ extern uint8_t* lwgeom_to_twkb(const LWGEOM *geom, uint8_t variant, int8_t preci
 
 extern uint8_t* lwgeom_to_twkb_with_idlist(const LWGEOM *geom, int64_t *idlist, uint8_t variant, int8_t precision_xy, int8_t precision_z, int8_t precision_m, size_t *twkb_size);
 
+extern void lwgeom_trim_bits_in_place(LWGEOM *geom, int digits_precision);
+
 /*******************************************************************************
  * SQLMM internal functions
  ******************************************************************************/

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -2166,7 +2166,7 @@ extern uint8_t* lwgeom_to_twkb(const LWGEOM *geom, uint8_t variant, int8_t preci
 
 extern uint8_t* lwgeom_to_twkb_with_idlist(const LWGEOM *geom, int64_t *idlist, uint8_t variant, int8_t precision_xy, int8_t precision_z, int8_t precision_m, size_t *twkb_size);
 
-extern void lwgeom_trim_bits_in_place(LWGEOM *geom, int digits_precision);
+extern void lwgeom_trim_bits_in_place(LWGEOM *geom, uint8_t significant_digits);
 
 /*******************************************************************************
  * SQLMM internal functions

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -2166,7 +2166,18 @@ extern uint8_t* lwgeom_to_twkb(const LWGEOM *geom, uint8_t variant, int8_t preci
 
 extern uint8_t* lwgeom_to_twkb_with_idlist(const LWGEOM *geom, int64_t *idlist, uint8_t variant, int8_t precision_xy, int8_t precision_z, int8_t precision_m, size_t *twkb_size);
 
-extern void lwgeom_trim_bits_in_place(LWGEOM *geom, uint8_t significant_digits);
+/**
+ * Trim the bits of an LWGEOM in place, to optimize it for compression.
+ * Sets all bits to zero that are not required to maintain a specified
+ * number of significant digits.
+ *
+ * @param geom input geometry
+ * @param sig_x significant digits in x dimension
+ * @param sig_y significant digits in y dimension
+ * @param sig_z significant digits in z dimension
+ * @param sig_m significant digits in m dimension
+ */
+extern void lwgeom_trim_bits_in_place(LWGEOM *geom, uint8_t sig_x, uint8_t sig_y, uint8_t sig_z, uint8_t sig_m);
 
 /*******************************************************************************
  * SQLMM internal functions

--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -2395,17 +2395,16 @@ lwgeom_is_trajectory(const LWGEOM *geom)
 	return lwline_is_trajectory((LWLINE*)geom);
 }
 
-static int
-bits_for_precision(int digits_precision)
+static uint8_t
+bits_for_precision(uint8_t significant_digits)
 {
-	if (digits_precision < 1)
-		lwerror("Must have at least one digit of precision");
+	if (significant_digits < 1)
+		lwerror("Must have at least one significant digit");
 	
-	if (digits_precision > 15) {
-		lwerror("Can't request more than 15 digits of precision");
-	}
+	if (significant_digits > 15)
+		lwerror("Can't request more than 15 significant digits");
 	
-	return (int) ceil(digits_precision / log10(2));
+	return (uint8_t) ceil(significant_digits / log10(2));
 }
 
 static inline
@@ -2418,14 +2417,15 @@ double mask_double(double d, int64_t mask)
 	return *((double*) double_bits);
 }
 
-void lwgeom_trim_bits_in_place(LWGEOM* geom, int digits_precision)
+void lwgeom_trim_bits_in_place(LWGEOM* geom, uint8_t significant_digits)
 {
 	LWPOINTITERATOR* it = lwpointiterator_create_rw(geom);
-	int bits_to_keep = bits_for_precision(digits_precision);
+	uint8_t bits_to_keep = bits_for_precision(significant_digits);
 	int64_t mask = 0xffffffffffffffff << (52 - bits_to_keep);
 	POINT4D p;
 	
-	while (lwpointiterator_has_next(it)) {
+	while (lwpointiterator_has_next(it))
+	{
 		lwpointiterator_peek(it, &p);
 		p.x = mask_double(p.x, mask);
 		p.y = mask_double(p.y, mask);

--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -2400,10 +2400,10 @@ bits_for_precision(uint8_t significant_digits)
 {
 	if (significant_digits < 1)
 		lwerror("Must have at least one significant digit");
-	
+
 	if (significant_digits > 15)
 		lwerror("Can't request more than 15 significant digits");
-	
+
 	return (uint8_t) ceil(significant_digits / log10(2));
 }
 
@@ -2411,9 +2411,9 @@ static inline
 double mask_double(double d, int64_t mask)
 {
 	int64_t* double_bits = (int64_t*) (&d);
-	
+
 	(*double_bits) &= mask;
-	
+
 	return *((double*) double_bits);
 }
 
@@ -2423,7 +2423,7 @@ void lwgeom_trim_bits_in_place(LWGEOM* geom, uint8_t significant_digits)
 	uint8_t bits_to_keep = bits_for_precision(significant_digits);
 	int64_t mask = 0xffffffffffffffff << (52 - bits_to_keep);
 	POINT4D p;
-	
+
 	while (lwpointiterator_has_next(it))
 	{
 		lwpointiterator_peek(it, &p);
@@ -2435,6 +2435,6 @@ void lwgeom_trim_bits_in_place(LWGEOM* geom, uint8_t significant_digits)
 			p.m = mask_double(p.m, mask);
 		lwpointiterator_modify_next(it, &p);
 	}
-	
+
 	lwpointiterator_destroy(it);
 }

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -2991,7 +2991,7 @@ Datum postgis_optimize_geometry(PG_FUNCTION_ARGS)
 	GSERIALIZED* result;
 	LWGEOM* g;
 	int significant_digits;
-	
+
 	input = PG_GETARG_GSERIALIZED_P_COPY(0);
 	significant_digits = PG_GETARG_INT32(1);
 	g = lwgeom_from_gserialized(input);
@@ -3011,7 +3011,7 @@ Datum postgis_optimize_geometry(PG_FUNCTION_ARGS)
 	}
 
 	lwgeom_trim_bits_in_place(g, significant_digits);
-	
+
 	result = geometry_serialize(g);
 	lwgeom_free(g);
 	PG_FREE_IF_COPY(input, 0);

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -19,6 +19,7 @@
  **********************************************************************
  *
  * Copyright 2001-2006 Refractions Research Inc.
+ * Copyright 2017-2018 Daniel Baston <dbaston@gmail.com>
  *
  **********************************************************************/
 
@@ -2990,27 +2991,42 @@ Datum postgis_optimize_geometry(PG_FUNCTION_ARGS)
 	GSERIALIZED* input;
 	GSERIALIZED* result;
 	LWGEOM* g;
-	int significant_digits;
+	int significant_digits_x = PG_ARGISNULL(1) ? -1 : PG_GETARG_INT32(1);
+	int significant_digits_y = PG_ARGISNULL(2) ? significant_digits_x : PG_GETARG_INT32(2);
+	int significant_digits_z = PG_ARGISNULL(3) ? significant_digits_x : PG_GETARG_INT32(3);
+	int significant_digits_m = PG_ARGISNULL(4) ? significant_digits_x : PG_GETARG_INT32(4);
 
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
 	input = PG_GETARG_GSERIALIZED_P_COPY(0);
-	significant_digits = PG_GETARG_INT32(1);
+
 	g = lwgeom_from_gserialized(input);
 
-	if (significant_digits < 1)
+	if (significant_digits_x < 1 ||
+		significant_digits_y < 1 ||
+		significant_digits_z < 1 ||
+		significant_digits_m < 1)
 	{
-	  lwerror("Must have at least one significant digit");
-	  PG_FREE_IF_COPY(input, 0);
-	  PG_RETURN_NULL();
+		lwpgerror("Must have at least one significant digit");
+		PG_FREE_IF_COPY(input, 0);
+		PG_RETURN_NULL();
 	}
 
-	if (significant_digits > 15)
+	if (significant_digits_x > 15 ||
+		significant_digits_y > 15 ||
+		significant_digits_z > 15 ||
+		significant_digits_m > 15)
 	{
-	  lwerror("Can't request more than 15 significant digits");
-	  PG_FREE_IF_COPY(input, 0);
-	  PG_RETURN_NULL();
+		lwpgerror("Can't request more than 15 significant digits");
+		PG_FREE_IF_COPY(input, 0);
+		PG_RETURN_NULL();
 	}
 
-	lwgeom_trim_bits_in_place(g, significant_digits);
+	lwgeom_trim_bits_in_place(g,
+		significant_digits_x,
+		significant_digits_y,
+		significant_digits_z,
+		significant_digits_m);
 
 	result = geometry_serialize(g);
 	lwgeom_free(g);

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -57,6 +57,7 @@ Datum LWGEOM_length2d_linestring(PG_FUNCTION_ARGS);
 Datum LWGEOM_length_linestring(PG_FUNCTION_ARGS);
 Datum LWGEOM_perimeter2d_poly(PG_FUNCTION_ARGS);
 Datum LWGEOM_perimeter_poly(PG_FUNCTION_ARGS);
+Datum postgis_optimize_geometry(PG_FUNCTION_ARGS);
 
 Datum LWGEOM_maxdistance2d_linestring(PG_FUNCTION_ARGS);
 Datum LWGEOM_mindistance2d(PG_FUNCTION_ARGS);
@@ -2981,4 +2982,24 @@ Datum ST_Points(PG_FUNCTION_ARGS)
 		lwmpoint_free(result);
 		PG_RETURN_POINTER(ret);
 	}
+}
+
+PG_FUNCTION_INFO_V1(postgis_optimize_geometry);
+Datum postgis_optimize_geometry(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED* input;
+	GSERIALIZED* result;
+	LWGEOM* g;
+	int digits_precision;
+	
+	input = PG_GETARG_GSERIALIZED_P_COPY(0);
+	digits_precision = PG_GETARG_INT32(1);
+	g = lwgeom_from_gserialized(input);
+	
+	lwgeom_trim_bits_in_place(g, digits_precision);
+	
+	result = geometry_serialize(g);
+	lwgeom_free(g);
+	PG_FREE_IF_COPY(input, 0);
+	PG_RETURN_POINTER(result);
 }

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -2990,13 +2990,27 @@ Datum postgis_optimize_geometry(PG_FUNCTION_ARGS)
 	GSERIALIZED* input;
 	GSERIALIZED* result;
 	LWGEOM* g;
-	int digits_precision;
+	int significant_digits;
 	
 	input = PG_GETARG_GSERIALIZED_P_COPY(0);
-	digits_precision = PG_GETARG_INT32(1);
+	significant_digits = PG_GETARG_INT32(1);
 	g = lwgeom_from_gserialized(input);
-	
-	lwgeom_trim_bits_in_place(g, digits_precision);
+
+	if (significant_digits < 1)
+	{
+	  lwerror("Must have at least one significant digit");
+	  PG_FREE_IF_COPY(input, 0);
+	  PG_RETURN_NULL();
+	}
+
+	if (significant_digits > 15)
+	{
+	  lwerror("Can't request more than 15 significant digits");
+	  PG_FREE_IF_COPY(input, 0);
+	  PG_RETURN_NULL();
+	}
+
+	lwgeom_trim_bits_in_place(g, significant_digits);
 	
 	result = geometry_serialize(g);
 	lwgeom_free(g);

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -1099,6 +1099,13 @@ CREATE OR REPLACE FUNCTION postgis_hasbbox(geometry)
 	AS 'MODULE_PATHNAME', 'LWGEOM_hasBBOX'
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL;
 
+-- Availability: 2.5.0
+CREATE OR REPLACE FUNCTION postgis_optimize_geometry(g geometry, digits_precision int)
+	RETURNS geometry
+	AS 'MODULE_PATHNAME', 'postgis_optimize_geometry'
+	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL
+	COST 10;
+
 ------------------------------------------------------------------------
 -- DEBUG
 ------------------------------------------------------------------------
@@ -6062,5 +6069,7 @@ CREATE OR REPLACE FUNCTION ST_Angle(line1 geometry, line2 geometry)
 GRANT SELECT ON TABLE geography_columns TO public;
 GRANT SELECT ON TABLE geometry_columns TO public;
 GRANT SELECT ON TABLE spatial_ref_sys TO public;
+
+
 
 COMMIT;

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -1100,7 +1100,7 @@ CREATE OR REPLACE FUNCTION postgis_hasbbox(geometry)
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL;
 
 -- Availability: 2.5.0
-CREATE OR REPLACE FUNCTION postgis_optimize_geometry(g geometry, digits_precision int)
+CREATE OR REPLACE FUNCTION postgis_optimize_geometry(g geometry, num_significant_digits int)
 	RETURNS geometry
 	AS 'MODULE_PATHNAME', 'postgis_optimize_geometry'
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -1100,10 +1100,10 @@ CREATE OR REPLACE FUNCTION postgis_hasbbox(geometry)
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL;
 
 -- Availability: 2.5.0
-CREATE OR REPLACE FUNCTION postgis_optimize_geometry(g geometry, num_significant_digits int)
+CREATE OR REPLACE FUNCTION postgis_optimize_geometry(g geometry, sig_digits_x int, sig_digits_y int DEFAULT NULL, sig_digits_z int DEFAULT NULL, sig_digits_m int DEFAULT NULL)
 	RETURNS geometry
 	AS 'MODULE_PATHNAME', 'postgis_optimize_geometry'
-	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL
+	LANGUAGE 'c' IMMUTABLE _PARALLEL
 	COST 10;
 
 ------------------------------------------------------------------------

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -6070,6 +6070,4 @@ GRANT SELECT ON TABLE geography_columns TO public;
 GRANT SELECT ON TABLE geometry_columns TO public;
 GRANT SELECT ON TABLE spatial_ref_sys TO public;
 
-
-
 COMMIT;

--- a/regress/Makefile.in
+++ b/regress/Makefile.in
@@ -103,6 +103,7 @@ TESTS = \
 	minimum_bounding_circle \
 	normalize \
 	operators \
+	optimize_geometry \
 	orientation \
 	out_geometry \
 	out_geography \

--- a/regress/optimize_geometry.sql
+++ b/regress/optimize_geometry.sql
@@ -1,0 +1,17 @@
+-- Returns NULL for NULL geometry
+SELECT 't1', postgis_optimize_geometry(NULL::geometry, 6) IS NULL;
+-- Throws error if no precision specified
+SELECT 't2', postgis_optimize_geometry('POINT (3 7)', NULL);
+-- Or if it is outside of bounds
+SELECT 't3', postgis_optimize_geometry('POINT (3 7)', 0);
+SELECT 't4', postgis_optimize_geometry('POINT (3 7)', 16);
+-- Preserves SRID
+SELECT 't5', ST_SRID(postgis_optimize_geometry('SRID=32611;POINT (3 7)', 5)) = 32611;
+-- Carries X precision through to other dimensions if not specified
+SELECT 't6', ST_X(postgis_optimize_geometry('POINT (1.2345678 1.2345678)', 3)) = ST_Y(postgis_optimize_geometry('POINT (1.2345678 1.2345678)', 3));
+-- Or they can be specified independently
+SELECT 't7', ST_X(postgis_optimize_geometry('POINT (1.2345678 1.2345678)', 7, 4)) != ST_Y(postgis_optimize_geometry('POINT (1.2345678 1.2345678)', 7, 4));
+-- Significant digits are preserved
+WITH input AS (SELECT ST_MakePoint(1.23456789012345, 0) AS geom)
+SELECT 't8', bool_and(abs(ST_X(geom)-ST_X(postgis_optimize_geometry(geom, i))) < pow(10, -i)) 
+FROM input, generate_series(1,15) AS i

--- a/regress/optimize_geometry_expected
+++ b/regress/optimize_geometry_expected
@@ -1,0 +1,8 @@
+t1|t
+ERROR:  Must have at least one significant digit
+ERROR:  Must have at least one significant digit
+ERROR:  Can't request more than 15 significant digits
+t5|t
+t6|t
+t7|t
+t8|t


### PR DESCRIPTION
This PR is to add a bit-setting function per the discussion at https://lists.osgeo.org/pipermail/postgis-devel/2018-February/026900.html

Trac ticket at https://trac.osgeo.org/postgis/ticket/4029#ticket

Comments on implementation welcome.

@strk, per your comments I removed references to "precision" and replaced them with the more-precise "significant digits." This should avoid a semantic conflict with a future PostGIS precision implementation.