### PR TITLE
ptarray_segmentize2d: Fix undefined behaviour when a high number of segments are required

### DIFF
--- a/liblwgeom/cunit/cu_measures.c
+++ b/liblwgeom/cunit/cu_measures.c
@@ -527,17 +527,23 @@ test_lwgeom_segmentize2d(void)
 	lwgeom_free(linein);
 	lwgeom_free(lineout);
 
+	/* test too many segments */
+	linein = lwgeom_from_wkt("LINESTRING(0 0,10 0)", LW_PARSER_CHECK_NONE);
+	lineout = lwgeom_segmentize2d(linein, 1e-100);
+	CU_ASSERT_EQUAL(lineout, NULL);
+	lwgeom_free(linein);
+
 	/* test interruption */
 
 	linein = lwgeom_from_wkt("LINESTRING(0 0,10 0)", LW_PARSER_CHECK_NONE);
 	lwgeom_request_interrupt();
-	lineout = lwgeom_segmentize2d(linein, 1e-100);
+	lineout = lwgeom_segmentize2d(linein, INT32_MAX);
 	CU_ASSERT_EQUAL(lineout, NULL);
 	lwgeom_free(linein);
 
 	linein = lwgeom_from_wkt("MULTILINESTRING((0 0,10 0),(20 0, 30 0))", LW_PARSER_CHECK_NONE);
 	lwgeom_request_interrupt();
-	lineout = lwgeom_segmentize2d(linein, 1e-100);
+	lineout = lwgeom_segmentize2d(linein, INT32_MAX);
 	CU_ASSERT_EQUAL(lineout, NULL);
 	lwgeom_free(linein);
 
@@ -545,7 +551,7 @@ test_lwgeom_segmentize2d(void)
 	  "MULTIPOLYGON(((0 0,20 0,20 20,0 20,0 0),(2 2,2 4,4 4,4 2,2 2),(6 6,6 8,8 8,8 6,6 6)),((40 0,40 20,60 20,60 0,40 0),(42 2,42 4,44 4,44 2,42 2)))"
 	  , LW_PARSER_CHECK_NONE);
 	lwgeom_request_interrupt();
-	lineout = lwgeom_segmentize2d(linein, 1e-100);
+	lineout = lwgeom_segmentize2d(linein, INT32_MAX);
 	CU_ASSERT_EQUAL(lineout, NULL);
 	lwgeom_free(linein);
 
@@ -554,13 +560,15 @@ test_lwgeom_segmentize2d(void)
 	  , LW_PARSER_CHECK_NONE);
 	CU_ASSERT_FATAL(linein != NULL);
 	lwgeom_request_interrupt();
-	lineout = lwgeom_segmentize2d(linein, 1e-100);
+	lineout = lwgeom_segmentize2d(linein, INT32_MAX);
 	CU_ASSERT_EQUAL(lineout, NULL);
 	lwgeom_free(linein);
 
 	linein = lwgeom_from_wkt("LINESTRING(20 0, 30 0)", LW_PARSER_CHECK_NONE);
+	CU_ASSERT_FATAL(linein != NULL);
 	/* NOT INTERRUPTED */
 	lineout = lwgeom_segmentize2d(linein, 5);
+	CU_ASSERT_NOT_EQUAL_FATAL(lineout, NULL);
 	strout = lwgeom_to_ewkt(lineout);
 	ASSERT_STRING_EQUAL(strout, "LINESTRING(20 0,25 0,30 0)");
 	lwfree(strout);

--- a/liblwgeom/ptarray.c
+++ b/liblwgeom/ptarray.c
@@ -442,12 +442,23 @@ ptarray_segmentize2d(const POINTARRAY *ipa, double dist)
 		 * breaks those "strict" rules.
 		 */
 		POINT4D *p1ptr=&p1, *p2ptr=&p2;
+		double segments;
 
 		getPoint4d_p(ipa, i, &p2);
 
 		segdist = distance2d_pt_pt((POINT2D *)p1ptr, (POINT2D *)p2ptr);
 		/* Split input segment into shorter even chunks */
-		nseg = ceil(segdist / dist);
+		segments = ceil(segdist / dist);
+
+		/* Uses INT32_MAX instead of UINT32_MAX to be safe that it fits */
+		if (segments >= INT32_MAX)
+		{
+			lwnotice("%s:%d - %s: Too many segments required (%e)",
+				__FILE__, __LINE__,__func__, segments);
+			ptarray_free(opa);
+			return NULL;
+		}
+		nseg = segments;
 
 		for (j = 1; j < nseg; j++)
 		{


### PR DESCRIPTION
```
$ ./cunit/.libs/lt-cu_tester test_lwgeom_segmentize2d

Running test 'test_lwgeom_segmentize2d' in suite 'measures'.
ptarray.c:450:10: runtime error: 1e+101 is outside the range of representable values of type 'unsigned int'
```

Trac issue created in https://trac.osgeo.org/postgis/ticket/4173#ticket