### PR TITLE
Proj6 impr cache

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -868,18 +868,6 @@ elif test ! -z "$PKG_CONFIG"; then
             ])
 fi
 
-
-dnl Check that we can find the proj_api.h header file
-CPPFLAGS_SAVE="$CPPFLAGS"
-CPPFLAGS="$PROJ_CPPFLAGS"
-AC_CHECK_HEADER([proj_api.h],
-	[],
-	[AC_CHECK_HEADER([proj.h],
-		[],
-		[AC_MSG_ERROR([could not find proj.h or proj_api.h - you may need to specify the directory of a PROJ installation using --with-projdir])]
-		)]
-	)
-
 dnl Return the PROJ.4 version number
 AC_PROJ_VERSION([POSTGIS_PROJ_VERSION])
 AC_DEFINE_UNQUOTED([POSTGIS_PROJ_VERSION], [$POSTGIS_PROJ_VERSION], [PROJ library version])
@@ -891,6 +879,20 @@ if test ! "$POSTGIS_PROJ_VERSION" -ge 46; then
 	AC_MSG_ERROR([PostGIS requires PROJ >= 4.6.0])
 fi
 
+dnl Check that we can find proj headers
+CPPFLAGS_SAVE="$CPPFLAGS"
+CPPFLAGS="$PROJ_CPPFLAGS"
+if test ! "$POSTGIS_PROJ_VERSION" -ge 60; then
+	AC_CHECK_HEADER([proj_api.h],
+		[],
+		[AC_MSG_ERROR([could not find proj.h or proj_api.h - you may need to specify the directory of a PROJ installation using --with-projdir])]
+	)
+else
+	AC_CHECK_HEADER([proj.h],
+		[],
+		[AC_MSG_ERROR([could not find proj.h or proj_api.h - you may need to specify the directory of a PROJ installation using --with-projdir])]
+        )
+fi
 AC_SUBST([PROJ_CPPFLAGS])
 AC_SUBST([PROJ_LDFLAGS])
 

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -48,12 +48,21 @@ typedef PJ LWPROJ;
 #else
 #include "proj.h"
 
-/* Typedef including PROJ projection and whether source or target crs are swapped */
+/* For PROJ6 we cache several extra values to avoid calls to proj_get_source_crs
+ * or proj_get_target_crs since those are very costly
+ */
 typedef struct LWPROJ
 {
 	PJ* pj;
+        /* CRSs are swapped: Used in transformation calls */
 	uint8_t source_swapped;
 	uint8_t target_swapped;
+        /* Source crs is geographic: Used in geography calls (source srid == dst srid) */
+        uint8_t source_is_latlong;
+
+        /* Source ellipsoid parameters */
+        double source_semi_major_metre;
+        double source_semi_minor_metre;
 } LWPROJ;
 #endif
 
@@ -2383,9 +2392,11 @@ int ptarray_transform(POINTARRAY *pa, LWPROJ* pj);
 #if POSTGIS_PROJ_VERSION >= 60
 
 /**
- * Allocate a new LWPROJ containing the reference to the PROJ' PJ
+ * Allocate a new LWPROJ containing the reference to the PROJ's PJ
+ * If extra_geography_data is true, it will generate the following values for
+ * the source srs: is_latlong (geometric or not) and spheroid values
  */
-LWPROJ* lwproj_from_PJ(PJ *pj);
+LWPROJ *lwproj_from_PJ(PJ *pj, int8_t extra_geography_data);
 
 #endif
 

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -30,8 +30,8 @@
 #define _LIBLWGEOM_H 1
 
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include "../postgis_config.h"
 
@@ -42,8 +42,19 @@ typedef struct PJ
     projPJ pj_from;
     projPJ pj_to;
 } PJ;
+
+typedef PJ LWPROJ;
+
 #else
 #include "proj.h"
+
+/* Typedef including PROJ projection and whether source or target crs are swapped */
+typedef struct LWPROJ
+{
+	PJ* pj;
+	uint8_t source_swapped;
+	uint8_t target_swapped;
+} LWPROJ;
 #endif
 
 #if POSTGIS_PROJ_VERSION < 49
@@ -2358,7 +2369,7 @@ int lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outst
  *
  * Eg: "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
  */
