### PR TITLE
ST_AsMVTGeom: Clip using tile coordinates also for buffer 0

### DIFF
--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -696,11 +696,7 @@ LWGEOM *mvt_geom(LWGEOM *lwgeom, const GBOX *gbox, uint32_t extent, uint32_t buf
 	gridspec grid;
 	double width = gbox->xmax - gbox->xmin;
 	double height = gbox->ymax - gbox->ymin;
-	double resx = width / extent;
-	double resy = height / extent;
-	double res = (resx < resy ? resx : resy)/2;
-	double fx = extent / width;
-	double fy = -(extent / height);
+	double resx, resy, res, fx, fy;
 	int preserve_collapsed = LW_TRUE;
 	POSTGIS_DEBUG(2, "mvt_geom called");
 
@@ -714,6 +710,12 @@ LWGEOM *mvt_geom(LWGEOM *lwgeom, const GBOX *gbox, uint32_t extent, uint32_t buf
 	if (extent == 0)
 		elog(ERROR, "mvt_geom: extent cannot be 0");
 
+	resx = width / extent;
+	resy = height / extent;
+	res = (resx < resy ? resx : resy)/2;
+	fx = extent / width;
+	fy = -(extent / height);
+
 	/* Remove all non-essential points (under the output resolution) */
 	lwgeom_remove_repeated_points_in_place(lwgeom, res);
 	lwgeom_simplify_in_place(lwgeom, res, preserve_collapsed);
@@ -726,8 +728,7 @@ LWGEOM *mvt_geom(LWGEOM *lwgeom, const GBOX *gbox, uint32_t extent, uint32_t buf
 	{
 		// We need to add an extra half pixel to include the points that
 		// fall into the bbox only after the coordinate transformation
-		double buffer_map_xunits = !buffer ?
-			0.0 : nextafterf(resx * (buffer + 0.5), 0.0);
+		double buffer_map_xunits = nextafterf(res, 0.0) + resx * buffer;
 		GBOX bgbox;
 		const GBOX *lwgeom_gbox = lwgeom_get_bbox(lwgeom);;
 		bgbox = *gbox;

--- a/regress/mvt.sql
+++ b/regress/mvt.sql
@@ -204,6 +204,59 @@ SELECT 'PG38', ST_AsText(ST_AsMVTGeom(
 	ST_MakeBox2D(ST_Point(0, 0), ST_Point(4096, 4096)),
 	4096, 256, true));
 
+SELECT 'PG39 - ON ', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('POLYGON((0 100, 100 100, 100 90, 94 90, 94 96, 90 96, 90 80, 100 80, 100 0, 0 0, 0 100))'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, true));
+
+SELECT 'PG39 - OFF', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('POLYGON((0 100, 100 100, 100 90, 94 90, 94 96, 90 96, 90 80, 100 80, 100 0, 0 0, 0 100))'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, false));
+
+-- Clipping isn't done since all points fall into the tile after grid
+SELECT 'PG40 - ON ', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('LINESTRING(0 0, 2 20, -2 40, -4 60, 4 80, 0 100)'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, true));
+
+SELECT 'PG40 - OFF', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('LINESTRING(0 0, 2 20, -2 40, -4 60, 4 80, 0 100)'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, false));
+
+-- Clipping isn't done since all points fall into the tile after grid
+SELECT 'PG41 - ON ', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('LINESTRING(0 0, 2 20, -2 40, -4 60, 4 80, 0 100, 10 100)'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, true));
+
+SELECT 'PG41 - OFF', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('LINESTRING(0 0, 2 20, -2 40, -4 60, 4 80, 0 100, 10 100)'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, false));
+
+SELECT 'PG42 - ON ', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('LINESTRING(0 0, 2 20, -2 40, -4 60, 4 80, 0 100, 11 100)'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, true));
+
+SELECT 'PG42 - OFF', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('LINESTRING(0 0, 2 20, -2 40, -4 60, 4 80, 0 100, 11 100)'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, false));
+
+-- Invalid polygon (intersection)
+SELECT 'PG43 - ON ', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('POLYGON((-10 -10, 110 110, -10 110, 110 -10, -10 -10))'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, true));
+
+SELECT 'PG43 - OFF', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('POLYGON((-10 -10, 110 110, -10 110, 110 -10, -10 -10))'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(100, 100)),
+	10, 0, false));
+
 -- geometry encoding tests
 SELECT 'TG1', encode(ST_AsMVT(q, 'test', 4096, 'geom'), 'base64') FROM (SELECT 1 AS c1,
 	ST_AsMVTGeom(ST_GeomFromText('POINT(25 17)'),

--- a/regress/mvt_expected
+++ b/regress/mvt_expected
@@ -36,6 +36,20 @@ PG35|POINT(4352 4352)
 PG36|
 PG37|
 PG38|
+PG39 - ON |POLYGON((0 0,10 0,9 2,10 2,10 10,0 10,0 0))
+PG39 - OFF|POLYGON((0 0,10 0,9 2,10 2,10 10,0 10,0 0))
+PG40 - ON |LINESTRING(0 10,0 0)
+PG40 - OFF|LINESTRING(0 10,0 0)
+PG41 - ON |LINESTRING(0 10,0 4,0 2,0 0,1 0)
+PG41 - OFF|LINESTRING(0 10,0 4,0 2,0 0,1 0)
+PG42 - ON |LINESTRING(0 10,0 0,1 0)
+PG42 - OFF|LINESTRING(0 10,0 0,1 0)
+NOTICE:  lwgeom_intersection: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
+NOTICE:  Self-intersection
+NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
+NOTICE:  Self-intersection
+PG43 - ON |MULTIPOLYGON(((0 10,5 5,10 10,0 10)),((5 5,0 0,10 0,5 5)))
+PG43 - OFF|MULTIPOLYGON(((5 5,-1 -1,11 -1,5 5)),((5 5,11 11,-1 11,5 5)))
 TG1|GiEKBHRlc3QSDBICAAAYASIECTLePxoCYzEiAigBKIAgeAI=
 TG2|GiMKBHRlc3QSDhICAAAYASIGETLePwIBGgJjMSICKAEogCB4Ag==
 TG3|GiYKBHRlc3QSERICAAAYAiIJCQCAQArQD88PGgJjMSICKAEogCB4Ag==


### PR DESCRIPTION
Does several things:
- Avoid undefined behaviour when extent == 0, which meant that the check could be removed by the compiler.
- Clips using tile coordinates also for buffer == 0.
- Adds some more extra tests for clipping.
- Adds a test with an invalid polygon so issues as the one being discussed in https://github.com/postgis/postgis/pull/268 are reflected somewhere in the tests.