### PR TITLE
Topology: Use the qualified names of the extension tables

### DIFF
--- a/extensions/postgis_topology/sql_bits/mark_editable_objects.sql.in
+++ b/extensions/postgis_topology/sql_bits/mark_editable_objects.sql.in
@@ -1,2 +1,2 @@
-SELECT pg_catalog.pg_extension_config_dump('topology', '');
-SELECT pg_catalog.pg_extension_config_dump('layer', '');
+SELECT pg_catalog.pg_extension_config_dump('topology.topology', '');
+SELECT pg_catalog.pg_extension_config_dump('topology.layer', '');


### PR DESCRIPTION
Fixes https://trac.osgeo.org/postgis/ticket/2503

Not sure how to test this (except manually) and how long do we need to backport it (at least 2.4). I'll have a look.