-projPJ lwproj_from_string(const char* txt);
+projPJ projpj_from_string(const char* txt);
 
 #endif
 /**
@@ -2366,8 +2377,17 @@ projPJ lwproj_from_string(const char* txt);
  * @param geom the geometry to transform
  * @param PJ the input and output
  */
-int lwgeom_transform(LWGEOM *geom, PJ* pj);
-int ptarray_transform(POINTARRAY *pa, PJ* pj);
+int lwgeom_transform(LWGEOM *geom, LWPROJ* pj);
+int ptarray_transform(POINTARRAY *pa, LWPROJ* pj);
+
+#if POSTGIS_PROJ_VERSION >= 60
+
+/**
+ * Allocate a new LWPROJ containing the reference to the PROJ' PJ
+ */
+LWPROJ* lwproj_from_PJ(PJ *pj);
+
+#endif
 
 
 /*******************************************************************************

--- a/liblwgeom/lwgeom_transform.c
+++ b/liblwgeom/lwgeom_transform.c
@@ -326,7 +326,7 @@ lwproj_from_PJ(PJ *pj, int8_t extra_geography_data)
 	uint8_t target_swapped = proj_crs_is_swapped(pj_target_crs);
 	proj_destroy(pj_target_crs);
 
-	LWPROJ *lp = malloc(sizeof(LWPROJ));
+	LWPROJ *lp = lwalloc(sizeof(LWPROJ));
 	lp->pj = pj;
 	lp->source_swapped = source_swapped;
 	lp->target_swapped = target_swapped;
@@ -365,7 +365,7 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 	int ret = lwgeom_transform(geom, lp);
 
 	proj_destroy(pj);
-	free(lp);
+	lwfree(lp);
 
 	return ret;
 }

--- a/liblwgeom/lwgeom_transform.c
+++ b/liblwgeom/lwgeom_transform.c
@@ -219,20 +219,26 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 	if (!pj)
 	{
 		PJ *pj_in = proj_create(NULL, instr);
-		PJ *pj_out = proj_create(NULL, outstr);
 		if (!pj_in)
 		{
 			lwerror("could not parse proj string '%s'", instr);
 		}
+		proj_destroy(pj_in);
+
+		PJ *pj_out = proj_create(NULL, outstr);
 		if (!pj_out)
 		{
-			proj_destroy(pj_in);
 			lwerror("could not parse proj string '%s'", outstr);
 		}
+		proj_destroy(pj_out);
+		lwerror("%s: Failed to transform", __func__);
 		return LW_FAILURE;
 	}
 
-	return lwgeom_transform(geom, pj);
+	int ret = lwgeom_transform(geom, pj);
+	proj_destroy(pj);
+
+	return ret;
 }
 
 int

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -12,7 +12,6 @@
 
 #include "postgres.h"
 #include "fmgr.h"
-#include "utils/memutils.h" //
 
 #include "../postgis_config.h"
 #include "lwgeom_cache.h"

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -12,6 +12,7 @@
 
 #include "postgres.h"
 #include "fmgr.h"
+#include "utils/memutils.h" //
 
 #include "../postgis_config.h"
 #include "lwgeom_cache.h"
@@ -89,13 +90,14 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 	if ( ! cache )
 	{
 		/* Allocate in the upper context */
