### PR TITLE
[EXPERIMENTAL] Speed up LWGEOM_noop

### DIFF
--- a/liblwgeom/gserialized.c
+++ b/liblwgeom/gserialized.c
@@ -221,7 +221,13 @@ int gserialized_ndims(const GSERIALIZED *g)
 */
 GSERIALIZED* gserialized_from_lwgeom(LWGEOM *geom, size_t *size)
 {
-	return gserialized2_from_lwgeom(geom, size);
+	return gserialized2_from_lwgeom_reuse(geom, size, NULL);
+}
+
+GSERIALIZED *
+gserialized_from_lwgeom_reuse(LWGEOM *geom, size_t *size, GSERIALIZED *g_in)
+{
+	return gserialized2_from_lwgeom_reuse(geom, size, g_in);
 }
 
 /**

--- a/liblwgeom/gserialized2.c
+++ b/liblwgeom/gserialized2.c
@@ -815,16 +815,16 @@ static size_t gserialized2_from_lwpoint(const LWPOINT *point, uint8_t *buf)
 	loc = buf;
 
 	/* Write in the type. */
-	memcpy(loc, &type, sizeof(uint32_t));
+	memmove(loc, &type, sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 	/* Write in the number of points (0 => empty). */
-	memcpy(loc, &(point->point->npoints), sizeof(uint32_t));
+	memmove(loc, &(point->point->npoints), sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Copy in the ordinates. */
 	if (point->point->npoints > 0)
 	{
-		memcpy(loc, getPoint_internal(point->point, 0), ptsize);
+		memmove(loc, getPoint_internal(point->point, 0), ptsize);
 		loc += ptsize;
 	}
 
@@ -851,11 +851,11 @@ static size_t gserialized2_from_lwline(const LWLINE *line, uint8_t *buf)
 	loc = buf;
 
 	/* Write in the type. */
-	memcpy(loc, &type, sizeof(uint32_t));
+	memmove(loc, &type, sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Write in the npoints. */
-	memcpy(loc, &(line->points->npoints), sizeof(uint32_t));
+	memmove(loc, &(line->points->npoints), sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	LWDEBUGF(3, "%s added npoints (%d)", __func__, line->points->npoints);
@@ -864,7 +864,7 @@ static size_t gserialized2_from_lwline(const LWLINE *line, uint8_t *buf)
 	if (line->points->npoints > 0)
 	{
 		size = line->points->npoints * ptsize;
-		memcpy(loc, getPoint_internal(line->points, 0), size);
+		memmove(loc, getPoint_internal(line->points, 0), size);
 		loc += size;
 	}
 	LWDEBUGF(3, "%s copied serialized_pointlist (%d bytes)", __func__, ptsize * line->points->npoints);
@@ -888,17 +888,17 @@ static size_t gserialized2_from_lwpoly(const LWPOLY *poly, uint8_t *buf)
 	loc = buf;
 
 	/* Write in the type. */
-	memcpy(loc, &type, sizeof(uint32_t));
+	memmove(loc, &type, sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Write in the nrings. */
-	memcpy(loc, &(poly->nrings), sizeof(uint32_t));
+	memmove(loc, &(poly->nrings), sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Write in the npoints per ring. */
 	for (i = 0; i < poly->nrings; i++)
 	{
-		memcpy(loc, &(poly->rings[i]->npoints), sizeof(uint32_t));
+		memmove(loc, &(poly->rings[i]->npoints), sizeof(uint32_t));
 		loc += sizeof(uint32_t);
 	}
 
@@ -920,7 +920,7 @@ static size_t gserialized2_from_lwpoly(const LWPOLY *poly, uint8_t *buf)
 
 		pasize = pa->npoints * ptsize;
 		if ( pa->npoints > 0 )
-			memcpy(loc, getPoint_internal(pa, 0), pasize);
+			memmove(loc, getPoint_internal(pa, 0), pasize);
 		loc += pasize;
 	}
 	return (size_t)(loc - buf);
@@ -946,11 +946,11 @@ static size_t gserialized2_from_lwtriangle(const LWTRIANGLE *triangle, uint8_t *
 	loc = buf;
 
 	/* Write in the type. */
-	memcpy(loc, &type, sizeof(uint32_t));
+	memmove(loc, &type, sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Write in the npoints. */
-	memcpy(loc, &(triangle->points->npoints), sizeof(uint32_t));
+	memmove(loc, &(triangle->points->npoints), sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	LWDEBUGF(3, "%s added npoints (%d)", __func__, triangle->points->npoints);
@@ -959,7 +959,7 @@ static size_t gserialized2_from_lwtriangle(const LWTRIANGLE *triangle, uint8_t *
 	if (triangle->points->npoints > 0)
 	{
 		size = triangle->points->npoints * ptsize;
-		memcpy(loc, getPoint_internal(triangle->points, 0), size);
+		memmove(loc, getPoint_internal(triangle->points, 0), size);
 		loc += size;
 	}
 	LWDEBUGF(3, "%s copied serialized_pointlist (%d bytes)", __func__, ptsize * triangle->points->npoints);
@@ -985,18 +985,18 @@ static size_t gserialized2_from_lwcircstring(const LWCIRCSTRING *curve, uint8_t 
 	loc = buf;
 
 	/* Write in the type. */
-	memcpy(loc, &type, sizeof(uint32_t));
+	memmove(loc, &type, sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Write in the npoints. */
-	memcpy(loc, &curve->points->npoints, sizeof(uint32_t));
+	memmove(loc, &curve->points->npoints, sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Copy in the ordinates. */
 	if (curve->points->npoints > 0)
 	{
 		size = curve->points->npoints * ptsize;
-		memcpy(loc, getPoint_internal(curve->points, 0), size);
+		memmove(loc, getPoint_internal(curve->points, 0), size);
 		loc += size;
 	}
 
@@ -1021,7 +1021,7 @@ static size_t gserialized2_from_lwcollection(const LWCOLLECTION *coll, uint8_t *
 	loc += sizeof(uint32_t);
 
 	/* Write in the number of subgeoms. */
-	memcpy(loc, &coll->ngeoms, sizeof(uint32_t));
+	memmove(loc, &coll->ngeoms, sizeof(uint32_t));
 	loc += sizeof(uint32_t);
 
 	/* Serialize subgeoms. */
@@ -1164,6 +1164,12 @@ static size_t gserialized2_from_gbox(const GBOX *gbox, uint8_t *buf)
 
 GSERIALIZED* gserialized2_from_lwgeom(LWGEOM *geom, size_t *size)
 {
+	return gserialized2_from_lwgeom_reuse(geom, size, NULL);
+}
+
+GSERIALIZED *
+gserialized2_from_lwgeom_reuse(LWGEOM *geom, size_t *size, GSERIALIZED *g_in)
+{
 	size_t expected_size = 0;
 	size_t return_size = 0;
 	uint8_t *ptr = NULL;
@@ -1185,8 +1191,15 @@ GSERIALIZED* gserialized2_from_lwgeom(LWGEOM *geom, size_t *size)
 
 	/* Set up the uint8_t buffer into which we are going to write the serialized geometry. */
 	expected_size = gserialized2_from_lwgeom_size(geom);
-	ptr = lwalloc(expected_size);
-	g = (GSERIALIZED*)(ptr);
+	if (g_in && SIZE_GET(g_in->size) >= expected_size)
+	{
+		ptr = (void *)g_in;
+	}
+	else
+	{
+		ptr = lwalloc(expected_size);
+	}
+	g = (GSERIALIZED *)(ptr);
 
 	/* Set the SRID! */
 	gserialized2_set_srid(g, geom->srid);
@@ -1616,15 +1629,19 @@ GSERIALIZED* gserialized2_set_gbox(GSERIALIZED *g, GBOX *gbox)
 		ptr_out = (uint8_t*)g_out;
 		ptr = ptr_in = (uint8_t*)g;
 		/* Copy the head of g into place */
-		memcpy(ptr_out, ptr_in, 8); ptr_out += 8; ptr_in += 8;
+		memmove(ptr_out, ptr_in, 8);
+		ptr_out += 8;
+		ptr_in += 8;
 		/* Optionally copy extended bit into place */
 		if (G2FLAGS_GET_EXTENDED(g->gflags))
 		{
-			memcpy(ptr_out, ptr_in, 8); ptr_out += 8; ptr_in += 8;
+			memmove(ptr_out, ptr_in, 8);
+			ptr_out += 8;
+			ptr_in += 8;
 		}
 		/* Copy the body of g into place after leaving space for the box */
 		ptr_out += box_size;
-		memcpy(ptr_out, ptr_in, varsize_in - (ptr_in - ptr));
+		memmove(ptr_out, ptr_in, varsize_in - (ptr_in - ptr));
 		G2FLAGS_SET_BBOX(g_out->gflags, 1);
 		SIZE_SET(g_out->size, varsize_out);
 	}

--- a/liblwgeom/gserialized2.c
+++ b/liblwgeom/gserialized2.c
@@ -1231,9 +1231,10 @@ GSERIALIZED* gserialized2_from_lwgeom(LWGEOM *geom, size_t *size)
 * De-serialize GSERIALIZED into an LWGEOM.
 */
 
-static LWGEOM* lwgeom_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size);
+static LWGEOM *lwgeom_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size, int32_t srid);
 
-static LWPOINT* lwpoint_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size)
+static LWPOINT *
+lwpoint_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size, int32_t srid)
 {
 	uint8_t *start_ptr = data_ptr;
 	LWPOINT *point;
@@ -1242,7 +1243,7 @@ static LWPOINT* lwpoint_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lw
 	assert(data_ptr);
 
 	point = (LWPOINT*)lwalloc(sizeof(LWPOINT));
-	point->srid = SRID_UNKNOWN; /* Default */
+	point->srid = srid;
 	point->bbox = NULL;
 	point->type = POINTTYPE;
 	point->flags = lwflags;
@@ -1264,7 +1265,8 @@ static LWPOINT* lwpoint_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lw
 	return point;
 }
 
-static LWLINE* lwline_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size)
+static LWLINE *
+lwline_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size, int32_t srid)
 {
 	uint8_t *start_ptr = data_ptr;
 	LWLINE *line;
@@ -1273,7 +1275,7 @@ static LWLINE* lwline_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwfl
 	assert(data_ptr);
 
 	line = (LWLINE*)lwalloc(sizeof(LWLINE));
-	line->srid = SRID_UNKNOWN; /* Default */
+	line->srid = srid;
 	line->bbox = NULL;
 	line->type = LINETYPE;
 	line->flags = lwflags;
@@ -1296,7 +1298,8 @@ static LWLINE* lwline_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwfl
 	return line;
 }
 
-static LWPOLY* lwpoly_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size)
+static LWPOLY *
+lwpoly_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size, int32_t srid)
 {
 	uint8_t *start_ptr = data_ptr;
 	LWPOLY *poly;
@@ -1307,7 +1310,7 @@ static LWPOLY* lwpoly_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwfl
 	assert(data_ptr);
 
 	poly = (LWPOLY*)lwalloc(sizeof(LWPOLY));
-	poly->srid = SRID_UNKNOWN; /* Default */
+	poly->srid = srid;
 	poly->bbox = NULL;
 	poly->type = POLYGONTYPE;
 	poly->flags = lwflags;
@@ -1353,7 +1356,8 @@ static LWPOLY* lwpoly_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwfl
 	return poly;
 }
 
-static LWTRIANGLE* lwtriangle_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size)
+static LWTRIANGLE *
+lwtriangle_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size, int32_t srid)
 {
 	uint8_t *start_ptr = data_ptr;
 	LWTRIANGLE *triangle;
@@ -1362,7 +1366,7 @@ static LWTRIANGLE* lwtriangle_from_gserialized2_buffer(uint8_t *data_ptr, lwflag
 	assert(data_ptr);
 
 	triangle = (LWTRIANGLE*)lwalloc(sizeof(LWTRIANGLE));
-	triangle->srid = SRID_UNKNOWN; /* Default */
+	triangle->srid = srid; /* Default */
 	triangle->bbox = NULL;
 	triangle->type = TRIANGLETYPE;
 	triangle->flags = lwflags;
@@ -1384,7 +1388,8 @@ static LWTRIANGLE* lwtriangle_from_gserialized2_buffer(uint8_t *data_ptr, lwflag
 	return triangle;
 }
 
-static LWCIRCSTRING* lwcircstring_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size)
+static LWCIRCSTRING *
+lwcircstring_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size, int32_t srid)
 {
 	uint8_t *start_ptr = data_ptr;
 	LWCIRCSTRING *circstring;
@@ -1393,7 +1398,7 @@ static LWCIRCSTRING* lwcircstring_from_gserialized2_buffer(uint8_t *data_ptr, lw
 	assert(data_ptr);
 
 	circstring = (LWCIRCSTRING*)lwalloc(sizeof(LWCIRCSTRING));
-	circstring->srid = SRID_UNKNOWN; /* Default */
+	circstring->srid = srid;
 	circstring->bbox = NULL;
 	circstring->type = CIRCSTRINGTYPE;
 	circstring->flags = lwflags;
@@ -1415,7 +1420,8 @@ static LWCIRCSTRING* lwcircstring_from_gserialized2_buffer(uint8_t *data_ptr, lw
 	return circstring;
 }
 
-static LWCOLLECTION* lwcollection_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size)
+static LWCOLLECTION *
+lwcollection_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *size, int32_t srid)
 {
 	uint32_t type;
 	uint8_t *start_ptr = data_ptr;
@@ -1429,7 +1435,7 @@ static LWCOLLECTION* lwcollection_from_gserialized2_buffer(uint8_t *data_ptr, lw
 	data_ptr += 4; /* Skip past the type. */
 
 	collection = (LWCOLLECTION*)lwalloc(sizeof(LWCOLLECTION));
-	collection->srid = SRID_UNKNOWN; /* Default */
+	collection->srid = srid;
 	collection->bbox = NULL;
 	collection->type = type;
 	collection->flags = lwflags;
@@ -1463,7 +1469,7 @@ static LWCOLLECTION* lwcollection_from_gserialized2_buffer(uint8_t *data_ptr, lw
 			lwfree(collection);
 			return NULL;
 		}
-		collection->geoms[i] = lwgeom_from_gserialized2_buffer(data_ptr, lwflags, &subsize);
+		collection->geoms[i] = lwgeom_from_gserialized2_buffer(data_ptr, lwflags, &subsize, srid);
 		data_ptr += subsize;
 	}
 
@@ -1473,7 +1479,8 @@ static LWCOLLECTION* lwcollection_from_gserialized2_buffer(uint8_t *data_ptr, lw
 	return collection;
 }
 
-LWGEOM* lwgeom_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *g_size)
+LWGEOM *
+lwgeom_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, size_t *g_size, int32_t srid)
 {
 	uint32_t type;
 
@@ -1487,15 +1494,15 @@ LWGEOM* lwgeom_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, si
 	switch (type)
 	{
 	case POINTTYPE:
-		return (LWGEOM *)lwpoint_from_gserialized2_buffer(data_ptr, lwflags, g_size);
+		return (LWGEOM *)lwpoint_from_gserialized2_buffer(data_ptr, lwflags, g_size, srid);
 	case LINETYPE:
-		return (LWGEOM *)lwline_from_gserialized2_buffer(data_ptr, lwflags, g_size);
+		return (LWGEOM *)lwline_from_gserialized2_buffer(data_ptr, lwflags, g_size, srid);
 	case CIRCSTRINGTYPE:
-		return (LWGEOM *)lwcircstring_from_gserialized2_buffer(data_ptr, lwflags, g_size);
+		return (LWGEOM *)lwcircstring_from_gserialized2_buffer(data_ptr, lwflags, g_size, srid);
 	case POLYGONTYPE:
-		return (LWGEOM *)lwpoly_from_gserialized2_buffer(data_ptr, lwflags, g_size);
+		return (LWGEOM *)lwpoly_from_gserialized2_buffer(data_ptr, lwflags, g_size, srid);
 	case TRIANGLETYPE:
-		return (LWGEOM *)lwtriangle_from_gserialized2_buffer(data_ptr, lwflags, g_size);
+		return (LWGEOM *)lwtriangle_from_gserialized2_buffer(data_ptr, lwflags, g_size, srid);
 	case MULTIPOINTTYPE:
 	case MULTILINETYPE:
 	case MULTIPOLYGONTYPE:
@@ -1506,7 +1513,7 @@ LWGEOM* lwgeom_from_gserialized2_buffer(uint8_t *data_ptr, lwflags_t lwflags, si
 	case POLYHEDRALSURFACETYPE:
 	case TINTYPE:
 	case COLLECTIONTYPE:
-		return (LWGEOM *)lwcollection_from_gserialized2_buffer(data_ptr, lwflags, g_size);
+		return (LWGEOM *)lwcollection_from_gserialized2_buffer(data_ptr, lwflags, g_size, srid);
 	default:
 		lwerror("Unknown geometry type: %d - %s", type, lwtype_name(type));
 		return NULL;
@@ -1543,7 +1550,7 @@ LWGEOM* lwgeom_from_gserialized2(const GSERIALIZED *g)
 	if (FLAGS_GET_BBOX(lwflags))
 		data_ptr += gbox_serialized_size(lwflags);
 
-	lwgeom = lwgeom_from_gserialized2_buffer(data_ptr, lwflags, &size);
+	lwgeom = lwgeom_from_gserialized2_buffer(data_ptr, lwflags, &size, srid);
 
 	if (!lwgeom)
 		lwerror("%s: unable create geometry", __func__); /* Ooops! */
@@ -1563,8 +1570,6 @@ LWGEOM* lwgeom_from_gserialized2(const GSERIALIZED *g)
 	{
 		lwgeom->bbox = NULL;
 	}
-
-	lwgeom_set_srid(lwgeom, srid);
 
 	return lwgeom;
 }

--- a/liblwgeom/gserialized2.h
+++ b/liblwgeom/gserialized2.h
@@ -153,6 +153,7 @@ int gserialized2_ndims(const GSERIALIZED *gser);
 * VARSIZE information.
 */
 GSERIALIZED* gserialized2_from_lwgeom(LWGEOM *geom, size_t *size);
+GSERIALIZED *gserialized2_from_lwgeom_reuse(LWGEOM *geom, size_t *size, GSERIALIZED *g_in);
 
 /**
 * Return the memory size a GSERIALIZED will occupy for a given LWGEOM.

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -800,6 +800,8 @@ extern int gserialized_cmp(const GSERIALIZED *g1, const GSERIALIZED *g2);
 */
 extern GSERIALIZED* gserialized_from_lwgeom(LWGEOM *geom, size_t *size);
 
+extern GSERIALIZED* gserialized_from_lwgeom_reuse(LWGEOM *geom, size_t *size, GSERIALIZED *g_in);
+
 /**
 * Allocate a new #LWGEOM from a #GSERIALIZED. The resulting #LWGEOM will have coordinates
 * that are double aligned and suitable for direct reading using getPoint2d_p_ro

--- a/libpgcommon/lwgeom_pg.c
+++ b/libpgcommon/lwgeom_pg.c
@@ -324,6 +324,23 @@ GSERIALIZED* geometry_serialize(LWGEOM *lwgeom)
 	return g;
 }
 
+/**
+ * Utility method to call the serialization and then set the
+ * PgSQL varsize header appropriately with the serialized size.
+ */
+GSERIALIZED *
+geometry_serialize_reuse(LWGEOM *lwgeom, GSERIALIZED *g_in)
+{
+	size_t ret_size = 0;
+	GSERIALIZED *g = NULL;
+
+	g = gserialized_from_lwgeom_reuse(lwgeom, &ret_size, g_in);
+	if (!g)
+		lwpgerror("Unable to serialize lwgeom.");
+	SET_VARSIZE(g, ret_size);
+	return g;
+}
+
 void
 lwpgnotice(const char *fmt, ...)
 {

--- a/libpgcommon/lwgeom_pg.h
+++ b/libpgcommon/lwgeom_pg.h
@@ -155,6 +155,12 @@ extern void pg_unparser_errhint(LWGEOM_UNPARSER_RESULT *lwg_unparser_result);
 GSERIALIZED *geometry_serialize(LWGEOM *lwgeom);
 
 /**
+ * Utility method to call the serialization and then set the
+ * PgSQL varsize header appropriately with the serialized size.
+ */
+GSERIALIZED *geometry_serialize_reuse(LWGEOM *lwgeom, GSERIALIZED *g_in);
+
+/**
 * Utility method to call the serialization and then set the
 * PgSQL varsize header appropriately with the serialized size.
 */

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -1895,11 +1895,9 @@ Datum LWGEOM_force_clockwise_poly(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(LWGEOM_noop);
 Datum LWGEOM_noop(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED *in = PG_GETARG_GSERIALIZED_P(0);
+	GSERIALIZED *in = PG_GETARG_GSERIALIZED_P_COPY(0);
 	LWGEOM *lwgeom = lwgeom_from_gserialized(in);
-	GSERIALIZED *out = geometry_serialize(lwgeom);
-	lwgeom_free(lwgeom);
-	PG_FREE_IF_COPY(in, 0);
+	GSERIALIZED *out = geometry_serialize_reuse(lwgeom, in);
 	PG_RETURN_POINTER(out);
 }
 


### PR DESCRIPTION
To continue with the streak of speeding up things, I decided to look up the serialization code and see where I can squeeze some extra performance and to do that there is nothing better than looking at `postgis_noop`:

This is a WIP and might change at any time, but right now I have:
* da7c51e: Pass the SRID during the geometry creation to avoid needing to update it later. This is only _slightly_ noticeable with big multigeometries, since those set its SRID in all subgeometries, so doing it during creation avoids all the memory jumps from iterating over it.
* d3676bf: This needs madness glasses. I've introduced a new function (`geometry_serialize_reuse`) that allows you to pass an already allocated buffer to serialize on top of it. For this to works it needs:
  * The gserialized buffer needs to a copy (`PG_GETARG_GSERIALIZED_P_COPY`), not a pointer that might point to the disk (`PG_GETARG_GSERIALIZED_P`).
  * The input buffer needs to be bigger or equal than the space required to store the geometry. I've added a safeguard for that to fallback to the old allocation if it isn't.
  * The tricky part: The geometry must either not contain no reference to the gserialized buffer (for example if it was cloned, passed to geos and back, etc) or, if it does, it's references keep the order that was initially given during the deserialization; i.e. when you read the geometry you don't find pointers to address in the buffer previous to address already pointed at. We are memmove'ing the data based on that knowledge.
  * When these conditions are met (which depends on the process done in liblwgeom and the call to geometry_serialize_reuse) this drops the time to gserialize a geometry masively; for example with big geometries, the run time of postgis_noop (deserialization + serialization) drops by over 50% (from 39ms to 18ms).


I want to see where this might take me since the impact of serialization is really important in already highly optimized functions.