### PR TITLE
ST_3DDistance: Handle invalid polygons

### DIFF
--- a/liblwgeom/cunit/cu_measures.c
+++ b/liblwgeom/cunit/cu_measures.c
@@ -235,7 +235,7 @@ test_mindistance3d_tolerance(void)
 	DIST3DTEST("LINESTRING(-10000 -10000 0, 0 0 1)", "POLYGON((0 0 0, 1 0 0, 1 1 0, 0 1 0, 0 0 0))", 1);
 
 	/* This is an invalid polygon since it defines just a line */
-	DIST3DTEST("LINESTRING(1 1 1 , 2 2 2)", "POLYGON((0 0 0, 2 2 2, 3 3 3, 0 0 0))", FLT_MAX);
+	DIST3DTEST("LINESTRING(1 1 1 , 2 2 2)", "POLYGON((0 0 0, 2 2 2, 3 3 3, 0 0 0))", 0);
 }
 
 static int tree_pt(RECT_NODE *tree, double x, double y)

--- a/liblwgeom/cunit/cu_measures.c
+++ b/liblwgeom/cunit/cu_measures.c
@@ -19,6 +19,7 @@
 #include "liblwgeom_internal.h"
 #include "cu_tester.h"
 #include "measures.h"
+#include "measures3d.h"
 #include "lwtree.h"
 
 static LWGEOM* lwgeom_from_text(const char *str)
@@ -29,9 +30,17 @@ static LWGEOM* lwgeom_from_text(const char *str)
 	return r.geom;
 }
 
-#define DIST2DTEST(str1, str2, res) do_test_mindistance2d_tolerance(str1, str2, res, __LINE__)
+#define DIST2DTEST(str1, str2, res) \
+	do_test_mindistance_tolerance(str1, str2, res, __LINE__, lwgeom_mindistance2d_tolerance)
+#define DIST3DTEST(str1, str2, res) \
+	do_test_mindistance_tolerance(str1, str2, res, __LINE__, lwgeom_mindistance3d_tolerance)
 
-static void do_test_mindistance2d_tolerance(char *in1, char *in2, double expected_res, int line)
+static void
+do_test_mindistance_tolerance(char *in1,
+			      char *in2,
+			      double expected_res,
+			      int line,
+			      double (*distancef)(const LWGEOM *, const LWGEOM *, double))
 {
 	LWGEOM *lw1;
 	LWGEOM *lw2;
@@ -53,7 +62,7 @@ static void do_test_mindistance2d_tolerance(char *in1, char *in2, double expecte
 		exit(1);
 	}
 
-	distance = lwgeom_mindistance2d_tolerance(lw1, lw2, 0.0);
+	distance = distancef(lw1, lw2, 0.0);
 	lwgeom_free(lw1);
 	lwgeom_free(lw2);
 
@@ -191,6 +200,42 @@ static void test_mindistance2d_tolerance(void)
 	*/
 	DIST2DTEST("LINESTRING(0.5 1,0.5 3)", "MULTICURVE(CIRCULARSTRING(2 3,3 2,2 1,1 2,2 3),(0 0, 0 5))", 0.5);
 
+}
+
+static void
+test_mindistance3d_tolerance(void)
+{
+	/* 2D [Z=0] should work just the same */
+	DIST3DTEST("POINT(0 0 0)", "MULTIPOINT(0 1.5 0, 0 2 0, 0 2.5 0)", 1.5);
+	DIST3DTEST("POINT(0 0 0)", "MULTIPOINT(0 1.5 0, 0 2 0, 0 2.5 0)", 1.5);
+	DIST3DTEST("POINT(0 0 0)", "GEOMETRYCOLLECTION(POINT(3 4 0))", 5.0);
+	DIST3DTEST("POINT(0 0 0)", "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(3 4 0)))", 5.0);
+	DIST3DTEST("POINT(0 0 0)", "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(3 4 0))))", 5.0);
+	DIST3DTEST("POINT(0 0)", "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(MULTIPOINT(3 4))))", 5.0);
+	DIST3DTEST("GEOMETRYCOLLECTION(POINT(0 0 0))", "GEOMETRYCOLLECTION(POINT(3 4 0))", 5.0);
+	DIST3DTEST("GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0 0)))",
+		   "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(3 4 0)))",
+		   5.0);
+	DIST3DTEST("GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(MULTIPOINT(0 0 0)))",
+		   "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(MULTIPOINT(3 4 0)))",
+		   5.0);
+	DIST3DTEST("LINESTRING(-2 0 0, -0.2 0 0)", "POINT(-2 0 0)", 0);
+	DIST3DTEST("LINESTRING(-0.2 0 0, -2 0 0)", "POINT(-2 0 0)", 0);
+	DIST3DTEST("LINESTRING(-1e-8 0 0, -0.2 0 0)", "POINT(-1e-8 0 0)", 0);
+	DIST3DTEST("LINESTRING(-0.2 0 0, -1e-8 0 0)", "POINT(-1e-8 0 0)", 0);
+
+	/* Tests around intersections */
+	DIST3DTEST("LINESTRING(1 0 0 , 2 0 0)", "POLYGON((1 1 0, 2 1 0, 2 2 0, 1 2 0, 1 1 0))", 1.0);
+	DIST3DTEST("LINESTRING(1 1 1 , 2 1 0)", "POLYGON((1 1 0, 2 1 0, 2 2 0, 1 2 0, 1 1 0))", 0.0);
+	DIST3DTEST("LINESTRING(1 1 1 , 2 1 1)", "POLYGON((1 1 0, 2 1 0, 2 2 0, 1 2 0, 1 1 0))", 1.0);
+	/* Line in polygon */
+	DIST3DTEST("LINESTRING(1 1 1 , 2 2 2)", "POLYGON((0 0 0, 2 2 2, 3 3 1, 0 0 0))", 0.0);
+
+	/* Line has a point in the same plane as the polygon but isn't the closest*/
+	DIST3DTEST("LINESTRING(-10000 -10000 0, 0 0 1)", "POLYGON((0 0 0, 1 0 0, 1 1 0, 0 1 0, 0 0 0))", 1);
+
+	/* This is an invalid polygon since it defines just a line */
+	DIST3DTEST("LINESTRING(1 1 1 , 2 2 2)", "POLYGON((0 0 0, 2 2 2, 3 3 3, 0 0 0))", FLT_MAX);
 }
 
 static int tree_pt(RECT_NODE *tree, double x, double y)
