### PR TITLE
[WIP] Proj 6 performance improvments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -868,18 +868,6 @@ elif test ! -z "$PKG_CONFIG"; then
             ])
 fi
 
-
-dnl Check that we can find the proj_api.h header file
-CPPFLAGS_SAVE="$CPPFLAGS"
-CPPFLAGS="$PROJ_CPPFLAGS"
-AC_CHECK_HEADER([proj_api.h],
-	[],
-	[AC_CHECK_HEADER([proj.h],
-		[],
-		[AC_MSG_ERROR([could not find proj.h or proj_api.h - you may need to specify the directory of a PROJ installation using --with-projdir])]
-		)]
-	)
-
 dnl Return the PROJ.4 version number
 AC_PROJ_VERSION([POSTGIS_PROJ_VERSION])
 AC_DEFINE_UNQUOTED([POSTGIS_PROJ_VERSION], [$POSTGIS_PROJ_VERSION], [PROJ library version])
@@ -891,6 +879,20 @@ if test ! "$POSTGIS_PROJ_VERSION" -ge 46; then
 	AC_MSG_ERROR([PostGIS requires PROJ >= 4.6.0])
 fi
 
+dnl Check that we can find proj headers
+CPPFLAGS_SAVE="$CPPFLAGS"
+CPPFLAGS="$PROJ_CPPFLAGS"
+if test ! "$POSTGIS_PROJ_VERSION" -ge 60; then
+	AC_CHECK_HEADER([proj_api.h],
+		[],
+		[AC_MSG_ERROR([could not find proj.h or proj_api.h - you may need to specify the directory of a PROJ installation using --with-projdir])]
+	)
+else
+	AC_CHECK_HEADER([proj.h],
+		[],
+		[AC_MSG_ERROR([could not find proj.h or proj_api.h - you may need to specify the directory of a PROJ installation using --with-projdir])]
+        )
+fi
 AC_SUBST([PROJ_CPPFLAGS])
 AC_SUBST([PROJ_LDFLAGS])
 

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -30,8 +30,9 @@
 #define _LIBLWGEOM_H 1
 
 #include <stdarg.h>
-#include <stdio.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include "../postgis_config.h"
 
@@ -42,8 +43,19 @@ typedef struct PJ
     projPJ pj_from;
     projPJ pj_to;
 } PJ;
+
+typedef LWPROJ PJ;
+
 #else
 #include "proj.h"
+
+/* Typedef including PROJ projection and whether source or target crs are swapped */
+typedef struct LWPROJ
+{
+	PJ* pj;
+	bool source_swapped;
+	bool target_swapped;
+} LWPROJ;
 #endif
 
 #if POSTGIS_PROJ_VERSION < 49
@@ -2336,7 +2348,7 @@ int lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outst
  *
  * Eg: "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
  */
-projPJ lwproj_from_string(const char* txt);
+projPJ projpj_from_string(const char* txt);
 
 #endif
 /**
@@ -2344,8 +2356,17 @@ projPJ lwproj_from_string(const char* txt);
  * @param geom the geometry to transform
  * @param PJ the input and output
  */
