### PR TITLE
Inline gml

### DIFF
--- a/postgis/geography_inout.c
+++ b/postgis/geography_inout.c
@@ -36,7 +36,7 @@
 #include "utils/array.h"
 #include "utils/builtins.h"  /* for pg_atoi */
 #include "lib/stringinfo.h"  /* For binary input */
-#include "catalog/pg_type.h" /* for CSTRINGOID */
+#include "catalog/pg_type.h" /* for CSTRINGOID, INT4OID */
 
 #include "liblwgeom.h"         /* For standard geometry types. */
 #include "lwgeom_cache.h"

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -31,6 +31,7 @@
 #include "float.h" /* for DBL_DIG */
 
 #include "postgres.h"
+#include "catalog/pg_type.h" /* for INT4OID */
 #include "executor/spi.h"
 #include "utils/builtins.h"
 #include "utils/jsonb.h"

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -4646,8 +4646,8 @@ CREATE OR REPLACE FUNCTION _ST_AsGML(int4, geometry, int4, int4, text, text)
 -- Changed: 2.0.0 to have default args
 CREATE OR REPLACE FUNCTION ST_AsGML(geom geometry, maxdecimaldigits int4 DEFAULT 15, options int4 DEFAULT 0)
 	RETURNS TEXT
-	AS $$ SELECT @extschema@._ST_AsGML(2, $1, $2, $3, null, null); $$
-	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	AS 'MODULE_PATHNAME','LWGEOM_asGML'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE
 	_COST_MEDIUM;
 
 -- ST_AsGML(version, geom, precision, option)
@@ -4659,8 +4659,8 @@ CREATE OR REPLACE FUNCTION ST_AsGML(geom geometry, maxdecimaldigits int4 DEFAULT
 -- Availability: 2.1.0
 CREATE OR REPLACE FUNCTION ST_AsGML(version int4, geom geometry, maxdecimaldigits int4 DEFAULT 15, options int4 DEFAULT 0, nprefix text DEFAULT null, id text DEFAULT null)
 	RETURNS TEXT
-	AS $$ SELECT @extschema@._ST_AsGML($1, $2, $3, $4, $5, $6); $$
-	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE
+	AS 'MODULE_PATHNAME','LWGEOM_asGML'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE
 	_COST_MEDIUM;
 
 -----------------------------------------------------------------------


### PR DESCRIPTION
Related to https://trac.osgeo.org/postgis/ticket/4674

Always use a C function directly in ST_AsGML(geometry) so the `getSRSbySRID` cache is used.

```
-- 683788 Points (1 vertex on avg)
-- EXPLAIN ANALYZE Select ST_AsGML(the_geom, 8) from benchmark_7773a711c8441d4b494a51fd9feebeac7a9b9c734619398620293;
-- Latency avg before: 8286.371 ms
-- Latency avg with cache: 223.431 ms
-- Perf: 37.08x
```

Follows the same style as st_asgml(geography), which was already doing this. I don't know why we have 2 implementations that are almost equal to be honest.