### PR TITLE
ST_AsMVTGeom: Fix bug that oversimplified vertical or horizontal lines

### DIFF
--- a/postgis/lwgeom_out_mvt.c
+++ b/postgis/lwgeom_out_mvt.c
@@ -95,15 +95,12 @@ Datum ST_AsMVTGeom(PG_FUNCTION_ARGS)
 			/* Shortcut to drop geometries smaller than the resolution */
 			double geom_width = gserialized_box.xmax - gserialized_box.xmin;
 			double geom_height = gserialized_box.ymax - gserialized_box.ymin;
-			double geom_area = geom_width * geom_height;
 
-			double bounds_width = (bounds->xmax - bounds->xmin) / extent;
-			double bounds_height = (bounds->ymax - bounds->ymin) / extent;
-
-			/* We use 1/4th of the grid square area as the minimum resolution */
-			double min_resolution_area = bounds_width * bounds_height / 4.0;
-
-			if (geom_area < min_resolution_area)
+			/* We use half of the square height and width as limit: We use this
+			 * and not area so it works properly with lines */
+			double bounds_width = ((bounds->xmax - bounds->xmin) / extent) / 2.0;
+			double bounds_height = ((bounds->ymax - bounds->ymin) / extent) / 2.0;
+			if (geom_width < bounds_width && geom_height < bounds_height)
 			{
 				PG_RETURN_NULL();
 			}

--- a/regress/core/mvt.sql
+++ b/regress/core/mvt.sql
@@ -569,6 +569,15 @@ SELECT '#3922', St_Area(ST_AsMVTGeom(
 		true
 		));
 
+SELECT '#4294_Horizontal', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('MULTILINESTRING((0 0, 0 5))'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(10, 10)),
+	10, 0, true));
+
+SELECT '#4294_Vertical', ST_AsText(ST_AsMVTGeom(
+	ST_GeomFromText('MULTILINESTRING((0 0, 5 0))'),
+	ST_MakeBox2D(ST_Point(0, 0), ST_Point(10, 10)),
+	10, 0, true));
 
 -- Feature id encoding tests
 SELECT 'FI1', encode(ST_AsMVT(q, 'test', 4096, 'geom', 'c1'), 'base64') FROM (

--- a/regress/core/mvt_expected
+++ b/regress/core/mvt_expected
@@ -123,6 +123,8 @@ TU2
 ERROR:  pgis_asmvt_transfn: parameter row cannot be other than a rowtype
 TU3|
 #3922|6.5
+#4294_Horizontal|LINESTRING(0 10,0 5)
+#4294_Vertical|LINESTRING(0 10,5 10)
 FI1|GicKBHRlc3QSDggBEgIAABgBIgQJMt4/GgJjMiIGCgRhYmNkKIAgeAI=
 FI2|GicKBHRlc3QSDggBEgIAABgBIgQJMt4/GgJjMiIGCgRhYmNkKIAgeAI=
 FI3|GicKBHRlc3QSDggBEgIAABgBIgQJMt4/GgJjMiIGCgRhYmNkKIAgeAI=


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/4294

The optimization removed all vertical lines :cry: as the area was `width * 0` or `height * 0`. I reverted it to something more similar to the previous simplification based on size.