-		cache = MemoryContextAlloc(FIContext(fcinfo), sizeof(PROJPortalCache));
+		cache = MemoryContextAlloc(CacheMemoryContext, sizeof(PROJPortalCache));
 
 		if (cache)
 		{
 			int i;
 
-			POSTGIS_DEBUGF(3, "Allocating PROJCache for portal with transform() MemoryContext %p", FIContext(fcinfo));
+			POSTGIS_DEBUGF(
+			    3, "Allocating PROJCache for portal with transform() MemoryContext %p", CacheMemoryContext);
 			/* Put in any required defaults */
 			for (i = 0; i < PROJ_CACHE_ITEMS; i++)
 			{
@@ -106,7 +108,7 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 			}
 			cache->type = PROJ_CACHE_ENTRY;
 			cache->PROJSRSCacheCount = 0;
-			cache->PROJSRSCacheContext = FIContext(fcinfo);
+			cache->PROJSRSCacheContext = CacheMemoryContext;
 
 			/* Store the pointer in GenericCache */
 			generic_cache->entry[PROJ_CACHE_ENTRY] = (GenericCache*)cache;

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -96,7 +96,6 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 			POSTGIS_DEBUGF(3,
 				       "Allocating PROJCache for portal with transform() MemoryContext %p",
 				       FIContext(fcinfo));
-			/* Put in any required defaults */
 			memset(cache->PROJSRSCache, 0, sizeof(PROJSRSCacheItem) * PROJ_CACHE_ITEMS);
 			cache->type = PROJ_CACHE_ENTRY;
 			cache->PROJSRSCacheCount = 0;

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -90,14 +90,15 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 	if ( ! cache )
 	{
 		/* Allocate in the upper context */
-		cache = MemoryContextAlloc(CacheMemoryContext, sizeof(PROJPortalCache));
+		cache = MemoryContextAlloc(TopTransactionContext, sizeof(PROJPortalCache));
 
 		if (cache)
 		{
 			int i;
 
-			POSTGIS_DEBUGF(
-			    3, "Allocating PROJCache for portal with transform() MemoryContext %p", CacheMemoryContext);
+			POSTGIS_DEBUGF(3,
+				       "Allocating PROJCache for portal with transform() MemoryContext %p",
+				       TopTransactionContext);
 			/* Put in any required defaults */
 			for (i = 0; i < PROJ_CACHE_ITEMS; i++)
 			{
@@ -108,7 +109,7 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 			}
 			cache->type = PROJ_CACHE_ENTRY;
 			cache->PROJSRSCacheCount = 0;
-			cache->PROJSRSCacheContext = CacheMemoryContext;
+			cache->PROJSRSCacheContext = TopTransactionContext;
 
 			/* Store the pointer in GenericCache */
 			generic_cache->entry[PROJ_CACHE_ENTRY] = (GenericCache*)cache;

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -93,19 +93,11 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 
 		if (cache)
 		{
-			int i;
-
 			POSTGIS_DEBUGF(3,
 				       "Allocating PROJCache for portal with transform() MemoryContext %p",
 				       FIContext(fcinfo));
 			/* Put in any required defaults */
-			for (i = 0; i < PROJ_CACHE_ITEMS; i++)
-			{
-				cache->PROJSRSCache[i].srid_from = SRID_UNKNOWN;
-				cache->PROJSRSCache[i].srid_to = SRID_UNKNOWN;
-				cache->PROJSRSCache[i].projection = NULL;
-				cache->PROJSRSCache[i].projection_mcxt = NULL;
-			}
+			memset(cache->PROJSRSCache, 0, sizeof(PROJSRSCacheItem) * PROJ_CACHE_ITEMS);
 			cache->type = PROJ_CACHE_ENTRY;
 			cache->PROJSRSCacheCount = 0;
 			cache->PROJSRSCacheContext = FIContext(fcinfo);

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -90,7 +90,7 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 	if ( ! cache )
 	{
 		/* Allocate in the upper context */
-		cache = MemoryContextAlloc(TopTransactionContext, sizeof(PROJPortalCache));
+		cache = MemoryContextAlloc(FIContext(fcinfo), sizeof(PROJPortalCache));
 
 		if (cache)
 		{
@@ -98,7 +98,7 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 
 			POSTGIS_DEBUGF(3,
 				       "Allocating PROJCache for portal with transform() MemoryContext %p",
-				       TopTransactionContext);
+				       FIContext(fcinfo));
 			/* Put in any required defaults */
 			for (i = 0; i < PROJ_CACHE_ITEMS; i++)
 			{
@@ -109,7 +109,7 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 			}
 			cache->type = PROJ_CACHE_ENTRY;
 			cache->PROJSRSCacheCount = 0;
-			cache->PROJSRSCacheContext = TopTransactionContext;
+			cache->PROJSRSCacheContext = FIContext(fcinfo);
 
 			/* Store the pointer in GenericCache */
 			generic_cache->entry[PROJ_CACHE_ENTRY] = (GenericCache*)cache;

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -73,7 +73,7 @@ typedef struct struct_PROJSRSCacheItem
 PROJSRSCacheItem;
 
 /* PROJ 4 lookup transaction cache methods */
-#define PROJ_CACHE_ITEMS	8
+#define PROJ_CACHE_ITEMS 64
 
 /*
 * The proj4 cache holds a fixed number of reprojection

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -84,7 +84,7 @@ typedef struct struct_PROJPortalCache
 {
 	int type;
 	PROJSRSCacheItem PROJSRSCache[PROJ_CACHE_ITEMS];
-	int PROJSRSCacheCount;
+	uint32_t PROJSRSCacheCount;
 	MemoryContext PROJSRSCacheContext;
 }
 PROJPortalCache;

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -67,6 +67,7 @@ typedef struct struct_PROJSRSCacheItem
 {
 	int32_t srid_from;
 	int32_t srid_to;
+	uint64_t hits;
 	LWPROJ *projection;
 #if POSTGIS_PGSQL_VERSION < 96
 	MemoryContext projection_mcxt;

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -68,7 +68,9 @@ typedef struct struct_PROJSRSCacheItem
 	int32_t srid_from;
 	int32_t srid_to;
 	LWPROJ *projection;
+#if POSTGIS_PGSQL_VERSION < 96
 	MemoryContext projection_mcxt;
+#endif
 }
 PROJSRSCacheItem;
 

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -73,7 +73,7 @@ typedef struct struct_PROJSRSCacheItem
 PROJSRSCacheItem;
 
 /* PROJ 4 lookup transaction cache methods */
-#define PROJ_CACHE_ITEMS 64
+#define PROJ_CACHE_ITEMS 128
 
 /*
 * The proj4 cache holds a fixed number of reprojection

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -67,7 +67,7 @@ typedef struct struct_PROJSRSCacheItem
 {
 	int32_t srid_from;
 	int32_t srid_to;
-	PJ* projection;
+	LWPROJ *projection;
 	MemoryContext projection_mcxt;
 }
 PROJSRSCacheItem;

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -91,9 +91,7 @@ static LWPROJ *GetPJHashEntry(MemoryContext mcxt);
 static void AddPJHashEntry(MemoryContext mcxt, LWPROJ *projection);
 
 /* Internal Cache API */
-/* static PROJPortalCache *GetPROJSRSCache(FunctionCallInfo fcinfo) ; */
-static bool IsInPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to);
-static void AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to);
+static LWPROJ *AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to);
 static void DeleteFromPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to);
 
 /* Search path for PROJ.4 library */
@@ -340,26 +338,6 @@ static void DeletePJHashEntry(MemoryContext mcxt)
 /*****************************************************************************
  * Per-cache management functions
  */
-
-static bool
-IsInPROJSRSCache(PROJPortalCache *cache, int32_t srid_from, int32_t srid_to)
-{
-	/*
-	 * Return true/false depending upon whether the item
-	 * is in the SRS cache.
-	 */
-	uint32_t i;
-	for (i = 0; i < PROJ_CACHE_ITEMS; i++)
-	{
-		if (cache->PROJSRSCache[i].srid_from == srid_from &&
-		    cache->PROJSRSCache[i].srid_to == srid_to)
-		{
-			return true;
-		}
-	}
-	/* Otherwise not found */
-	return false;
-}
 
 static LWPROJ *
 GetProjectionFromPROJCache(PROJPortalCache *cache, int32_t srid_from, int32_t srid_to)
@@ -626,7 +604,7 @@ GetProj4String(int32_t srid)
  * we must make sure the entry we choose to delete does not contain other_srid
  * which is the definition for the other half of the transformation.
  */
-static void
+static LWPROJ *
 AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to)
 {
 	MemoryContext PJMemoryContext;
@@ -681,13 +659,13 @@ AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to
 	if (!projpj)
 	{
 		elog(ERROR, "could not form projection (PJ) from 'srid=%d' to 'srid=%d'", srid_from, srid_to);
-		return;
+		return NULL;
 	}
 	LWPROJ *projection = lwproj_from_PJ(projpj, srid_from == srid_to);
 	if (!projection)
 	{
 		elog(ERROR, "could not form projection (LWPROJ) from 'srid=%d' to 'srid=%d'", srid_from, srid_to);
-		return;
+		return NULL;
 	}
 #endif
 
@@ -770,6 +748,8 @@ AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to
 	PROJCache->PROJSRSCache[PROJCache->PROJSRSCacheCount].projection = projection;
 	PROJCache->PROJSRSCache[PROJCache->PROJSRSCacheCount].projection_mcxt = PJMemoryContext;
 	PROJCache->PROJSRSCacheCount++;
+
+	return projection;
 }
 
 static void
