### PR TITLE
Fix undefined behaviour in SADFWrite

### DIFF
--- a/liblwgeom/lwutil.c
+++ b/liblwgeom/lwutil.c
@@ -280,13 +280,13 @@ char *lwmessage_truncate(char *str, int startpos, int endpos, int maxlength, int
 			{
 				/* Add "..." prefix */
 				outstart = str + endpos + 1 - maxlength + 3;
-				strncat(output, "...", 3);
+				strncat(output, "...", 4);
 				strncat(output, outstart, maxlength - 3);
 			}
 			else
 			{
 				/* maxlength is too small; just output "..." */
-				strncat(output, "...", 3);
+				strncat(output, "...", 4);
 			}
 		}
 	}
@@ -307,12 +307,12 @@ char *lwmessage_truncate(char *str, int startpos, int endpos, int maxlength, int
 				/* Add "..." suffix */
 				outstart = str + startpos;
 				strncat(output, outstart, maxlength - 3);
-				strncat(output, "...", 3);
+				strncat(output, "...", 4);
 			}
 			else
 			{
 				/* maxlength is too small; just output "..." */
-				strncat(output, "...", 3);
+				strncat(output, "...", 4);
 			}
 		}
 	}

--- a/loader/pgsql2shp-core.c
+++ b/loader/pgsql2shp-core.c
@@ -1549,7 +1549,7 @@ ShpDumperOpenTable(SHPDUMPERSTATE *state)
 		{
 			if (!strncasecmp(dbffieldname, state->dbffieldnames[j], 10))
 			{
-				sprintf(dbffieldname, "%.7s_%.2d", ptr, tmpint % 100);
+				sprintf(dbffieldname, "%.7s_%.2d", ptr, abs(tmpint) % 100);
 				tmpint++;
 				continue;
 			}

--- a/loader/safileio.c
+++ b/loader/safileio.c
@@ -115,8 +115,9 @@ SAOffset SADFRead( void *p, SAOffset size, SAOffset nmemb, SAFile file )
 SAOffset SADFWrite( void *p, SAOffset size, SAOffset nmemb, SAFile file )
 
 {
-    return (SAOffset) fwrite( p, (size_t) size, (size_t) nmemb,
-                              (FILE *) file );
+	if (!nmemb || !p) return 0;
+	return (SAOffset) fwrite( p, (size_t) size, (size_t) nmemb,
+				(FILE *) file );
 }
 
 /************************************************************************/


### PR DESCRIPTION
- Addresses warning under gcc 8.2.1.
- Fixes undefined behaviour in SADFWrite

Trac issue: https://trac.osgeo.org/postgis/ticket/4189