### PR TITLE
ST_Simplify: Don't copy if nothing is removed

### DIFF
--- a/liblwgeom/ptarray.c
+++ b/liblwgeom/ptarray.c
@@ -1692,7 +1692,7 @@ ptarray_simplify_in_place(POINTARRAY *pa, double tolerance, uint32_t minpts)
 		       pa->serialized_pointlist + pt_size * (pa->npoints - 1),
 		       pt_size);
 	}
-	else
+	else if (pa->npoints != keptn) /* We don't need to move any points if we are keeping them all */
 	{
 		for (uint32_t i = 1; i < pa->npoints; i++)
 		{


### PR DESCRIPTION
Corner case optimization: When nothing has been removed, there is no need to move points around.

Trac: https://trac.osgeo.org/postgis/ticket/4651