### PR TITLE
Fix postgis_proc_set_search_path.pl to handle complex defaults quotes

### DIFF
--- a/utils/postgis_proc_set_search_path.pl
+++ b/utils/postgis_proc_set_search_path.pl
@@ -93,14 +93,14 @@ open( INPUT, $sql_file ) || die "Couldn't open file: $sql_file\n";
 while(<INPUT>)
 {
 
-	if ( /^create or replace function([^\)]+)([\)]{0,1})/i )
+	if ( /^create or replace function([^(]+([^)']+'[^']+')*[^)]+)([)]{0,1})/i )
 	{
 		my $funchead = $1; # contains function header except the end )
 		my $endhead = 0;
-		my $endfunchead = $2;
+		my $endfunchead = $3;
 		my $search_path_safe = -1; # we can put a search path on it without disrupting spatial index use
 		
-		if ($2 eq ')') ## reached end of header
+		if ($endfunchead eq ')') ## reached end of header
 		{
 			$endhead = 1;
 		}
@@ -144,7 +144,7 @@ while(<INPUT>)
 		#strip quoted , trips up the default strip
 		$funchead =~ s/(',')+//ig;
 		#strip off default args from the function header
-		$funchead =~ s/(default\s+[A-Za-z\.\+\-0-9\'\[\]\:\s]*)//ig;
+		$funchead =~ s/(default\s+('[^']*'|[-A-Za-z.+0-9\[\]:\s]*)+)//ig;
 		
 		#check to see if function is STRICT or c or plpgsql
 		# we can't put search path on non-STRICT sql since search path breaks SQL inlining


### PR DESCRIPTION
As discovered in https://github.com/postgis/postgis/pull/514,
an argument default with parenthesis instide the string breaks
regression sql generator (evil regexes).  Fixed with more evil regexes:
now it has a special handling for a '...' -- ignoring all chars inside.

Escaping is not handled (doesn't seem like PostGIS has any of them)

Example:

The script can now convert this:

CREATE OR REPLACE FUNCTION ST_TileEnvelope(zoom integer, x integer, y integer, margin float8, bounds geometry DEFAULT 'SRID=3857;LINESTRING(-20037508.342789 -20037508.342789, 20037508.342789 20037508.342789)'::geometry)

into this:

ST_TileEnvelope(zoom integer, x integer, y integer, bounds geometry)