### PR TITLE
Remove geometry autofix behavior, for now

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,9 +85,6 @@ PostGIS 2.5.0
   - #2508, ST_OffsetCurve now works with collections (Darafei Praliaskouski)
   - #4006, ST_GeomFromGeoJSON support for json and jsonb as input
            (Paul Ramsey, Regina Obe)
-  - #4037, Invalid input geometry is fixed with MakeValid for GEOS exceptions in
-           ST_Intersection, ST_Union, ST_Difference, ST_SymDifference (Darafei
-           Praliaskouski)
   - #4038, ST_Subdivide now selects pivot for geometry split that reuses input
            vertices. ST_ClipByBox2D is stubbed with ST_Intersection because of
            robustness issues. (Darafei Praliaskouski)
@@ -100,7 +97,6 @@ PostGIS 2.5.0
   - #4084: Fixed wrong code-comment regarding front/back of BOX3D (Matthias Bay)
   - #4060, #4094, PostgreSQL JIT support (Raúl Marín, Laurenz Albe)
   - #3960, ST_Centroid now uses lwgeom_centroid (Darafei Praliaskouski)
-  - #4103, ST_PointOnSurface can handle invalid (Darafei Praliaskouski)
   - #4027, Remove duplicated code in lwgeom_geos (Darafei Praliaskouski,
            Daniel Baston)
 

