### PR TITLE
Master toast cache

### DIFF
--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -13,7 +13,12 @@
 #include "postgres.h"
 #include "fmgr.h"
 #include "access/tuptoaster.h"
+
+#if POSTGIS_PGSQL_VERSION >= 120
 #include "utils/hashutils.h"
+#else
+#include "access/hash.h"
+#endif
 
 #include "../postgis_config.h"
 #include "lwgeom_cache.h"

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -145,9 +145,10 @@ GetGeomCache(FunctionCallInfo fcinfo,
 
 	/* Cache hit on the first argument */
 	if ( g1 &&
-	     cache->argnum != 2 &&
-	     cache->geom1_size == VARSIZE(g1) &&
-	     memcmp(cache->geom1, g1, cache->geom1_size) == 0 )
+	     cache->argnum != 2 && (
+	     (g1 == cache->geom1) ||
+	     (cache->geom1_size == VARSIZE(g1) && memcmp(cache->geom1, g1, cache->geom1_size) == 0)
+	     ))
 	{
 		cache_hit = 1;
 		geom = cache->geom1;
@@ -155,9 +156,10 @@ GetGeomCache(FunctionCallInfo fcinfo,
 	}
 	/* Cache hit on second argument */
 	else if ( g2 &&
-	          cache->argnum != 1 &&
-	          cache->geom2_size == VARSIZE(g2) &&
-	          memcmp(cache->geom2, g2, cache->geom2_size) == 0 )
+	          cache->argnum != 1 && (
+	          (g2 == cache->geom2) ||
+	          (cache->geom2_size == VARSIZE(g2) && memcmp(cache->geom2, g2, cache->geom2_size) == 0)
+	          ))
 	{
 		cache_hit = 2;
 		geom = cache->geom2;

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -117,7 +117,8 @@ GeomCache *GetGeomCache(FunctionCallInfo fcinfo,
 
 typedef struct
 {
-	uint64_t hash;
+	Oid valueid;
+	Oid toastrelid;
 	GSERIALIZED *geom;
 } ToastCacheArgument;
 

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -26,8 +26,9 @@
 #define RTREE_CACHE_ENTRY 2
 #define CIRC_CACHE_ENTRY 3
 #define RECT_CACHE_ENTRY 4
+#define TOAST_CACHE_ENTRY 5
 
-#define NUM_CACHE_ENTRIES 16
+#define NUM_CACHE_ENTRIES 8
 
 
 /*
@@ -109,5 +110,24 @@ GeomCache *GetGeomCache(FunctionCallInfo fcinfo,
 			const GeomCacheMethods *cache_methods,
 			const GSERIALIZED *g1,
 			const GSERIALIZED *g2);
+
+/******************************************************************************/
+
+#define ToastCacheSize 2
+
+typedef struct
+{
+	uint64_t hash;
+	GSERIALIZED *geom;
+} ToastCacheArgument;
+
+typedef struct
+{
+	int type;
+	ToastCacheArgument arg[ToastCacheSize];
+} ToastCache;
+
+GSERIALIZED* ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum);
+
 
 #endif /* LWGEOM_CACHE_H_ */

--- a/postgis/geography_measurement.c
+++ b/postgis/geography_measurement.c
@@ -212,8 +212,8 @@ Datum geography_distance(PG_FUNCTION_ARGS)
 	SPHEROID s;
 
 	/* Get our geometry objects loaded into memory. */
-	g1 = PG_GETARG_GSERIALIZED_P(0);
-	g2 = PG_GETARG_GSERIALIZED_P(1);
+	g1 = ToastCacheGetGeometry(fcinfo, 0);
+	g2 = ToastCacheGetGeometry(fcinfo, 1);
 
 	if (PG_NARGS() > 2)
 		use_spheroid = PG_GETARG_BOOL(2);
@@ -230,8 +230,6 @@ Datum geography_distance(PG_FUNCTION_ARGS)
 	/* Return NULL on empty arguments. */
 	if ( gserialized_is_empty(g1) || gserialized_is_empty(g2) )
 	{
-		PG_FREE_IF_COPY(g1, 0);
-		PG_FREE_IF_COPY(g2, 1);
 		PG_RETURN_NULL();
 	}
 
@@ -249,10 +247,6 @@ Datum geography_distance(PG_FUNCTION_ARGS)
 		lwgeom_free(lwgeom2);
 		*/
 	}
