### PR TITLE
Revert to old ST_ClipByBox2d behaviour with invalids

### DIFF
--- a/doc/reference_processing.xml
+++ b/doc/reference_processing.xml
@@ -490,14 +490,16 @@ FROM (SELECT ST_Buffer(
 		<title>Description</title>
 
     <para>
-Clips a geometry by a 2D box.</para>
+Clips a geometry by a 2D box. The output geometry is not guaranteed to be valid
+(self-intersections for a polygon may be introduced).
+Topologically invalid input geometries do not result in exceptions being thrown.
+    </para>
 
 		<para>Performed by the GEOS module.</para>
 		<note><para>Requires GEOS 3.5.0+</para></note>
 
 		<para>Availability: 2.2.0 - requires GEOS &gt;= 3.5.0.</para>
-                <para>Changed: 2.5.0 - wrapper around ST_Intersection to work around GEOS bugs.
-                      No longer supports invalid input geometry.</para>
+		<para>Changed: 2.5.0 - wrapper around ST_Intersection to work around GEOS bugs. </para>
 
 	  </refsection>
 

--- a/liblwgeom/cunit/cu_clip_by_rect.c
+++ b/liblwgeom/cunit/cu_clip_by_rect.c
@@ -64,6 +64,15 @@ static void test_lwgeom_clip_by_rect(void)
 	//tmp = lwgeom_to_ewkt(out); printf("%s\n", tmp); lwfree(tmp);
 	CU_ASSERT(lwgeom_is_empty(out));
 	lwgeom_free(out); lwgeom_free(in);
+
+	/* Invalid polygon (lineal self-intersection) */
+	wkt = "POLYGON((0 0, 10 10, 0 10, 10 0, 0 0))";
+	in = lwgeom_from_wkt(wkt, LW_PARSER_CHECK_NONE);
+	out = lwgeom_clip_by_rect(in, 2, 2, 8, 8);
+	tmp = lwgeom_to_ewkt(out);
+	printf("%s\n", tmp);
+	CU_ASSERT_STRING_EQUAL("MULTIPOLYGON(((2 2,5 5,8 2,2 2)),((5 5,2 8,8 8,5 5)))", tmp);
+	lwfree(tmp); lwgeom_free(out); lwgeom_free(in);
 }
 
 /*

--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -858,19 +858,52 @@ LWGEOM *
 lwgeom_clip_by_rect(const LWGEOM *geom1, double x1, double y1, double x2, double y2)
 {
 	LWGEOM *result;
-	LWGEOM *tmp;
+	GEOSGeometry *geos_orig, *geos_env, *geos_result;
 
 	/* This lwgeom_intersection should be a call to GEOSClipByRect:
 	 * g3 = GEOSClipByRect(g1, x1, y1, x2, y2);
 	 * Unfortunately as of GEOS 3.7 it chokes on practical inputs.
 	 * GEOS ticket: https://trac.osgeo.org/geos/ticket/865
-	 */
+	 * Instead we manually call GEOSIntersection and handle exceptions to guarantee
+	 * the function works with invalid inputs */
+
+	if (!geom1)
+		return NULL;
+	if (lwgeom_is_empty(geom1))
+		return lwgeom_clone_deep(geom1);
+
+	initGEOS(lwnotice, lwgeom_geos_error);
+
+	if (!(geos_orig = LWGEOM2GEOS(geom1, LW_TRUE)))
+		GEOS_FAIL();
 
 	LWGEOM *envelope = (LWGEOM *)lwpoly_construct_envelope(geom1->srid, x1, y1, x2, y2);
-	result = lwgeom_intersection(geom1, envelope);
+	geos_env = LWGEOM2GEOS(envelope, LW_TRUE);
 	lwgeom_free(envelope);
+	if (!geos_env)
+		GEOS_FREE_AND_FAIL(geos_orig);
 
-	if (!result) return NULL;
+	if (!(geos_result = GEOSIntersection(geos_orig, geos_env)))
+	{
+		// Handle invalid input
+		GEOSGeometry* geos_orig_fixed;
+		if ((geos_orig_fixed = LWGEOM_GEOS_makeValid(geos_orig)))
+		{
+			geos_result = GEOSIntersection(geos_orig_fixed, geos_env);
+			GEOSGeom_destroy(geos_orig_fixed);
+		}
+	}
+
+	GEOSGeom_destroy(geos_orig);
+	GEOSGeom_destroy(geos_env);
+
+	if (!geos_result)
+		return NULL;
+
+	if (!(result = GEOS2LWGEOM(geos_result, FLAGS_GET_Z(geom1->flags))))
+		GEOS_FREE_AND_FAIL(geos_result);
+	GEOS_FREE(geos_result);
+	result->srid = geom1->srid;
 
 	/* clipping should not produce lower dimension objects */
 	if (
@@ -879,7 +912,8 @@ lwgeom_clip_by_rect(const LWGEOM *geom1, double x1, double y1, double x2, double
 	    /* output may have different things inside */
 	    result->type == COLLECTIONTYPE)
 	{
-		tmp = lwcollection_as_lwgeom(lwcollection_extract(lwgeom_as_lwcollection(result), lwgeom_dimension(geom1) + 1));
+		LWGEOM *tmp = lwcollection_as_lwgeom(lwcollection_extract(lwgeom_as_lwcollection(result),
+																  lwgeom_dimension(geom1) + 1));
 		lwfree(result);
 		result = tmp;
 		if (!result) return NULL;

--- a/regress/clipbybox2d_expected
+++ b/regress/clipbybox2d_expected
@@ -2,7 +2,8 @@
 2|BOX(5 5,8 8)
 3|BOX(2 2,8 8)
 4|MULTIPOINT(0 0,2 2)
-ERROR:  lwgeom_intersection: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
+NOTICE:  Self-intersection
+5|MULTIPOLYGON(((2 2,5 5,8 2,2 2)),((5 5,2 8,8 8,5 5)))
 6|MULTIPOLYGON(((2.5 2,5 4,5 5,10 5,10 2,2.5 2)))
 7|POLYGON((2 2,2 5,5 5,5 2,2 2))
 8|SRID=3857;POLYGON EMPTY

--- a/regress/mvt_expected
+++ b/regress/mvt_expected
@@ -44,9 +44,6 @@ PG41 - ON |LINESTRING(0 10,0 4,0 2,0 0,1 0)
 PG41 - OFF|LINESTRING(0 10,0 4,0 2,0 0,1 0)
 PG42 - ON |LINESTRING(0 10,0 0,1 0)
 PG42 - OFF|LINESTRING(0 10,0 0,1 0)
-NOTICE:  lwgeom_intersection: GEOS Error: TopologyException: Input geom 0 is invalid: Self-intersection
-NOTICE:  Self-intersection
-NOTICE:  Your geometry dataset is not valid per OGC Specification. Please fix it with manual review of entries that are not ST_IsValid(geom). Retrying GEOS operation with ST_MakeValid of your input.
 NOTICE:  Self-intersection
 PG43 - ON |MULTIPOLYGON(((0 10,5 5,10 10,0 10)),((5 5,0 0,10 0,5 5)))
 PG43 - OFF|MULTIPOLYGON(((5 5,-1 -1,11 -1,5 5)),((5 5,11 11,-1 11,5 5)))


### PR DESCRIPTION
After some tests with MVTs I didn't see any significant performance difference between doing the validation before calling `lwgeom_clip_by_rect` or implementing my own call to GEOSIntersection with error handling, probably because the input was always correct and not so many of the geometries needed clipping (most fall inside the tile completely), so I decided to kill 2 birds and adapt the call directly in `lwgeom_clip_by_rect` so we get the old behaviour (validity tolerance) in 2.5.

This should fix https://trac.osgeo.org/postgis/ticket/4135 and https://trac.osgeo.org/postgis/ticket/4134.

BTW, here are some of the stuff I tested in case you are curious:
- Implementation in MVT_geom: https://github.com/Algunenano/postgis/blob/bb8d4512f5edc9813130ce6064f98db1fb27c109/postgis/mvt.c#L744
- Implementation forcing validation with memory handling: https://github.com/Algunenano/postgis/blob/1085acd64ac84e86ca1a7e6f377e9b796eab174b/postgis/mvt.c#L742
- Without memory handling: https://github.com/Algunenano/postgis/blob/33c39109bc2f16553daa8304f4e2f26dd1096598/postgis/mvt.c#L747