-int lwgeom_transform(LWGEOM *geom, PJ* pj);
-int ptarray_transform(POINTARRAY *pa, PJ* pj);
+int lwgeom_transform(LWGEOM *geom, LWPROJ* pj);
+int ptarray_transform(POINTARRAY *pa, LWPROJ* pj);
+
+#if POSTGIS_PROJ_VERSION >= 60
+
+/**
+ * Allocate a new LWPROJ containing the reference to the PROJ' PJ
+ */
+LWPROJ* lwproj_from_PJ(PJ *pj);
+
+#endif
 
 
 /*******************************************************************************

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -30,7 +30,6 @@
 #define _LIBLWGEOM_H 1
 
 #include <stdarg.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -53,8 +52,8 @@ typedef PJ LWPROJ;
 typedef struct LWPROJ
 {
 	PJ* pj;
-	bool source_swapped;
-	bool target_swapped;
+	uint8_t source_swapped;
+	uint8_t target_swapped;
 } LWPROJ;
 #endif
 

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -44,7 +44,7 @@ typedef struct PJ
     projPJ pj_to;
 } PJ;
 
-typedef LWPROJ PJ;
+typedef PJ LWPROJ;
 
 #else
 #include "proj.h"

--- a/liblwgeom/lwgeom_transform.c
+++ b/liblwgeom/lwgeom_transform.c
@@ -130,7 +130,7 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 		return LW_FAILURE;
 	}
 
-	rv = lwgeom_transform(geom, pj);
+	rv = lwgeom_transform(geom, &pj);
 	pj_free(pj.pj_from);
 	pj_free(pj.pj_to);
 	return rv;

--- a/liblwgeom/lwgeom_transform.c
+++ b/liblwgeom/lwgeom_transform.c
@@ -219,20 +219,26 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 	if (!pj)
 	{
 		PJ *pj_in = proj_create(NULL, instr);
-		PJ *pj_out = proj_create(NULL, outstr);
 		if (!pj_in)
 		{
 			lwerror("could not parse proj string '%s'", instr);
 		}
+		proj_destroy(pj_in);
+
+		PJ *pj_out = proj_create(NULL, outstr);
 		if (!pj_out)
 		{
-			proj_destroy(pj_in);
 			lwerror("could not parse proj string '%s'", outstr);
 		}
+		proj_destroy(pj_out);
+		lwerror("%s: Failed to transform", __func__);
 		return LW_FAILURE;
 	}
 
-	return lwgeom_transform(geom, pj);
+	int ret = lwgeom_transform(geom, pj);
+	proj_destroy(pj);
+
+	return ret;
 }
 
 int

--- a/liblwgeom/lwgeom_transform.c
+++ b/liblwgeom/lwgeom_transform.c
@@ -48,9 +48,8 @@ to_dec(POINT4D *pt)
 
 #if POSTGIS_PROJ_VERSION < 60
 
-
 static int
-point4d_transform(POINT4D *pt, PJ* pj)
+point4d_transform(POINT4D *pt, LWPROJ *pj)
 {
 	POINT3D orig_pt = {pt->x, pt->y, pt->z}; /* Copy for error report*/
 
@@ -90,7 +89,7 @@ point4d_transform(POINT4D *pt, PJ* pj)
  * from inpj projection to outpj projection
  */
 int