@@ -862,11 +842,11 @@ GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, LW
 		return LW_FAILURE;
 
 	/* Add the output srid to the cache if it's not already there */
-	if (!IsInPROJSRSCache(proj_cache, srid_from, srid_to))
-		AddToPROJSRSCache(proj_cache, srid_from, srid_to);
-
-	/* Get the projections */
 	*pj = GetProjectionFromPROJCache(proj_cache, srid_from, srid_to);
+	if (*pj == NULL)
+	{
+		*pj = AddToPROJSRSCache(proj_cache, srid_from, srid_to);
+	}
 
 	return LW_SUCCESS;
 }

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -354,12 +354,10 @@ IsInPROJSRSCache(PROJPortalCache *cache, int32_t srid_from, int32_t srid_to)
 		if (cache->PROJSRSCache[i].srid_from == srid_from &&
 		    cache->PROJSRSCache[i].srid_to == srid_to)
 		{
-			lwnotice("IsInPROJSRSCache found %d - %d", srid_from, srid_to);
 			return true;
 		}
 	}
 	/* Otherwise not found */
-	lwnotice("IsInPROJSRSCache not found %d - %d", srid_from, srid_to);
 	return false;
 }
 

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -40,12 +40,11 @@
 */
 static char *spatialRefSysSchema = NULL;
 