-
-	/* Clean up */
-	PG_FREE_IF_COPY(g1, 0);
-	PG_FREE_IF_COPY(g2, 1);
 
 	/* Knock off any funny business at the nanometer level, ticket #2168 */
 	distance = round(distance * INVMINDIST) / INVMINDIST;
@@ -274,8 +268,8 @@ Datum geography_distance(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(geography_dwithin);
 Datum geography_dwithin(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED *g1 = PG_GETARG_GSERIALIZED_P(0);
-	GSERIALIZED *g2 = PG_GETARG_GSERIALIZED_P(1);
+	GSERIALIZED *g1 = ToastCacheGetGeometry(fcinfo, 0);
+	GSERIALIZED *g2 = ToastCacheGetGeometry(fcinfo, 1);
 	SPHEROID s;
 	double tolerance = 0.0;
 	bool use_spheroid = true;
@@ -317,8 +311,6 @@ Datum geography_dwithin(PG_FUNCTION_ARGS)
 		lwgeom_free(lwgeom2);
 	}
 
-	PG_FREE_IF_COPY(g1, 0);
-	PG_FREE_IF_COPY(g2, 1);
 	PG_RETURN_BOOL(dwithin);
 }
 

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -1658,8 +1658,8 @@ Datum overlaps(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(contains);
 Datum contains(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED *geom1 = PG_GETARG_GSERIALIZED_P(0);
-	GSERIALIZED *geom2 = PG_GETARG_GSERIALIZED_P(1);
+	GSERIALIZED *geom1 = ToastCacheGetGeometry(fcinfo, 0);
+	GSERIALIZED *geom2 = ToastCacheGetGeometry(fcinfo, 1);
 	int result;
 	GEOSGeometry *g1, *g2;
 	GBOX box1, box2;
@@ -1777,8 +1777,6 @@ Datum contains(PG_FUNCTION_ARGS)
 
 	if (result == 2) HANDLE_GEOS_ERROR("GEOSContains");
 
-	PG_FREE_IF_COPY(geom1, 0);
-	PG_FREE_IF_COPY(geom2, 1);
 	PG_RETURN_BOOL(result > 0);
 }
 
@@ -1801,8 +1799,8 @@ Datum containsproperly(PG_FUNCTION_ARGS)
 	GBOX 			box1, box2;
 	PrepGeomCache *	prep_cache;
 
-	geom1 = PG_GETARG_GSERIALIZED_P(0);
-	geom2 = PG_GETARG_GSERIALIZED_P(1);
+	geom1 = ToastCacheGetGeometry(fcinfo, 0);
+	geom2 = ToastCacheGetGeometry(fcinfo, 1);
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
 	/* A.ContainsProperly(Empty) == FALSE */
@@ -1851,9 +1849,6 @@ Datum containsproperly(PG_FUNCTION_ARGS)
 
 	if (result == 2) HANDLE_GEOS_ERROR("GEOSContains");
 
-	PG_FREE_IF_COPY(geom1, 0);
-	PG_FREE_IF_COPY(geom2, 1);
-
 	PG_RETURN_BOOL(result);
 }
 
@@ -1870,8 +1865,8 @@ Datum covers(PG_FUNCTION_ARGS)
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
 
