### PR TITLE
Specified 1-indexing in ST_SetValues

### DIFF
--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -5314,7 +5314,7 @@ GROUP BY (foo.geomval).val;
 			<refsection>
 				<title>Description</title>
 				<para>
-					Returns modified raster resulting from setting specified pixels to new value(s) for the designated band.
+					Returns modified raster resulting from setting specified pixels to new value(s) for the designated band. Row and Column are 1-indexed.
 				</para>
 
 				<para>


### PR DESCRIPTION
According to ticket https://trac.osgeo.org/postgis/ticket/2835 ST_SetValues needed to be specified about raw and column are 1-indexed.