### PR TITLE
Use user provided CFLAGS in topology and address standardizer

### DIFF
--- a/extensions/address_standardizer/Makefile.in
+++ b/extensions/address_standardizer/Makefile.in
@@ -51,7 +51,7 @@ EXTRA_CLEAN += sql/*.sql
 
 
 DOCS = README.address_standardizer
-PG_CPPFLAGS = @CPPFLAGS@ -g -O0
+PG_CPPFLAGS = @CFLAGS@ @CPPFLAGS@
 
 SHLIB_LINK = @SHLIB_LINK@ -lpcre
 EXTRA_CLEAN = usps-st-city-name.txt mk-st-regexp mk-city-regex test_main

--- a/extensions/address_standardizer/parseaddress-api.c
+++ b/extensions/address_standardizer/parseaddress-api.c
@@ -57,7 +57,7 @@ const char *get_state_regex(char *st)
 
 int clean_trailing_punct(char *s)
 {
-    int i;
+    size_t i;
     int ret = 0;
 
     i=strlen(s)-1;
@@ -70,7 +70,7 @@ int clean_trailing_punct(char *s)
 
 char *clean_leading_punct(char *s)
 {
-    int i;
+    size_t i;
 
     for (i=0; i<strlen(s); i++)
         if (!(ispunct(s[i]) || isspace(s[i])))
@@ -81,7 +81,7 @@ char *clean_leading_punct(char *s)
 
 void strtoupper(char *s)
 {
-    int i;
+    size_t i;
 
     for (i=0; i<strlen(s); i++)
         s[i] = toupper(s[i]);
@@ -120,7 +120,7 @@ ADDRESS *parseaddress(HHash *stH, char *s, int *reterr)
     char *state = NULL;
     char *regx;
     int mi;
-    int i, j;
+    size_t ui, uj;
     int rc;
     int comma = 0;
     ADDRESS *ret;
@@ -145,16 +145,16 @@ ADDRESS *parseaddress(HHash *stH, char *s, int *reterr)
 
     /* clean the string of multiple white spaces and . */
 