-
 /*
  * PROJ 4 backend hash table initial hash size
  * (since 16 is the default portal hash table size, and we would
  * typically have 2 entries per portal
- * then we shall use a default size of 32)
+ * then we shall use a default size of 256)
  */
 #define PROJ_BACKEND_HASH_SIZE 256
 

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -47,8 +47,7 @@ static char *spatialRefSysSchema = NULL;
  * typically have 2 entries per portal
  * then we shall use a default size of 32)
  */
-#define PROJ_BACKEND_HASH_SIZE	32
-
+#define PROJ_BACKEND_HASH_SIZE 256
 
 /**
  * Backend PROJ hash table

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -133,10 +133,10 @@ PROJSRSDestroyPJ(LWPROJ *pj)
 		pj_free(pj->pj_from);
 	if (pj->pj_to)
 		pj_free(pj->pj_to);
-	free(pj);
+	pfree(pj);
 #else
 	proj_destroy(pj->pj);
-	free(pj);
+	pfree(pj);
 #endif
 }
 
@@ -313,7 +313,7 @@ GetPJHashEntry(MemoryContext mcxt)
 	/* Return the projection object from the hash */
 	he = (PJHashEntry *) hash_search(PJHash, key, HASH_FIND, NULL);
 
-	return he->projection;
+	return he ? he->projection : NULL;
 }
 
 
