### PR TITLE
Disable C asserts when building without "--enable-debug"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,7 @@ PostGIS 3.1.0
   - #4574, Link Time Optimizations enabled (Darafei Praliaskouski)
   - #4578, Add parallellism and cost properties to brin functions (Raúl Marín)
   - #4473, Silence yacc warnings (Raúl Marín)
+  - #4589, Disable C asserts when building without "--enable-debug" (Raúl Marín)
 
 * Bug fixes *
   - #4544, Fix leak when parsing a WKT geometry_list (Raúl Marín)

--- a/configure.ac
+++ b/configure.ac
@@ -1127,7 +1127,7 @@ if test $ENABLE_DEBUG -eq 1; then
     CFLAGS="$CFLAGS -g"
 else
     AC_DEFINE([PARANOIA_LEVEL], [0], [Disable use of memory checks])
-    AC_DEFINE([NDEBUG], [0], [Disable C asserts])
+    CPPFLAGS="-DNDEBUG $CPPFLAGS"
 fi
 
 


### PR DESCRIPTION
Trac https://trac.osgeo.org/postgis/ticket/4589