-    for (i=0, j=0; i<strlen(s); i++) {
-        c = s[i];
-        if (c == '.') c = s[i] = ' ';
-        if (j == 0 && isspace(c)) continue;
-        if (i && isspace(c) && isspace(s[i-1])) continue;
-        s[j] = s[i];
-        j++;
+    for (ui=0, uj=0; ui<strlen(s); ui++) {
+        c = s[ui];
+        if (c == '.') c = s[ui] = ' ';
+        if (uj == 0 && isspace(c)) continue;
+        if (ui && isspace(c) && isspace(s[ui-1])) continue;
+        s[uj] = s[ui];
+        uj++;
     }
-    if (isspace(s[j-1])) j--;
-    s[j] = '\0';
+    if (isspace(s[uj-1])) uj--;
+    s[uj] = '\0';
 
     /* clean trailing punctuation */
     comma |= clean_trailing_punct(s);
@@ -299,6 +299,7 @@ ADDRESS *parseaddress(HHash *stH, char *s, int *reterr)
     }
     DBG("Checked for state-city: %d", rc);
     if (rc <= 0) {
+        int i;
         /* run through the regx's and see if we get a match */
         for (i=0; i<nreg; i++) {
             mi++;

--- a/liblwgeom/liblwgeom_topo.h
+++ b/liblwgeom/liblwgeom_topo.h
@@ -188,6 +188,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param ids an array of element identifiers
    * @param numelems input/output parameter, pass number of node identifiers
    *                 in the input array, gets number of node in output array.
+   *	TODO: Should be uint64 to match SPI_processed
    * @param fields fields to be filled in the returned structure, see
    *               LWT_COL_NODE_* macros
    *
@@ -212,6 +213,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param numelems output parameter, gets number of elements found
    *                 if the return is not null, otherwise see @return
    *                 section for semantic.
+   *	TODO: Should be uint64 to match SPI_processed
    * @param fields fields to be filled in the returned structure, see
    *               LWT_COL_NODE_* macros
    * @param limit max number of nodes to return, 0 for no limit, -1
@@ -239,6 +241,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param nodes the nodes to insert. Those with a node_id set to -1
    *              it will be replaced to an automatically assigned identifier
    * @param nelems number of elements in the nodes array
+   *	TODO: Should be uint64 to match SPI_processed
    *
    * @return 1 on success, 0 on error (@see lastErrorMessage)
    */
@@ -319,6 +322,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param edges the edges to insert. Those with a edge_id set to -1
    *              it will be replaced to an automatically assigned identifier
    * @param nelems number of elements in the edges array
+   *	TODO: Should be uint64 to match SPI_processed
    *
    * @return number of inserted edges, or -1 (@see lastErrorMessage)
    */
@@ -555,6 +559,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param faces the faces to insert. Those with a node_id set to -1
    *              it will be replaced to an automatically assigned identifier
    * @param nelems number of elements in the faces array
+   *	TODO: Should be uint64 to match SPI_processed
    *
    * @return number of inserted faces, or -1 (@see lastErrorMessage)
    */
@@ -571,6 +576,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param faces an array of LWT_ISO_FACE object with selecting id
    *              and setting mbr.
    * @param numfaces number of faces in the "faces" array
+   *	TODO: Should be uint64 to match SPI_processed
    *
    * @return number of faces being updated or -1 on error
    *         (@see lastErroMessage)
@@ -598,6 +604,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    *             side (left if positive, right if negative)
    *             and direction (forward if positive, backward if negative).
    * @param numedges output parameter, gets the number of edges visited
+   *
    * @param limit max edges to return (to avoid an infinite loop in case
    *              of a corrupted topology). 0 is for unlimited.
    *              The function is expected to error out if the limit is hit.
@@ -618,6 +625,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param edges an array of LWT_ISO_EDGE object with selecting id
    *              and updating fields.
    * @param numedges number of edges in the "edges" array
+   *	TODO: Should be uint64 to match SPI_processed
    * @param upd_fields fields to be updated for the selected edges,
    *                   see LWT_COL_EDGE_* macros
    *
@@ -641,6 +649,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    *                 in the input array, gets number of edges in output array
    *                 if the return is not null, otherwise see @return
    *                 section for semantic.
+   *	TODO: Should be uint64 to match SPI_processed
    * @param fields fields to be filled in the returned structure, see
    *               LWT_COL_EDGE_* macros
    * @param box optional bounding box to further restrict matches, use
@@ -665,6 +674,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    *                 identifiers in the input array, gets number of
    *                 nodes in output array if the return is not null,
    *                 otherwise see @return section for semantic.
+   *	TODO: Should be uint64 to match SPI_processed
    * @param fields fields to be filled in the returned structure, see
    *               LWT_COL_NODE_* macros
    * @param box optional bounding box to further restrict matches, use
@@ -687,6 +697,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param nodes an array of LWT_ISO_EDGE objects with selecting id
    *              and updating fields.
    * @param numnodes number of nodes in the "nodes" array
+   *	TODO: Should be uint64 to match SPI_processed
    * @param upd_fields fields to be updated for the selected edges,
    *                   see LWT_COL_NODE_* macros
    *
@@ -705,6 +716,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param topo the topology to act upon
    * @param ids an array of face identifiers
    * @param numelems number of face identifiers in the ids array
+   *	TODO: Should be uint64 to match SPI_processed
    *
    * @return number of faces being deleted or -1 on error
    *         (@see lastErrorMessage)
@@ -744,6 +756,7 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param topo the topology to act upon
    * @param ids an array of node identifiers
    * @param numelems number of node identifiers in the ids array
+   *	TODO: Should be uint64 to match SPI_processed
    *
    * @return number of nodes being deleted or -1 on error
    *         (@see lastErrorMessage)
@@ -847,10 +860,11 @@ typedef struct LWT_BE_CALLBACKS_T {
    * @param numelems output parameter, gets number of elements found
    *                 if the return is not null, otherwise see @return
    *                 section for semantic.
+   *	TODO: Should be uint64 to match SPI_processed
    * @param fields fields to be filled in the returned structure, see
    *               LWT_COL_FACE_* macros
    * @param limit max number of faces to return, 0 for no limit, -1
-   *              to only check for existance if a matching row.
+   *              to only check for existence if a matching row.
    *
    * @return an array of faces or null in the following cases:
    *         - limit=-1 ("numelems" is set to 1 if found, 0 otherwise)

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -44,7 +44,7 @@ OBJS = postgis_topology.o
 # to an existing liblwgeom.so in the PostgreSQL $libdir supplied by an
 # older version of PostGIS, rather than with the static liblwgeom.a
 # supplied with newer versions of PostGIS
-PG_CPPFLAGS += -I../liblwgeom -I../libpgcommon @CPPFLAGS@ -fPIC
+PG_CPPFLAGS += -I../liblwgeom @CFLAGS@ -I../libpgcommon @CPPFLAGS@ -fPIC
 SHLIB_LINK_F = ../libpgcommon/libpgcommon.a ../liblwgeom/.libs/liblwgeom.a @SHLIB_LINK@
 
 # Add SFCGAL Flags if defined


### PR DESCRIPTION
For both extensions, use the CFLAGS provided in the `configure` step.

For topology I've decided to not change the function type signatures to get this into 2.5, so I've left several `TODO`s as the implementation is buggy if more rows are turned that `INT_MAX`. I've tried to make it so if this happens only information would be lost instead of having undefined behaviour.