### PR TITLE
Travis CI: Lint Python code for syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 services:
   - docker
 
-sudo: true
 language: c
 
 env:
@@ -20,6 +19,11 @@ env:
 matrix:
   allow_failures:
     - env: tag=latest mode=tests
+  include:
+    - language: python
+      script:
+        - pip install flake8  # lint Python code for syntax errors
+        - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 
 script:
   - echo "/tmp/logbt-coredumps/core.%p.%E" | sudo tee /proc/sys/kernel/core_pattern

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ matrix:
   allow_failures:
     - env: tag=latest mode=tests
   include:
-    - language: python
+    - name: "Lint: python3 -m flake8 . --select=E9,F63,F72,F82"
+      language: python
       script:
         - pip install flake8  # lint Python code for syntax errors
         - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -39,7 +39,7 @@ clean-local:
 # TODO: drop 'test' target..
 test: check
 
-check: all docs-check check-no-trailing-blanks
+check: all docs-check check-no-trailing-blanks lint-python
 
 check-no-trailing-blanks:
 	! find . -name '*.c' -o -name '*.h' -o -name '*.proto' | \
@@ -48,6 +48,10 @@ check-no-trailing-blanks:
 		grep -v vector_tile.pb-c | \
 		grep -v postgis/sqldefines.h | \
 		xargs grep -n '[[:space:]]$$'
+
+lint-python:
+	python3 -m pip install --upgrade flake8
+	flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 
 installcheck: installcheck-base installcheck-upgrade
 

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -39,7 +39,7 @@ clean-local:
 # TODO: drop 'test' target..
 test: check
 
-check: all docs-check check-no-trailing-blanks lint-python
+check: all docs-check check-no-trailing-blanks
 
 check-no-trailing-blanks:
 	! find . -name '*.c' -o -name '*.h' -o -name '*.proto' | \
@@ -48,10 +48,6 @@ check-no-trailing-blanks:
 		grep -v vector_tile.pb-c | \
 		grep -v postgis/sqldefines.h | \
 		xargs grep -n '[[:space:]]$$'
-
-lint-python:
-	python3 -m pip install --upgrade flake8
-	flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 
 installcheck: installcheck-base installcheck-upgrade
 

--- a/raster/scripts/python/raster2pgsql.py
+++ b/raster/scripts/python/raster2pgsql.py
@@ -669,7 +669,7 @@ def wkblify_raster_header(options, ds, level, ulp, xsize = None, ysize = None):
     """Writes WKT Raster header based on given GDAL into HEX-encoded WKB."""
     assert ds is not None, "Error: Missing GDAL dataset"
     assert level >= 1
-    assert len(ulp) == 2 is not None, "Error: invalid upper-left corner"
+    assert len(ulp) == 2, "Error: invalid upper-left corner"
 
     if xsize is None or ysize is None:
         assert xsize is None and ysize is None

--- a/raster/scripts/python/rtreader.py
+++ b/raster/scripts/python/rtreader.py
@@ -175,7 +175,7 @@ class RasterReader(object):
             self._sizes = self._query_single_row(sql)
 
         if self._sizes is None:
-            raise RasterError("Falied to query %dx%d of band %d is none" %(x, y, band))
+            raise RasterError("Falied to query raster size of dim {} with force {}".format(dim, force))
         return self._sizes[dim]
 
     def _query_pixel_types(self):


### PR DESCRIPTION
These test will fail until #410 (or similar) is landed.

Also the __sudo:__ tag is now deprecated in Travis CI: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"

@mwtoews Your review please?