### PR TITLE
Enable debug code in Travis build

### DIFF
--- a/ci/travis/run_tests.sh
+++ b/ci/travis/run_tests.sh
@@ -4,10 +4,12 @@ set -e
 WARNINGS="-Werror -Wall -Wextra -Wformat -Werror=format-security"
 WARNINGS_DISABLED="-Wno-unused-parameter -Wno-implicit-fallthrough -Wno-unknown-warning-option -Wno-cast-function-type"
 
+# Standard flags, as we might build PostGIS for production
 CFLAGS_STD="-g -O2 -mtune=generic -fno-omit-frame-pointer ${WARNINGS} ${WARNINGS_DISABLED}"
 LDFLAGS_STD="-Wl,-Bsymbolic-functions -Wl,-z,relro"
 
-CFLAGS_COV="-g -O0 --coverage"
+# Second build with coverage and debugging code enabled
+CFLAGS_COV="-g -O0 --coverage --enable-debug"
 LDFLAGS_COV="--coverage"
 
 export CUNIT_WITH_VALGRIND=YES


### PR DESCRIPTION
Make sure we catch compile or test failures with `--enable-debug`.