### PR TITLE
Remove SFCGAL ST_Distance

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -46,7 +46,7 @@ PostGIS 3.0.0
   - #4139, Make mixed-dimension ND index build tree correctly (Darafei Praliaskouski,
            Arthur Lesuisse, Andrew Gierth, Raúl Marín)
   - #4262, Document MULTISURFACE compatibility of ST_LineToCurve (Steven Ottens)
-  - #4258, Remove SFCGAL support for ST_Area (Darafei Praliaskouski)
+  - #4258, Remove SFCGAL support for ST_Area, ST_Distance (Darafei Praliaskouski)
 
 PostGIS 2.5.0
 2018/09/23

--- a/doc/reference_measure.xml
+++ b/doc/reference_measure.xml
@@ -2454,71 +2454,69 @@ SELECT ST_Disjoint('POINT(0 0)'::geometry, 'LINESTRING ( 0 0, 0 2 )'::geometry);
 		<para>&sfs_compliant;</para>
 		<para>&sqlmm_compliant; SQL-MM 3: 5.1.23</para>
 		<para>&curve_support;</para>
-		<para>&sfcgal_enhanced;</para>
 
 		<para>Availability: 1.5.0 geography support was introduced in 1.5.  Speed improvements for planar to better handle large or many vertex geometries</para>
 		<para>Enhanced: 2.1.0 improved speed for geography. See <ulink url="http://boundlessgeo.com/2012/07/making-geography-faster/">Making Geography faster</ulink> for details.</para>
 		<para>Enhanced: 2.1.0 - support for curved geometries was introduced.</para>
 		<para>Enhanced: 2.2.0 - measurement on spheroid performed with GeographicLib for improved accuracy and robustness. Requires Proj &gt;= 4.9.0 to take advantage of the new feature.</para>
+		<para>Changed: 3.0.0 - does not depend on SFCGAL anymore.</para>
 	  </refsection>
 
 	  <refsection>
 		<title>Basic Geometry Examples</title>
 
