### PR TITLE
Fix fuzzer building since lwgeom uses GEOSNode()

### DIFF
--- a/fuzzers/wkb_import_fuzzer.cpp
+++ b/fuzzers/wkb_import_fuzzer.cpp
@@ -110,6 +110,7 @@ void GEOSCoordSeq_getZ() { assert(0); }
 void GEOSGeom_createLinearRing() { assert(0); }
 void GEOSGeomType() { assert(0); }
 void GEOSDelaunayTriangulation() { assert(0); }
+void GEOSNode() { assert(0); }
 
 void geod_init() { assert(0); }
 void geod_inverse() { assert(0); }

--- a/fuzzers/wkt_import_fuzzer.cpp
+++ b/fuzzers/wkt_import_fuzzer.cpp
@@ -110,6 +110,7 @@ void GEOSCoordSeq_getZ() { assert(0); }
 void GEOSGeom_createLinearRing() { assert(0); }
 void GEOSGeomType() { assert(0); }
 void GEOSDelaunayTriangulation() { assert(0); }
+void GEOSNode() { assert(0); }
 
 void geod_init() { assert(0); }
 void geod_inverse() { assert(0); }


### PR DESCRIPTION
PostGIS build in OSS-Fuzz is currently broken https://oss-fuzz-build-logs.storage.googleapis.com/index.html . This fixes it