### PR TITLE
Use Pg CallerFInfoFunctionCallN infrastructure

### DIFF
--- a/libpgcommon/lwgeom_pg.h
+++ b/libpgcommon/lwgeom_pg.h
@@ -189,4 +189,12 @@ void lwpgerror(const char *fmt, ...);
 void lwpgnotice(const char *fmt, ...);
 void lwpgwarning(const char *fmt, ...);
 
+#if POSTGIS_PGSQL_VERSION < 100
+Datum CallerFInfoFunctionCall1(PGFunction func, FmgrInfo *flinfo, Oid collation, Datum arg1);
+Datum CallerFInfoFunctionCall2(PGFunction func, FmgrInfo *flinfo, Oid collation, Datum arg1, Datum arg2);
+#endif
+Datum CallerFInfoFunctionCall3(PGFunction func, FmgrInfo *flinfo, Oid collation, Datum arg1, Datum arg2, Datum arg3);
+
+
+
 #endif /* !defined _LWGEOM_PG_H */


### PR DESCRIPTION
preserving fcinfo data, so that cache calls still work,
makes for easier re-binding of functions without
SQL wrapping