-	geom1 = PG_GETARG_GSERIALIZED_P(0);
-	geom2 = PG_GETARG_GSERIALIZED_P(1);
+	geom1 = ToastCacheGetGeometry(fcinfo, 0);
+	geom2 = ToastCacheGetGeometry(fcinfo, 1);
 
 	/* A.Covers(Empty) == FALSE */
 	if ( gserialized_is_empty(geom1) || gserialized_is_empty(geom2) )
@@ -1936,8 +1931,6 @@ Datum covers(PG_FUNCTION_ARGS)
 			PG_RETURN_NULL();
 		}
 
-		PG_FREE_IF_COPY(geom1, 0);
-		PG_FREE_IF_COPY(geom2, 1);
 		PG_RETURN_BOOL(retval);
 	}
 	else
@@ -1976,11 +1969,7 @@ Datum covers(PG_FUNCTION_ARGS)
 
 	if (result == 2) HANDLE_GEOS_ERROR("GEOSCovers");
 
-	PG_FREE_IF_COPY(geom1, 0);
-	PG_FREE_IF_COPY(geom2, 1);
-
 	PG_RETURN_BOOL(result);
-
 }
 
 
@@ -2005,8 +1994,8 @@ Datum coveredby(PG_FUNCTION_ARGS)
 	GBOX box1, box2;
 	char *patt = "**F**F***";
 
-	geom1 = PG_GETARG_GSERIALIZED_P(0);
-	geom2 = PG_GETARG_GSERIALIZED_P(1);
+	geom1 = ToastCacheGetGeometry(fcinfo, 0);
+	geom2 = ToastCacheGetGeometry(fcinfo, 1);
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
 	/* A.CoveredBy(Empty) == FALSE */
@@ -2072,8 +2061,6 @@ Datum coveredby(PG_FUNCTION_ARGS)
 			PG_RETURN_NULL();
 		}
 
-		PG_FREE_IF_COPY(geom1, 0);
-		PG_FREE_IF_COPY(geom2, 1);
 		PG_RETURN_BOOL(retval);
 	}
 	else
@@ -2102,9 +2089,6 @@ Datum coveredby(PG_FUNCTION_ARGS)
 	GEOSGeom_destroy(g2);
 
 	if (result == 2) HANDLE_GEOS_ERROR("GEOSCoveredBy");
-
-	PG_FREE_IF_COPY(geom1, 0);
-	PG_FREE_IF_COPY(geom2, 1);
 
 	PG_RETURN_BOOL(result);
 }
@@ -2174,8 +2158,8 @@ Datum ST_Intersects(PG_FUNCTION_ARGS)
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
 
-	geom1 = PG_GETARG_GSERIALIZED_P(0);
-	geom2 = PG_GETARG_GSERIALIZED_P(1);
+	geom1 = ToastCacheGetGeometry(fcinfo, 0);
+	geom2 = ToastCacheGetGeometry(fcinfo, 1);
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
 	/* A.Intersects(Empty) == FALSE */
@@ -2238,8 +2222,6 @@ Datum ST_Intersects(PG_FUNCTION_ARGS)
 			PG_RETURN_NULL();
 		}
 
-		PG_FREE_IF_COPY(geom1, 0);
-		PG_FREE_IF_COPY(geom2, 1);
 		PG_RETURN_BOOL(retval);
 	}
 
@@ -2282,9 +2264,6 @@ Datum ST_Intersects(PG_FUNCTION_ARGS)
 	}
 
 	if (result == 2) HANDLE_GEOS_ERROR("GEOSIntersects");
-
-	PG_FREE_IF_COPY(geom1, 0);
-	PG_FREE_IF_COPY(geom2, 1);
 
 	PG_RETURN_BOOL(result);
 }


### PR DESCRIPTION
Put a simple cache in front of the de-toasting in functions that use an in-memory cached index scheme. This does not replace in in-memory scheme, so there's some inefficiency, but it makes the patch much simpler than a complete re-write to join the two schemes together while not sacrificing performance in some common cases, like point-in-polygon.