### PR TITLE
Avoid NULL dereferencing before calling GEOSisEmpty

### DIFF
--- a/liblwgeom/lwgeom_geos_clean.c
+++ b/liblwgeom/lwgeom_geos_clean.c
@@ -573,11 +573,15 @@ LWGEOM_GEOS_makeValidMultiLine(const GEOSGeometry* gin)
 		const GEOSGeometry* g = GEOSGetGeometryN(gin, i);
 		GEOSGeometry* vg;
 		vg = LWGEOM_GEOS_makeValidLine(g);
+		/* Drop any invalid or empty geometry */
+		if (!vg)
+			continue;
 		if (GEOSisEmpty(vg))
 		{
-			/* we don't care about this one */
 			GEOSGeom_destroy(vg);
+			continue;
 		}
+
 		if (GEOSGeomTypeId(vg) == GEOS_POINT)
 			points[npoints++] = vg;
 		else if (GEOSGeomTypeId(vg) == GEOS_LINESTRING)
@@ -827,7 +831,7 @@ LWGEOM_GEOS_makeValid(const GEOSGeometry* gin)
 		pd = GEOSDifference(pi, po); /* input points - output points */
 		GEOSGeom_destroy(pi);
 		GEOSGeom_destroy(po);
-		loss = !GEOSisEmpty(pd);
+		loss = pd && !GEOSisEmpty(pd);
 		GEOSGeom_destroy(pd);
 		if (loss)
 		{

--- a/liblwgeom/lwgeom_geos_cluster.c
+++ b/liblwgeom/lwgeom_geos_cluster.c
@@ -178,7 +178,7 @@ union_intersecting_pairs(GEOSGeometry** geoms, uint32_t num_geoms, UNIONFIND* uf
 	{
 		const GEOSPreparedGeometry* prep = NULL;
 
-		if (GEOSisEmpty(geoms[p]))
+		if (!geoms[p] || GEOSisEmpty(geoms[p]))
 			continue;
 
 		cxt.num_items_found = 0;


### PR DESCRIPTION
Related to https://trac.osgeo.org/postgis/ticket/4275

I haven't been able to find a case when this crashed in my system, so it might be fixed with changes in the surrounding code (`LWGEOM_GEOS_nodeLines`?).