@@ -1404,6 +1449,7 @@ void measures_suite_setup(void)
 {
 	CU_pSuite suite = CU_add_suite("measures", NULL, NULL);
 	PG_ADD_TEST(suite, test_mindistance2d_tolerance);
+	PG_ADD_TEST(suite, test_mindistance3d_tolerance);
 	PG_ADD_TEST(suite, test_rect_tree_contains_point);
 	PG_ADD_TEST(suite, test_rect_tree_intersects_tree);
 	PG_ADD_TEST(suite, test_lwgeom_segmentize2d);

--- a/liblwgeom/measures.h
+++ b/liblwgeom/measures.h
@@ -34,6 +34,9 @@
  *
  **********************************************************************/
 
+#ifndef _MEASURES_H
+#define _MEASURES_H 1
+
 #include "liblwgeom_internal.h"
 
 /* for the measure functions*/
@@ -124,4 +127,4 @@ double lw_arc_length(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3);
 LWGEOM* lw_dist2d_distancepoint(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode);
 LWGEOM* lw_dist2d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int srid, int mode);
 
-
+#endif /* !defined _MEASURES_H  */

--- a/liblwgeom/measures3d.c
+++ b/liblwgeom/measures3d.c
@@ -1167,13 +1167,14 @@ int
 define_plane(POINTARRAY *pa, PLANE3D *pl)
 {
 	const uint32_t POL_BREAKS = 3;
+	uint32_t unique_points = pa->npoints - 1;
 	uint32_t i;
 
 	/* Calculate the average point */
 	pl->pop.x = 0.0;
 	pl->pop.y = 0.0;
 	pl->pop.z = 0.0;
-	for (i = 0; i < pa->npoints; i++)
+	for (i = 0; i < unique_points; i++)
 	{
 		POINT3DZ p;
 		getPoint3dz_p(pa, i, &p);
@@ -1182,9 +1183,9 @@ define_plane(POINTARRAY *pa, PLANE3D *pl)
 		pl->pop.z += p.z;
 	}
 
-	pl->pop.x /= pa->npoints;
-	pl->pop.y /= pa->npoints;
-	pl->pop.z /= pa->npoints;
+	pl->pop.x /= unique_points;
+	pl->pop.y /= unique_points;
+	pl->pop.z /= unique_points;
 
 	pl->pv.x = 0.0;
 	pl->pv.y = 0.0;
@@ -1194,12 +1195,8 @@ define_plane(POINTARRAY *pa, PLANE3D *pl)
 		POINT3DZ point1, point2;
 		VECTOR3D v1, v2, vp;
 		uint32_t n1, n2;
-		n1 = i * pa->npoints / POL_BREAKS;
-		n2 = n1 + pa->npoints / POL_BREAKS;
-		if (n2 == pa->npoints)
-		{
-			n2 = pa->npoints - 1;
-		}
+		n1 = i * unique_points / POL_BREAKS;
+		n2 = n1 + unique_points / POL_BREAKS; /* May overflow back to the first / last point */
 
 		if (n1 == n2)
 			continue;

--- a/liblwgeom/measures3d.c
+++ b/liblwgeom/measures3d.c
@@ -59,7 +59,7 @@ get_3dcross_product(VECTOR3D *v1,VECTOR3D *v2, VECTOR3D *v)
 	v->y=(v1->z*v2->x)-(v1->x*v2->z);
 	v->z=(v1->x*v2->y)-(v1->y*v2->x);
 
-	return ((fabs(v->x) > DBL_EPSILON) || (fabs(v->y) > DBL_EPSILON) || (fabs(v->z) > DBL_EPSILON));
+	return (!FP_IS_ZERO(v->x) || !FP_IS_ZERO(v->y) || !FP_IS_ZERO(v->z));
 }
 
 
