### PR TITLE
Fix bug of mapping long pg field name to dbf field name

### DIFF
--- a/loader/pgsql2shp-core.c
+++ b/loader/pgsql2shp-core.c
@@ -1532,7 +1532,7 @@ ShpDumperOpenTable(SHPDUMPERSTATE *state)
 		 * use this to create the dbf field name from
 		 * the PostgreSQL column name */
 		{
-		  const char *mapped = colmap_dbf_by_pg(&state->column_map, dbffieldname);
+		  const char *mapped = colmap_dbf_by_pg(&state->column_map, pgfieldname);
 		  if (mapped)
 		  {
 			  strncpy(dbffieldname, mapped, 10);


### PR DESCRIPTION
pg field name should be passed to the second argument of function colmap_dbf_by_pg, but dbffieldname is truncated to 10 chars and will fail to match pg field name in column mapping file.