@@ -607,7 +607,7 @@ GetProj4String(int32_t srid)
 static LWPROJ *
 AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to)
 {
-	MemoryContext PJMemoryContext;
+	MemoryContext PJMemoryContext, oldContext;
 
 	PjStrs from_strs, to_strs;
 	char *pj_from_str, *pj_to_str;
@@ -623,8 +623,10 @@ AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to
 	if (!pjstrs_has_entry(&to_strs))
 		elog(ERROR, "got NULL for SRID (%d)", srid_to);
 
+	oldContext = MemoryContextSwitchTo(PROJCache->PROJSRSCacheContext);
+
 #if POSTGIS_PROJ_VERSION < 60
-	PJ* projection = malloc(sizeof(PJ));
+	PJ *projection = palloc(sizeof(PJ));
 	pj_from_str = from_strs.proj4text;
 	pj_to_str = to_strs.proj4text;
 	projection->pj_from = projpj_from_string(pj_from_str);
@@ -749,6 +751,7 @@ AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to
 	PROJCache->PROJSRSCache[PROJCache->PROJSRSCacheCount].projection_mcxt = PJMemoryContext;
 	PROJCache->PROJSRSCacheCount++;
 
+	MemoryContextSwitchTo(oldContext);
 	return projection;
 }
 

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -342,7 +342,7 @@ static LWPROJ *
 GetProjectionFromPROJCache(PROJPortalCache *cache, int32_t srid_from, int32_t srid_to)
 {
 	uint32_t i;
-	for (i = 0; i < PROJ_CACHE_ITEMS; i++)
+	for (i = 0; i < cache->PROJSRSCacheCount; i++)
 	{
 		if (cache->PROJSRSCache[i].srid_from == srid_from &&
 		    cache->PROJSRSCache[i].srid_to == srid_to)

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -353,9 +353,13 @@ IsInPROJSRSCache(PROJPortalCache *cache, int32_t srid_from, int32_t srid_to)
 	{
 		if (cache->PROJSRSCache[i].srid_from == srid_from &&
 		    cache->PROJSRSCache[i].srid_to == srid_to)
+		{
+			lwnotice("IsInPROJSRSCache found %d - %d", srid_from, srid_to);
 			return true;
+		}
 	}
 	/* Otherwise not found */
+	lwnotice("IsInPROJSRSCache not found %d - %d", srid_from, srid_to);
 	return false;
 }
 

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -93,11 +93,6 @@ static void AddPJHashEntry(MemoryContext mcxt, LWPROJ *projection);
 static LWPROJ *AddToPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to);
 static void DeleteFromPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t srid_to);
 
-/* Search path for PROJ.4 library */
-static bool IsPROJLibPathSet = false;
-void SetPROJLibPath(void);
-
-
 /*
 * Given a function call context, figure out what namespace the
 * function is being called from, and copy that into a global
@@ -782,58 +777,10 @@ DeleteFromPROJSRSCache(PROJPortalCache *PROJCache, int32_t srid_from, int32_t sr
 }
 
 
-/**
- * Specify an alternate directory for the PROJ.4 grid files
- * (this should augment the PROJ.4 compile-time path)
- *
- * It's main purpose is to allow Win32 PROJ.4 installations
- * to find a set grid shift files, although other platforms
- * may find this useful too.
- *
- * Note that we currently ignore this on PostgreSQL < 8.0
- * since the method of determining the current installation
- * path are different on older PostgreSQL versions.
- */
-void SetPROJLibPath(void)
-{
-	char *path;
-	char *share_path;
-	const char **proj_lib_path;
-
-	if (!IsPROJLibPathSet) {
-
-		/*
-		 * Get the sharepath and append /contrib/postgis/proj to form a suitable
-		 * directory in which to store the grid shift files
-		 */
-		proj_lib_path = palloc(sizeof(char *));
-
-		share_path = palloc(MAXPGPATH);
-		get_share_path(my_exec_path, share_path);
-
-		path = palloc(MAXPGPATH);
-		*proj_lib_path = path;
-
-		snprintf(path, MAXPGPATH - 1, "%s/contrib/postgis-%s.%s/proj", share_path, POSTGIS_MAJOR_VERSION, POSTGIS_MINOR_VERSION);
-#if POSTGIS_PROJ_VERSION < 60
-		/* Set the search path for PROJ.4 */
-		pj_set_searchpath(1, proj_lib_path);
-#else
-		/* Set the search path for PROJ */
-		proj_context_set_search_paths(NULL, 1, proj_lib_path);
-#endif
-		/* Ensure we only do this once... */
-		IsPROJLibPathSet = true;
-	}
-}
-
 int
 GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, LWPROJ **pj)
 {
 	PROJPortalCache *proj_cache = NULL;
-
-	/* Set the search path if we haven't already */
-	SetPROJLibPath();
 
 	/* Look up the spatial_ref_sys schema if we haven't already */
 	SetSpatialRefSysSchema(fcinfo);

--- a/libpgcommon/lwgeom_transform.h
+++ b/libpgcommon/lwgeom_transform.h
@@ -32,7 +32,7 @@ typedef void *ProjCache ;
 void SetPROJLibPath(void);
 bool IsInPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
 PJ *GetPJFromPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
-int GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, PJ **pj);
+int GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, LWPROJ **pj);
 int spheroid_init_from_srid(FunctionCallInfo fcinfo, int32_t srid, SPHEROID *s);
 void srid_check_latlong(FunctionCallInfo fcinfo, int32_t srid);
 srs_precision srid_axis_precision(FunctionCallInfo fcinfo, int32_t srid, int precision);

