### PR TITLE
ST_Hexagon: Improve precision

### DIFF
--- a/postgis/lwgeom_generate_grid.c
+++ b/postgis/lwgeom_generate_grid.c
@@ -68,24 +68,20 @@ GeometryGridState;
 
 /* Build origin hexagon centered around origin point */
 static const double hex_x[] = {-1.0, -0.5,  0.5, 1.0, 0.5, -0.5, -1.0};
-static const double hex_y[] = { 0.0, -1*H, -1*H, 0.0,   H,    H,  0.0};
+static const double hex_y[] = {0.0, -0.5, -0.5, 0.0, 0.5, 0.5, 0.0};
 
 static LWGEOM *
 hexagon(double origin_x, double origin_y, double size, int cell_i, int cell_j, int32_t srid)
 {
-	double height = size * 2 * H;
-	POINT4D pt;
 	POINTARRAY **ppa = lwalloc(sizeof(POINTARRAY*));
 	POINTARRAY *pa = ptarray_construct(0, 0, 7);
-	uint32_t i;
 
-	double offset_x = origin_x + (1.5 * size * cell_i);
-	double offset_y = origin_y + (height * cell_j) + (0.5 * height * (abs(cell_i) % 2));
-
-	for (i = 0; i < 7; ++i)
+	for (uint32_t i = 0; i < 7; ++i)
 	{
-		pt.x = size * hex_x[i] + offset_x;
-		pt.y = size * hex_y[i] + offset_y;
+		double height = size * 2 * H;
+		POINT4D pt;
+		pt.x = origin_x + size * (1.5 * cell_i + hex_x[i]);
+		pt.y = origin_y + height * (cell_j + 0.5 * (abs(cell_i) % 2) + hex_y[i]);
 		ptarray_set_point4d(pa, i, &pt);
 	}
 

--- a/regress/core/regress.sql
+++ b/regress/core/regress.sql
@@ -307,6 +307,23 @@ select '313', Count(*) FROM ST_SquareGrid(100000, ST_TileEnvelope(4, 7, 7)) hex,
 select '314', Count(*) FROM ST_SquareGrid(100000, ST_TileEnvelope(4, 2, 2));
 select '315', Count(*) FROM ST_SquareGrid(100000, ST_TileEnvelope(4, 2, 2)) hex, ST_TileEnvelope(4, 2, 2) tile WHERE NOT ST_Intersects(hex.geom, tile);
 
+WITH geoms AS
+(
+    SELECT * FROM  (SELECT (ST_HexagonGrid(5, '01030000000100000005000000fdffffffff7f66c0fcffffffff7f56c0fdffffffff7f66c07cc0e71a95e8544000000000008066407cc0e71a95e854400000000000806640fcffffffff7f56c0fdffffffff7f66c0fcffffffff7f56c0')).*) sq  WHERE i = 5 AND j IN (0, 1)
+),
+j0 AS
+(
+    SELECT * FROM geoms WHERE i = 5 AND j = 0
+),
+j1 AS
+(
+    SELECT * FROM geoms WHERE i = 5 AND j = 1
+)
+SELECT '316',
+    ST_Intersects(j0.geom, j1.geom),
+    ST_AsText(ST_Intersection(j0.geom, j1.geom))
+FROM j0,j1;
+
 -- Drop test table
 DROP table test;
 

--- a/regress/core/regress_expected
+++ b/regress/core/regress_expected
@@ -230,3 +230,4 @@ ERROR:  ST_TileEnvelope: Margin must not be less than -50%, margin=-0.510000
 313|0
 314|676
 315|0
+316|t|LINESTRING(40 8.66025403784439,35 8.66025403784439)


### PR DESCRIPTION
Will depend on architecture, but on x86 long doubles should be
80bit precision (vs 64b). Might not work on Windows

Trac: https://trac.osgeo.org/postgis/ticket/4627