### PR TITLE
Improve notice message when unable to compute stats

### DIFF
--- a/regress/core/estimatedextent.sql
+++ b/regress/core/estimatedextent.sql
@@ -206,3 +206,10 @@ select '4.b box',_postgis_index_extent('test', 'geom2');
 -- select '6.b null', _postgis_index_extent('test', 'geom2');
 drop table test cascade;
 
+-- Check NOTICE message
+create table test (id serial primary key, geom1 geometry, geom2 geometry);
+insert into test (geom1, geom2) select NULL, NULL;
+insert into test (geom1, geom2) select NULL, NULL;
+insert into test (geom1, geom2) select NULL, NULL;
+ANALYZE test;
+drop table test cascade;

--- a/regress/core/estimatedextent_expected
+++ b/regress/core/estimatedextent_expected
@@ -47,3 +47,5 @@ NOTICE:  drop cascades to 2 other objects
 3.b null|
 4.a box|BOX(-100 -100,100 100)
 4.b box|BOX(-200 -200,200 200)
+NOTICE:  PostGIS: Unable to compute statistics for "test.geom1": No non-null/empty features
+NOTICE:  PostGIS: Unable to compute statistics for "test.geom2": No non-null/empty features


### PR DESCRIPTION
Trac issue: https://trac.osgeo.org/postgis/ticket/4272

2 things:
- Outputs table and geometry name when the error occurs.
- Doesn't call `compute_gserialized_stats_mode` the second time (for N dimensions) if the first one (for just 2) failed. 

Before:
```
# analyze;
NOTICE:  no non-null/empty features, unable to compute statistics
NOTICE:  no non-null/empty features, unable to compute statistics
NOTICE:  no non-null/empty features, unable to compute statistics
NOTICE:  no non-null/empty features, unable to compute statistics
NOTICE:  no non-null/empty features, unable to compute statistics
NOTICE:  no non-null/empty features, unable to compute statistics
NOTICE:  no non-null/empty features, unable to compute statistics
NOTICE:  no non-null/empty features, unable to compute statistics
ANALYZE
```

After (as n-d isn't called there are half the log messages):
```
# analyze;
NOTICE:  PostGIS: Unable to compute statistics for "krakow_final.the_geom": No non-null/empty features
NOTICE:  PostGIS: Unable to compute statistics for "krakow_final.the_geom_webmercator": No non-null/empty features
NOTICE:  PostGIS: Unable to compute statistics for "lion_nyc_streets_lat_lon_enumerated_wkt.the_geom": No non-null/empty features
NOTICE:  PostGIS: Unable to compute statistics for "lion_nyc_streets_lat_lon_enumerated_wkt.the_geom_webmercator": No non-null/empty features
ANALYZE
```