### PR TITLE
fix memory malloc and free not matching

### DIFF
--- a/raster/rt_pg/rtpostgis.c
+++ b/raster/rt_pg/rtpostgis.c
@@ -373,11 +373,11 @@ rtpg_assignHookGDALEnabledDrivers(const char *enabled_drivers, void *extra) {
 		}
 
 		for (i = 0; i < drv_count; i++) {
-			pfree(drv_set[i].short_name);
-			pfree(drv_set[i].long_name);
-			pfree(drv_set[i].create_options);
+			rtdealloc(drv_set[i].short_name);
+			rtdealloc(drv_set[i].long_name);
+			rtdealloc(drv_set[i].create_options);
 		}
-		if (drv_count) pfree(drv_set);
+		if (drv_count) rtdealloc(drv_set);
 
 	}
 


### PR DESCRIPTION
The variable within drv_set and itself is using rtalloc() method to allocate memory, but using pfree() to free memory ,This is not true.


ps: And I want to try to be a contributor for project postgis, Can I? Thanks