--- a/doc/reference_processing.xml
+++ b/doc/reference_processing.xml
@@ -490,16 +490,14 @@ FROM (SELECT ST_Buffer(
 		<title>Description</title>
 
     <para>
-Clips a geometry by a 2D box. The output geometry is not guaranteed to be valid
-(self-intersections for a polygon may be introduced).
-Topologically invalid input geometries do not result in exceptions being thrown.
-    </para>
+Clips a geometry by a 2D box.</para>
 
 		<para>Performed by the GEOS module.</para>
 		<note><para>Requires GEOS 3.5.0+</para></note>
 
 		<para>Availability: 2.2.0 - requires GEOS &gt;= 3.5.0.</para>
-		<para>Changed: 2.5.0 - wrapper around ST_Intersection to work around GEOS bugs. </para>
+                <para>Changed: 2.5.0 - wrapper around ST_Intersection to work around GEOS bugs.
+                      No longer supports invalid input geometry.</para>
 
 	  </refsection>
 

--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -618,24 +618,6 @@ lwgeom_intersection(const LWGEOM* geom1, const LWGEOM* geom2)
 
 	g3 = GEOSIntersection(g1, g2);
 
-	if (!g3)
-	{
-		GEOSGeometry *g1v, *g2v;
-		lwnotice("%s: GEOS Error: %s", __func__, lwgeom_geos_errmsg);
-
-		if (!GEOSisValid(g1) || !GEOSisValid(g2))
-		{
-			lwnotice(
-			    "Your geometry dataset is not valid per OGC Specification. "
-			    "Please fix it with manual review of entries that are not ST_IsValid(geom). "
-			    "Retrying GEOS operation with ST_MakeValid of your input.");
-			g1v = LWGEOM_GEOS_makeValid(g1);
-			g2v = LWGEOM_GEOS_makeValid(g2);
-			g3 = GEOSIntersection(g1v, g2v);
-			GEOS_FREE(g1v, g2v);
-		}
-	}
-
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
 	GEOSSetSRID(g3, srid);
 
@@ -730,24 +712,6 @@ lwgeom_difference(const LWGEOM* geom1, const LWGEOM* geom2)
 
 	g3 = GEOSDifference(g1, g2);
 
-	if (!g3)
-	{
-		GEOSGeometry *g1v, *g2v;
-		lwnotice("%s: GEOS Error: %s", __func__, lwgeom_geos_errmsg);
-
-		if (!GEOSisValid(g1) || !GEOSisValid(g2))
-		{
-			lwnotice(
-			    "Your geometry dataset is not valid per OGC Specification. "
-			    "Please fix it with manual review of entries that are not ST_IsValid(geom). "
-			    "Retrying GEOS operation with ST_MakeValid of your input.");
-			g1v = LWGEOM_GEOS_makeValid(g1);
-			g2v = LWGEOM_GEOS_makeValid(g2);
-			g3 = GEOSDifference(g1v, g2v);
-			GEOS_FREE(g1v, g2v);
-		}
-	}
-
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
 	GEOSSetSRID(g3, srid);
 
@@ -780,24 +744,6 @@ lwgeom_symdifference(const LWGEOM* geom1, const LWGEOM* geom2)
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
 
 	g3 = GEOSSymDifference(g1, g2);
-
-	if (!g3)
-	{
-		GEOSGeometry *g1v, *g2v;
-		lwnotice("%s: GEOS Error: %s", __func__, lwgeom_geos_errmsg);
-
-		if (!GEOSisValid(g1) || !GEOSisValid(g2))
-		{
-			lwnotice(
-			    "Your geometry dataset is not valid per OGC Specification. "
-			    "Please fix it with manual review of entries that are not ST_IsValid(geom). "
-			    "Retrying GEOS operation with ST_MakeValid of your input.");
-			g1v = LWGEOM_GEOS_makeValid(g1);
-			g2v = LWGEOM_GEOS_makeValid(g2);
-			g3 = GEOSSymDifference(g1v, g2v);
-			GEOS_FREE(g1v, g2v);
-		}
-	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
 	GEOSSetSRID(g3, srid);
@@ -864,23 +810,6 @@ lwgeom_pointonsurface(const LWGEOM *geom)
 
 	g3 = GEOSPointOnSurface(g1);
 
-	if (!g3)
-	{
-		GEOSGeometry *g1v;
-		lwnotice("%s: GEOS Error: %s", __func__, lwgeom_geos_errmsg);
-
-		if (!GEOSisValid(g1))
-		{
-			lwnotice(
-			    "Your geometry dataset is not valid per OGC Specification. "
-			    "Please fix it with manual review of entries that are not ST_IsValid(geom). "
-			    "Retrying GEOS operation with ST_MakeValid of your input.");
-			g1v = LWGEOM_GEOS_makeValid(g1);
-			g3 = GEOSPointOnSurface(g1v);
-			GEOS_FREE(g1v);
-		}
-	}
-
 	if (!g3) GEOS_FREE_AND_FAIL(g1);
 	GEOSSetSRID(g3, srid);
 
@@ -914,24 +843,6 @@ lwgeom_union(const LWGEOM* geom1, const LWGEOM* geom2)
 	if (!(g2 = LWGEOM2GEOS(geom2, AUTOFIX))) GEOS_FREE_AND_FAIL(g1);
 
 	g3 = GEOSUnion(g1, g2);
-
-	if (!g3)
-	{
-		GEOSGeometry *g1v, *g2v;
-		lwnotice("%s: GEOS Error: %s", __func__, lwgeom_geos_errmsg);
-
-		if (!GEOSisValid(g1) || !GEOSisValid(g2))
-		{
-			lwnotice(
-			    "Your geometry dataset is not valid per OGC Specification. "
-			    "Please fix it with manual review of entries that are not ST_IsValid(geom). "
-			    "Retrying GEOS operation with ST_MakeValid of your input.");
-			g1v = LWGEOM_GEOS_makeValid(g1);
-			g2v = LWGEOM_GEOS_makeValid(g2);
-			g3 = GEOSUnion(g1v, g2v);
-			GEOS_FREE(g1v, g2v);
-		}
-	}
 
 	if (!g3) GEOS_FREE_AND_FAIL(g1, g2);
 	GEOSSetSRID(g3, srid);

--- a/regress/clipbybox2d_expected
+++ b/regress/clipbybox2d_expected
@@ -2,11 +2,7 @@
 2|BOX(5 5,8 8)
 3|BOX(2 2,8 8)
 4|MULTIPOINT(0 0,2 2)
-NOTICE:  lwgeom_intersection: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
-NOTICE:  Self-intersection
-NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
-NOTICE:  Self-intersection
-5|MULTIPOLYGON(((2 2,5 5,8 2,2 2)),((5 5,2 8,8 8,5 5)))
+ERROR:  lwgeom_intersection: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
 6|MULTIPOLYGON(((2.5 2,5 4,5 5,10 5,10 2,2.5 2)))
 7|POLYGON((2 2,2 5,5 5,5 2,2 2))
 8|SRID=3857;POLYGON EMPTY

--- a/regress/tickets_expected
+++ b/regress/tickets_expected
@@ -326,31 +326,11 @@ NOTICE:  Too few points in geometry component at or near point 0 0
 #4011|ST_MultiLineString|MULTILINESTRING EMPTY|t|t
 #4011|ST_GeometryCollection|MULTILINESTRING((0 0,0 0))|f|f
 #4025|
-NOTICE:  lwgeom_intersection: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
-NOTICE:  Self-intersection
-NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
-NOTICE:  Self-intersection
-#4037.1|MULTIPOLYGON(((2 2,5 5,8 2,2 2)),((5 5,2 8,8 8,5 5)))
-NOTICE:  lwgeom_difference: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
-NOTICE:  Self-intersection
-NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
-NOTICE:  Self-intersection
-#4037.2|MULTIPOLYGON(((0 0,2 2,8 2,10 0,0 0)),((2 8,0 10,10 10,8 8,2 8)))
-NOTICE:  lwgeom_symdifference: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
-NOTICE:  Self-intersection
-NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
-NOTICE:  Self-intersection
-#4037.3|MULTIPOLYGON(((0 0,2 2,8 2,10 0,0 0)),((5 5,2 2,2 8,5 5)),((8 2,5 5,8 8,8 2)),((2 8,0 10,10 10,8 8,2 8)))
-NOTICE:  lwgeom_union: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
-NOTICE:  Self-intersection
-NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
-NOTICE:  Self-intersection
-#4037.4|POLYGON((0 0,2 2,2 8,0 10,10 10,8 8,8 2,10 0,0 0))
+ERROR:  lwgeom_intersection: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
+ERROR:  lwgeom_difference: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
+ERROR:  lwgeom_symdifference: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
+ERROR:  lwgeom_union: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
 #4055a|4326
 #4055b|4326
 #4089|LINESTRING Z (1 1 1,3 3 1)
-NOTICE:  lwgeom_pointonsurface: GEOS Error: TopologyException: Input geom 1 is invalid: Self-intersection
-NOTICE:  Self-intersection
-NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
-NOTICE:  Self-intersection
-#4103|t
+ERROR:  lwgeom_pointonsurface: GEOS Error: TopologyException: Input geom 1 is invalid: Self-intersection


### PR DESCRIPTION
This PR reverts the geometry autofixing behavior that was added for 2.5 to avoid conflict with a comprehensive, documented approach in 3.0.