### PR TITLE
Accumulate into List instead of Array

### DIFF
--- a/postgis/lwgeom_accum.c
+++ b/postgis/lwgeom_accum.c
@@ -141,7 +141,7 @@ pgis_accum_finalfn(CollectionBuildState *state, MemoryContext mctx, __attribute_
 	int16 elmlen;
 	bool elmbyval;
 	char elmalign;
-	int i = 0;
+	size_t i = 0;
 	ArrayType *arr;
 	int dims[1];
 	int lbs[1] = {1};

--- a/postgis/lwgeom_accum.c
+++ b/postgis/lwgeom_accum.c
@@ -43,7 +43,6 @@
 Datum PGISDirectFunctionCall1(PGFunction func, Datum arg1);
 Datum PGISDirectFunctionCall2(PGFunction func, Datum arg1, Datum arg2);
 Datum pgis_geometry_accum_transfn(PG_FUNCTION_ARGS);
-Datum pgis_geometry_accum_transfn1(PG_FUNCTION_ARGS);
 Datum pgis_geometry_collect_finalfn(PG_FUNCTION_ARGS);
 Datum pgis_geometry_polygonize_finalfn(PG_FUNCTION_ARGS);
 Datum pgis_geometry_makeline_finalfn(PG_FUNCTION_ARGS);
@@ -60,8 +59,9 @@ Datum LWGEOM_makeline_garray(PG_FUNCTION_ARGS);
 
 
 /**
-** The transfer function builds a GeometryCollection allocated
-** in the aggregate memory context.
+** The transfer function builds a List of LWGEOM* allocated
+** in the aggregate memory context. The pgis_accum_finalfn
+** converts that List into a Pg Array.
 */
 PG_FUNCTION_INFO_V1(pgis_geometry_accum_transfn);
 Datum
@@ -128,8 +128,8 @@ pgis_geometry_accum_transfn(PG_FUNCTION_ARGS)
 Datum pgis_accum_finalfn(CollectionBuildState *state, MemoryContext mctx, FunctionCallInfo fcinfo);
 
 /**
-** The final function rescues the built array from the side memory context
-** using the PostgreSQL built-in function makeMdArrayResult
+** The final function reads the List of LWGEOM* from the aggregate
+** memory context and constructs an Array using construct_md_array()
 */
 Datum
 pgis_accum_finalfn(CollectionBuildState *state, MemoryContext mctx, __attribute__((__unused__)) FunctionCallInfo fcinfo)

--- a/postgis/lwgeom_accum.h
+++ b/postgis/lwgeom_accum.h
@@ -1,3 +1,29 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * PostGIS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PostGIS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************
+ *
+ * Copyright (c) 2019, Paul Ramsey <pramsey@cleverelephant.ca>
+ *
+ **********************************************************************/
+
+#ifndef _LWGEOM_ACCUM_H
+#define _LWGEOM_ACCUM_H 1
 
 /**
 ** To pass the internal state of our collection between the
@@ -13,3 +39,6 @@ typedef struct CollectionBuildState
 	Datum data[CollectionBuildStateDataSize];
 	Oid geomOid;
 } CollectionBuildState;
+
+
+#endif /* _LWGEOM_ACCUM_H */

--- a/postgis/lwgeom_accum.h
+++ b/postgis/lwgeom_accum.h
@@ -1,0 +1,15 @@
+
+/**
+** To pass the internal state of our collection between the
+** transfn and finalfn we need to wrap it into a custom type first,
+** the CollectionBuildState type in our case.  The extra "data" member
+** can optionally be used to pass additional constant
+** arguments to a finalizer function.
+*/
+#define CollectionBuildStateDataSize 2
+typedef struct CollectionBuildState
+{
+	List *geoms;  /* collected geometries */
+	Datum data[CollectionBuildStateDataSize];
+	Oid geomOid;
+} CollectionBuildState;

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -27,6 +27,8 @@
 
 #include "../postgis_config.h"
 
+#include "float.h" /* for DBL_DIG */
+
 /* PostgreSQL */
 #include "postgres.h"
 #include "funcapi.h"
@@ -34,9 +36,7 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/numeric.h"
-
 #include "access/htup_details.h"
-
 
 /* PostGIS */
 #include "lwgeom_functions_analytic.h" /* for point_in_polygon */
@@ -44,7 +44,7 @@
 #include "liblwgeom.h"
 #include "lwgeom_rtree.h"
 #include "lwgeom_geos_prepared.h"
-#include "float.h" /* for DBL_DIG */
+#include "lwgeom_accum.h"
 
 
 /* Return NULL on GEOS error
@@ -107,6 +107,7 @@ Datum ST_BuildArea(PG_FUNCTION_ARGS);
 Datum ST_DelaunayTriangles(PG_FUNCTION_ARGS);
 
 Datum pgis_union_geometry_array(PG_FUNCTION_ARGS);
+Datum pgis_geometry_union_finalfn(PG_FUNCTION_ARGS);
 
 /*
 ** Prototypes end
@@ -505,135 +506,62 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(gser_out);
 }
 
-typedef struct UnionBuildState
-{
-	MemoryContext mcontext; /* where all the temp stuff is kept */
-	GEOSGeometry **geoms;   /* collected GEOS geometries*/
-	int empty_type;
-	uint32_t alen;   /* allocated length of above arrays */
-	uint32_t ngeoms; /* number of valid entries in above arrays */
-	int32_t srid;
-	bool is3d;
-} UnionBuildState;
-
-PG_FUNCTION_INFO_V1(pgis_geometry_union_transfn);
-Datum pgis_geometry_union_transfn(PG_FUNCTION_ARGS)
-{
-	MemoryContext aggcontext;
-	MemoryContext old;
-	UnionBuildState *state;
-	GSERIALIZED *gser_in;
-	uint32_t curgeom;
-	GEOSGeometry *g;
-
-	if (!AggCheckCallContext(fcinfo, &aggcontext))
-	{
-		/* cannot be called directly because of dummy-type argument */
-		elog(ERROR, "%s called in non-aggregate context", __func__);
-		aggcontext = NULL; /* keep compiler quiet */
-	}
-
-	if (!PG_ARGISNULL(0))
-	{
-		state = (UnionBuildState *)PG_GETARG_POINTER(0);
-	}
-	else
-	{
-		old = MemoryContextSwitchTo(aggcontext);
-		state = (UnionBuildState *)palloc(sizeof(UnionBuildState));
-
-		state->mcontext = aggcontext;
-		state->alen = 10;
-		state->ngeoms = 0;
-		state->geoms = palloc(sizeof(GEOSGeometry *) * state->alen);
-		state->is3d = false;
-		state->srid = 0;
-		state->empty_type = 0;
-
-		initGEOS(lwpgnotice, lwgeom_geos_error);
-
-		MemoryContextSwitchTo(old);
-	};
-
-	/* do we have geometry to push? */
-	if (!PG_ARGISNULL(1))
-	{
-		old = MemoryContextSwitchTo(state->mcontext);
-		gser_in = PG_GETARG_GSERIALIZED_P_COPY(1);
-		MemoryContextSwitchTo(old);
-
-		if (state->ngeoms > 0)
-		{
-			if (state->srid != gserialized_get_srid(gser_in))
-				for (curgeom = 0; curgeom < state->ngeoms; curgeom++)
-					GEOSGeom_destroy(state->geoms[curgeom]);
-
-			gserialized_error_if_srid_mismatch_reference(gser_in, state->srid, __func__);
-		}
-
-		if (!gserialized_is_empty(gser_in))
-		{
-			if (state->ngeoms == 0)
-			{
-				state->srid = gserialized_get_srid(gser_in);
-				state->is3d = gserialized_has_z(gser_in);
-			}
-
-			old = MemoryContextSwitchTo(state->mcontext);
-			g = POSTGIS2GEOS(gser_in);
-			MemoryContextSwitchTo(old);
-
-			if (!g)
-			{
-				for (curgeom = 0; curgeom < state->ngeoms; curgeom++)
-					GEOSGeom_destroy(state->geoms[curgeom]);
-				HANDLE_GEOS_ERROR("One of the geometries in the set could not be converted to GEOS");
-			}
-
-			curgeom = state->ngeoms;
-			state->ngeoms++;
-
-			if (state->ngeoms > state->alen)
-			{
-				old = MemoryContextSwitchTo(state->mcontext);
-				state->alen *= 2;
-				state->geoms = repalloc(state->geoms, sizeof(GEOSGeometry *) * state->alen);
-				MemoryContextSwitchTo(old);
-			}
-
-			state->geoms[curgeom] = g;
-		}
-		else
-		{
-			int gser_type = gserialized_get_type(gser_in);
-			if (gser_type > state->empty_type)
-				state->empty_type = gser_type;
-		}
-	}
-
-	PG_RETURN_POINTER(state);
-}
 
 PG_FUNCTION_INFO_V1(pgis_geometry_union_finalfn);
 Datum pgis_geometry_union_finalfn(PG_FUNCTION_ARGS)
 {
-	UnionBuildState *state;
-	GSERIALIZED *gser_out = NULL;
-	GEOSGeometry *g = NULL;
-	GEOSGeometry *g_union = NULL;
+	CollectionBuildState *state;
+	ListCell *l;
+	LWGEOM **geoms;
+	GSERIALIZED *gser_out;
+	size_t ngeoms = 0;
+	int empty_type = 0;
+	bool first = true;
+	int32_t srid;
+	int has_z;
 
 	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL(); /* returns null iff no input values */
 
-	state = (UnionBuildState *)PG_GETARG_POINTER(0);
+	state = (CollectionBuildState *)PG_GETARG_POINTER(0);
+	geoms = palloc(list_length(state->geoms) * sizeof(LWGEOM*));
+
+	/* Read contents of list into an array of only non-null values */
+	foreach (l, state->geoms)
+	{
+		LWGEOM *geom = (LWGEOM*)(lfirst(l));
+		if (geom)
+		{
+			if (!lwgeom_is_empty(geom))
+			{
+				geoms[ngeoms++] = geom;
+				if (first)
+				{
+					srid = lwgeom_get_srid(geom);
+					has_z = lwgeom_has_z(geom);
+					first = false;
+				}
+			}
+			else
+			{
+				int type = lwgeom_get_type(geom);
+				empty_type = type > empty_type ? type : empty_type;
+			}
+		}
+	}
 
 	/*
 	** Take our GEOS geometries and turn them into a GEOS collection,
 	** then pass that into cascaded union.
 	*/
-	if (state->ngeoms > 0)
+	if (ngeoms > 0)
 	{
-		g = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION, state->geoms, state->ngeoms);
+		GEOSGeometry *g = NULL;
+		GEOSGeometry *g_union = NULL;
+		LWCOLLECTION* col = lwcollection_construct(COLLECTIONTYPE, srid, NULL, ngeoms, geoms);
+
+		initGEOS(lwpgnotice, lwgeom_geos_error);
+		g = LWGEOM2GEOS((LWGEOM*)col, LW_FALSE);
 		if (!g)
 			HANDLE_GEOS_ERROR("Could not create GEOS COLLECTION from geometry array");
 
@@ -642,17 +570,17 @@ Datum pgis_geometry_union_finalfn(PG_FUNCTION_ARGS)
 		if (!g_union)
 			HANDLE_GEOS_ERROR("GEOSUnaryUnion");
 
-		GEOSSetSRID(g_union, state->srid);
-		gser_out = GEOS2POSTGIS(g_union, state->is3d);
+		GEOSSetSRID(g_union, srid);
+		gser_out = GEOS2POSTGIS(g_union, has_z);
 		GEOSGeom_destroy(g_union);
 	}
 	/* No real geometries in our array, any empties? */
 	else
 	{
 		/* If it was only empties, we'll return the largest type number */
-		if (state->empty_type > 0)
+		if (empty_type > 0)
 			PG_RETURN_POINTER(
-			    geometry_serialize(lwgeom_construct_empty(state->empty_type, state->srid, state->is3d, 0)));
+			    geometry_serialize(lwgeom_construct_empty(empty_type, srid, has_z, 0)));
 
 		/* Nothing but NULL, returns NULL */
 		else
