### PR TITLE
Fix repeated reference to enable_outdb_rasters, instead of gdal_enabled_drivers

### DIFF
--- a/doc/reference_guc.xml
+++ b/doc/reference_guc.xml
@@ -209,7 +209,7 @@ SET postgis.gdal_enabled_drivers = 'DISABLE_ALL';
 
 				<note>
 					<para>
-						Even if <varname>postgis.enable_outdb_rasters</varname> is True, the GUC <varname>postgis.enable_outdb_rasters</varname> determines the accessible raster formats.
+						Even if <varname>postgis.enable_outdb_rasters</varname> is True, the GUC <varname>postgis.gdal_enabled_drivers</varname> determines the accessible raster formats.
 					</para>
 				</note>
 

--- a/doc/reference_guc.xml
+++ b/doc/reference_guc.xml
@@ -155,7 +155,7 @@ SET postgis.gdal_datapath = 'C:/Program Files/PostgreSQL/9.3/gdal-data';</progra
 				<programlisting>ALTER DATABASE mygisdb SET postgis.gdal_enabled_drivers TO 'GTiff PNG JPEG';</programlisting>
 
 				<para>Sets default enabled drivers for all new connections to server. Requires super user access and PostgreSQL 9.4+.
-				    Also not that database, session, and user settings override this.</para>
+				    Also note that database, session, and user settings override this.</para>
 				<programlisting>ALTER SYSTEM SET postgis.gdal_enabled_drivers TO 'GTiff PNG JPEG';
 SELECT pg_reload_conf();
 				</programlisting>


### PR DESCRIPTION
This fixes a very tiny issue in the GUC documentation. It's easier to read the diff than this long description :-)