### PR TITLE
sp-gist index for BOX3D

### DIFF
--- a/libpgcommon/lwgeom_pg.h
+++ b/libpgcommon/lwgeom_pg.h
@@ -151,6 +151,29 @@ Datum BOX2D_union(PG_FUNCTION_ARGS);
 Datum LWGEOM_same(PG_FUNCTION_ARGS);
 Datum BOX3D_construct(PG_FUNCTION_ARGS);
 
+Datum BOX3D_contains(PG_FUNCTION_ARGS);
+Datum BOX3D_contained(PG_FUNCTION_ARGS);
+Datum BOX3D_overlaps(PG_FUNCTION_ARGS);
+Datum BOX3D_same(PG_FUNCTION_ARGS);
+Datum BOX3D_left(PG_FUNCTION_ARGS);
+Datum BOX3D_overleft(PG_FUNCTION_ARGS);
+Datum BOX3D_right(PG_FUNCTION_ARGS)    ;
+Datum BOX3D_overright(PG_FUNCTION_ARGS);
+Datum BOX3D_below(PG_FUNCTION_ARGS);
+Datum BOX3D_overbelow(PG_FUNCTION_ARGS);
+Datum BOX3D_above(PG_FUNCTION_ARGS);
+Datum BOX3D_overabove(PG_FUNCTION_ARGS);
+Datum BOX3D_before(PG_FUNCTION_ARGS);
+Datum BOX3D_overbefore(PG_FUNCTION_ARGS);
+Datum BOX3D_after(PG_FUNCTION_ARGS);
+Datum BOX3D_overafter(PG_FUNCTION_ARGS);
+Datum BOX3D_distance(PG_FUNCTION_ARGS);
+
+#define DatumGetBox3DP(X)    ((BOX3D *) DatumGetPointer(X))
+#define Box3DPGetDatum(X)    PointerGetDatum(X)
+#define PG_GETARG_BOX3D_P(n) DatumGetBox3DP(PG_GETARG_DATUM(n))
+#define PG_RETURN_BOX3D_P(x) return Box3DPGetDatum(x)
+
 Datum LWGEOM_force_2d(PG_FUNCTION_ARGS);
 Datum LWGEOM_force_3dm(PG_FUNCTION_ARGS);
 Datum LWGEOM_force_3dz(PG_FUNCTION_ARGS);

--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -107,7 +107,8 @@ PG_OBJS= \
 	mvt.o \
 	lwgeom_out_mvt.o \
 	geobuf.o \
-	lwgeom_out_geobuf.o
+	lwgeom_out_geobuf.o \
+	spgist_box3d.o
 
 # Objects to build using PGXS
 OBJS=$(PG_OBJS)

--- a/postgis/lwgeom_box3d.c
+++ b/postgis/lwgeom_box3d.c
@@ -58,6 +58,25 @@ Datum BOX3D_zmax(PG_FUNCTION_ARGS);
 Datum BOX3D_combine(PG_FUNCTION_ARGS);
 Datum BOX3D_combine_BOX3D(PG_FUNCTION_ARGS);
 