@@ -667,6 +595,8 @@ Datum pgis_geometry_union_finalfn(PG_FUNCTION_ARGS)
 
 	PG_RETURN_POINTER(gser_out);
 }
+
+
 
 /**
  * @example ST_UnaryUnion {@link #geomunion} SELECT ST_UnaryUnion(

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -517,8 +517,8 @@ Datum pgis_geometry_union_finalfn(PG_FUNCTION_ARGS)
 	size_t ngeoms = 0;
 	int empty_type = 0;
 	bool first = true;
-	int32_t srid;
-	int has_z;
+	int32_t srid = SRID_UNKNOWN;
+	int has_z = LW_FALSE;
 
 	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL(); /* returns null iff no input values */

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -551,7 +551,7 @@ Datum pgis_geometry_union_finalfn(PG_FUNCTION_ARGS)
 	}
 
 	/*
-	** Take our GEOS geometries and turn them into a GEOS collection,
+	** Take our array of LWGEOM* and turn it into a GEOS collection,
 	** then pass that into cascaded union.
 	*/
 	if (ngeoms > 0)

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -3835,12 +3835,6 @@ CREATE OR REPLACE FUNCTION pgis_geometry_accum_transfn(internal, geometry, float
 	AS 'MODULE_PATHNAME'
 	LANGUAGE 'c' _PARALLEL;
 
--- Availability: 3.0.0
-CREATE OR REPLACE FUNCTION pgis_geometry_union_transfn(internal, geometry)
-	RETURNS internal
-	AS 'MODULE_PATHNAME'
-	LANGUAGE 'c' _PARALLEL;
-
 -- Availability: 1.4.0
 -- Changed: 2.5.0 use 'internal' transfer type
 CREATE OR REPLACE FUNCTION pgis_geometry_union_finalfn(internal)
@@ -3896,7 +3890,7 @@ CREATE OR REPLACE FUNCTION ST_Union (geometry[])
 -- Changed: 2.5.0 use 'internal' stype
 -- Changed: 3.0.0 transfn now converts to GEOS
 CREATE AGGREGATE ST_Union (geometry) (
-	sfunc = pgis_geometry_union_transfn,
+	sfunc = pgis_geometry_accum_transfn,
 	stype = internal,
 #if POSTGIS_PGSQL_VERSION >= 96
 	parallel = safe,

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -3888,7 +3888,6 @@ CREATE OR REPLACE FUNCTION ST_Union (geometry[])
 -- we don't want to force drop of this agg since its often used in views
 -- parallel handling dealt with in postgis_after_upgrade.sql
 -- Changed: 2.5.0 use 'internal' stype
--- Changed: 3.0.0 transfn now converts to GEOS
 CREATE AGGREGATE ST_Union (geometry) (
 	sfunc = pgis_geometry_accum_transfn,
 	stype = internal,

--- a/postgis/postgis_after_upgrade.sql
+++ b/postgis/postgis_after_upgrade.sql
@@ -227,6 +227,8 @@ DROP FUNCTION IF EXISTS st_combine_bbox(box3d, geometry);
 DROP FUNCTION IF EXISTS st_combine_bbox(box2d, geometry);
 DROP FUNCTION IF EXISTS st_distance_sphere(geometry, geometry);
 
+-- dev function 3.0 cycle
+DROP FUNCTION IF EXISTS pgis_geometry_union_transfn(internal, geometry);
 
 -- pgis_abs type was increased from 8 bytes in 2.1 to 16 bytes in 2.2
 -- See #3460

--- a/postgis/postgis_before_upgrade.sql
+++ b/postgis/postgis_before_upgrade.sql
@@ -198,6 +198,8 @@ DROP FUNCTION IF EXISTS st_askml(geography, integer); -- Does not conflict
 -- This signature was superseeded
 DROP FUNCTION IF EXISTS st_buffer(geometry, double precision); -- Does not conflict
 
+-- dev function 3.0 cycle
+DROP FUNCTION IF EXISTS pgis_geometry_union_transfn(internal, geometry);
 
 -- FUNCTION ST_CurveToLine changed to add defaults in 2.5
 -- These signatures were superseeded

--- a/postgis/postgis_before_upgrade.sql
+++ b/postgis/postgis_before_upgrade.sql
@@ -198,9 +198,6 @@ DROP FUNCTION IF EXISTS st_askml(geography, integer); -- Does not conflict
 -- This signature was superseeded
 DROP FUNCTION IF EXISTS st_buffer(geometry, double precision); -- Does not conflict
 
--- dev function 3.0 cycle
-DROP FUNCTION IF EXISTS pgis_geometry_union_transfn(internal, geometry);
-
 -- FUNCTION ST_CurveToLine changed to add defaults in 2.5
 -- These signatures were superseeded
 DROP FUNCTION IF EXISTS ST_CurveToLine(geometry, integer); -- Does not conflict

--- a/postgis/postgis_legacy.c
+++ b/postgis/postgis_legacy.c
@@ -74,6 +74,5 @@ POSTGIS_DEPRECATE("3.0.0", distance3d);
 POSTGIS_DEPRECATE("3.0.0", sfcgal_distance3d);
 POSTGIS_DEPRECATE("3.0.0", LWGEOM_mindistance3d);
 POSTGIS_DEPRECATE("3.0.0", intersects);
-POSTGIS_DEPRECATE("3.0.0", pgis_geometry_accum_finalfn);
 POSTGIS_DEPRECATE("3.0.0", postgis_autocache_bbox);
 POSTGIS_DEPRECATE("2.0.0", postgis_uses_stats);

--- a/postgis/postgis_legacy.c
+++ b/postgis/postgis_legacy.c
@@ -74,5 +74,6 @@ POSTGIS_DEPRECATE("3.0.0", distance3d);
 POSTGIS_DEPRECATE("3.0.0", sfcgal_distance3d);
 POSTGIS_DEPRECATE("3.0.0", LWGEOM_mindistance3d);
 POSTGIS_DEPRECATE("3.0.0", intersects);
+POSTGIS_DEPRECATE("3.0.0", pgis_geometry_accum_finalfn);
 POSTGIS_DEPRECATE("3.0.0", postgis_autocache_bbox);
 POSTGIS_DEPRECATE("2.0.0", postgis_uses_stats);


### PR DESCRIPTION
Faster accumulate, but still with Array at the finalfn stage, to avoid re-writing all the old finalfns. Replace union finalfn with one that works on the list, thus keeping the transfn identical to the other aggregates, but avoiding the limitations of the Array type. Should side-step size limitations, and open up possibility for slightly faster accumulation when other final functions are modernized to use the List.