### PR TITLE
Only build static liblwgeom

### DIFF
--- a/liblwgeom/Makefile.in
+++ b/liblwgeom/Makefile.in
@@ -171,7 +171,7 @@ $(LT_OBJS): ../postgis_config.h ../postgis_svn_revision.h $(SA_HEADERS)
 
 liblwgeom.la: $(LT_OBJS)
 	$(LIBTOOL) --tag=CC --mode=link $(CC) -rpath $(libdir) $(LT_OBJS) \
-             -release $(SOVER) -version-info $(VERSION_INFO) $(LDFLAGS) -o $@
+             -release $(SOVER) -version-info $(VERSION_INFO) $(LDFLAGS) -static -o $@
 
 maintainer-clean: clean
 	rm -f lwin_wkt_lex.c

--- a/liblwgeom/cunit/Makefile.in
+++ b/liblwgeom/cunit/Makefile.in
@@ -95,7 +95,7 @@ endif
 
 # Build the main unit test executable
 cu_tester: ../liblwgeom.la $(OBJS)
-	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) ../liblwgeom.la $(LDFLAGS)
+	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS) -static ../liblwgeom.la
 
 # Command to build each of the .o files
 $(OBJS): %.o: %.c


### PR DESCRIPTION
Related to https://trac.osgeo.org/postgis/ticket/4260

Since we don't want to link liblwgeom dynamically anymore there is no point in still building it.