### PR TITLE
spatial_ref_sys.sql: refresh with PROJ 6 and add Geographic3D CRS and ESRI definitions

### DIFF
--- a/regress/core/regress_proj.sql
+++ b/regress/core/regress_proj.sql
@@ -65,5 +65,5 @@ SELECT 13, count(*) FROM
 (
     SELECT ST_Transform('SRID=4326; POINT(0 0)'::geometry, srid) AS g
     FROM
-        ( SELECT srid FROM spatial_ref_sys LIMIT 150 ) _a
+        ( SELECT srid FROM spatial_ref_sys WHERE srtext LIKE 'GEOGCS%' AND proj4text NOT LIKE '%clrk80ign%' LIMIT 150 ) _a
 ) _b WHERE g IS NOT NULL;


### PR DESCRIPTION
- I've tried to keep the structure as close as possible as previous file
- When possible, WKT1 is used
- For Geographic 3D CRS, WKT2 is used since WKT1 is not possible
- TOWGS84 clauses might have disappear when there are several datum transformations
  possible. This is not a problem when using the modern proj_create_crs_to_crs() with
  the EPSG/ESRI codes.

Was generated with `python swig/python/scripts/epsg_tr.py -postgis > out.sql` from latest GDAL master