### PR TITLE
[WIP] Speed up geojson output

### DIFF
--- a/liblwgeom/lwout_geojson.c
+++ b/liblwgeom/lwout_geojson.c
@@ -722,49 +722,56 @@ asgeojson_geom_buf(const LWGEOM *geom, char *output, GBOX *bbox, int precision)
 static size_t
 pointArray_to_geojson(POINTARRAY *pa, char *output, int precision)
 {
-	uint32_t i;
-	char *ptr;
-	char x[OUT_DOUBLE_BUFFER_SIZE];
-	char y[OUT_DOUBLE_BUFFER_SIZE];
-	char z[OUT_DOUBLE_BUFFER_SIZE];
+	char *ptr = output;
 
 	assert ( precision <= OUT_MAX_DOUBLE_PRECISION );
-	ptr = output;
 
-	/* TODO: rewrite this loop to be simpler and possibly quicker */
 	if (!FLAGS_GET_Z(pa->flags))
 	{
-		for (i=0; i<pa->npoints; i++)
+		for (uint32_t i = 0; i < pa->npoints; i++)
 		{
-			const POINT2D *pt;
-			pt = getPoint2d_cp(pa, i);
+			if (i)
+			{
+				*ptr = ',';
+				ptr++;
+			}
+			const POINT2D *pt = getPoint2d_cp(pa, i);
 
-			lwprint_double(
-			    pt->x, precision, x, OUT_DOUBLE_BUFFER_SIZE);
-			lwprint_double(
-			    pt->y, precision, y, OUT_DOUBLE_BUFFER_SIZE);
-
-			if ( i ) ptr += sprintf(ptr, ",");
-			ptr += sprintf(ptr, "[%s,%s]", x, y);
+			*ptr = '[';
+			ptr++;
+			ptr += lwprint_double(pt->x, precision, ptr, OUT_DOUBLE_BUFFER_SIZE);
+			*ptr = ',';
+			ptr++;
+			ptr += lwprint_double(pt->y, precision, ptr, OUT_DOUBLE_BUFFER_SIZE);
+			*ptr = ']';
+			ptr++;
 		}
 	}
 	else
 	{
-		for (i=0; i<pa->npoints; i++)
+		for (uint32_t i = 0; i < pa->npoints; i++)
 		{
+			if (i)
+			{
+				*ptr = ',';
+				ptr++;
+			}
+
 			const POINT3D *pt = getPoint3d_cp(pa, i);
-
-			lwprint_double(
-			    pt->x, precision, x, OUT_DOUBLE_BUFFER_SIZE);
-			lwprint_double(
-			    pt->y, precision, y, OUT_DOUBLE_BUFFER_SIZE);
-			lwprint_double(
-			    pt->z, precision, z, OUT_DOUBLE_BUFFER_SIZE);
-
-			if ( i ) ptr += sprintf(ptr, ",");
-			ptr += sprintf(ptr, "[%s,%s,%s]", x, y, z);
+			*ptr = '[';
+			ptr++;
+			ptr += lwprint_double(pt->x, precision, ptr, OUT_DOUBLE_BUFFER_SIZE);
+			*ptr = ',';
+			ptr++;
+			ptr += lwprint_double(pt->y, precision, ptr, OUT_DOUBLE_BUFFER_SIZE);
+			*ptr = ',';
+			ptr++;
+			ptr += lwprint_double(pt->z, precision, ptr, OUT_DOUBLE_BUFFER_SIZE);
+			*ptr = ']';
+			ptr++;
 		}
 	}
+	*ptr = '\0';
 
 	return (ptr-output);
 }


### PR DESCRIPTION
Trac issue: https://trac.osgeo.org/postgis/ticket/4615

Printing the doubles directly into the output buffer doubles the tps with big inputs:

Before 02e62ee:
```
number of clients: 1
number of threads: 1
duration: 30 s
number of transactions actually processed: 31
latency average = 975.931 ms
tps = 1.024663 (including connections establishing)
tps = 1.024788 (excluding connections establishing)
```

After 02e62ee:
```
number of clients: 1
number of threads: 1
duration: 30 s
number of transactions actually processed: 58
latency average = 518.217 ms
tps = 1.929693 (including connections establishing)
tps = 1.929935 (excluding connections establishing)
```

After the introduction of Ryu (https://trac.osgeo.org/postgis/ticket/4543) there are new rough corners, so I plan to keep polishing for a while before merging.