### PR TITLE
Simplify zigzag

### DIFF
--- a/liblwgeom/varint.c
+++ b/liblwgeom/varint.c
@@ -167,44 +167,32 @@ varint_size(const uint8_t *the_start, const uint8_t *the_end)
 
 uint64_t zigzag64(int64_t val)
 {
-	return val >= 0 ?
-		((uint64_t)val) << 1 :
-		((((uint64_t)(-1 - val)) << 1) | 0x01);
+	return ((uint64_t)(val) << 1) ^ (uint64_t)(val >> 63);
 }
 
 uint32_t zigzag32(int32_t val)
 {
-	return val >= 0 ?
-		((uint32_t)val) << 1 :
-		((((uint32_t)(-1 - val)) << 1) | 0x01);
+	return ((uint32_t)(val) << 1) ^ (uint32_t)(val >> 31);
 }
 
 uint8_t zigzag8(int8_t val)
 {
-	return val >= 0 ?
-		((uint8_t)val) << 1 :
-		((((uint8_t)(-1 - val)) << 1) | 0x01);
+	return ((uint8_t)(val) << 1) ^ (uint8_t)(val >> 7);
 }
 
 int64_t unzigzag64(uint64_t val)
 {
-	return !(val & 0x01) ?
-		((int64_t)(val >> 1)) :
-		(-1 * (int64_t)((val+1) >> 1));
+	return (int64_t)((val >> 1) ^ (~(val & 1) + 1));
 }
 
 int32_t unzigzag32(uint32_t val)
 {
-	return !(val & 0x01) ?
-		((int32_t)(val >> 1)) :
-		(-1 * (int32_t)((val+1) >> 1));
+	return (int32_t)((val >> 1) ^ (~(val & 1) + 1));
 }
 
 int8_t unzigzag8(uint8_t val)
 {
-	return !(val & 0x01) ?
-		((int8_t)(val >> 1)) :
-		(-1 * (int8_t)((val+1) >> 1));
+	return (int8_t)((val >> 1) ^ (~(val & 1) + 1));
 }
 
 

--- a/liblwgeom/varint.c
+++ b/liblwgeom/varint.c
@@ -167,17 +167,17 @@ varint_size(const uint8_t *the_start, const uint8_t *the_end)
 
 uint64_t zigzag64(int64_t val)
 {
-	return ((uint64_t)(val) << 1) ^ (uint64_t)(val >> 63);
+	return (((uint64_t)val) << 1) ^ (uint64_t)(val >> 63);
 }
 
 uint32_t zigzag32(int32_t val)
 {
-	return ((uint32_t)(val) << 1) ^ (uint32_t)(val >> 31);
+	return (((uint32_t)val) << 1) ^ (uint32_t)(val >> 31);
 }
 
 uint8_t zigzag8(int8_t val)
 {
-	return ((uint8_t)(val) << 1) ^ (uint8_t)(val >> 7);
+	return (((uint8_t)val) << 1) ^ (uint8_t)(val >> 7);
 }
 
 int64_t unzigzag64(uint64_t val)


### PR DESCRIPTION
This only has an impact on GCC, as clang optimizes it already when using -O3: https://godbolt.org/z/XWYBki