### PR TITLE
Uniformize how PGXS is used

### DIFF
--- a/doc/Makefile.comments.in
+++ b/doc/Makefile.comments.in
@@ -20,7 +20,7 @@ MODULEDIR=contrib/$(MODULE_doc)
 DATA_built=postgis_comments.sql raster_comments.sql topology_comments.sql sfcgal_comments.sql
 
 # PGXS information
-PG_CONFIG = @PG_CONFIG@ 
+PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
 include $(PGXS)
 

--- a/extensions/address_standardizer/Makefile.in
+++ b/extensions/address_standardizer/Makefile.in
@@ -56,10 +56,6 @@ SHLIB_LINK = @SHLIB_LINK@ -lpcre
 EXTRA_CLEAN = usps-st-city-name.txt mk-st-regexp mk-city-regex test_main
 REGRESS = test-init-extensions test-parseaddress test-standardize_address_1 test-standardize_address_2
 
-# PGXS information
-PG_CONFIG = @PG_CONFIG@
-
-PGVER := $(shell $(PG_CONFIG) --version)
 
 # Borrow the $libdir substitution from PGXS but customise by running the preprocessor
 # and adding the version number
@@ -184,6 +180,7 @@ EXTRA_CLEAN += sql/$(EXTENSION)--$(EXTVERSION).sql sql/$(EXTENSION)--unpackaged-
 distclean: clean
 	rm Makefile
 
+PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
 include $(PGXS)
 PERL = @PERL@

--- a/extensions/postgis/Makefile.in
+++ b/extensions/postgis/Makefile.in
@@ -59,8 +59,6 @@ RASTER_DROP_SCRIPTS = \
 	../../raster/rt_pg/rtpostgis_drop.sql \
 	../../raster/rt_pg/uninstall_rtpostgis.sql
 
