### PR TITLE
Address 32bit warning

### DIFF
--- a/postgis/geobuf.c
+++ b/postgis/geobuf.c
@@ -90,7 +90,7 @@ static void set_int_value(Data__Value *value, int64 intval) {
 		value->pos_int_value = (uint64_t) intval;
 	} else {
 		value->value_type_case = DATA__VALUE__VALUE_TYPE_NEG_INT_VALUE;
-		value->neg_int_value = (uint64_t) labs(intval);
+		value->neg_int_value = (uint64_t)llabs(intval);
 	}
 }
 


### PR DESCRIPTION
geobuf.c:93:37: warning: absolute value function 'labs' given an argument of type 'int64' (aka 'long long') but has parameter of type 'long' which may cause truncation of value [-Wabsolute-value]
                value->neg_int_value = (uint64_t) labs(intval);
                                                  ^
geobuf.c:93:37: note: use function 'llabs' instead
                value->neg_int_value = (uint64_t) labs(intval);
                                                  ^~~~
                                                  llabs