### PR TITLE
Provide a way to opt out from autofix

### DIFF
--- a/postgis/harden.sql
+++ b/postgis/harden.sql
@@ -1,0 +1,64 @@
+-- This file replaces standard PostGIS functions with their versions
+-- actively checking input to be valid.
+
+begin;
+create or replace function _ST_FailOnInvalid(geom geometry)
+returns boolean as
+$$
+declare
+	v valid_detail;
+begin
+	v = ST_IsValidDetail(geom);
+	if (not v.valid) then
+		raise exception 'Input geometry of type % with % points is invalid at location %: %',
+		ST_GeometryType(geom), ST_NPoints(geom), ST_AsText(v.location), v.reason;
+	end if;
+	return true;
+end
+$$
+language plpgsql volatile strict parallel safe cost 1;
+
+alter function ST_Intersection(geometry, geometry) rename to ST_Intersection_real;
+create function ST_Intersection(geom1 geometry, geom2 geometry)
+returns geometry
+as $$
+select ST_Intersection_real(geom1, geom2) where _ST_FailOnInvalid(geom1) and _ST_FailOnInvalid(geom2)
+$$ language sql parallel safe;
+
+alter function ST_Union(geometry, geometry) rename to ST_Union_real;
+create function ST_Union(geom1 geometry, geom2 geometry)
+returns geometry
+as $$
+select ST_Union_real(geom1, geom2) where _ST_FailOnInvalid(geom1) and _ST_FailOnInvalid(geom2)
+$$ language sql parallel safe;
+
+alter function ST_Difference(geometry, geometry) rename to ST_Difference_real;
+create function ST_Difference(geom1 geometry, geom2 geometry)
+returns geometry
+as $$
+select ST_Difference_real(geom1, geom2) where _ST_FailOnInvalid(geom1) and _ST_FailOnInvalid(geom2)
+$$ language sql parallel safe;
+
+alter function ST_SymDifference(geometry, geometry) rename to ST_SymDifference_real;
+create function ST_SymDifference(geom1 geometry, geom2 geometry)
+returns geometry
+as $$
+select ST_SymDifference_real(geom1, geom2) where _ST_FailOnInvalid(geom1) and _ST_FailOnInvalid(geom2)
+$$ language sql parallel safe;
+
+alter function ST_Buffer(geometry, float) rename to ST_Buffer_real;
+create function ST_Buffer(geom1 geometry, r float)
+returns geometry
+as $$
+select ST_Buffer_real(geom1, r) where _ST_FailOnInvalid(geom1)
+$$ language sql parallel safe;
+
+alter function ST_PointOnSurface(geometry) rename to ST_PointOnSurface_real;
+create function ST_PointOnSurface(geom1 geometry)
+returns geometry
+as $$
+select ST_PointOnSurface_real(geom1) where _ST_FailOnInvalid(geom1)
+$$ language sql parallel safe;
+
+commit;
+


### PR DESCRIPTION
In https://trac.osgeo.org/postgis/ticket/4040 there is a request to provide a way that works for users that are concerned with data integrity.

In https://github.com/postgis/postgis/pull/268 it is expected that data integrity can be preserved by reverting the change. However, it's not the case: GEOS can produce an incorrect result from overlay operation on invalid geometries without throwing any exception. Example:

```
SELECT ST_AsGeoJSON(ST_Intersection('POLYGON((0 0,5 4,5 6,0 10,10 10,5 6,5 4,10 0,0 0))', ST_MakeEnvelope(2,2,10,5)));
------
{"type":"GeometryCollection","geometries":[{"type":"LineString","coordinates":[[5,5],[5,4],[7.5,2]]},{"type":"Polygon","coordinates":[[[2.5,2],[5,4],[5,5],[10,5],[10,2],[7.5,2],[2.5,2]]]}]} 
```
input:
![image](https://user-images.githubusercontent.com/810638/43040705-5f68cce6-8d53-11e8-9a1d-a1cce0de3c67.png)

result:
![image](https://user-images.githubusercontent.com/810638/43040718-b7ad1a88-8d53-11e8-8f79-26fb78e84447.png)

To satisfy people who are concerned with data integrity, we can provide them with a way of replacing the functions with their versions checking the inputs. Then, even with this example, it feels like "old" behavior and provides some guarantees:

```
01:55:27 [kom] > SELECT ST_AsGeoJSON(ST_Intersection('POLYGON((0 0,5 4,5 6,0 10,10 10,5 6,5 4,10 0,0 0))', ST_MakeEnvelope(2,2,10,5)));
ERROR:  P0001: Input geometry of type ST_Polygon with 9 points is invalid at location POINT(5 4): Self-intersection
CONTEXT:  PL/pgSQL function _st_failoninvalid(geometry) line 7 at RAISE
SQL function "st_intersection" statement 1
LOCATION:  exec_stmt_raise, pl_exec.c:3725
Time: 1,514 ms
```