--- a/libpgcommon/lwgeom_transform.h
+++ b/libpgcommon/lwgeom_transform.h
@@ -29,7 +29,6 @@ char *GetProj4String(int32_t srid);
  */
 typedef void *ProjCache ;
 
-void SetPROJLibPath(void);
 bool IsInPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
 PJ *GetPJFromPROJCache(ProjCache cache, int32_t srid_from, int32_t srid_to);
 int GetPJUsingFCInfo(FunctionCallInfo fcinfo, int32_t srid_from, int32_t srid_to, LWPROJ **pj);

--- a/postgis/lwgeom_in_gml.c
+++ b/postgis/lwgeom_in_gml.c
@@ -354,7 +354,7 @@ gml_reproject_pa(POINTARRAY *pa, int32_t srid_in, int32_t srid_out)
 	snprintf(text_out, 32, "EPSG:%d", srid_out);
 	pj = proj_create_crs_to_crs(NULL, text_in, text_out, NULL);
 
-	lwp = lwproj_from_PJ(pj);
+	lwp = lwproj_from_PJ(pj, LW_FALSE);
 	if (!lwp)
 	{
 		proj_destroy(pj);

--- a/postgis/lwgeom_in_gml.c
+++ b/postgis/lwgeom_in_gml.c
@@ -311,8 +311,8 @@ gml_reproject_pa(POINTARRAY *pa, int32_t srid_in, int32_t srid_out)
 	text_in = GetProj4String(srid_in);
 	text_out = GetProj4String(srid_out);
 
-	pj.pj_from = lwproj_from_string(text_in);
-	pj.pj_to = lwproj_from_string(text_out);
+	pj.pj_from = projpj_from_string(text_in);
+	pj.pj_to = projpj_from_string(text_out);
 
 	lwfree(text_in);
 	lwfree(text_out);
@@ -337,21 +337,39 @@ static POINTARRAY *
 gml_reproject_pa(POINTARRAY *pa, int32_t srid_in, int32_t srid_out)
 {
 	PJ *pj;
+	LWPROJ *lwp;
 	char text_in[32];
 	char text_out[32];
 
-	if (srid_in == SRID_UNKNOWN) return pa; /* nothing to do */
-	if (srid_out == SRID_UNKNOWN) gml_lwpgerror("invalid GML representation", 3);
+	if (srid_in == SRID_UNKNOWN)
+		return pa; /* nothing to do */
+
+	if (srid_out == SRID_UNKNOWN)
+	{
+		gml_lwpgerror("invalid GML representation", 3);
+		return NULL;
+	}
 
 	snprintf(text_in, 32, "EPSG:%d", srid_in);
 	snprintf(text_out, 32, "EPSG:%d", srid_out);
 	pj = proj_create_crs_to_crs(NULL, text_in, text_out, NULL);
 
-	if (ptarray_transform(pa, pj) == LW_FAILURE)
+	lwp = lwproj_from_PJ(pj);
+	if (!lwp)
 	{
+		proj_destroy(pj);
+		gml_lwpgerror("Could not create LWPROJ*", 57);
+		return NULL;
+	}
+
+	if (ptarray_transform(pa, lwp) == LW_FAILURE)
+	{
+		proj_destroy(pj);
 		elog(ERROR, "gml_reproject_pa: reprojection failed");
+		return NULL;
 	}
 	proj_destroy(pj);
+	free(lwp);
 
 	return pa;
 }

--- a/postgis/lwgeom_in_gml.c
+++ b/postgis/lwgeom_in_gml.c
@@ -369,7 +369,7 @@ gml_reproject_pa(POINTARRAY *pa, int32_t srid_in, int32_t srid_out)
 		return NULL;
 	}
 	proj_destroy(pj);
-	free(lwp);
+	pfree(lwp);
 
 	return pa;
 }

--- a/postgis/lwgeom_transform.c
+++ b/postgis/lwgeom_transform.c
@@ -119,9 +119,6 @@ Datum transform_geom(PG_FUNCTION_ARGS)
 	/* Take a copy, since we will be altering the coordinates */
 	gser = PG_GETARG_GSERIALIZED_P_COPY(0);
 
