### PR TITLE
Ryu Makefile: Include shell variable

### DIFF
--- a/deps/ryu/Makefile.in
+++ b/deps/ryu/Makefile.in
@@ -25,6 +25,8 @@
 CC=@CC@
 CFLAGS = -I.. @CPPFLAGS@ @CFLAGS@ @PICFLAGS@ -DRYU_NO_TRAILING_ZEROS
 top_builddir = @top_builddir@
+SHELL = @SHELL@
+INSTALL = @INSTALL@
 LIBTOOL = @LIBTOOL@
 
 RYU_OBJS = d2fixed.o


### PR DESCRIPTION
Libtool uses the default shell, and for dronie this seems to be
different than bash so it fails to understand the  syntax.

References #4543

Drone logs:
```

/bin/sh ../../libtool --mode=compile gcc -I..  -I/usr/local/include  -I/usr/local/include   -I/usr/include/libxml2  -I/usr/include/json-c    -DNDEBUG  -std=gnu99 -O2 -Wall -fno-omit-frame-pointer -Werror -fno-math-errno -fno-signed-zeros  -fPIC -DPIC -DRYU_NO_TRAILING_ZEROS -c -o d2fixed.lo d2fixed.c
--
535 | ../../libtool: 1: eval: base_compile+= gcc: not found
536 | ../../libtool: 1: eval: base_compile+= -I..: not found
537 | ../../libtool: 1: eval: base_compile+= -I/usr/local/include: not found
538 | ../../libtool: 1: eval: base_compile+= -I/usr/local/include: not found
539 | ../../libtool: 1: eval: base_compile+= -I/usr/include/libxml2: not found
540 | ../../libtool: 1: eval: base_compile+= -I/usr/include/json-c: not found
541 | ../../libtool: 1: eval: base_compile+= -DNDEBUG: not found
542 | ../../libtool: 1: eval: base_compile+= -std=gnu99: not found
543 | ../../libtool: 1: eval: base_compile+= -O2: not found
544 | ../../libtool: 1: eval: base_compile+= -Wall: not found
545 | ../../libtool: 1: eval: base_compile+= -fno-omit-frame-pointer: not found
546 | ../../libtool: 1: eval: base_compile+= -Werror: not found
547 | ../../libtool: 1: eval: base_compile+= -fno-math-errno: not found
548 | ../../libtool: 1: eval: base_compile+= -fno-signed-zeros: not found
549 | ../../libtool: 1: eval: base_compile+= -fPIC: not found
550 | ../../libtool: 1: eval: base_compile+= -DPIC: not found
551 | ../../libtool: 1: eval: base_compile+= -DRYU_NO_TRAILING_ZEROS: not found
552 | ../../libtool: 1: eval: base_compile+= -c: not found
553 | ../../libtool: 1: eval: CC_quoted+= gcc: not found
554 | ../../libtool: 1: eval: CC_quoted+= gcc: not found
555 | libtool: compile: you must specify a compilation command
556 | libtool: compile: Try `libtool --help --mode=compile' for more information.
```