### PR TITLE
Fix memory leak in lwgeom_offsetcurve

### DIFF
--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -1389,13 +1389,15 @@ lwgeom_offsetcurve(const LWGEOM* geom, double size, int quadsegs, int joinStyle,
 		}
 
 		if (result)
+		{
+			if (noded) lwgeom_free(noded);
 			return result;
+		}
 		else if (!noded)
 		{
 			noded = lwgeom_node(geom);
 			if (!noded)
 			{
-				lwfree(noded);
 				lwerror("lwgeom_offsetcurve: cannot node input");
 				return NULL;
 			}
@@ -1403,10 +1405,12 @@ lwgeom_offsetcurve(const LWGEOM* geom, double size, int quadsegs, int joinStyle,
 		}
 		else
 		{
+			lwgeom_free(noded);
 			lwerror("lwgeom_offsetcurve: noded geometry cannot be offset");
 			return NULL;
 		}
 	}
+
 	return result;
 }
 


### PR DESCRIPTION
```bash
$ ./cunit/.libs/lt-cu_tester test_geos_offsetcurve_crash

Running test 'test_geos_offsetcurve_crash' in suite 'geos'.

    PASSED - asserts -   0 passed,   0 failed,   0 total.




=================================================================
==25759==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x55dfc4a27631 in __interceptor_malloc (/home/raul/dev/public/postgis/liblwgeom/cunit/.libs/lt-cu_tester+0xf0631)
    #1 0x7f8ca2eede6e in lwline_construct /home/raul/dev/public/postgis/liblwgeom/lwline.c:45:21
    #2 0x7f8ca2f88d24 in GEOS2LWGEOM /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:180:19
    #3 0x7f8ca2f92b3e in lwgeom_node /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos_node.c:172:10
    #4 0x7f8ca2f8c6d3 in lwgeom_offsetcurve /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:1395:12
    #5 0x55dfc4a6c51b in test_geos_offsetcurve_crash /home/raul/dev/public/postgis/liblwgeom/cunit/cu_geos.c:118:16
    #6 0x7f8ca2c08117  (/usr/lib/libcunit.so.1+0x4117)

Indirect leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x55dfc4a27631 in __interceptor_malloc (/home/raul/dev/public/postgis/liblwgeom/cunit/.libs/lt-cu_tester+0xf0631)
    #1 0x7f8ca2ed6b0e in ptarray_construct_empty /home/raul/dev/public/postgis/liblwgeom/ptarray.c:84:30
    #2 0x7f8ca2ed6b0e in ptarray_construct /home/raul/dev/public/postgis/liblwgeom/ptarray.c:64
    #3 0x7f8ca2f88934 in ptarray_from_GEOSCoordSeq /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:129:7
    #4 0x7f8ca2f88d16 in GEOS2LWGEOM /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:179:8
    #5 0x7f8ca2f92b3e in lwgeom_node /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos_node.c:172:10
    #6 0x7f8ca2f8c6d3 in lwgeom_offsetcurve /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:1395:12
    #7 0x55dfc4a6c51b in test_geos_offsetcurve_crash /home/raul/dev/public/postgis/liblwgeom/cunit/cu_geos.c:118:16
    #8 0x7f8ca2c08117  (/usr/lib/libcunit.so.1+0x4117)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x55dfc4a27631 in __interceptor_malloc (/home/raul/dev/public/postgis/liblwgeom/cunit/.libs/lt-cu_tester+0xf0631)
    #1 0x7f8ca2ed6a51 in ptarray_construct_empty /home/raul/dev/public/postgis/liblwgeom/ptarray.c:72:19
    #2 0x7f8ca2ed6a51 in ptarray_construct /home/raul/dev/public/postgis/liblwgeom/ptarray.c:64
    #3 0x7f8ca2f88934 in ptarray_from_GEOSCoordSeq /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:129:7
    #4 0x7f8ca2f88d16 in GEOS2LWGEOM /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:179:8
    #5 0x7f8ca2f92b3e in lwgeom_node /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos_node.c:172:10
    #6 0x7f8ca2f8c6d3 in lwgeom_offsetcurve /home/raul/dev/public/postgis/liblwgeom/lwgeom_geos.c:1395:12
    #7 0x55dfc4a6c51b in test_geos_offsetcurve_crash /home/raul/dev/public/postgis/liblwgeom/cunit/cu_geos.c:118:16
    #8 0x7f8ca2c08117  (/usr/lib/libcunit.so.1+0x4117)

SUMMARY: AddressSanitizer: 152 byte(s) leaked in 3 allocation(s).
```