### PR TITLE
Rewrite getSRIDbySRS

### DIFF
--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -29,7 +29,9 @@
  */
 
 #include "float.h" /* for DBL_DIG */
+
 #include "postgres.h"
+#include "catalog/pg_type_d.h" /* for CSTRINGOID */
 #include "executor/spi.h"
 #include "utils/builtins.h"
 

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -125,13 +125,14 @@ getSRSbySRID(int32_t srid, bool short_crs)
 */
 int getSRIDbySRS(const char* srs)
 {
-	char query[256];
+	char *query = palloc(256 + strlen(srs));
 	int32_t srid, err;
 
 	if (!srs) return 0;
 
 	if (SPI_OK_CONNECT != SPI_connect ())
 	{
+		pfree(query);
 		elog(NOTICE, "getSRIDbySRS: could not connect to SPI manager");
 		return 0;
 	}
@@ -145,6 +146,7 @@ int getSRIDbySRS(const char* srs)
 	err = SPI_exec(query, 1);
 	if ( err < 0 )
 	{
+		pfree(query);
 		elog(NOTICE, "getSRIDbySRS: error executing query %d", err);
 		SPI_finish();
 		return 0;
@@ -163,12 +165,14 @@ int getSRIDbySRS(const char* srs)
 		err = SPI_exec(query, 1);
 		if ( err < 0 )
 		{
+			pfree(query);
 			elog(NOTICE, "getSRIDbySRS: error executing query %d", err);
 			SPI_finish();
 			return 0;
 		}
 
 		if (SPI_processed <= 0) {
+			pfree(query);
 			SPI_finish();
 			return 0;
 		}
@@ -176,6 +180,7 @@ int getSRIDbySRS(const char* srs)
 
 	srid = atoi(SPI_getvalue(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1));
 
+	pfree(query);
 	SPI_finish();
 
 	return srid;

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -133,14 +133,14 @@ int getSRIDbySRS(const char* srs)
 	if (SPI_OK_CONNECT != SPI_connect ())
 	{
 		elog(NOTICE, "getSRIDbySRS: could not connect to SPI manager");
-		SPI_finish();
 		return 0;
 	}
 	sprintf(query,
 		"SELECT srid "
 		"FROM spatial_ref_sys, "
-		"regexp_matches('%s', E'([a-z]+):([0-9]+)', 'gi') AS re "
-		"WHERE re[1] ILIKE auth_name AND int4(re[2]) = auth_srid", srs);
+		"regexp_matches(quote_ident('%s'), E'([a-z]+):([0-9]+)', 'gi') AS re "
+		"WHERE re[1] ILIKE auth_name AND int4(re[2]) = auth_srid",
+		srs);
 
 	err = SPI_exec(query, 1);
 	if ( err < 0 )
@@ -156,8 +156,9 @@ int getSRIDbySRS(const char* srs)
 		sprintf(query,
 			"SELECT srid "
 			"FROM spatial_ref_sys, "
-			"regexp_matches('%s', E'urn:ogc:def:crs:([a-z]+):.*:([0-9]+)', 'gi') AS re "
-			"WHERE re[1] ILIKE auth_name AND int4(re[2]) = auth_srid", srs);
+			"regexp_matches(quote_ident('%s'), E'urn:ogc:def:crs:([a-z]+):.*:([0-9]+)', 'gi') AS re "
+			"WHERE re[1] ILIKE auth_name AND int4(re[2]) = auth_srid",
+			srs);
 
 		err = SPI_exec(query, 1);
 		if ( err < 0 )

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -31,7 +31,7 @@
 #include "float.h" /* for DBL_DIG */
 
 #include "postgres.h"
-#include "catalog/pg_type_d.h" /* for CSTRINGOID */
+#include "catalog/pg_type.h" /* for CSTRINGOID */
 #include "executor/spi.h"
 #include "utils/builtins.h"
 


### PR DESCRIPTION
- Prevents stack overflow when the srs is long (query + srs > 256 chars).
- Prevents sql injection.

Should be backported to all stable releases.