### PR TITLE
Avoid pfree'ing the result of getenv

### DIFF
--- a/raster/rt_pg/rtpostgis.c
+++ b/raster/rt_pg/rtpostgis.c
@@ -468,7 +468,8 @@ _PG_init(void) {
 		if (strcmp(env, "1") == 0)
 			boot_postgis_enable_outdb_rasters = true;
 
-		pfree(env);
+		if (env != env_postgis_enable_outdb_rasters)
+			pfree(env);
 	}
 	POSTGIS_RT_DEBUGF(
 		4,


### PR DESCRIPTION
Fix for https://trac.osgeo.org/postgis/ticket/4327