+Datum BOX3D_contains(PG_FUNCTION_ARGS);
+Datum BOX3D_contained(PG_FUNCTION_ARGS);
+Datum BOX3D_overlaps(PG_FUNCTION_ARGS);
+Datum BOX3D_same(PG_FUNCTION_ARGS);
+Datum BOX3D_left(PG_FUNCTION_ARGS);
+Datum BOX3D_overleft(PG_FUNCTION_ARGS);
+Datum BOX3D_right(PG_FUNCTION_ARGS)    ;
+Datum BOX3D_overright(PG_FUNCTION_ARGS);
+Datum BOX3D_below(PG_FUNCTION_ARGS);
+Datum BOX3D_overbelow(PG_FUNCTION_ARGS);
+Datum BOX3D_above(PG_FUNCTION_ARGS);
+Datum BOX3D_overabove(PG_FUNCTION_ARGS);
+Datum BOX3D_before(PG_FUNCTION_ARGS);
+Datum BOX3D_overbefore(PG_FUNCTION_ARGS);
+Datum BOX3D_after(PG_FUNCTION_ARGS);
+Datum BOX3D_overafter(PG_FUNCTION_ARGS);
+Datum BOX3D_distance(PG_FUNCTION_ARGS);
+
+
 /**
  *  BOX3D_in - takes a string rep of BOX3D and returns internal rep
  *
@@ -600,4 +619,385 @@ Datum BOX3D_construct(PG_FUNCTION_ARGS)
 	result->srid = minpoint->srid;
 
 	PG_RETURN_POINTER(result);
+}
+
+/*****************************************************************************
+ * BOX3D functions
+ *****************************************************************************/
+
+/* contains? */
+
+bool
+BOX3D_contains_internal(BOX3D *box1, BOX3D *box2)
+{
+	return (FPge(box1->xmax, box2->xmax) &&
+			FPle(box1->xmin, box2->xmin) &&
+			FPge(box1->ymax, box2->ymax) &&
+			FPle(box1->ymin, box2->ymin) &&
+			FPge(box1->zmax, box2->zmax) &&
+			FPle(box1->zmin, box2->zmin));
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_contains);
+
+PGDLLEXPORT Datum
+BOX3D_contains(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_contains_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* contained by? */
+
+bool
+BOX3D_contained_internal(BOX3D *box1, BOX3D *box2)
+{
+	return BOX3D_contains_internal(box2, box1);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_contained);
+
+PGDLLEXPORT Datum
+BOX3D_contained(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_contained_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* overlaps? */
+
+bool
+BOX3D_overlaps_internal(BOX3D *box1, BOX3D *box2)
+{
+	return (FPle(box1->xmin, box2->xmax) &&
+			FPle(box2->xmin, box1->xmax) &&
+			FPle(box1->ymin, box2->ymax) &&
+			FPle(box2->ymin, box1->ymax) &&
+			FPle(box1->zmin, box2->zmax) &&
+			FPle(box2->zmin, box1->zmax));
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_overlaps);
+
+PGDLLEXPORT Datum
+BOX3D_overlaps(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_overlaps_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* same? */
+
+bool
+BOX3D_same_internal(BOX3D *box1, BOX3D *box2)
+{
+	return (FPeq(box1->xmax, box2->xmax) &&
+			FPeq(box1->xmin, box2->xmin) &&
+			FPeq(box1->ymax, box2->ymax) &&
+			FPeq(box1->ymin, box2->ymin) &&
+			FPeq(box1->zmax, box2->zmax) &&
+			FPeq(box1->zmin, box2->zmin));
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_same);
+
+PGDLLEXPORT Datum
+BOX3D_same(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_same_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* strictly left of? */
+
+bool
+BOX3D_left_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPlt(box1->xmax, box2->xmin);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_left);
+
+PGDLLEXPORT Datum
+BOX3D_left(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_left_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* does not extend to right of? */
+
+bool
+BOX3D_overleft_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPle(box1->xmax, box2->xmax);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_overleft);
+
+PGDLLEXPORT Datum
+BOX3D_overleft(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_overleft_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* strictly right of? */
+
+bool
+BOX3D_right_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPgt(box1->xmin, box2->xmax);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_right);
+
+PGDLLEXPORT Datum
+BOX3D_right(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_right_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* does not extend to left of? */
+
+bool
+BOX3D_overright_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPge(box1->xmin, box2->xmin);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_overright);
+
+PGDLLEXPORT Datum
+BOX3D_overright(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_overright_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* strictly below of? */
+
+bool
+BOX3D_below_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPlt(box1->ymax, box2->ymin);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_below);
+
+PGDLLEXPORT Datum
+BOX3D_below(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_below_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* does not extend above of? */
+
+bool
+BOX3D_overbelow_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPle(box1->ymax, box2->ymax);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_overbelow);
+
+PGDLLEXPORT Datum
+BOX3D_overbelow(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_overbelow_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* strictly above of? */
+
+bool
+BOX3D_above_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPgt(box1->ymin, box2->ymax);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_above);
+
+PGDLLEXPORT Datum
+BOX3D_above(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_above_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* does not extend below of? */
+
+bool
+BOX3D_overabove_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPge(box1->ymin, box2->ymin);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_overabove);
+
+PGDLLEXPORT Datum
+BOX3D_overabove(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_overabove_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* strictly in before of? */
+
+bool
+BOX3D_before_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPlt(box1->zmax, box2->zmin);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_before);
+
+PGDLLEXPORT Datum
+BOX3D_before(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_before_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* does not extend to the after of? */
+
+bool
+BOX3D_overbefore_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPle(box1->zmax, box2->zmax);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_overbefore);
+
+PGDLLEXPORT Datum
+BOX3D_overbefore(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_overbefore_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* strictly after of? */
+
+bool
+BOX3D_after_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPgt(box1->zmin, box2->zmax);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_after);
+
+PGDLLEXPORT Datum
+BOX3D_after(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_after_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* does not extend to the before of? */
+
+bool
+BOX3D_overafter_internal(BOX3D *box1, BOX3D *box2)
+{
+	return FPge(box1->zmin, box2->zmin);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_overafter);
+
+PGDLLEXPORT Datum
+BOX3D_overafter(PG_FUNCTION_ARGS)
+{
+	BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+	BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+	bool result = BOX3D_overafter_internal(box1, box2);
+	PG_RETURN_BOOL(result);
+}
+
+/* Minimum distance between 2 bounding boxes */
+
+double
+BOX3D_distance_internal(BOX3D *box1, BOX3D *box2)
+{
+    double      sqrDist = 0;
+    double      d;
+
+    if (BOX3D_overlaps_internal(box1, box2))
+        return 0.0;
+
+    /* X axis */
+    if (box1->xmax < box2->xmin)
+    {
+        d = box1->xmax - box2->xmin;
+        sqrDist += d * d;
+    }
+    else if (box1->xmin > box2->xmax)
+    {
+        d = box1->xmin - box2->xmax;
+        sqrDist += d * d;
+    }
+    /* Y axis */
+    if (box1->ymax < box2->ymin)
+    {
+        d = box1->ymax - box2->ymin;
+        sqrDist += d * d;
+    }
+    else if (box1->ymin > box2->ymax)
+    {
+        d = box1->ymin - box2->ymax;
+        sqrDist += d * d;
+    }
+    /* Z axis */
+    if (box1->zmax < box2->zmin)
+    {
+        d = box1->zmax - box2->zmin;
+        sqrDist += d * d;
+    }
+    else if (box1->zmin > box2->zmax)
+    {
+        d = box1->zmin - box2->zmax;
+        sqrDist += d * d;
+    }
+
+    return sqrt(sqrDist);
+}
+
+PG_FUNCTION_INFO_V1(BOX3D_distance);
+
+PGDLLEXPORT Datum
+BOX3D_distance(PG_FUNCTION_ARGS)
+{
+    BOX3D *box1 = PG_GETARG_BOX3D_P(0);
+    BOX3D *box2 = PG_GETARG_BOX3D_P(1);
+    PG_RETURN_FLOAT8(BOX3D_distance_internal(box1, box2));
 }

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -6098,4 +6098,275 @@ GRANT SELECT ON TABLE geography_columns TO public;
 GRANT SELECT ON TABLE geometry_columns TO public;
 GRANT SELECT ON TABLE spatial_ref_sys TO public;
 
+-----------------------------------------------------------------------
+-- BOX3D spGist stuff, not sure where to put this
+-----------------------------------------------------------------------
+
+CREATE FUNCTION box3D_contains(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_contains'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION box3D_contained(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_contained'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION box3D_overlaps(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_overlaps'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION box3D_same(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_same'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION box3D_distance(box3D, box3D)
+	RETURNS float
+	AS 'MODULE_PATHNAME', 'BOX3D_distance'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+	
+-- Availability: 2.5.0
+CREATE OPERATOR @> (
+	PROCEDURE = box3D_contains,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = <@,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR <@ (
+	PROCEDURE = box3D_contained,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = @>,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR && (
+	PROCEDURE = box3D_overlaps,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = &&,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR ~= (
+	PROCEDURE = box3D_same,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = ~=,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR <-> (
+	PROCEDURE = box3D_distance,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = <->
+);
+
+CREATE FUNCTION temporal_left(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_left'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_overleft(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_overleft'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_right(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_right'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_overright(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_overright'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_below(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_below'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_overbelow(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_overbelow'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_above(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_above'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_overabove(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_overabove'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_before(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_before'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_overbefore(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_overbefore'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_after(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_after'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION temporal_overafter(box3D, box3D)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'BOX3D_overafter'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+
+-- Availability: 2.5.0
+CREATE OPERATOR << (
+	PROCEDURE = temporal_left,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = '>>',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR &< (
+	PROCEDURE = temporal_overleft,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR >> (
+	LEFTARG = box3D, RIGHTARG = box3D,
+	PROCEDURE = temporal_right,
+	COMMUTATOR = '<<',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR &> (
+	PROCEDURE = temporal_overright,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR <<| (
+	PROCEDURE = temporal_below,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = '|>>',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR &<| (
+	PROCEDURE = temporal_overbelow,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR |>> (
+	PROCEDURE = temporal_above,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = '<<|',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR |&> (
+	PROCEDURE = temporal_overabove,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR <</ (
+	PROCEDURE = temporal_before,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = '/>>',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR &</ (
+	PROCEDURE = temporal_overbefore,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = '/&>',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR />> (
+	PROCEDURE = temporal_after,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = '<</',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+-- Availability: 2.5.0
+CREATE OPERATOR /&> (
+	PROCEDURE = temporal_overafter,
+	LEFTARG = box3D, RIGHTARG = box3D,
+	COMMUTATOR = '&</',
+	RESTRICT = positionsel, JOIN = positionjoinsel
+);
+
+CREATE FUNCTION spgist_box3D_octree_config(internal, internal)
+	RETURNS void
+	AS 'MODULE_PATHNAME', 'spgist_box3D_octree_config'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION spgist_box3D_octree_choose(internal, internal)
+	RETURNS void
+	AS 'MODULE_PATHNAME', 'spgist_box3D_octree_choose'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION spgist_box3D_octree_picksplit(internal, internal)
+	RETURNS void
+	AS 'MODULE_PATHNAME', 'spgist_box3D_octree_picksplit'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION spgist_box3D_octree_inner_consistent(internal, internal)
+	RETURNS void
+	AS 'MODULE_PATHNAME', 'spgist_box3D_octree_inner_consistent'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+CREATE FUNCTION spgist_box3D_octree_leaf_consistent(internal, internal)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'spgist_box3D_octree_leaf_consistent'
+	LANGUAGE C IMMUTABLE STRICT _PARALLEL;
+
+-- Availability: 2.5.0
+CREATE OPERATOR CLASS spgist_box3D_octree_ops
+	DEFAULT FOR TYPE BOX3D USING SPGiST
+	AS
+	-- strictly left
+	OPERATOR	1	<<,
+	-- overlaps or left
+	OPERATOR	2	&<,
+	-- overlaps 
+	OPERATOR	3	&&,
+	-- overlaps or right
+	OPERATOR	4	&>,
+	-- strictly right
+	OPERATOR	5	>>,
+	-- same
+	OPERATOR	6	~=,
+	-- contains
+	OPERATOR	7	@>,
+	-- contained by
+	OPERATOR	8	<@,
+	-- overlaps or below
+	OPERATOR	9	&<|,
+	-- strictly below
+	OPERATOR	10	<<|,
+	-- strictly above
+	OPERATOR	11	|>>,
+	-- overlaps or above
+	OPERATOR	12	|&>,
+	-- overlaps or before
+	OPERATOR	28	&</,
+	-- strictly before
+	OPERATOR	29	<</,
+	-- strictly after
+	OPERATOR	30	/>>,
+	-- overlaps or after
+	OPERATOR	31	/&>,
+	-- functions
+	FUNCTION	1	spgist_box3D_octree_config(internal, internal),
+	FUNCTION	2	spgist_box3D_octree_choose(internal, internal),
+	FUNCTION	3	spgist_box3D_octree_picksplit(internal, internal),
+	FUNCTION	4	spgist_box3D_octree_inner_consistent(internal, internal),
+	FUNCTION	5	spgist_box3D_octree_leaf_consistent(internal, internal);
+	
+
+
 COMMIT;

--- a/postgis/spgist_box3d.c
+++ b/postgis/spgist_box3d.c
@@ -1,0 +1,736 @@
+/*****************************************************************************
+ *
+ * Box3DSpgist.c
+ *	  SP-GiST implementation of 6-dimensional oct-tree over 3D boxes
+ *
+ * This module provides SP-GiST implementation for boxes using oct tree
+ * analogy in 4-dimensional space.  SP-GiST doesn't allow indexing of
+ * overlapping objects.  We are making 3D objects never-overlapping in
+ * 6D space.  This technique has some benefits compared to traditional
+ * R-Tree which is implemented as GiST.  The performance tests reveal
+ * that this technique especially beneficial with too much overlapping
+ * objects, so called "spaghetti data".
+ *
+ * Unlike the original oct-tree, we are splitting the tree into 64
+ * octants in 6D space.  It is easier to imagine it as splitting space
+ * three times into 3:
+ *
+ *				|	   |						|	   |		
+ *				|	   |						|	   |		
+ *				| -----+-----					| -----+-----
+ *				|	   |						|	   |		
+ *				|	   |						|	   |		
+ * -------------+------------- -+- -------------+-------------
+ *				|								|
+ *				|								|
+ *				|								|
+ *				|								|
+ *				|								|
+ *			  FRONT							  BACK
+ *
+ * We are using box3D data type as the prefix, but we are treating them
+ * as points in 6-dimensional space, because 3D boxes are not enough
+ * to represent the octant boundaries in 6D space.  They however are
+ * sufficient to point out the additional boundaries of the next
+ * octant.
+ *
+ * We are using traversal values provided by SP-GiST to calculate and
+ * to store the bounds of the octants, while traversing into the tree.
+ * Traversal value has all the boundaries in the 6D space, and is is
+ * capable of transferring the required boundaries to the following
+ * traversal values.  In conclusion, three things are necessary
+ * to calculate the next traversal value:
+ *
+ *	(1) the traversal value of the parent
+ *	(2) the octant of the current node
+ *	(3) the prefix of the current node
+ *
+ * If we visualize them on our simplified drawing (see the drawing above);
+ * transferred boundaries of (1) would be the outer axis, relevant part
+ * of (2) would be the up range_y part of the other axis, and (3) would be
+ * the inner axis.
+ *
+ * For example, consider the case of overlapping.  When recursion
+ * descends deeper and deeper down the tree, all octants in
+ * the current node will be checked for overlapping.  The boundaries
+ * will be re-calculated for all octants.  Overlap check answers
+ * the question: can any box from this octant overlap with the given
+ * box?  If yes, then this octant will be walked.  If no, then this
+ * octant will be skipped.
+ *
+ * This method provides restrictions for minimum and maximum values of
+ * every dimension of every corner of the box on every level of the tree
+ * except the root.  For the root node, we are setting the boundaries
+ * that we don't yet have as infinity.
+ *
+ * Portions Copyright (c) 2018, Esteban Zimanyi, Arthur Lesuisse, 
+ * 		Université Libre de Bruxelles
+ * Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *****************************************************************************/
+
+#include "spgist_box3d.h"
+#include "lwgeom_pg.h"
+
+/*
+ * Comparator for qsort
+ *
+ * We don't need to use the floating point macros in here, because this
+ * is only going to be used in a place to effect the performance
+ * of the index, not the correctness.
+ */
+static int
+compareDoubles(const void *a, const void *b)
+{
+	double		x = *(double *) a;
+	double		y = *(double *) b;
+
+	if (x == y)
+		return 0;
+	return (x > y) ? 1 : -1;
+}
+
+typedef struct
+{
+	BOX3D	left;
+	BOX3D	right;
+} CubeBox3D;
+
+/*
+ * Calculate the octant
+ *
+ * The octant is 8 bit unsigned integer with 6 least bits in use.
+ * This function accepts 2 BOX3D as input. All 6 bits are set by comparing 
+ * a corner of the box. This makes 64 octants in total.
+ */
+static uint8
+getOctant(BOX3D *centroid, BOX3D *inBox)
+{
+	uint8		octant = 0;
+
+	if (inBox->xmin > centroid->xmin)
+		octant |= 0x20;
+
+	if (inBox->xmax > centroid->xmax)
+		octant |= 0x10;
+
+	if (inBox->ymin > centroid->ymin)
+		octant |= 0x08;
+
+	if (inBox->ymax > centroid->ymax)
+		octant |= 0x04;
+	
+	if (inBox->zmin > centroid->zmin)
+		octant |= 0x02;
+
+	if (inBox->zmax > centroid->zmax)
+		octant |= 0x01;
+
+	return octant;
+}
+
+/*
+ * Initialize the traversal value
+ *
+ * In the beginning, we don't have any restrictions.  We have to
+ * initialize the struct to cover the whole 6D space.
+ */
+static CubeBox3D *
+initCubeBox(void)
+{
+	CubeBox3D  *cube_box = (CubeBox3D *) palloc(sizeof(CubeBox3D));
+	double		infinity = get_float8_infinity();
+
+	cube_box->left.xmin = -infinity;
+	cube_box->left.xmax = infinity;
+
+	cube_box->left.ymin = -infinity;
+	cube_box->left.ymax = infinity;
+
+	cube_box->left.zmin = -infinity;
+	cube_box->left.zmax = infinity;
+
+	cube_box->right.xmin = -infinity;
+	cube_box->right.xmax = infinity;
+
+	cube_box->right.ymin = -infinity;
+	cube_box->right.ymax = infinity;
+
+	cube_box->right.zmin = -infinity;
+	cube_box->right.zmax = infinity;
+
+	return cube_box;
+}
+
+/*
+ * Calculate the next traversal value
+ *
+ * All centroids are bounded by CubeBox3D, but SP-GiST only keeps
+ * boxes.  When we are traversing the tree, we must calculate CubeBox3D,
+ * using centroid and octant.
+ */
+static CubeBox3D *
+nextCubeBox3D(CubeBox3D *cube_box, BOX3D *centroid, uint8 octant)
+{
+	CubeBox3D    *next_cube_box = (CubeBox3D *) palloc(sizeof(CubeBox3D));
+
+	memcpy(next_cube_box, cube_box, sizeof(CubeBox3D));
+
+	if (octant & 0x20)
+		next_cube_box->left.xmin = centroid->xmin;
+	else
+		next_cube_box->left.xmax = centroid->xmin;
+
+	if (octant & 0x10)
+		next_cube_box->right.xmin = centroid->xmax;
+	else
+		next_cube_box->right.xmax = centroid->xmax;
+
+	if (octant & 0x08)
+		next_cube_box->left.ymin = centroid->ymin;
+	else
+		next_cube_box->left.ymax = centroid->ymin;
+
+	if (octant & 0x04)
+		next_cube_box->right.ymin = centroid->ymax;
+	else
+		next_cube_box->right.ymax = centroid->ymax;
+
+	if (octant & 0x02)
+		next_cube_box->left.zmin = centroid->zmin;
+	else
+		next_cube_box->left.zmax = centroid->zmin;
+
+	if (octant & 0x01)
+		next_cube_box->right.zmin = centroid->zmax;
+	else
+		next_cube_box->right.zmax = centroid->zmax;
+
+	return next_cube_box;
+} 
+
+/* Can any cube from cube_box overlap with query? */
+static bool
+overlap6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return (FPle(cube_box->left.xmin, query->xmax) &&
+			FPge(cube_box->right.xmax, query->xmin) &&
+			FPle(cube_box->left.ymin, query->ymax) &&
+			FPge(cube_box->right.ymax, query->ymin) &&
+			FPle(cube_box->left.zmin, query->zmax) &&
+			FPge(cube_box->right.zmax, query->zmin));
+}
+
+/* Can any cube from cube_box contain query? */
+static bool
+contain6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return (FPge(cube_box->right.xmax, query->xmax) &&
+			FPle(cube_box->left.xmin, query->xmin) &&
+			FPge(cube_box->right.ymax, query->ymax) &&
+			FPle(cube_box->left.ymin, query->ymin) &&
+			FPge(cube_box->right.zmax, query->zmax) &&
+			FPle(cube_box->left.zmin, query->zmin));
+}
+
+/* Can any cube from cube_box be contained by query? */
+static bool
+contained6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return (FPle(cube_box->right.xmax, query->xmax) &&
+			FPge(cube_box->left.xmin, query->xmin) &&
+			FPle(cube_box->right.ymax, query->ymax) &&
+			FPge(cube_box->left.ymin, query->ymin) &&
+			FPle(cube_box->right.zmax, query->zmax) &&
+			FPge(cube_box->left.zmin, query->zmin));
+}
+
+/* Can any cube from cube_box be left of query? */
+static bool
+left6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPle(cube_box->right.xmax, query->xmin);
+}
+
+/* Can any cube from cube_box does not extend the right of query? */
+static bool
+overLeft6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPle(cube_box->right.xmax, query->xmax);
+}
+
+/* Can any cube from cube_box be right of query? */
+static bool
+right6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPge(cube_box->left.xmin, query->xmax);
+}
+
+/* Can any cube from cube_box does not extend the left of query? */
+static bool
+overRight6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPge(cube_box->left.xmin, query->xmin);
+}
+
+/* Can any cube from cube_box be below of query? */
+static bool
+below6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPle(cube_box->right.ymax, query->ymin);
+}
+
+/* Can any cube from cube_box does not extend above query? */
+static bool
+overBelow6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPle(cube_box->right.ymax, query->ymax);
+}
+
+/* Can any cube from cube_box be above of query? */
+static bool
+above6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPge(cube_box->left.ymin, query->ymax);
+}
+
+/* Can any cube from cube_box does not extend below of query? */
+static bool
+overAbove6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPge(cube_box->left.ymin, query->ymin);
+}
+
+/* Can any cube from cube_box be before of query? */
+static bool
+before6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPle(cube_box->right.zmax, query->zmin);
+}
+
+/* Can any cube from cube_box does not extend the after of query? */
+static bool
+overBefore6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPle(cube_box->right.zmax, query->zmax);
+}
+
+/* Can any cube from cube_box be after of query? */
+static bool
+after6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPge(cube_box->left.zmin, query->zmax);
+}
+
+/* Can any cube from cube_box does not extend the before of query? */
+static bool
+overAfter6D(CubeBox3D *cube_box, BOX3D *query)
+{
+	return FPge(cube_box->left.zmin, query->zmin);
+}
+
+/*
+ * SP-GiST config function
+ */
+ 
+PG_FUNCTION_INFO_V1(spgist_box3D_octree_config);
+
+PGDLLEXPORT Datum
+spgist_box3D_octree_config(PG_FUNCTION_ARGS)
+{
+	spgConfigOut *cfg = (spgConfigOut *) PG_GETARG_POINTER(1);
+
+	cfg->prefixType = TypenameGetTypid("box3d");
+	cfg->labelType = VOIDOID;	/* We don't need node labels. */
+	cfg->canReturnData = true;
+	cfg->longValuesOK = false;
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * SP-GiST choose function
+ */
+ 
+PG_FUNCTION_INFO_V1(spgist_box3D_octree_choose);
+
+PGDLLEXPORT Datum
+spgist_box3D_octree_choose(PG_FUNCTION_ARGS)
+{
+	spgChooseIn *in = (spgChooseIn *) PG_GETARG_POINTER(0);
+	spgChooseOut *out = (spgChooseOut *) PG_GETARG_POINTER(1);
+	BOX3D	   *centroid = DatumGetBox3DP(in->prefixDatum),
+			   *box = DatumGetBox3DP(in->datum);
+
+	out->resultType = spgMatchNode;
+	out->result.matchNode.restDatum = Box3DPGetDatum(box);
+
+	/* nodeN will be set by core, when allTheSame. */
+	if (!in->allTheSame)
+		out->result.matchNode.nodeN = getOctant(centroid, box);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * SP-GiST pick-split function
+ *
+ * It splits a list of boxes into octants by choosing a central 6D
+ * point as the median of the coordinates of the boxes.
+ */
+PG_FUNCTION_INFO_V1(spgist_box3D_octree_picksplit);
+
+PGDLLEXPORT Datum
+spgist_box3D_octree_picksplit(PG_FUNCTION_ARGS)
+{
+	spgPickSplitIn *in = (spgPickSplitIn *) PG_GETARG_POINTER(0);
+	spgPickSplitOut *out = (spgPickSplitOut *) PG_GETARG_POINTER(1);
+	BOX3D	   *centroid;
+	int			median,
+				i;
+	double	   *lowXs = palloc(sizeof(double) * in->nTuples);
+	double	   *highXs = palloc(sizeof(double) * in->nTuples);
+	double	   *lowYs = palloc(sizeof(double) * in->nTuples);
+	double	   *highYs = palloc(sizeof(double) * in->nTuples);
+	double	   *lowZs = palloc(sizeof(double) * in->nTuples);
+	double	   *highZs = palloc(sizeof(double) * in->nTuples);
+
+	BOX3D		   *box = DatumGetBox3DP(in->datums[0]);
+	int32_t 		srid = box->srid;
+	
+	/* Calculate median of all 6D coordinates */
+	for (i = 0; i < in->nTuples; i++)
+	{
+		BOX3D		   *box = DatumGetBox3DP(in->datums[i]);
+
+		lowXs[i] = box->xmin;
+		highXs[i] = box->xmax;
+		lowYs[i] = box->ymin;
+		highYs[i] = box->ymax;
+		lowZs[i] = box->zmin;
+		highZs[i] = box->zmax;
+	}
+
+	qsort(lowXs, in->nTuples, sizeof(double), compareDoubles);
+	qsort(highXs, in->nTuples, sizeof(double), compareDoubles);
+	qsort(lowYs, in->nTuples, sizeof(double), compareDoubles);
+	qsort(highYs, in->nTuples, sizeof(double), compareDoubles);
+	qsort(lowZs, in->nTuples, sizeof(double), compareDoubles);
+	qsort(highZs, in->nTuples, sizeof(double), compareDoubles);
+
+	median = in->nTuples / 2;
+
+	centroid = palloc(sizeof(BOX3D));
+
+	centroid->xmin = lowXs[median];
+	centroid->xmax = highXs[median];
+	centroid->ymin = lowYs[median];
+	centroid->ymax = highYs[median];
+	centroid->zmin = lowZs[median];
+	centroid->zmax = highZs[median];
+	centroid->srid = srid;
+
+	/* Fill the output */
+	out->hasPrefix = true;
+	out->prefixDatum = Box3DPGetDatum(centroid);
+
+	out->nNodes = 64;
+	out->nodeLabels = NULL;		/* We don't need node labels. */
+
+	out->mapTuplesToNodes = palloc(sizeof(int) * in->nTuples);
+	out->leafTupleDatums = palloc(sizeof(Datum) * in->nTuples);
+
+	/*
+	 * Assign ranges to corresponding nodes according to octants relative to
+	 * the "centroid" range
+	 */
+	for (i = 0; i < in->nTuples; i++)
+	{
+		BOX3D	   *box = DatumGetBox3DP(in->datums[i]);
+		uint8		octant = getOctant(centroid, box);
+
+		out->leafTupleDatums[i] = Box3DPGetDatum(box);
+		out->mapTuplesToNodes[i] = octant;
+	}
+
+	pfree(lowXs);
+	pfree(highXs);
+	pfree(lowYs);
+	pfree(highYs);
+	pfree(lowZs);
+	pfree(highZs);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * SP-GiST inner consistent function
+ */
+PG_FUNCTION_INFO_V1(spgist_box3D_octree_inner_consistent);
+
+PGDLLEXPORT Datum
+spgist_box3D_octree_inner_consistent(PG_FUNCTION_ARGS)
+{
+	spgInnerConsistentIn *in = (spgInnerConsistentIn *) PG_GETARG_POINTER(0);
+	spgInnerConsistentOut *out = (spgInnerConsistentOut *) PG_GETARG_POINTER(1);
+	int			i;
+	MemoryContext old_ctx;
+	CubeBox3D   *cube_box;
+	uint8		octant;
+	BOX3D	   *centroid;
+	int		   *nodeNumbers;
+	void	  **traversalValues;
+
+	if (in->allTheSame)
+	{
+		/* Report that all nodes should be visited */
+		out->nNodes = in->nNodes;
+		out->nodeNumbers = (int *) palloc(sizeof(int) * in->nNodes);
+		for (i = 0; i < in->nNodes; i++)
+			out->nodeNumbers[i] = i;
+
+		PG_RETURN_VOID();
+	}
+
+	/*
+	 * We are saving the traversal value or initialize it an unbounded one, if
+	 * we have just begun to walk the tree.
+	 */
+	if (in->traversalValue)
+		cube_box = in->traversalValue;
+	else
+		cube_box = initCubeBox();
+
+	centroid = DatumGetBox3DP(in->prefixDatum);
+
+	/* Allocate enough memory for nodes */
+	out->nNodes = 0;
+	// out->nodeNumbers = (int *) palloc(sizeof(int) * in->nNodes);
+	// out->traversalValues = (void **) palloc(sizeof(void *) * in->nNodes);
+	nodeNumbers = (int *) palloc(sizeof(int) * in->nNodes);
+	traversalValues = (void **) palloc(sizeof(void *) * in->nNodes);
+
+	/*
+	 * We switch memory context, because we want to allocate memory for new
+	 * traversal values (next_cube_box) and pass these pieces of memory to
+	 * further call of this function.
+	 */
+	old_ctx = MemoryContextSwitchTo(in->traversalMemoryContext);
+
+	for (octant = 0; octant < in->nNodes; octant++)
+	{
+		CubeBox3D  *next_cube_box = nextCubeBox3D(cube_box, centroid, octant);
+		bool		flag = true;
+
+		for (i = 0; i < in->nkeys; i++)
+		{
+			StrategyNumber strategy = in->scankeys[i].sk_strategy;
+
+			switch (strategy)
+			{
+				case RTOverlapStrategyNumber:
+				case RTContainedByStrategyNumber:
+					flag = overlap6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTContainsStrategyNumber:
+				case RTSameStrategyNumber:
+					flag = contain6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTLeftStrategyNumber:
+					flag = !overRight6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTOverLeftStrategyNumber:
+					flag = !right6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTRightStrategyNumber:
+					flag = !overLeft6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTOverRightStrategyNumber:
+					flag = !left6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTAboveStrategyNumber:
+					flag = !overBelow6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTOverAboveStrategyNumber:
+					flag = !below6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTBelowStrategyNumber:
+					flag = !overAbove6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTOverBelowStrategyNumber:
+					flag = !above6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTAfterStrategyNumber:
+					flag = !overBefore6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTOverAfterStrategyNumber:
+					flag = !before6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTBeforeStrategyNumber:
+					flag = !overAfter6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				case RTOverBeforeStrategyNumber:
+					flag = !after6D(next_cube_box, DatumGetBox3DP(in->scankeys[i].sk_argument));
+					break;
+
+				default:
+					elog(ERROR, "unrecognized strategy: %d", strategy);
+			}			
+
+			/* If any check is failed, we have found our answer. */
+			if (!flag)
+				break;
+		}
+
+		if (flag)
+		{
+			traversalValues[out->nNodes] = next_cube_box;
+			nodeNumbers[out->nNodes] = octant;
+			out->nNodes++;
+		}
+		else
+		{
+			/*
+			 * If this node is not selected, we don't need to keep the next
+			 * traversal value in the memory context.
+			 */
+			pfree(next_cube_box);
+		}
+	}
+
+	/* Pass to the next level only the values that need to be traversed */
+	out->nodeNumbers = (int *) palloc(sizeof(int) * out->nNodes);
+	out->traversalValues = (void **) palloc(sizeof(void *) * out->nNodes);
+	for (i = 0; i < out->nNodes; i++)
+	{
+		out->nodeNumbers[i] = nodeNumbers[i];
+		out->traversalValues[i] = traversalValues[i];
+	}
+	pfree(nodeNumbers);
+	pfree(traversalValues);
+
+	/* Switch after */
+	MemoryContextSwitchTo(old_ctx);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * SP-GiST inner consistent function
+ */
+PG_FUNCTION_INFO_V1(spgist_box3D_octree_leaf_consistent);
+
+PGDLLEXPORT Datum
+spgist_box3D_octree_leaf_consistent(PG_FUNCTION_ARGS)
+{
+	spgLeafConsistentIn *in = (spgLeafConsistentIn *) PG_GETARG_POINTER(0);
+	spgLeafConsistentOut *out = (spgLeafConsistentOut *) PG_GETARG_POINTER(1);
+	BOX3D		*leaf = DatumGetBox3DP(in->leafDatum);
+	bool		flag = true;
+	int			i;
+
+	/* All tests are exact. */
+	out->recheck = false;
+
+	/* leafDatum is what it is... */
+	out->leafValue = in->leafDatum;
+
+	/* Perform the required comparison(s) */
+	for (i = 0; i < in->nkeys; i++)
+	{
+		StrategyNumber strategy = in->scankeys[i].sk_strategy;
+		BOX3D		*query = DatumGetBox3DP(in->scankeys[i].sk_argument);
+
+		switch (strategy)
+		{
+			case RTOverlapStrategyNumber:
+				flag = BOX3D_overlaps_internal(leaf, query);
+				break;
+
+			case RTContainsStrategyNumber:
+				flag = BOX3D_contains_internal(leaf, query);
+				break;
+
+			case RTContainedByStrategyNumber:
+				flag = BOX3D_contained_internal(leaf, query);
+				break;
+
+			case RTSameStrategyNumber:
+				flag = BOX3D_same_internal(leaf, query);
+				break;
+
+			case RTLeftStrategyNumber:
+				flag = BOX3D_left_internal(leaf, query);
+				break;
+
+			case RTOverLeftStrategyNumber:
+				flag = BOX3D_overleft_internal(leaf, query);
+				break;
+
+			case RTRightStrategyNumber:
+				flag = BOX3D_right_internal(leaf, query);
+				break;
+
+			case RTOverRightStrategyNumber:
+				flag = BOX3D_overright_internal(leaf, query);
+				break;
+
+			case RTAboveStrategyNumber:
+				flag = BOX3D_above_internal(leaf, query);
+				break;
+
+			case RTOverAboveStrategyNumber:
+				flag = BOX3D_overabove_internal(leaf, query);
+				break;
+
+			case RTBelowStrategyNumber:
+				flag = BOX3D_below_internal(leaf, query);
+				break;
+
+			case RTOverBelowStrategyNumber:
+				flag = BOX3D_overbelow_internal(leaf, query);
+				break;
+
+			case RTAfterStrategyNumber:
+				flag = BOX3D_after_internal(leaf, query);
+				break;
+
+			case RTOverAfterStrategyNumber:
+				flag = BOX3D_overafter_internal(leaf, query);
+				break;
+
+			case RTBeforeStrategyNumber:
+				flag = BOX3D_before_internal(leaf, query);
+				break;
+
+			case RTOverBeforeStrategyNumber:
+				flag = BOX3D_overbefore_internal(leaf, query);
+				break;
+
+			default:
+				elog(ERROR, "unrecognized strategy: %d", strategy);
+		}
+
+		/* If any check is failed, we have found our answer. */
+		if (!flag)
+			break;
+	}
+
+	PG_RETURN_BOOL(flag);
+}
+
+/*****************************************************************************/

--- a/postgis/spgist_box3d.h
+++ b/postgis/spgist_box3d.h
@@ -1,0 +1,43 @@
+
+#include <postgres.h>
+#include <liblwgeom.h>
+#include <math.h>
+
+#include <access/spgist.h>
+#include <access/stratnum.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_type.h>
+#include <utils/builtins.h>
+#include <utils/geo_decls.h>
+
+/*****************************************************************************
+ * Operator strategy numbers used in the GiST and SP-GiST temporal opclasses 
+ *****************************************************************************/
+
+#define RTOverBeforeStrategyNumber		28		/* for &</ */
+#define RTBeforeStrategyNumber			29		/* for <</ */
+#define RTAfterStrategyNumber			30		/* for />> */
+#define RTOverAfterStrategyNumber		31		/* for /&> */
+
+/*****************************************************************************
+ * BOX3D operators
+ *****************************************************************************/
+
+
+bool BOX3D_contains_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_contained_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_overlaps_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_same_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_left_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_overleft_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_right_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_overright_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_below_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_overbelow_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_above_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_overabove_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_before_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_overbefore_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_after_internal(BOX3D *box1, BOX3D *box2);
+bool BOX3D_overafter_internal(BOX3D *box1, BOX3D *box2);
+double BOX3D_distance_internal(BOX3D *box1, BOX3D *box2);


### PR DESCRIPTION
Implementation of the SP-GIST indexes for the BOX3D type provided by PostGIS. It implements a 6-dimensional oct-tree over 3D boxes that generalizes and improves the 4-dimensional quad-tree over 2D boxes provided by PostgreSQL in the file geo_spgist.c.