-ptarray_transform(POINTARRAY *pa, PJ* pj)
+ptarray_transform(POINTARRAY *pa, LWPROJ *pj)
 {
 	uint32_t i;
 	POINT4D p;
@@ -110,9 +109,9 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 {
 	char *pj_errstr;
 	int rv;
-	PJ pj;
+	LWPROJ pj;
 
-	pj.pj_from = lwproj_from_string(instr);
+	pj.pj_from = projpj_from_string(instr);
 	if (!pj.pj_from)
 	{
 		pj_errstr = pj_strerrno(*pj_get_errno_ref());
@@ -121,7 +120,7 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 		return LW_FAILURE;
 	}
 
-	pj.pj_to = lwproj_from_string(outstr);
+	pj.pj_to = projpj_from_string(outstr);
 	if (!pj.pj_to)
 	{
 		pj_free(pj.pj_from);
@@ -131,7 +130,7 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 		return LW_FAILURE;
 	}
 
-	rv = lwgeom_transform(geom, &pj);
+	rv = lwgeom_transform(geom, pj);
 	pj_free(pj.pj_from);
 	pj_free(pj.pj_to);
 	return rv;
@@ -142,7 +141,7 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
  * from inpj projection to outpj projection
  */
 int
-lwgeom_transform(LWGEOM *geom, PJ* pj)
+lwgeom_transform(LWGEOM *geom, LWPROJ *pj)
 {
 	uint32_t i;
 
@@ -199,7 +198,7 @@ lwgeom_transform(LWGEOM *geom, PJ* pj)
 }
 
 projPJ
-lwproj_from_string(const char *str1)
+projpj_from_string(const char *str1)
 {
 	if (!str1 || str1[0] == '\0')
 	{
@@ -211,6 +210,86 @@ lwproj_from_string(const char *str1)
 /***************************************************************************/
 
 #else /* POSTGIS_PROJ_VERION >= 60 */
+
+static bool
+proj_crs_is_swapped(const PJ *pj_crs)
+{
+	PJ *pj_cs;
+	bool rv = LW_FALSE;
+
+	if (proj_get_type(pj_crs) == PJ_TYPE_COMPOUND_CRS)
+	{
+		PJ *pj_horiz_crs = proj_crs_get_sub_crs(NULL, pj_crs, 0);
+		if (!pj_horiz_crs)
+			lwerror("%s: proj_crs_get_sub_crs returned NULL", __func__);
+		pj_cs = proj_crs_get_coordinate_system(NULL, pj_horiz_crs);
+		proj_destroy(pj_horiz_crs);
+	}
+	else if (proj_get_type(pj_crs) == PJ_TYPE_BOUND_CRS)
+	{
+		PJ *pj_src_crs = proj_get_source_crs(NULL, pj_crs);
+		if (!pj_src_crs)
+			lwerror("%s: proj_get_source_crs returned NULL", __func__);
+		pj_cs = proj_crs_get_coordinate_system(NULL, pj_src_crs);
+		proj_destroy(pj_src_crs);
+	}
+	else
+	{
+		pj_cs = proj_crs_get_coordinate_system(NULL, pj_crs);
+	}
+	if (!pj_cs)
+		lwerror("%s: proj_crs_get_coordinate_system returned NULL", __func__);
+	int axis_count = proj_cs_get_axis_count(NULL, pj_cs);
+	if (axis_count > 0)
+	{
+		const char *out_name, *out_abbrev, *out_direction;
+		double out_unit_conv_factor;
+		const char *out_unit_name, *out_unit_auth_name, *out_unit_code;
+		/* Read only first axis, see if it is degrees / north */
+		proj_cs_get_axis_info(NULL,
+				      pj_cs,
+				      0,
+				      &out_name,
+				      &out_abbrev,
+				      &out_direction,
+				      &out_unit_conv_factor,
+				      &out_unit_name,
+				      &out_unit_auth_name,
+				      &out_unit_code);
+		rv = (strcasecmp(out_direction, "north") == 0);
+	}
+	proj_destroy(pj_cs);
+	return rv;
+}
+
+LWPROJ *
+lwproj_from_PJ(PJ *pj)
+{
+	PJ *pj_source_crs = proj_get_source_crs(NULL, pj);
+	if (!pj_source_crs)
+	{
+		lwerror("%s: unable to access source crs", __func__);
+		return NULL;
+	}
+	bool source_swapped = proj_crs_is_swapped(pj_source_crs);
+	proj_destroy(pj_source_crs);
+
+	PJ *pj_target_crs = proj_get_target_crs(NULL, pj);
+	if (!pj_target_crs)
+	{
+		lwerror("%s: unable to access target crs", __func__);
+		return NULL;
+	}
+	bool target_swapped = proj_crs_is_swapped(pj_target_crs);
+	proj_destroy(pj_target_crs);
+
+	LWPROJ *lp = malloc(sizeof(LWPROJ));
+	lp->pj = pj;
+	lp->source_swapped = source_swapped;
+	lp->target_swapped = target_swapped;
+
+	return lp;
+}
 
 int
 lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
@@ -235,14 +314,18 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 		return LW_FAILURE;
 	}
 
-	int ret = lwgeom_transform(geom, pj);
+	LWPROJ *lp = lwproj_from_PJ(pj);
+
+	int ret = lwgeom_transform(geom, lp);
+
 	proj_destroy(pj);
+	free(lp);
 
 	return ret;
 }
 
 int
-lwgeom_transform(LWGEOM* geom, PJ* pj)
+lwgeom_transform(LWGEOM *geom, LWPROJ *pj)
 {
 	uint32_t i;
 
@@ -301,56 +384,8 @@ lwgeom_transform(LWGEOM* geom, PJ* pj)
 	return LW_SUCCESS;
 }
 
-static int
-proj_crs_is_swapped(const PJ* pj_crs)
-{
-	PJ *pj_cs;
-	int rv = LW_FALSE;
-
-	if (proj_get_type(pj_crs) == PJ_TYPE_COMPOUND_CRS)
-	{
-		PJ *pj_horiz_crs = proj_crs_get_sub_crs(NULL, pj_crs, 0);
-		if (!pj_horiz_crs) lwerror("%s: proj_crs_get_sub_crs returned NULL", __func__);
-		pj_cs = proj_crs_get_coordinate_system(NULL, pj_horiz_crs);
-		proj_destroy(pj_horiz_crs);
-	}
-	else if (proj_get_type(pj_crs) == PJ_TYPE_BOUND_CRS)
-	{
-		PJ *pj_src_crs = proj_get_source_crs(NULL, pj_crs);
-		if (!pj_src_crs) lwerror("%s: proj_get_source_crs returned NULL", __func__);
-		pj_cs = proj_crs_get_coordinate_system(NULL, pj_src_crs);
-		proj_destroy(pj_src_crs);
-	}
-	else
-	{
-		pj_cs = proj_crs_get_coordinate_system(NULL, pj_crs);
-	}
-	if (!pj_cs) lwerror("%s: proj_crs_get_coordinate_system returned NULL", __func__);
-	int axis_count = proj_cs_get_axis_count(NULL, pj_cs);
-	if (axis_count > 0)
-	{
-		const char *out_name, *out_abbrev, *out_direction;
-		double out_unit_conv_factor;
-		const char *out_unit_name, *out_unit_auth_name, *out_unit_code;
-		/* Read only first axis, see if it is degrees / north */
-		proj_cs_get_axis_info(NULL, pj_cs, 0,
-			&out_name,
-			&out_abbrev,
-			&out_direction,
-			&out_unit_conv_factor,
-			&out_unit_name,
-			&out_unit_auth_name,
-			&out_unit_code
-			);
-		rv = (strcasecmp(out_direction, "north") == 0);
-	}
-	proj_destroy(pj_cs);
-	return rv;
-}
-
-
 int
-ptarray_transform(POINTARRAY* pa, PJ* pj)
+ptarray_transform(POINTARRAY *pa, LWPROJ *pj)
 {
 	uint32_t i;
 	POINT4D p;
@@ -359,24 +394,9 @@ ptarray_transform(POINTARRAY* pa, PJ* pj)
 	size_t point_size = ptarray_point_size(pa);
 	int has_z = ptarray_has_z(pa);
 	double *pa_double = (double*)(pa->serialized_pointlist);
-	int input_swapped, output_swapped;
-
-	PJ* pj_source_crs = proj_get_source_crs(NULL, pj);
-	PJ* pj_target_crs = proj_get_target_crs(NULL, pj);
-
-	if (!(pj_source_crs && pj_target_crs))
-	{
-		lwerror("ptarray_transform: unable to access source and target crs");
-		return LW_FAILURE;
-	}
-
-	input_swapped = proj_crs_is_swapped(pj_source_crs);
-	output_swapped = proj_crs_is_swapped(pj_target_crs);
-	proj_destroy(pj_source_crs);
-	proj_destroy(pj_target_crs);
 
 	/* Convert to radians if necessary */
-	if (proj_angular_input(pj, PJ_FWD))
+	if (proj_angular_input(pj->pj, PJ_FWD)) /* CACHE THIS TOO */
 	{
 		for (i = 0; i < pa->npoints; i++)
 		{
@@ -385,7 +405,7 @@ ptarray_transform(POINTARRAY* pa, PJ* pj)
 		}
 	}
 
-	if (input_swapped)
+	if (pj->source_swapped)
 		ptarray_swap_ordinates(pa, LWORD_X, LWORD_Y);
 
 	/*
@@ -396,15 +416,21 @@ ptarray_transform(POINTARRAY* pa, PJ* pj)
 	* double *t, size_t st, size_t nt)
 	*/
 
-	n_converted = proj_trans_generic(
-		pj, PJ_FWD,
-		pa_double,     point_size, n_points, /* X */
-		pa_double + 1, point_size, n_points, /* Y */
-		has_z ? pa_double + 2 : NULL,
-		has_z ? point_size : 0,
-		has_z ? n_points : 0, /* Z */
-		NULL, 0, 0 /* M */
-		);
+	n_converted = proj_trans_generic(pj->pj,
+					 PJ_FWD,
+					 pa_double,
+					 point_size,
+					 n_points, /* X */
+					 pa_double + 1,
+					 point_size,
+					 n_points, /* Y */
+					 has_z ? pa_double + 2 : NULL,
+					 has_z ? point_size : 0,
+					 has_z ? n_points : 0, /* Z */
+					 NULL,
+					 0,
+					 0 /* M */
+	);
 
 	if (n_converted != n_points)
 	{
@@ -413,7 +439,7 @@ ptarray_transform(POINTARRAY* pa, PJ* pj)
 		return LW_FAILURE;
 	}
 
-	int pj_errno_val = proj_errno(pj);
+	int pj_errno_val = proj_errno(pj->pj);
 	if (pj_errno_val)
 	{
 		lwerror("transform: %s (%d)",
@@ -421,11 +447,11 @@ ptarray_transform(POINTARRAY* pa, PJ* pj)
 		return LW_FAILURE;
 	}
 
-	if (output_swapped)
+	if (pj->target_swapped)
 		ptarray_swap_ordinates(pa, LWORD_X, LWORD_Y);
 
 	/* Convert radians to degrees if necessary */
-	if (proj_angular_output(pj, PJ_FWD))
+	if (proj_angular_output(pj->pj, PJ_FWD))
 	{
 		for (i = 0; i < pa->npoints; i++)
 		{

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -67,7 +67,7 @@ typedef struct struct_PROJSRSCacheItem
 {
 	int32_t srid_from;
 	int32_t srid_to;
-	PJ* projection;
+	LWPROJ *projection;
 	MemoryContext projection_mcxt;
 }
 PROJSRSCacheItem;

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -819,7 +819,7 @@ static int
 proj_pj_is_latlong(const LWPROJ *pj)
 {
 #if POSTGIS_PROJ_VERSION < 60
-	return pj_is_latlong(pj - pj_from);
+	return pj_is_latlong(pj->pj_from);
 #else
 	PJ_TYPE pj_type;
 	PJ *pj_src_crs = proj_get_source_crs(NULL, pj->pj);

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -77,7 +77,7 @@ typedef struct {
 typedef struct struct_PJHashEntry
 {
 	MemoryContext ProjectionContext;
-	PJ* projection;
+	LWPROJ *projection;
 }
 PJHashEntry;
 
@@ -87,8 +87,8 @@ uint32 mcxt_ptr_hash(const void *key, Size keysize);
 
 static HTAB *CreatePJHash(void);
 static void DeletePJHashEntry(MemoryContext mcxt);
-static PJ* GetPJHashEntry(MemoryContext mcxt);
-static void AddPJHashEntry(MemoryContext mcxt, PJ* projection);
+static LWPROJ *GetPJHashEntry(MemoryContext mcxt);
+static void AddPJHashEntry(MemoryContext mcxt, LWPROJ *projection);
 
 /* Internal Cache API */
 /* static PROJPortalCache *GetPROJSRSCache(FunctionCallInfo fcinfo) ; */
@@ -122,7 +122,7 @@ SetSpatialRefSysSchema(FunctionCallInfo fcinfo)
 }
 
 static void
-PROJSRSDestroyPJ(PJ* pj)
+PROJSRSDestroyPJ(LWPROJ *pj)
 {
 #if POSTGIS_PROJ_VERSION < 60
 /* Ape the Proj 6+ API for versions < 6 */
@@ -132,7 +132,8 @@ PROJSRSDestroyPJ(PJ* pj)
 		pj_free(pj->pj_to);
 	free(pj);
 #else
-	proj_destroy(pj);
+	proj_destroy(pj->pj);
+	free(pj);
 #endif
 }
 
@@ -158,7 +159,7 @@ PROJSRSCacheDelete(void *ptr)
 #endif
 
 	/* Lookup the PJ pointer in the global hash table so we can free it */
-	PJ* projection = GetPJHashEntry(context);
+	LWPROJ *projection = GetPJHashEntry(context);
 
 	if (!projection)
 		elog(ERROR, "PROJSRSCacheDelete: Trying to delete non-existant projection object with MemoryContext key (%p)", (void *)context);
@@ -273,7 +274,8 @@ static HTAB *CreatePJHash(void)
 	return hash_create("PostGIS PROJ Backend MemoryContext Hash", PROJ_BACKEND_HASH_SIZE, &ctl, (HASH_ELEM | HASH_FUNCTION));
 }
 
-static void AddPJHashEntry(MemoryContext mcxt, PJ* projection)
+static void
+AddPJHashEntry(MemoryContext mcxt, LWPROJ *projection)
 {
 	bool found;
 	void **key;
@@ -296,7 +298,8 @@ static void AddPJHashEntry(MemoryContext mcxt, PJ* projection)
 	}
 }
 
-static PJ* GetPJHashEntry(MemoryContext mcxt)
+static LWPROJ *
+GetPJHashEntry(MemoryContext mcxt)
 {
 	void **key;
 	PJHashEntry *he;
@@ -351,7 +354,7 @@ IsInPROJSRSCache(PROJPortalCache *cache, int32_t srid_from, int32_t srid_to)
 	return false;
 }
 
-static PJ *
+static LWPROJ *
 GetProjectionFromPROJCache(PROJPortalCache *cache, int32_t srid_from, int32_t srid_to)
 {
 	uint32_t i;
@@ -639,8 +642,8 @@ AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to
 	PJ* projection = malloc(sizeof(PJ));
 	pj_from_str = from_strs.proj4text;
 	pj_to_str = to_strs.proj4text;
-	projection->pj_from = lwproj_from_string(pj_from_str);
-	projection->pj_to = lwproj_from_string(pj_to_str);
+	projection->pj_from = projpj_from_string(pj_from_str);
+	projection->pj_to = projpj_from_string(pj_to_str);
 
 	if (!projection->pj_from)
 		elog(ERROR,
@@ -652,7 +655,7 @@ AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to
 		    "could not form projection from 'srid=%d' to 'srid=%d'",
 		    srid_from, srid_to);
 #else
-	PJ* projection = NULL;
+	PJ *projpj = NULL;
 	/* Try combinations of ESPG/SRTEXT/PROJ4TEXT until we find */
 	/* one that gives us a usable transform. Note that we prefer */
 	/* EPSG numbers over SRTEXT and SRTEXT over PROJ4TEXT */
@@ -664,15 +667,20 @@ AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to
 		pj_to_str   = pgstrs_get_entry(&to_strs,   i % 3);
 		if (!(pj_from_str && pj_to_str))
 			continue;
-		projection = proj_create_crs_to_crs(NULL, pj_from_str, pj_to_str, NULL);
-		if (projection && !proj_errno(projection))
+		projpj = proj_create_crs_to_crs(NULL, pj_from_str, pj_to_str, NULL);
+		if (projpj && !proj_errno(projpj))
 			break;
 	}
+	if (!projpj)
+	{
+		elog(ERROR, "could not form projection (PJ) from 'srid=%d' to 'srid=%d'", srid_from, srid_to);
+		return;
+	}
+	LWPROJ *projection = lwproj_from_PJ(projpj);
 	if (!projection)
 	{
-		elog(ERROR,
-		    "could not form projection from 'srid=%d' to 'srid=%d'",
-		    srid_from, srid_to);
+		elog(ERROR, "could not form projection (LWPROJ) from 'srid=%d' to 'srid=%d'", srid_from, srid_to);
+		return;
 	}
 #endif
 
@@ -784,9 +792,8 @@ DeleteFromPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t sr
 	}
 }
 
-
 int
-GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, PJ **pj)
+GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, LWPROJ **pj)
 {
 	PROJPortalCache *proj_cache = NULL;
 
@@ -809,13 +816,13 @@ GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, PJ
 }
 
 static int
-proj_pj_is_latlong(const PJ* pj)
+proj_pj_is_latlong(const LWPROJ *pj)
 {
 #if POSTGIS_PROJ_VERSION < 60
-	return pj_is_latlong(pj->pj_from);
+	return pj_is_latlong(pj - pj_from);
 #else
 	PJ_TYPE pj_type;
-	PJ *pj_src_crs = proj_get_source_crs(NULL, pj);
+	PJ *pj_src_crs = proj_get_source_crs(NULL, pj->pj);
 	if (!pj_src_crs)
 		elog(ERROR, "%s: proj_get_source_crs returned NULL", __func__);
 	pj_type = proj_get_type(pj_src_crs);
@@ -828,7 +835,7 @@ proj_pj_is_latlong(const PJ* pj)
 static int
 srid_is_latlong(FunctionCallInfo fcinfo, int32_t srid)
 {
-	PJ* pj;
+	LWPROJ *pj;
 	if ( GetPJUsingFCInfo(fcinfo, srid, srid, &pj) == LW_FAILURE)
 		return LW_FALSE;
 	return proj_pj_is_latlong(pj);
@@ -871,7 +878,7 @@ srid_axis_precision(FunctionCallInfo fcinfo, int32_t srid, int precision)
 int
 spheroid_init_from_srid(FunctionCallInfo fcinfo, int32_t srid, SPHEROID *s)
 {
-	PJ* pj;
+	LWPROJ *pj;
 #if POSTGIS_PROJ_VERSION >= 60
 	double out_semi_major_metre, out_semi_minor_metre, out_inv_flattening;
 	int out_is_semi_minor_computed;
@@ -886,7 +893,7 @@ spheroid_init_from_srid(FunctionCallInfo fcinfo, int32_t srid, SPHEROID *s)
 #if POSTGIS_PROJ_VERSION >= 60
 	if (!proj_pj_is_latlong(pj))
 		return LW_FAILURE;
-	pj_crs = proj_get_source_crs(NULL, pj);
+	pj_crs = proj_get_source_crs(NULL, pj->pj);
 	if (!pj_crs)
 	{
 		lwerror("%s: proj_get_source_crs returned NULL", __func__);

--- a/libpgcommon/lwgeom_transform.h
+++ b/libpgcommon/lwgeom_transform.h
@@ -29,7 +29,6 @@ char *GetProj4String(int32_t srid);
  */
 typedef void *ProjCache ;
 
-void SetPROJLibPath(void);
 bool IsInPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
 PJ *GetPJFromPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
 int GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, PJ **pj);

--- a/libpgcommon/lwgeom_transform.h
+++ b/libpgcommon/lwgeom_transform.h
@@ -31,7 +31,7 @@ typedef void *ProjCache ;
 
 bool IsInPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
 PJ *GetPJFromPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
-int GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, PJ **pj);
+int GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, LWPROJ **pj);
 int spheroid_init_from_srid(FunctionCallInfo fcinfo, int32_t srid, SPHEROID *s);
 void srid_check_latlong(FunctionCallInfo fcinfo, int32_t srid);
 srs_precision srid_axis_precision(FunctionCallInfo fcinfo, int32_t srid, int precision);

--- a/postgis/lwgeom_in_gml.c
+++ b/postgis/lwgeom_in_gml.c
@@ -337,6 +337,7 @@ static POINTARRAY *
 gml_reproject_pa(POINTARRAY *pa, int32_t srid_in, int32_t srid_out)
 {
 	PJ *pj;
+	LWPROJ *lwp;
 	char text_in[32];
 	char text_out[32];
 
@@ -353,7 +354,7 @@ gml_reproject_pa(POINTARRAY *pa, int32_t srid_in, int32_t srid_out)
 	snprintf(text_out, 32, "EPSG:%d", srid_out);
 	pj = proj_create_crs_to_crs(NULL, text_in, text_out, NULL);
 
-	LWPROJ *lwp = lwproj_from_PJ(pj);
+	lwp = lwproj_from_PJ(pj);
 	if (!lwp)
 	{
 		proj_destroy(pj);

--- a/postgis/lwgeom_transform.c
+++ b/postgis/lwgeom_transform.c
@@ -119,9 +119,6 @@ Datum transform_geom(PG_FUNCTION_ARGS)
 	/* Take a copy, since we will be altering the coordinates */
 	gser = PG_GETARG_GSERIALIZED_P_COPY(0);
 
-	/* Set the search path if we haven't already */
-	SetPROJLibPath();
-
 	/* Convert from text to cstring for libproj */
 	input_srs = text_to_cstring(PG_GETARG_TEXT_P(1));
 	output_srs = text_to_cstring(PG_GETARG_TEXT_P(2));

--- a/postgis/lwgeom_transform.c
+++ b/postgis/lwgeom_transform.c
@@ -50,7 +50,7 @@ Datum transform(PG_FUNCTION_ARGS)
 	GSERIALIZED* geom;
 	GSERIALIZED* result=NULL;
 	LWGEOM* lwgeom;
-	PJ* pj;
+	LWPROJ *pj;
 	int32 srid_to, srid_from;
 
 	srid_to = PG_GETARG_INT32(1);
@@ -213,7 +213,7 @@ Datum LWGEOM_asKML(PG_FUNCTION_ARGS)
 
 	if (srid_from != srid_to)
 	{
-		PJ* pj;
+		LWPROJ *pj;
 		if (GetPJUsingFCInfo(fcinfo, srid_from, srid_to, &pj) == LW_FAILURE)
 		{
 			PG_FREE_IF_COPY(geom, 0);


### PR DESCRIPTION
Related to https://trac.osgeo.org/postgis/ticket/4372

Changes:
- Configure.ac: Only try proj_api.h for PROJ6-, and test proj.h directly for PROJ6. This removes some error messages.
-  lwgeom_transform_from_str was leaking resources.
-  Removes the calls to SetPROJLibPath. This was conflicting with my (default) installation of PROJ6 as by changing PROJ's searchpath it was unable to locate proj.db (but still work). I need to investigate further as, by removing this, certain transformations become 10x slower.
- Cache whether the projections srs's are swapped to avoid checking it in every call. With this the performance of ST_Transform'ign a table of points is almost as good as PROJ5 (and not 4x slower).