### PR TITLE
WIP: Clean memory sanitizer warnings around GEOS code

### DIFF
--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -377,7 +377,7 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 			shell = ptarray_to_GEOSLinearRing(lwpoly->rings[0], autofix);
 			if (!shell) return NULL;
 			ngeoms = lwpoly->nrings - 1;
-			if (ngeoms > 0) geoms = malloc(sizeof(GEOSGeom) * ngeoms);
+			if (ngeoms > 0) geoms = lwalloc(sizeof(GEOSGeom) * ngeoms);
 
 			for (i = 1; i < lwpoly->nrings; i++)
 			{
@@ -387,13 +387,13 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 					uint32_t k;
 					for (k = 0; k < i - 1; k++)
 						GEOSGeom_destroy(geoms[k]);
-					free(geoms);
+					lwfree(geoms);
 					GEOSGeom_destroy(shell);
 					return NULL;
 				}
 			}
 			g = GEOSGeom_createPolygon(shell, geoms, ngeoms);
-			if (geoms) free(geoms);
+			if (geoms) lwfree(geoms);
 		}
 		if (!g) return NULL;
 		break;
@@ -413,7 +413,7 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 		lwc = (LWCOLLECTION*)lwgeom;
 
 		ngeoms = lwc->ngeoms;
-		if (ngeoms > 0) geoms = malloc(sizeof(GEOSGeom) * ngeoms);
+		if (ngeoms > 0) geoms = lwalloc(sizeof(GEOSGeom) * ngeoms);
 
 		j = 0;
 		for (i = 0; i < ngeoms; ++i)
@@ -428,13 +428,13 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 				uint32_t k;
 				for (k = 0; k < j; k++)
 					GEOSGeom_destroy(geoms[k]);
-				free(geoms);
+				lwfree(geoms);
 				return NULL;
 			}
 			geoms[j++] = g;
 		}
 		g = GEOSGeom_createCollection(geostype, geoms, j);
-		if (ngeoms > 0) free(geoms);
+		if (ngeoms > 0) lwfree(geoms);
 		if (!g) return NULL;
 		break;
 

--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -62,9 +62,9 @@ POINTARRAY*
 ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3d)
 {
 	uint32_t dims = 2;
-	uint32_t size, i;
+	uint32_t size = 0, i;
 	POINTARRAY* pa;
-	POINT4D point;
+	POINT4D point = { 0.0, 0.0, 0.0, 0.0 };
 
 	LWDEBUG(2, "ptarray_fromGEOSCoordSeq called");
 

--- a/liblwgeom/lwgeom_geos_clean.c
+++ b/liblwgeom/lwgeom_geos_clean.c
@@ -43,11 +43,11 @@ GEOSGeometry* LWGEOM_GEOS_getPointN(const GEOSGeometry*, uint32_t);
 GEOSGeometry*
 LWGEOM_GEOS_getPointN(const GEOSGeometry* g_in, uint32_t n)
 {
-	uint32_t dims;
+	uint32_t dims = 0;
 	const GEOSCoordSequence* seq_in;
 	GEOSCoordSeq seq_out;
 	double val;
-	uint32_t sz;
+	uint32_t sz = 0;
 	int gn;
 	GEOSGeometry* ret;
 

--- a/liblwgeom/lwprint.c
+++ b/liblwgeom/lwprint.c
@@ -378,6 +378,8 @@ static char * lwdouble_to_dms(double val, const char *pos_dir_symbol, const char
 
 	/* Allocate space for the result.  Leave plenty of room for excess digits, negative sign, etc.*/
 	result = (char*)lwalloc(format_length + WORK_SIZE);
+	memset(result, 0, format_length + WORK_SIZE);
+
 	/* Append all the pieces together. There may be less than 9, but in that case the rest will be blank. */
 	strcpy(result, pieces[0]);
 	for (index = 1; index < NUM_PIECES; index++)

--- a/liblwgeom/lwspheroid.c
+++ b/liblwgeom/lwspheroid.c
@@ -84,7 +84,7 @@ double spheroid_distance(const GEOGRAPHIC_POINT *a, const GEOGRAPHIC_POINT *b, c
 	double lon1 = a->lon * 180.0 / M_PI;
 	double lat2 = b->lat * 180.0 / M_PI;
 	double lon2 = b->lon * 180.0 / M_PI;
-	double s12; /* return distance */
+	double s12 = 0.0; /* return distance */
 	geod_inverse(&gd, lat1, lon1, lat2, lon2, &s12, 0, 0);
 	return s12;
 }


### PR DESCRIPTION
Shut up some of the warnings I get when running unit tests with -fsanitizer=memory