### PR TITLE
Fix postgis_tiger_geocoder.control generation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1459,7 +1459,6 @@ AC_OUTPUT([GNUmakefile
    extensions/postgis_sfcgal/Makefile
    extensions/postgis_topology/Makefile
    extensions/postgis_tiger_geocoder/Makefile
-   extensions/postgis_tiger_geocoder/postgis_tiger_geocoder.control
    extensions/address_standardizer/Makefile
    liblwgeom/Makefile
    liblwgeom/cunit/Makefile


### PR DESCRIPTION
Commit 639308e94df7b77c42e3ef73798d277fa80c971b moved the
postgis_tiger_geocoder.control into the Makefile, but forgot to remove
the file from configure.ac, which still generates the file, so the
Makefile rule is not effective and the resulting .control file has the
raw @EXTVERSION@ line from the .in file.

Cc: @strk 