### PR TITLE
ST_Interscts support GEOMETRYCOLLECTION

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ PostGIS 3.0.0
   - #4161, MVT: Drop geometries smaller than the resolution (Raúl Marín)
   - #4172, Fix memory leak in lwgeom_offsetcurve (Raúl Marín)
   - #4173, Fix undefined behaviour in ptarray_segmentize2d (Raúl Marín)
+  - #4176, ST_Intersects supports GEOMETRYCOLLECTION (Darafei Praliaskouski)
 
 PostGIS 2.5.0rc1
 2018/08/19

--- a/doc/reference_measure.xml
+++ b/doc/reference_measure.xml
@@ -3474,12 +3474,8 @@ FROM test;
 				returns true, then the geometries also spatially intersect.
 				Disjoint implies false for spatial intersection.</para>
 
-	  <important>
-		<para>Do not call with a <varname>GEOMETRYCOLLECTION</varname> as an argument for geometry version.  The geography
-			version supports GEOMETRYCOLLECTION since its a thin wrapper around distance implementation.</para>
-	  </important>
-	  <para>Enhanced: 2.3.0 Enhancement to PIP short-circuit extended to support MultiPoints with few points. Prior versions only supported point in polygon.</para>
-
+			<para>Enhanced: 2.5.0 Supports GEOMETRYCOLLECTION.</para>
+			<para>Enhanced: 2.3.0 Enhancement to PIP short-circuit extended to support MultiPoints with few points. Prior versions only supported point in polygon.</para>
 			<para>Performed by the GEOS module (for geometry), geography is native</para>
 			<para>Availability: 1.5 support for geography was introduced.</para>
 			<note>

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -2148,7 +2148,6 @@ Datum geos_intersects(PG_FUNCTION_ARGS)
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
 
-	errorIfGeometryCollection(geom1,geom2);
 	error_if_srid_mismatch(gserialized_get_srid(geom1), gserialized_get_srid(geom2));
 
 	/* A.Intersects(Empty) == FALSE */

--- a/regress/tickets.sql
+++ b/regress/tickets.sql
@@ -1103,3 +1103,5 @@ SELECT ST_AsText(ST_GeomFromGeoJSON('{"type": "Polygon", "coordinates": [[0,0],[
 
 -- Clean up
 DELETE FROM spatial_ref_sys;
+
+SELECT '#4176', ST_Intersects('POLYGON((0 0, 10 10, 3 5, 0 0))', 'GEOMETRYCOLLECTION(POINT(10 10), LINESTRING(0 0, 3 3))');

--- a/regress/tickets_expected
+++ b/regress/tickets_expected
@@ -336,3 +336,4 @@ ERROR:  lwgeom_union: GEOS Error: TopologyException: Input geom 0 is invalid: Se
 ERROR:  lwgeom_pointonsurface: GEOS Error: TopologyException: Input geom 1 is invalid: Self-intersection
 #4081|f|t
 ERROR:  The 'coordinates' in GeoJSON polygon are not sufficiently nested
+#4176|t


### PR DESCRIPTION
GEOS supports GEOSIntersects for GEOMETRYCOLLECTION.
An extra guard can be removed.

https://trac.osgeo.org/postgis/ticket/4176

