### PR TITLE
Share gserialized cache between cache types

### DIFF
--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -35,6 +35,11 @@
 /* Returns the MemoryContext used to store the caches */
 MemoryContext PostgisCacheContext(FunctionCallInfo fcinfo);
 
+typedef struct {
+	uint32_t count; /* For PgSQL use only, use VAR* macros to manipulate. */
+	GSERIALIZED *geom;
+} SHARED_GSERIALIZED;
+
 /*
 * A generic GeomCache just needs space for the cache type,
 * the cache keys (GSERIALIZED geometries), the key sizes,
@@ -43,8 +48,8 @@ MemoryContext PostgisCacheContext(FunctionCallInfo fcinfo);
 */
 typedef struct {
 	int                         type;
-	GSERIALIZED*                geom1;
-	GSERIALIZED*                geom2;
+	SHARED_GSERIALIZED shared_geom1[1];
+	SHARED_GSERIALIZED shared_geom2[1];
 	size_t                      geom1_size;
 	size_t                      geom2_size;
 	LWGEOM*                     lwgeom1;
@@ -123,7 +128,7 @@ typedef struct
 {
 	Oid valueid;
 	Oid toastrelid;
-	GSERIALIZED *geom;
+	SHARED_GSERIALIZED shared_geom[1];
 } ToastCacheArgument;
 
 typedef struct

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -48,8 +48,8 @@ typedef struct {
 */
 typedef struct {
 	int                         type;
-	SHARED_GSERIALIZED shared_geom1[1];
-	SHARED_GSERIALIZED shared_geom2[1];
+	SHARED_GSERIALIZED *shared_geom1;
+	SHARED_GSERIALIZED *shared_geom2;
 	size_t                      geom1_size;
 	size_t                      geom2_size;
 	LWGEOM*                     lwgeom1;
@@ -128,7 +128,7 @@ typedef struct
 {
 	Oid valueid;
 	Oid toastrelid;
-	SHARED_GSERIALIZED shared_geom[1];
+	SHARED_GSERIALIZED *shared_geom;
 } ToastCacheArgument;
 
 typedef struct


### PR DESCRIPTION
This enables sharing pointers between the toast cache and the geom caches (multiple types). This is done to enable the fast path where pointer comparison is enough to find the geometry in `GetGeomCache`, which avoids the costly memcmp call.

Using @pramsey infamous dataset for a quick comparison:
```
explain analyze SELECT count(*), c.name    FROM countries c   JOIN places p   ON ST_Intersects(c.geom, p.geom)   GROUP BY c.name;
-- Before latency average = 626.083 ms
-- After latency average = 347.727 ms
-- Perf: 1.80x
```

Almost a 2x.

This needs a more in depth review (it's my third big PR today) to make sure memory bookkeeping is correct.