-PG_CONFIG    = @PG_CONFIG@
-
 SQL_BITS     = $(wildcard sql/*.sql)
 EXTRA_CLEAN += ${SQL_BITS} sql/*.sql
 
@@ -131,6 +129,7 @@ include ../upgrade-paths-rules.mk
 distclean: clean
 	rm -f Makefile
 
-PGXS := $(shell $(PG_CONFIG) --pgxs)
+PG_CONFIG := @PG_CONFIG@
+PGXS := @PGXS@
 include $(PGXS)
 PERL = @PERL@

--- a/extensions/postgis_raster/Makefile.in
+++ b/extensions/postgis_raster/Makefile.in
@@ -51,8 +51,6 @@ EXTENSION_UPGRADE_SCRIPTS = \
 EXTENSION_UNPACKAGED_UPGRADE_SCRIPTS = \
 	sql/rtpostgis.sql
 
-PG_CONFIG    = @PG_CONFIG@
-
 SQL_BITS     = $(wildcard sql/*.sql)
 EXTRA_CLEAN += ${SQL_BITS} sql/*.sql
 
@@ -109,6 +107,7 @@ include ../upgrade-paths-rules.mk
 distclean: clean
 	rm -f Makefile
 
-PGXS := $(shell $(PG_CONFIG) --pgxs)
+PG_CONFIG := @PG_CONFIG@
+PGXS := @PGXS@
 include $(PGXS)
 PERL = @PERL@

--- a/extensions/postgis_sfcgal/Makefile.in
+++ b/extensions/postgis_sfcgal/Makefile.in
@@ -39,8 +39,6 @@ EXTENSION_UNPACKAGED_UPGRADE_SCRIPTS = \
 	sql_bits/sfcgal.sql \
 	../../utils/create_unpackaged.pl
 
-PG_CONFIG    =  @PG_CONFIG@
-
 SQL_BITS     = $(wildcard sql_bits/*.sql)
 EXTRA_CLEAN += sql/*.sql ${SQL_BITS}
 
@@ -108,6 +106,7 @@ include ../upgrade-paths-rules.mk
 distclean: clean
 	rm Makefile
 
-PGXS := $(shell $(PG_CONFIG) --pgxs)
+PG_CONFIG := @PG_CONFIG@
+PGXS := @PGXS@
 include $(PGXS)
 PERL = @PERL@

--- a/extensions/postgis_tiger_geocoder/Makefile.in
+++ b/extensions/postgis_tiger_geocoder/Makefile.in
@@ -31,8 +31,6 @@ DATA_built = \
 REGRESS = test-normalize_address test-upgrade
 REGRESS_OPTS = --load-extension=fuzzystrmatch --load-extension=postgis --load-extension=$(EXTENSION)
 
-PG_CONFIG    =  @PG_CONFIG@
-
 SQL_BITS     = $(wildcard sql_bits/*.sql)
 EXTRA_CLEAN += sql/*.sql ${SQL_BITS}
 
@@ -249,6 +247,7 @@ EXTRA_CLEAN += $(wildcard expected/*--*.out)
 distclean: clean
 	rm Makefile
 
-PGXS := $(shell $(PG_CONFIG) --pgxs)
+PG_CONFIG := @PG_CONFIG@
+PGXS := @PGXS@
 include $(PGXS)
 PERL=@PERL@

--- a/extensions/postgis_topology/Makefile.in
+++ b/extensions/postgis_topology/Makefile.in
@@ -40,8 +40,6 @@ EXTENSION_UPGRADE_SCRIPTS = \
 	sql_bits/topology_comments.sql \
 	../postgis_extension_helper_uninstall.sql
 
-PG_CONFIG    = @PG_CONFIG@
-
 SQL_BITS     = $(wildcard sql_bits/*.sql)
 EXTRA_CLEAN += sql/*.sql ${SQL_BITS}
 
@@ -99,6 +97,7 @@ include ../upgrade-paths-rules.mk
 distclean: clean
 	rm Makefile
 
-PGXS := $(shell $(PG_CONFIG) --pgxs)
+PG_CONFIG := @PG_CONFIG@
+PGXS := @PGXS@
 include $(PGXS)
 PERL=@PERL@

--- a/loader/Makefile.in
+++ b/loader/Makefile.in
@@ -15,7 +15,7 @@
 # the DESTDIR variable so we can get the correct install paths.
 # Hence we include the PGXS Makefile here, but ensure that we override the
 # 'all' and 'install' targets with the ones we really want to use below.
-PG_CONFIG = @PG_CONFIG@
+PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
 include $(PGXS)
 

--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -158,7 +158,7 @@ EXTRA_CLEAN=$(SQL_OBJS) \
 	geobuf.pb-c.h
 
 # PGXS information
-PG_CONFIG = @PG_CONFIG@
+PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
 # NO_TEMP_INSTALL is a workaround for a 9.5dev bug. See:
 # http://www.postgresql.org/message-id/CAB7nPqTsR5o3g-fBi6jbsVdhfPiLFWQ_0cGU5=94Rv_8W3qvFA@mail.gmail.com

--- a/raster/rt_pg/Makefile.in
+++ b/raster/rt_pg/Makefile.in
@@ -82,7 +82,7 @@ SHLIB_LINK_F = ../rt_core/librtcore.a $(LIBLWGEOM_LDFLAGS) $(LIBPGCOMMON_LDFLAGS
 EXTRA_CLEAN=$(SQL_OBJS) $(DATA_built) rtpostgis_upgrade.sql.in rtpostgis_upgrade_for_extension.sql.in
 
 # PGXS information
-PG_CONFIG = @PG_CONFIG@
+PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
 # NO_TEMP_INSTALL is a workaround for a 9.5dev bug. See:
 # http://www.postgresql.org/message-id/CAB7nPqTsR5o3g-fBi6jbsVdhfPiLFWQ_0cGU5=94Rv_8W3qvFA@mail.gmail.com

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -64,7 +64,7 @@ endif
 EXTRA_CLEAN=$(SQL_OBJS) topology_upgrade.sql.in
 
 # PGXS information
-PG_CONFIG = @PG_CONFIG@
+PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
 # NO_TEMP_INSTALL is a workaround for a 9.5dev bug. See:
 # http://www.postgresql.org/message-id/CAB7nPqTsR5o3g-fBi6jbsVdhfPiLFWQ_0cGU5=94Rv_8W3qvFA@mail.gmail.com

--- a/utils/Makefile.in
+++ b/utils/Makefile.in
@@ -21,7 +21,7 @@ MODULEDIR=contrib/$(MODULE_doc)
 DATA_built=postgis_restore.pl
 
 # PGXS information
-PG_CONFIG = @PG_CONFIG@
+PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
 include $(PGXS)
 


### PR DESCRIPTION
Remove some PG_CONFIG usage and variables (so we aren't tempted to use it again) and use instead the variables set during the configuration step.