-	/* Set the search path if we haven't already */
-	SetPROJLibPath();
-
 	/* Convert from text to cstring for libproj */
 	input_srs = text_to_cstring(PG_GETARG_TEXT_P(1));
 	output_srs = text_to_cstring(PG_GETARG_TEXT_P(2));

--- a/postgis/lwgeom_transform.c
+++ b/postgis/lwgeom_transform.c
@@ -50,7 +50,7 @@ Datum transform(PG_FUNCTION_ARGS)
 	GSERIALIZED* geom;
 	GSERIALIZED* result=NULL;
 	LWGEOM* lwgeom;
-	PJ* pj;
+	LWPROJ *pj;
 	int32 srid_to, srid_from;
 
 	srid_to = PG_GETARG_INT32(1);
@@ -216,7 +216,7 @@ Datum LWGEOM_asKML(PG_FUNCTION_ARGS)
 
 	if (srid_from != srid_to)
 	{
-		PJ* pj;
+		LWPROJ *pj;
 		if (GetPJUsingFCInfo(fcinfo, srid_from, srid_to, &pj) == LW_FAILURE)
 		{
 			PG_FREE_IF_COPY(geom, 0);

--- a/regress/core/regress_proj.sql
+++ b/regress/core/regress_proj.sql
@@ -58,3 +58,12 @@ SELECT 12, ST_AsEWKT(ST_Transform(
 
 DELETE FROM spatial_ref_sys WHERE srid >= 100000;
 
+--- Overflow proj cache
+TRUNCATE spatial_ref_sys;
+\i ../../spatial_ref_sys.sql
+SELECT 13, count(*) FROM
+(
+    SELECT ST_Transform('SRID=4326; POINT(0 0)'::geometry, srid) AS g
+    FROM
+        ( SELECT srid FROM spatial_ref_sys LIMIT 150 ) _a
+) _b WHERE g IS NOT NULL;

--- a/regress/core/regress_proj_expected
+++ b/regress/core/regress_proj_expected
@@ -11,3 +11,4 @@ ERROR:  Input geometry has unknown (0) SRID
 10|POINT(574600 5316780)
 11|SRID=100001;POINT(574600 5316780)
 ERROR:  could not parse proj string 'invalid projection'
+13|150


### PR DESCRIPTION
Replaces  https://github.com/postgis/postgis/pull/422
Related to https://trac.osgeo.org/postgis/ticket/4372

What this does:
- Cleans up configure.ac when running under PROJ6 (avoids error message that its ignored).
- PROJ 6+ (and only 6+):
  - Caches source_swapped / target_swapped for all PJs. This brings ST_Transform to, more or less, almost the same performance as 5.1 (except the first row, which creates the PJ).
  - Caches source_is_latlong / source_semi_major_metre / source_semi_minor_metre when required (source srid == target srid). This brings a bunch of functions (ST_AsTWKB, geography functions) to, more or less, the same performance as before (except the first row, which creates the PJ).
  - Uses `proj_trans` instead of `proj_trans_generic` for single points (faster and makes it on par of 5.2 performance for that case).
- PROJ (all releases):
  - Allocate auxiliar memory (LWPROJ / PJ) in the parent memory context instead of manually using malloc/free.
  - Avoid double lookup (one to check if the item is in the cache, one for retrieval).
  - Increases PROJ_CACHE_ITEMS from **16** to **128**. PROJ_BACKEND_HASH_SIZE goes from **32** to **256**. This is to minimize the huge impact of creating projections between 5.2 and 6.1, specially for ST_Buffer(geography) which autogenerates srids based on `SRID_RESERVE_OFFSET`. There are over 120+ used SRIDs in that range, so deleting and recreating PJs is a huge performance loss (it isn't as bad for 5.1 since PJ creation is much faster).
  - Removes the call to `proj_context_set_search_paths`. AFAIK, we don't distribute proj files anymore so this is legacy. It's also preventing the default proj installation of finding proj.db and using the fallback method (faster but more imprecise). If it breaks something, I'll consider reading it just for Windows (as it's mentioned in the comments of the function).

@pramsey Any thoughts about this?
