### PR TITLE
Wagyu build improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1494,6 +1494,7 @@ if test "x$HAVE_PROTOBUF" = "xyes"; then
 
             WAGYU_CXX=`"$PG_CONFIG" --cc`
             CPPFLAGS="-x c++"
+            CFLAGS=""
             CXX="$WAGYU_CXX"
             AC_PROG_CXX
             AX_CXX_COMPILE_STDCXX(11, noext, mandatory)

--- a/configure.ac
+++ b/configure.ac
@@ -1483,11 +1483,53 @@ if test "x$HAVE_PROTOBUF" = "xyes"; then
             WAGYU_LIB=libwagyu.la
             AC_SUBST([WAGYU_LIB])
 
+            dnl ============================================================
+            dnl We force  to use the same compiler as Postgresql
+            dnl ============================================================
+            CXX_SAVE="$CXX"
+            CC_SAVE="$CC"
+            CFLAGS_SAVE="$CFLAGS_SAVE"
+
+            WAGYU_CXX=`"$PG_CONFIG" --cc`
+            if test "x$WAGYU_CXX" = "xclang"; then
+                WAGYU_CXX="clang++"
+            elif test "x$WAGYU_CXX" = "xgcc"; then
+                WAGYU_CXX="g++"
+            else
+                WAGYU_CXX="$CXX"
+            fi
+
+            CXX="$WAGYU_CXX"
             AC_PROG_CXX
             AX_CXX_COMPILE_STDCXX(11, noext, mandatory)
+            WAGYU_CXX="$CXX"
+
+            dnl ============================================================
+            dnl Check if we can declare the c++ stdlib
+            dnl ============================================================
+            CC=`"$PG_CONFIG" --cc`
+
+            AC_CHECK_LIB(c++, main, [HAVE_CPP=yes], [HAVE_CPP=no])
+            AC_CHECK_LIB(stdc++, main, [HAVE_STDCPP=yes], [HAVE_STDCPP=no])
+
+            if test "x$HAVE_CPP" = "xyes"; then
+                WAGYU_LDFLAGS="-lc++"
+            elif test "x$HAVE_STDCPP" = "xyes"; then
+                WAGYU_LDFLAGS="-lstdc++"
+            else
+                AC_MSG_WARN("Could not find a C++ standard library")
+                WAGYU_LDFLAGS=""
+            fi
+
+            CXX="$CXX_SAVE"
+            CC="$CC_SAVE"
+            CFLAGS="$CFLAGS_SAVE"
 
             AC_DEFINE([HAVE_WAGYU], [1], [Define to 1 if wagyu is being built])
             AC_SUBST([HAVE_WAGYU])
+            AC_SUBST([WAGYU_CXX])
+            AC_SUBST([WAGYU_LDFLAGS])
+
             DEPS_MAKEFILE_LIST="$DEPS_MAKEFILE_LIST
                     deps/wagyu/Makefile"
     fi
@@ -1555,7 +1597,7 @@ AC_MSG_RESULT()
 AC_MSG_RESULT([ -------------- Compiler Info ------------- ])
 AC_MSG_RESULT([  C compiler:           ${CC} ${CFLAGS}])
 if test "x$HAVE_WAGYU" = "xyes"; then
-    AC_MSG_RESULT([  C++ compiler:         ${CXX} ${CXXFLAGS}])
+    AC_MSG_RESULT([  C++ compiler (Wagyu): ${WAGYU_CXX} ${CXXFLAGS}])
 fi
 AC_MSG_RESULT([  CPPFLAGS:             $CPPFLAGS])
 AC_MSG_RESULT([  SQL preprocessor:     ${SQLPP}])

--- a/configure.ac
+++ b/configure.ac
@@ -1488,26 +1488,21 @@ if test "x$HAVE_PROTOBUF" = "xyes"; then
             dnl ============================================================
             CXX_SAVE="$CXX"
             CC_SAVE="$CC"
-            CFLAGS_SAVE="$CFLAGS_SAVE"
+            CFLAGS_SAVE="$CFLAGS"
+            CXXFLAGS_SAVE="$CXXFLAGS"
+            CPPFLAGS_SAVE="$CPPFLAGS_SAVE"
 
             WAGYU_CXX=`"$PG_CONFIG" --cc`
-            if test "x$WAGYU_CXX" = "xclang"; then
-                WAGYU_CXX="clang++"
-            elif test "x$WAGYU_CXX" = "xgcc"; then
-                WAGYU_CXX="g++"
-            else
-                WAGYU_CXX="$CXX"
-            fi
-
+            CPPFLAGS="-x c++"
             CXX="$WAGYU_CXX"
             AC_PROG_CXX
             AX_CXX_COMPILE_STDCXX(11, noext, mandatory)