-		<programlisting>
---Geometry example - units in planar degrees 4326 is WGS 84 long lat unit=degrees
-SELECT ST_Distance(
+		<para>Geometry example - units in planar degrees 4326 is WGS 84 long lat, units are degrees.</para>
+		<programlisting>SELECT ST_Distance(
 		'SRID=4326;POINT(-72.1235 42.3521)'::geometry,
 		'SRID=4326;LINESTRING(-72.1260 42.45, -72.123 42.1546)'::geometry
 	);
 st_distance
 -----------------
-0.00150567726382282
+0.00150567726382282</programlisting>
 
--- Geometry example - units in meters (SRID: 3857, proportional to pixels on popular web maps)
--- although the value is off, nearby ones can be compared correctly,
--- which makes it a good choice for algorithms like KNN or KMeans.
-SELECT ST_Distance(
+<para>Geometry example - units in meters (SRID: 3857, proportional to pixels on popular web maps).
+Although the value is off, nearby ones can be compared correctly,
+which makes it a good choice for algorithms like KNN or KMeans.</para>
+<programlisting>SELECT ST_Distance(
 			ST_Transform('SRID=4326;POINT(-72.1235 42.3521)'::geometry, 3857),
 			ST_Transform('SRID=4326;LINESTRING(-72.1260 42.45, -72.123 42.1546)'::geometry, 3857)
 		);
 st_distance
 -----------------
-167.441410065196
+167.441410065196</programlisting>
 
--- Geometry example - units in meters (SRID: 3857 as above, but corrected by cos(lat) to account for distortion)
-SELECT ST_Distance(
+<para>Geometry example - units in meters (SRID: 3857 as above, but corrected by cos(lat) to account for distortion)</para>
+<programlisting>SELECT ST_Distance(
 			ST_Transform('SRID=4326;POINT(-72.1235 42.3521)'::geometry, 3857),
 			ST_Transform('SRID=4326;LINESTRING(-72.1260 42.45, -72.123 42.1546)'::geometry, 3857)
 		) * cosd(42.3521);
 st_distance
 -----------------
-123.742351254151
+123.742351254151</programlisting>
 
--- Geometry example - units in meters (SRID: 26986 Massachusetts state plane meters) (most accurate for Massachusetts)
-SELECT ST_Distance(
+<para>Geometry example - units in meters (SRID: 26986 Massachusetts state plane meters) (most accurate for Massachusetts)</para>
+<programlisting>SELECT ST_Distance(
 			ST_Transform('SRID=4326;POINT(-72.1235 42.3521)'::geometry, 26986),
 			ST_Transform('SRID=4326;LINESTRING(-72.1260 42.45, -72.123 42.1546)'::geometry, 26986)
 		);
 st_distance
 -----------------
-123.797937878454
+123.797937878454</programlisting>
 
--- Geometry example - units in meters (SRID: 2163 US National Atlas Equal area) (least accurate)
-SELECT ST_Distance(
+<para>Geometry example - units in meters (SRID: 2163 US National Atlas Equal area) (least accurate) </para>
+<programlisting>SELECT ST_Distance(
 			ST_Transform('SRID=4326;POINT(-72.1235 42.3521)'::geometry, 2163),
 			ST_Transform('SRID=4326;LINESTRING(-72.1260 42.45, -72.123 42.1546)'::geometry, 2163)
 		);
 
 st_distance
 ------------------
-126.664256056812
-</programlisting>
+126.664256056812</programlisting>
 	</refsection>
 	  <refsection>
 		<title>Geography Examples</title>
-<programlisting>-- same as geometry example but note units in meters - use sphere for slightly faster less accurate
-SELECT ST_Distance(gg1, gg2) As spheroid_dist, ST_Distance(gg1, gg2, false) As sphere_dist
+<para>Same as geometry example but note units in meters - use sphere for slightly faster and less accurate computation.</para>
+<programlisting>SELECT ST_Distance(gg1, gg2) As spheroid_dist, ST_Distance(gg1, gg2, false) As sphere_dist
 FROM (SELECT
 	'SRID=4326;POINT(-72.1235 42.3521)'::geography as gg1,
 	'SRID=4326;LINESTRING(-72.1260 42.45, -72.123 42.1546)'::geography as gg2
@@ -2526,12 +2524,8 @@ FROM (SELECT
 
   spheroid_dist   |   sphere_dist
 ------------------+------------------
- 123.802076746848 | 123.475736916397
-</programlisting>
+ 123.802076746848 | 123.475736916397</programlisting>
 	</refsection>
-
-
-
 	  <refsection>
 		<title>See Also</title>
 

--- a/liblwgeom/measures.c
+++ b/liblwgeom/measures.c
@@ -201,7 +201,6 @@ lwgeom_maxdistance2d_tolerance(const LWGEOM *lw1, const LWGEOM *lw2, double tole
 double
 lwgeom_mindistance2d(const LWGEOM *lw1, const LWGEOM *lw2)
 {
-	LWDEBUG(2, "lwgeom_mindistance2d is called");
 	return lwgeom_mindistance2d_tolerance( lw1, lw2, 0.0 );
 }
 

--- a/postgis/legacy.sql.in
+++ b/postgis/legacy.sql.in
@@ -766,7 +766,7 @@ CREATE OR REPLACE FUNCTION crosses(geometry,geometry)
 -- Deprecation in 1.2.3
 CREATE OR REPLACE FUNCTION distance(geometry,geometry)
 	RETURNS float8
-	AS 'MODULE_PATHNAME', 'LWGEOM_mindistance2d'
+	AS 'MODULE_PATHNAME', 'ST_Distance'
 	LANGUAGE 'c' IMMUTABLE STRICT
 	COST 100;
 

--- a/postgis/lwgeom_backend_api.c
+++ b/postgis/lwgeom_backend_api.c
@@ -71,7 +71,6 @@ struct lwgeom_backend_definition lwgeom_backends[LWGEOM_NUM_BACKENDS] = {{.name 
 									  .intersection_fn = geos_intersection,
 									  .difference_fn = geos_difference,
 									  .union_fn = geos_geomunion,
-									  .distance_fn = LWGEOM_mindistance2d,
 									  .distance3d_fn = LWGEOM_mindistance3d},
 #if HAVE_SFCGAL
 									 {.name = "sfcgal",
@@ -80,7 +79,6 @@ struct lwgeom_backend_definition lwgeom_backends[LWGEOM_NUM_BACKENDS] = {{.name 
 									  .intersection_fn = sfcgal_intersection,
 									  .difference_fn = sfcgal_difference,
 									  .union_fn = sfcgal_union,
-									  .distance_fn = sfcgal_distance,
 									  .distance3d_fn = sfcgal_distance3D}
 #endif
 };
@@ -185,12 +183,6 @@ Datum geomunion(PG_FUNCTION_ARGS)
 	return (*lwgeom_backend->union_fn)(fcinfo);
 }
 
-PG_FUNCTION_INFO_V1(distance);
-Datum distance(PG_FUNCTION_ARGS)
-{
-	return (*lwgeom_backend->distance_fn)(fcinfo);
-}
-
 PG_FUNCTION_INFO_V1(distance3d);
 Datum distance3d(PG_FUNCTION_ARGS)
 {
@@ -204,8 +196,7 @@ Datum intersects3d(PG_FUNCTION_ARGS)
 }
 
 /* intersects3d through dwithin
- * used by the 'geos' backend
- */
+ * used by the 'geos' backend */
 PG_FUNCTION_INFO_V1(intersects3d_dwithin);
 Datum intersects3d_dwithin(PG_FUNCTION_ARGS)
 {

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -59,7 +59,7 @@ Datum LWGEOM_perimeter2d_poly(PG_FUNCTION_ARGS);
 Datum LWGEOM_perimeter_poly(PG_FUNCTION_ARGS);
 
 Datum LWGEOM_maxdistance2d_linestring(PG_FUNCTION_ARGS);
-Datum LWGEOM_mindistance2d(PG_FUNCTION_ARGS);
+Datum ST_Distance(PG_FUNCTION_ARGS);
 Datum LWGEOM_closestpoint(PG_FUNCTION_ARGS);
 Datum LWGEOM_shortestline2d(PG_FUNCTION_ARGS);
 Datum LWGEOM_longestline2d(PG_FUNCTION_ARGS);
@@ -690,8 +690,8 @@ Datum LWGEOM_longestline2d(PG_FUNCTION_ARGS)
 /**
  Minimum 2d distance between objects in geom1 and geom2.
  */
-PG_FUNCTION_INFO_V1(LWGEOM_mindistance2d);
-Datum LWGEOM_mindistance2d(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(ST_Distance);
+Datum ST_Distance(PG_FUNCTION_ARGS)
 {
 	double mindist;
 	GSERIALIZED *geom1 = PG_GETARG_GSERIALIZED_P(0);
@@ -709,7 +709,7 @@ Datum LWGEOM_mindistance2d(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(geom1, 0);
 	PG_FREE_IF_COPY(geom2, 1);
 
-	/*if called with empty geometries the ingoing mindistance is untouched, and makes us return NULL*/
+	/* if called with empty geometries the ingoing mindistance is untouched, and makes us return NULL*/
 	if (mindist < FLT_MAX)
 		PG_RETURN_FLOAT8(mindist);
 
@@ -2593,8 +2593,8 @@ Datum optimistic_overlap(PG_FUNCTION_ARGS)
 	 * compute distances
 	 * should be a fast calc if they actually do intersect
 	 */
-	calc_dist = DatumGetFloat8(
-	    DirectFunctionCall2(LWGEOM_mindistance2d, PointerGetDatum(pg_geom1), PointerGetDatum(pg_geom2)));
+	calc_dist =
+	    DatumGetFloat8(DirectFunctionCall2(ST_Distance, PointerGetDatum(pg_geom1), PointerGetDatum(pg_geom2)));
 
 	PG_RETURN_BOOL(calc_dist < dist);
 }

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -579,16 +579,16 @@ CREATE OPERATOR ~= (
 CREATE OR REPLACE FUNCTION geometry_distance_centroid(geom1 geometry, geom2 geometry)
 	RETURNS float8
 #if POSTGIS_PGSQL_VERSION >= 95
-  AS 'MODULE_PATHNAME' ,'distance'
+	AS 'MODULE_PATHNAME', 'ST_Distance'
 #else
-  AS 'MODULE_PATHNAME' ,'gserialized_distance_centroid_2d'
+	AS 'MODULE_PATHNAME', 'gserialized_distance_centroid_2d'
 #endif
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL;
 
 -- Availability: 2.0.0
 CREATE OR REPLACE FUNCTION geometry_distance_box(geom1 geometry, geom2 geometry)
 	RETURNS float8
-  AS 'MODULE_PATHNAME' ,'gserialized_distance_box_2d'
+  AS 'MODULE_PATHNAME', 'gserialized_distance_box_2d'
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL;
 
 -- Availability: 2.0.0
@@ -1321,12 +1321,10 @@ CREATE OR REPLACE FUNCTION ST_distance_spheroid(geom1 geometry, geom2 geometry,s
   $$
 	LANGUAGE 'sql' IMMUTABLE STRICT _PARALLEL;
 
--- Minimum distance. 2d only.
-
--- PostGIS equivalent function: distance(geom1 geometry, geom2 geometry)
+-- Minimum distance. 2D only.
 CREATE OR REPLACE FUNCTION ST_Distance(geom1 geometry, geom2 geometry)
 	RETURNS float8
-	AS 'MODULE_PATHNAME', 'distance'
+	AS 'MODULE_PATHNAME', 'ST_Distance'
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL
 	COST 25; --changed from 100 should be 1/5th to 1/10 spheroid
 

--- a/postgis/postgis_legacy.c
+++ b/postgis/postgis_legacy.c
@@ -53,3 +53,5 @@ POSTGIS_DEPRECATE("2.5.0", pgis_abs_in);
 POSTGIS_DEPRECATE("2.5.0", pgis_abs_out);
 POSTGIS_DEPRECATE("3.0.0", area);
 POSTGIS_DEPRECATE("3.0.0", LWGEOM_area_polygon);
+POSTGIS_DEPRECATE("3.0.0", distance);
+POSTGIS_DEPRECATE("3.0.0", LWGEOM_mindistance2d);

--- a/regress/sfcgal/empty_expected
+++ b/regress/sfcgal/empty_expected
@@ -30,7 +30,7 @@ ST_Intersection(geometry, empty) == geometry|t
 ST_Intersection(empty, empty) == empty|t
 ST_Difference(geometry, empty) == geometry|t
 ST_Difference(empty, geometry) == empty|t
-ST_Distance(geometry, empty) == NULL|inf
+ST_Distance(geometry, empty) == NULL|
 ST_DWithin(geometry, empty, tolerance) == FALSE|f
 ST_Within(geometry, empty) == FALSE|f
 ST_Contains(empty, geometry) == FALSE|f

--- a/regress/sfcgal/tickets_expected
+++ b/regress/sfcgal/tickets_expected
@@ -15,7 +15,7 @@ ERROR:  lwgeom_longitude_shift: unsupported geom type: CircularString
 #73|GEOMETRYCOLLECTION(CIRCULARSTRING(1 1,2 3,4 5,6 7,5 6))
 #80|MULTILINESTRING((0 0,1 1))
 #83|MULTICURVE(CIRCULARSTRING(220268 150415,220227 150505,220227 150406))
-ERROR:  LWGEOM2SFCGAL: Unknown geometry type !
+#85|0
 #112|GEOMETRYCOLLECTION(POINT(-10 50))
 WARNING:  ST_Locate_Between_Measures and ST_Locate_Along_Measure were deprecated in 2.2.0. Please use ST_LocateAlong and ST_LocateBetween
 ERROR:  Geometry argument does not have an 'M' ordinate


### PR DESCRIPTION
Suddenly SFCGAL ST_Distance didn't support CIRCULARSTRIND and wasn't behaving with EMPTY.

https://trac.osgeo.org/postgis/ticket/4258