### PR TITLE
Remove unused errno.h includes

### DIFF
--- a/extensions/address_standardizer/std_pg_hash.c
+++ b/extensions/address_standardizer/std_pg_hash.c
@@ -23,7 +23,6 @@
 #include <sys/time.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 #ifdef DEBUG
 #define SET_TIME(a) gettimeofday(&(a), NULL)

--- a/extras/wkb_reader/wkbtest.h
+++ b/extras/wkb_reader/wkbtest.h
@@ -2,9 +2,7 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 #include <endian.h>
-
 
 #include <libpq-fe.h>
 

--- a/liblwgeom/lwgeom_api.c
+++ b/liblwgeom/lwgeom_api.c
@@ -29,7 +29,6 @@
 #include "lwgeom_log.h"
 
 #include <stdio.h>
-#include <errno.h>
 #include <assert.h>
 #include "../postgis_svn_revision.h"
 

--- a/liblwgeom/lwgeom_topo.c
+++ b/liblwgeom/lwgeom_topo.c
@@ -35,7 +35,6 @@
 
 #include <stdio.h>
 #include <inttypes.h> /* for PRId64 */
-#include <errno.h>
 #include <math.h>
 
 #ifdef WIN32

--- a/liblwgeom/lwgeom_transform.c
+++ b/liblwgeom/lwgeom_transform.c
@@ -28,7 +28,6 @@
 #include "lwgeom_log.h"
 #include <string.h>
 
-
 /** convert decimal degress to radians */
 static void
 to_rad(POINT4D *pt)
@@ -173,6 +172,3 @@ lwproj_from_string(const char *str1)
 	}
 	return pj_init_plus(str1);
 }
-
-
-

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -31,7 +31,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 
 /**

--- a/postgis/geography_inout.c
+++ b/postgis/geography_inout.c
@@ -31,7 +31,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "utils/elog.h"
 #include "utils/array.h"

--- a/postgis/geography_measurement.c
+++ b/postgis/geography_measurement.c
@@ -31,7 +31,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "liblwgeom.h"         /* For standard geometry types. */
 #include "liblwgeom_internal.h"         /* For FP comparators. */

--- a/postgis/gserialized_estimate.c
+++ b/postgis/gserialized_estimate.c
@@ -118,7 +118,6 @@ dimensionality cases. (2D geometry) &&& (3D column), etc.
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 #include <ctype.h>
 
 

--- a/postgis/gserialized_typmod.c
+++ b/postgis/gserialized_typmod.c
@@ -31,7 +31,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "utils/elog.h"
 #include "utils/array.h"

--- a/postgis/lwgeom_box.c
+++ b/postgis/lwgeom_box.c
@@ -39,8 +39,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
-
 
 /* forward defs */
 Datum BOX2D_in(PG_FUNCTION_ARGS);

--- a/postgis/lwgeom_box3d.c
+++ b/postgis/lwgeom_box3d.c
@@ -38,7 +38,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 #define SHOW_DIGS_DOUBLE 15
 #define MAX_DIGS_DOUBLE (SHOW_DIGS_DOUBLE + 6 + 1 + 3 + 1)

--- a/postgis/lwgeom_btree.c
+++ b/postgis/lwgeom_btree.c
@@ -38,7 +38,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 Datum lwgeom_lt(PG_FUNCTION_ARGS);
 Datum lwgeom_le(PG_FUNCTION_ARGS);

--- a/postgis/lwgeom_dump.c
+++ b/postgis/lwgeom_dump.c
@@ -27,7 +27,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 #include <assert.h>
 
 #include "postgres.h"

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -39,7 +39,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 Datum LWGEOM_mem_size(PG_FUNCTION_ARGS);
 Datum LWGEOM_summary(PG_FUNCTION_ARGS);

--- a/postgis/lwgeom_functions_temporal.c
+++ b/postgis/lwgeom_functions_temporal.c
@@ -37,8 +37,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
-
 
 /*
  * Return the measure at which interpolated points on the two

--- a/postgis/lwgeom_in_kml.c
+++ b/postgis/lwgeom_in_kml.c
@@ -41,7 +41,6 @@
 
 #include <libxml/tree.h>
 #include <libxml/parser.h>
-#include <errno.h>
 #include <string.h>
 
 #include "postgres.h"

--- a/postgis/lwgeom_inout.c
+++ b/postgis/lwgeom_inout.c
@@ -30,7 +30,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 #include <assert.h>
 
 #include "access/gist.h"

--- a/postgis/lwgeom_ogc.c
+++ b/postgis/lwgeom_ogc.c
@@ -29,7 +29,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "access/gist.h"
 #include "access/itup.h"

--- a/postgis/lwgeom_spheroid.c
+++ b/postgis/lwgeom_spheroid.c
@@ -30,7 +30,6 @@
 #include <float.h>
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "access/gist.h"
 #include "access/itup.h"

--- a/postgis/lwgeom_transform.c
+++ b/postgis/lwgeom_transform.c
@@ -31,12 +31,9 @@
 #include "liblwgeom.h"
 #include "lwgeom_transform.h"
 
-
 Datum transform(PG_FUNCTION_ARGS);
 Datum transform_geom(PG_FUNCTION_ARGS);
 Datum postgis_proj_version(PG_FUNCTION_ARGS);
-
-
 
 /**
  * transform( GEOMETRY, INT (output srid) )


### PR DESCRIPTION
In #294 @dbaston asked whether it's safe to use `-fno-math-errno`. Tests suggest it's safe, but a global search found a lot of includes of errno.h. However, it's not used in any math operations and can be safely removed.