### PR TITLE
Fix several bugs around index support functions

### DIFF
--- a/regress/core/regress_brin_index_geography.sql
+++ b/regress/core/regress_brin_index_geography.sql
@@ -50,6 +50,9 @@ SELECT 'scan_idx', qnodes('select * from test where the_geog && ST_GeographyFrom
 SELECT 'scan_idx', qnodes('SELECT * FROM test WHERE the_geog IS NULL');
  SELECT COUNT(num) FROM test WHERE the_geog IS NULL;
 
+SELECT '#4608-1', count(*) FROM test where ST_Covers(ST_GeogFromText('POLYGON((0 0, 45 0, 45 45, 0 45, 0 0))'), the_geog);
+SELECT '#4608-2', count(*) FROM test where ST_CoveredBy(the_geog, ST_GeogFromText('POLYGON((0 0, 45 0, 45 45, 0 45, 0 0))'));
+
 DROP INDEX brin_geog;
 
 -- cleanup

--- a/regress/core/regress_brin_index_geography_expected
+++ b/regress/core/regress_brin_index_geography_expected
@@ -168,3 +168,5 @@ scan_idx|Bitmap Heap Scan,Bitmap Index Scan
 42.99|POINT Z (42.99 42.99 42.99)
 scan_idx|Bitmap Heap Scan,Bitmap Index Scan
 1001
+#4608-1|3681
+#4608-2|3681


### PR DESCRIPTION
Fix for https://trac.osgeo.org/postgis/ticket/4608

- ST_Covers and ST_CoveredBy in geography were using the wrong strategy (which didn't exist).
- st_containsproperly in geometry was using the wrong strategy.
- st_3dintersects was duplicated so I removed the bad one.