### PR TITLE
Speed up ST_RemoveRepeatedPoints

### DIFF
--- a/liblwgeom/cunit/cu_algorithm.c
+++ b/liblwgeom/cunit/cu_algorithm.c
@@ -1159,23 +1159,27 @@ static void test_lwgeom_remove_repeated_points(void)
 {
 	LWGEOM *g;
 	char *ewkt;
+	int modified = LW_FALSE;
 
 	g = lwgeom_from_wkt("MULTIPOINT(0 0, 10 0, 10 10, 10 10, 0 10, 0 10, 0 10, 0 0, 0 0, 0 0, 5 5, 0 0, 5 5)", LW_PARSER_CHECK_NONE);
-	lwgeom_remove_repeated_points_in_place(g, 1);
+	modified = lwgeom_remove_repeated_points_in_place(g, 1);
+	ASSERT_INT_EQUAL(modified, LW_TRUE);
 	ewkt = lwgeom_to_ewkt(g);
 	ASSERT_STRING_EQUAL(ewkt, "MULTIPOINT(0 0,10 0,10 10,0 10,5 5)");
 	lwgeom_free(g);
 	lwfree(ewkt);
 
 	g = lwgeom_from_wkt("LINESTRING(1612830.15445 4841287.12672,1612830.15824 4841287.12674,1612829.98813 4841274.56198)", LW_PARSER_CHECK_NONE);
-	lwgeom_remove_repeated_points_in_place(g, 0.01);
+	modified = lwgeom_remove_repeated_points_in_place(g, 0.01);
+	ASSERT_INT_EQUAL(modified, LW_TRUE);
 	ewkt = lwgeom_to_ewkt(g);
 	ASSERT_STRING_EQUAL(ewkt, "LINESTRING(1612830.15445 4841287.12672,1612829.98813 4841274.56198)");
 	lwgeom_free(g);
 	lwfree(ewkt);
 
 	g = lwgeom_from_wkt("MULTIPOINT(0 0,10 0,10 10,10 10,0 10,0 10,0 10,0 0,0 0,0 0,5 5,5 5,5 8,8 8,8 8,8 8,8 5,8 5,5 5,5 5,5 5,5 5,5 5,50 50,50 50,50 50,50 60,50 60,50 60,60 60,60 50,60 50,50 50,55 55,55 58,58 58,58 55,58 55,55 55)", LW_PARSER_CHECK_NONE);
-	lwgeom_remove_repeated_points_in_place(g, 1);
+	modified = lwgeom_remove_repeated_points_in_place(g, 1);
+	ASSERT_INT_EQUAL(modified, LW_TRUE);
 	ewkt = lwgeom_to_ewkt(g);
 	ASSERT_STRING_EQUAL(
 	    ewkt, "MULTIPOINT(0 0,10 0,10 10,0 10,5 5,5 8,8 8,8 5,50 50,50 60,60 60,60 50,55 55,55 58,58 58,58 55)");
@@ -1183,9 +1187,62 @@ static void test_lwgeom_remove_repeated_points(void)
 	lwfree(ewkt);
 
 	g = lwgeom_from_wkt("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))", LW_PARSER_CHECK_NONE);
-	lwgeom_remove_repeated_points_in_place(g, 10000);
+	modified = lwgeom_remove_repeated_points_in_place(g, 10000);
+	ASSERT_INT_EQUAL(modified, LW_TRUE);
 	ewkt = lwgeom_to_ewkt(g);
 	ASSERT_STRING_EQUAL(ewkt, "POLYGON((0 0,1 1,1 0,0 0))");
+	lwgeom_free(g);
+	lwfree(ewkt);
+
+	// Test the return value (modified or not)
+	g = lwgeom_from_wkt("POINT(0 0)", LW_PARSER_CHECK_NONE);
+	modified = lwgeom_remove_repeated_points_in_place(g, 10000);
+	ASSERT_INT_EQUAL(modified, LW_FALSE);
+	lwgeom_free(g);
+
+	g = lwgeom_from_wkt("TRIANGLE((0 0, 5 0, 3 3, 0 0))", LW_PARSER_CHECK_NONE);
+	modified = lwgeom_remove_repeated_points_in_place(g, 10000);
+	ASSERT_INT_EQUAL(modified, LW_FALSE);
+	lwgeom_free(g);
+
+	g = lwgeom_from_wkt("POLYGON((0 0,0 1,1 1,1 0,0 0))", LW_PARSER_CHECK_NONE);
+	modified = lwgeom_remove_repeated_points_in_place(g, 0.1);
+	ASSERT_INT_EQUAL(modified, LW_FALSE);
+	ewkt = lwgeom_to_ewkt(g);
+	ASSERT_STRING_EQUAL(ewkt, "POLYGON((0 0,0 1,1 1,1 0,0 0))");
+	lwgeom_free(g);
+	lwfree(ewkt);
+
+	g = lwgeom_from_wkt("POLYGON((0 0,0 1,1 1,1 0,0 0), (0.4 0.4, 0.4 0.4, 0.4 0.5, 0.5 0.5, 0.5 0.4, 0.4 0.4))",
+			    LW_PARSER_CHECK_NONE);
+	modified = lwgeom_remove_repeated_points_in_place(g, 0.1);
+	ASSERT_INT_EQUAL(modified, LW_TRUE);
+	ewkt = lwgeom_to_ewkt(g);
+	ASSERT_STRING_EQUAL(ewkt, "POLYGON((0 0,0 1,1 1,1 0,0 0),(0.4 0.4,0.5 0.5,0.5 0.4,0.4 0.4))");
+	lwgeom_free(g);
+	lwfree(ewkt);
+
+	g = lwgeom_from_wkt("GEOMETRYCOLLECTION(POINT(2 0),POLYGON((0 0,1 0,1 1,0 1,0 0)))", LW_PARSER_CHECK_NONE);
+	modified = lwgeom_remove_repeated_points_in_place(g, 0.1);
+	ASSERT_INT_EQUAL(modified, LW_FALSE);
+	ewkt = lwgeom_to_ewkt(g);
+	ASSERT_STRING_EQUAL(ewkt, "GEOMETRYCOLLECTION(POINT(2 0),POLYGON((0 0,1 0,1 1,0 1,0 0)))");
+	lwgeom_free(g);
+	lwfree(ewkt);
+
+	g = lwgeom_from_wkt("GEOMETRYCOLLECTION(POINT(2 0),POLYGON((0 0, 0 1, 1 1, 1 0, 0 0)))", LW_PARSER_CHECK_NONE);
+	modified = lwgeom_remove_repeated_points_in_place(g, 10000);
+	ASSERT_INT_EQUAL(modified, LW_TRUE);
+	ewkt = lwgeom_to_ewkt(g);
+	ASSERT_STRING_EQUAL(ewkt, "GEOMETRYCOLLECTION(POINT(2 0),POLYGON((0 0,1 1,1 0,0 0)))");
+	lwgeom_free(g);
+	lwfree(ewkt);
+
+	g = lwgeom_from_wkt("GEOMETRYCOLLECTION(POLYGON((0 0, 0 1, 1 1, 1 0, 0 0)),POINT(2 0))", LW_PARSER_CHECK_NONE);
+	modified = lwgeom_remove_repeated_points_in_place(g, 10000);
+	ASSERT_INT_EQUAL(modified, LW_TRUE);
+	ewkt = lwgeom_to_ewkt(g);
+	ASSERT_STRING_EQUAL(ewkt, "GEOMETRYCOLLECTION(POLYGON((0 0,1 1,1 0,0 0)),POINT(2 0))");
 	lwgeom_free(g);
 	lwfree(ewkt);
 }

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1365,7 +1365,7 @@ extern void lwgeom_longitude_shift(LWGEOM *lwgeom);
 extern void lwgeom_simplify_in_place(LWGEOM *igeom, double dist, int preserve_collapsed);
 extern void lwgeom_affine(LWGEOM *geom, const AFFINE *affine);
 extern void lwgeom_scale(LWGEOM *geom, const POINT4D *factors);