@@ -1225,7 +1225,7 @@ So, we already have a direction from p to find p0, but we don't know the distanc
 		return 0.0;
 
 	f = DOT(pl->pv, v1);
-	if (fabs(f) < DBL_EPSILON)
+	if (FP_IS_ZERO(f))
 	{
 		/* Point is in the plane */
 		*p0 = *p;

--- a/regress/core/measures.sql
+++ b/regress/core/measures.sql
@@ -221,6 +221,10 @@ SELECT '3dDistancetest6',
 	ST_3DDistance(a,b) FROM (
 	SELECT 'LINESTRING(1 1 1 , 2 2 2)'::geometry as a, 'POLYGON((0 0 0, 2 2 2, 3 3 3, 0 0 0))'::geometry as b) as foo;
 
+SELECT '3dDistancetest7',
+	ST_3DDistance(a,b) FROM (
+	SELECT 'LINESTRING(1 1 1 , 2 2 2)'::geometry as a, 'POLYGON((0 0 0, 2 2 2, 3 3 1, 0 0 0))'::geometry as b) as foo;
+
 -- 3D mixed dimmentionality #2034
 --closestpoint with 2d as first point and 3d as second
 select st_astext(st_3dclosestpoint('linestring(0 0,1 1,2 0)'::geometry, 'linestring(0 2 3, 3 2 3)'::geometry));

--- a/regress/core/measures_expected
+++ b/regress/core/measures_expected
@@ -34,7 +34,8 @@ distancepoly6|0|32.5269119345812|LINESTRING(2 2,2 2)|LINESTRING(2 2,2 2)|LINESTR
 3dDistancetest3|4.09994192757944|6.48074069840786|t|f|LINESTRING(1 1 1,0.61904761904762 -0.19047619047619 4.90476190476191)|POINT(1 1 1)|LINESTRING(1 1 1,5 2 6)
 3dDistancetest4|2|10.0498756211209|t|f|LINESTRING(1 1 3,1 1 1)|POINT(1 1 3)|LINESTRING(5 7 8,1 1 1)
 3dDistancetest5|2|10|t|f|LINESTRING(5 0 5,5 2 5)|POINT(5 0 5)|LINESTRING(11 0 5,5 0 13)
-3dDistancetest6|0
+ERROR:  lw_dist3d_line_poly: Polygon does not define a plane
+3dDistancetest7|0
 NOTICE:  One or both of the geometries is missing z-value. The unknown z-value will be regarded as "any value"
 POINT Z (1 1 3)
 NOTICE:  One or both of the geometries is missing z-value. The unknown z-value will be regarded as "any value"

--- a/regress/core/measures_expected
+++ b/regress/core/measures_expected
@@ -34,7 +34,7 @@ distancepoly6|0|32.5269119345812|LINESTRING(2 2,2 2)|LINESTRING(2 2,2 2)|LINESTR
 3dDistancetest3|4.09994192757944|6.48074069840786|t|f|LINESTRING(1 1 1,0.61904761904762 -0.19047619047619 4.90476190476191)|POINT(1 1 1)|LINESTRING(1 1 1,5 2 6)
 3dDistancetest4|2|10.0498756211209|t|f|LINESTRING(1 1 3,1 1 1)|POINT(1 1 3)|LINESTRING(5 7 8,1 1 1)
 3dDistancetest5|2|10|t|f|LINESTRING(5 0 5,5 2 5)|POINT(5 0 5)|LINESTRING(11 0 5,5 0 13)
-ERROR:  lw_dist3d_line_poly: Polygon does not define a plane
+3dDistancetest6|0
 3dDistancetest7|0
 NOTICE:  One or both of the geometries is missing z-value. The unknown z-value will be regarded as "any value"
 POINT Z (1 1 3)


### PR DESCRIPTION
- Added guards in "measures.h" since it didn't have them.
- Simplified `define_plane` to calculate the plane with the first 3 non collinear points of the ptarray.
- Added tests in liblwgeom as it was easier to debug.
- Avoid division by zero in lw_dist3d_ptarray_poly when the point is the same plane as the polygon.
- Add a bunch of extra tests (some copied from the 2d tests, some extras around the same plane issue).
- When a 3d polygon is defined by collinear points, consider it as a 3d linestring (by ignoring any inner ring).

Trac issue: https://trac.osgeo.org/postgis/ticket/4246