### PR TITLE
Run ubsan in topology too

### DIFF
--- a/ci/travis/run_usan_clang.sh
+++ b/ci/travis/run_usan_clang.sh
@@ -9,6 +9,5 @@ LDFLAGS_STD="-Wl,-Bsymbolic-functions -Wl,-z,relro"
 ./autogen.sh
 
 # Build with Clang and usan flags
-# TODO: Fix topology ubsan
-./configure CC=clang CFLAGS="${CFLAGS_STD}" LDFLAGS="${LDFLAGS_STD}" --without-topology
+./configure CC=clang CFLAGS="${CFLAGS_STD}" LDFLAGS="${LDFLAGS_STD}"
 bash ./ci/travis/logbt -- make -j check RUNTESTFLAGS=--verbose

--- a/ci/travis/run_usan_gcc.sh
+++ b/ci/travis/run_usan_gcc.sh
@@ -9,6 +9,5 @@ LDFLAGS_STD="-Wl,-Bsymbolic-functions -Wl,-z,relro"
 ./autogen.sh
 
 # Build with GCC and usan flags
-# TODO: Fix topology ubsan
-./configure CC=gcc CFLAGS="${CFLAGS_STD}" LDFLAGS="${LDFLAGS_STD}" --without-topology
+./configure CC=gcc CFLAGS="${CFLAGS_STD}" LDFLAGS="${LDFLAGS_STD}"
 bash ./ci/travis/logbt -- make -j check RUNTESTFLAGS=--verbose

--- a/postgis/lwgeom_box.c
+++ b/postgis/lwgeom_box.c
@@ -93,13 +93,21 @@ Datum BOX2D_in(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(BOX2D_out);
 Datum BOX2D_out(PG_FUNCTION_ARGS)
 {
-	GBOX *box = (GBOX *) PG_GETARG_POINTER(0);
 	char tmp[500]; /* big enough */
 	char *result;
 	int size;
 
-	size  = sprintf(tmp,"BOX(%.15g %.15g,%.15g %.15g)",
-	                box->xmin, box->ymin, box->xmax, box->ymax);
+	GBOX *box = (GBOX *)PG_GETARG_POINTER(0);
+	/* Avoid unaligned access to the gbox struct */
+	GBOX box_aligned;
+	memcpy(&box_aligned, box, sizeof(GBOX));
+
+	size = sprintf(tmp,
+		       "BOX(%.15g %.15g,%.15g %.15g)",
+		       box_aligned.xmin,
+		       box_aligned.ymin,
+		       box_aligned.xmax,
+		       box_aligned.ymax);
 
 	result= palloc(size+1); /* +1= null term */
 	memcpy(result,tmp,size+1);


### PR DESCRIPTION
Fixes an error accessing unaligned memory in BOX2D_out and enables UBSan in topology tests.