-extern void lwgeom_remove_repeated_points_in_place(LWGEOM *in, double tolerance);
+extern int lwgeom_remove_repeated_points_in_place(LWGEOM *in, double tolerance);
 
 
 /**

--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -1550,20 +1550,23 @@ void lwgeom_set_srid(LWGEOM *geom, int32_t srid)
 /**************************************************************/
 
 
-void
+int
 lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 {
+	int geometry_modified = LW_FALSE;
 	switch (geom->type)
 	{
 		/* No-op! Cannot remote points */
 		case POINTTYPE:
 		case TRIANGLETYPE:
-			return;
+			return geometry_modified;
 		case LINETYPE:
 		{
 			LWLINE *g = (LWLINE*)(geom);
 			POINTARRAY *pa = g->points;
+			uint32_t npoints = pa->npoints;
 			ptarray_remove_repeated_points_in_place(pa, tolerance, 2);
+			geometry_modified = npoints != pa->npoints;
 			/* Invalid output */
 			if (pa->npoints == 1 && pa->maxpoints > 1)
 			{
@@ -1581,13 +1584,17 @@ lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 			{
 				POINTARRAY *pa = g->rings[i];
 				int minpoints = 4;
+				uint32_t npoints = 0;
 				/* Skip zero'ed out rings */
 				if(!pa)
 					continue;
+				npoints = pa->npoints;
 				ptarray_remove_repeated_points_in_place(pa, tolerance, minpoints);
+				geometry_modified |= npoints != pa->npoints;
 				/* Drop collapsed rings */
 				if(pa->npoints < 4)
 				{
+					geometry_modified = LW_TRUE;
 					ptarray_free(pa);
 					continue;
 				}
@@ -1608,7 +1615,8 @@ lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 			int use_heap = (mpt->ngeoms > out_stack_size);
 
 			/* No-op on empty */
-			if (mpt->ngeoms == 0) return;
+			if (mpt->ngeoms == 0)
+				return geometry_modified;
 
 			/* We cannot write directly back to the multipoint */
 			/* geoms array because we're reading out of it still */
@@ -1645,14 +1653,15 @@ lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 			/* Copy remaining points back into the input */
 			/* array */
 			memcpy(mpt->geoms, out, sizeof(LWPOINT *) * n);
+			geometry_modified = mpt->ngeoms != n;
 			mpt->ngeoms = n;
 			if (use_heap) lwfree(out);
-			return;
+			break;
 		}
 
 		case CIRCSTRINGTYPE:
 			/* Dunno how to handle these, will return untouched */
-			return;
+			return geometry_modified;
 
 		/* Can process most multi* types as generic collection */
 		case MULTILINETYPE:
@@ -1672,7 +1681,7 @@ lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 			{
 				LWGEOM *g = col->geoms[i];
 				if (!g) continue;
-				lwgeom_remove_repeated_points_in_place(g, tolerance);
+				geometry_modified |= lwgeom_remove_repeated_points_in_place(g, tolerance);
 				/* Drop zero'ed out geometries */
 				if(lwgeom_is_empty(g))
 				{
@@ -1691,7 +1700,12 @@ lwgeom_remove_repeated_points_in_place(LWGEOM *geom, double tolerance)
 			break;
 		}
 	}
-	return;
+
+	if (geometry_modified)
+	{
+		lwgeom_drop_bbox(geom);
+	}
+	return geometry_modified;
 }
 
 

--- a/liblwgeom/ptarray.c
+++ b/liblwgeom/ptarray.c
@@ -1464,10 +1464,9 @@ ptarray_remove_repeated_points_in_place(POINTARRAY *pa, double tolerance, uint32
 	if ( n_points <= min_points ) return;
 
 	last = getPoint2d_cp(pa, 0);
-	for (i = 1; i < n_points; i++)
+	void *p_to = ((char *)last) + pt_size;
+	for (i = 1; i < n_points - 1; i++)
 	{
-		int last_point = (i == n_points-1);
-
 		/* Look straight into the abyss */
 		pt = getPoint2d_cp(pa, i);
 
@@ -1479,7 +1478,7 @@ ptarray_remove_repeated_points_in_place(POINTARRAY *pa, double tolerance, uint32
 				/* Only drop points that are within our tolerance */
 				dsq = distance2d_sqr_pt_pt(last, pt);
 				/* Allow any point but the last one to be dropped */
-				if (!last_point && dsq <= tolsq)
+				if (dsq <= tolsq)
 				{
 					continue;
 				}
@@ -1490,21 +1489,36 @@ ptarray_remove_repeated_points_in_place(POINTARRAY *pa, double tolerance, uint32
 				if (memcmp((char*)pt, (char*)last, pt_size) == 0)
 					continue;
 			}
+		}
 
+		/* Compact all remaining values to front of array */
+		memcpy(p_to, pt, pt_size);
+		n_points_out++;
+		p_to += pt_size;
+		last = pt;
+	}
+
+	/* Last point has a different behaviour */
+	{
+		pt = getPoint2d_cp(pa, n_points - 1);
+		if ((n_points + n_points_out > min_points + i) && (n_points_out > 1) && (tolerance > 0.0))
+		{
 			/* Got to last point, and it's not very different from */
 			/* the point that preceded it. We want to keep the last */
 			/* point, not the second-to-last one, so we pull our write */
 			/* index back one value */
-			if (last_point && n_points_out > 1 && tolerance > 0.0 && dsq <= tolsq)
+			dsq = distance2d_sqr_pt_pt(last, pt);
+			if (dsq <= tolsq)
 			{
 				n_points_out--;
+				p_to -= pt_size;
 			}
 		}
 
-		/* Compact all remaining values to front of array */
-		ptarray_copy_point(pa, i, n_points_out++);
-		last = pt;
+		memcpy(p_to, pt, pt_size);
+		n_points_out++;
 	}
+
 	/* Adjust array length */
 	pa->npoints = n_points_out;
 	return;

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -2748,11 +2748,10 @@ Datum ST_RemoveRepeatedPoints(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_RemoveRepeatedPoints);
 Datum ST_RemoveRepeatedPoints(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED *g_in = PG_GETARG_GSERIALIZED_P(0);
-	int type = gserialized_get_type(g_in);
+	GSERIALIZED *g_in = PG_GETARG_GSERIALIZED_P_COPY(0);
+	uint32_t type = gserialized_get_type(g_in);
 	GSERIALIZED *g_out;
 	LWGEOM *lwgeom_in = NULL;
-	LWGEOM *lwgeom_out = NULL;
 	double tolerance = 0.0;
 
 	/* Don't even start to think about points */
@@ -2763,22 +2762,15 @@ Datum ST_RemoveRepeatedPoints(PG_FUNCTION_ARGS)
 		tolerance = PG_GETARG_FLOAT8(1);
 
 	lwgeom_in = lwgeom_from_gserialized(g_in);
-	lwgeom_out = lwgeom_remove_repeated_points(lwgeom_in, tolerance);
+	lwgeom_remove_repeated_points_in_place(lwgeom_in, tolerance);
 
 	/* COMPUTE_BBOX TAINTING */
 	if (lwgeom_in->bbox)
-		lwgeom_refresh_bbox(lwgeom_out);
+		lwgeom_refresh_bbox(lwgeom_in);
 
-	g_out = geometry_serialize(lwgeom_out);
+	g_out = geometry_serialize(lwgeom_in);
 
-	if (lwgeom_out != lwgeom_in)
-	{
-		lwgeom_free(lwgeom_out);
-	}
-
-	lwgeom_free(lwgeom_in);
-
-	PG_FREE_IF_COPY(g_in, 0);
+	pfree(g_in);
 	PG_RETURN_POINTER(g_out);
 }
 


### PR DESCRIPTION
### First query

The table contains 1083175 multipolygons with an average of 9.01 points per geometry.

```sql
explain analyze Select ST_RemoveRepeatedPoints(the_geom_webmercator, 1) from public.benchmark_af85af967525e69373b7b8678f3bd409a8e78f447671344b7535d;
```

Trunk:
```
duration: 20 s
number of transactions actually processed: 66
latency average = 306.126 ms
```

With this PR:
```
number of transactions actually processed: 77
latency average = 263.052 ms
```


### Second query

13 multipolygons with an average of 260843.07 points per geometry.

```sql
explain analyze Select ST_RemoveRepeatedPoints(the_geom_webmercator, 1) from public.benchmark_4c7214d90a79aa6760367a084a4d4a2f61fbe1c6cc4f7f9e76020;
```

Trunk:
```
number of transactions actually processed: 241
latency average = 83.137 ms
```

With this PR:
```
number of transactions actually processed: 375
latency average = 53.409 ms
```

### Explanation

- PG facing (`ST_RemoveRepeatedPoints`)
  - Use `PG_GETARG_GSERIALIZED_P_COPY` and `lwgeom_remove_repeated_points_in_place`: In some cases (like the second query) this avoids an extra geometry clone (one to copy the gserialized and the second one done in lwgeom_remove_repeated_points).
  - Remove the calls to `lwgeom_free`. It will be freed by PG automatically in a faster way. I've kept the call to free the GSERIALIZED copy because the comment in PGs code doesn't give me enough peace of mind (https://github.com/postgres/postgres/blob/bde7493d10898831100a0c6c233a5f3030bfcecd/src/include/fmgr.h#L251-L253)

- liblwgeom (`ptarray_remove_repeated_points_in_place`):
  - Keep a reference to where we want to write and use memcpy instead of `ptarray_copy_point`. With this we avoid calculating the position every time and also the size of the point (which won't change).

  ~~- Move the last_point special case outside the loop. This doesn't have a really big impact since the CPU is pretty good at predicting those branches.~~