-            WAGYU_CXX="$CXX"
+            WAGYU_CXX="$CXX -x c++"
 
             dnl ============================================================
             dnl Check if we can declare the c++ stdlib
             dnl ============================================================
-            CC=`"$PG_CONFIG" --cc`
+            CC="$WAGYU_CXX"
 
             AC_CHECK_LIB(c++, main, [HAVE_CPP=yes], [HAVE_CPP=no])
             AC_CHECK_LIB(stdc++, main, [HAVE_STDCPP=yes], [HAVE_STDCPP=no])
@@ -1524,6 +1519,8 @@ if test "x$HAVE_PROTOBUF" = "xyes"; then
             CXX="$CXX_SAVE"
             CC="$CC_SAVE"
             CFLAGS="$CFLAGS_SAVE"
+            CXXFLAGS="$CXXFLAGS_SAVE"
+            CPPFLAGS="$CPPFLAGS_SAVE"
 
             AC_DEFINE([HAVE_WAGYU], [1], [Define to 1 if wagyu is being built])
             AC_SUBST([HAVE_WAGYU])

--- a/deps/wagyu/Makefile.in
+++ b/deps/wagyu/Makefile.in
@@ -22,8 +22,8 @@
 # *
 # **********************************************************************/
 
-CXX = @CXX@
-CXXFLAGS =-I../../liblwgeom -Iinclude @CPPFLAGS@ @WARNFLAGS@ @CXXFLAGS@ @PICFLAGS@
+CXX = @WAGYU_CXX@
+CXXFLAGS =-I../../liblwgeom -Iinclude @CPPFLAGS@ @CXXFLAGS@ @PICFLAGS@
 LDFLAGS = @LDFLAGS@
 top_builddir = @top_builddir@
 libdir = @libdir@

--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -241,7 +241,7 @@ psql -d yourdatabase -f sfcgal_comments.sql
 			  To enable ST_AsMVT protobuf-c library (for usage) and the protoc-c compiler (for building) are required.
 				Also, pkg-config is required to verify the correct minimum version of protobuf-c.
 				See <ulink url="https://github.com/protobuf-c/protobuf-c">protobuf-c</ulink>.
-                To use Wagyu to validate MVT polygons faster, a c++11 compiler is required. It will use the CXX and CXXFLAGS and needs <varname>--with-wagyu</varname> to be passed during configure.
+                To use Wagyu to validate MVT polygons faster, a c++11 compiler is required. It will use CXXFLAGS and the same compiler as the PostgreSQL installation; and it needs <varname>--with-wagyu</varname> to be passed during configure.
 			</para>
 		</listitem>
 

--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -241,7 +241,7 @@ psql -d yourdatabase -f sfcgal_comments.sql
 			  To enable ST_AsMVT protobuf-c library (for usage) and the protoc-c compiler (for building) are required.
 				Also, pkg-config is required to verify the correct minimum version of protobuf-c.
 				See <ulink url="https://github.com/protobuf-c/protobuf-c">protobuf-c</ulink>.
-                To use Wagyu to validate MVT polygons faster, a c++11 compiler is required. It will use CXXFLAGS and the same compiler as the PostgreSQL installation; and it needs <varname>--with-wagyu</varname> to be passed during configure.
+                To use Wagyu to validate MVT polygons faster, a c++11 compiler is required. It requires <varname>--with-wagyu</varname> to be passed during configure; and it will use CXXFLAGS and the same compiler as the PostgreSQL installation.
 			</para>
 		</listitem>
 

--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -63,7 +63,7 @@ endif
 WAGYU_LIBPATH = ../deps/wagyu/@WAGYU_LIB@
 ifeq (@HAVE_WAGYU@,yes)
 WAYGU_INCLUDE += -I../deps/wagyu
-WAYGU_LIB = $(WAGYU_LIBPATH)
+WAYGU_LIB = $(WAGYU_LIBPATH) @WAGYU_LDFLAGS@
 WAGYU_DEP = $(WAGYU_LIBPATH)
 endif
 


### PR DESCRIPTION
- If possible (it uses a really basic heuristic) use the same compiler to build wagyu as the one used to build postgresql to reduce friction. Otherwise CXX will be used.
- Add the linker flag to postgis.so for the C++ Standard Library when compiling wagyu. It will tey to use `lc++`, `libstdc++` or nothing in that order.

@pramsey Any chance you could try this with OSX, please? I've managed to compile it in a VM, but I'm still missing a lot of pieces to be able to run the tests. It isn't a very welcoming OS to program from the command line :smile: 

Related to https://trac.osgeo.org/postgis/ticket/4321