### PR TITLE
Share gserialized cache between cache types alternative

### DIFF
--- a/libpgcommon/Makefile.in
+++ b/libpgcommon/Makefile.in
@@ -21,7 +21,8 @@ SA_OBJS = \
 	gserialized_gist.o \
 	lwgeom_transform.o \
 	lwgeom_cache.o \
-	lwgeom_pg.o
+	lwgeom_pg.o \
+	shared_gserialized.o
 
 
 SA_HEADERS = \

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -292,11 +292,6 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
 	/* We've seen this object before? */
 	if (arg->valueid == valueid && arg->toastrelid == toastrelid)
 	{
-		if (arg->geom)
-			return arg->geom;
-
-		/* Take a copy into the upper context */
-		arg->geom = shared_gserialized_new_cached(fcinfo, datum);
 		return arg->geom;
 	}
 	/* New object, clear our old copies and see if it */
@@ -307,8 +302,8 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
 			shared_gserialized_unref(fcinfo, arg->geom);
 		arg->valueid = valueid;
 		arg->toastrelid = toastrelid;
-		arg->geom = NULL;
-		return shared_gserialized_new_nocache(datum);
+		arg->geom = shared_gserialized_new_cached(fcinfo, datum);
+		return arg->geom;
 	}
 }
 

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -133,8 +133,8 @@ GetPROJSRSCache(FunctionCallInfo fcinfo)
 GeomCache *
 GetGeomCache(FunctionCallInfo fcinfo,
 	     const GeomCacheMethods *cache_methods,
-	     const GSERIALIZED *g1,
-	     const GSERIALIZED *g2)
+	     SHARED_GSERIALIZED *g1,
+	     SHARED_GSERIALIZED *g2)
 {
 	GeomCache* cache;
 	int cache_hit = 0;
@@ -147,7 +147,6 @@ GetGeomCache(FunctionCallInfo fcinfo,
 	Assert(entry_number < NUM_CACHE_ENTRIES);
 
 	cache = (GeomCache*)(generic_cache->entry[entry_number]);
-
 	if ( ! cache )
 	{
 		old_context = MemoryContextSwitchTo(PostgisCacheContext(fcinfo));
@@ -160,25 +159,16 @@ GetGeomCache(FunctionCallInfo fcinfo,
 	}
 
 	/* Cache hit on the first argument */
-	if ( g1 &&
-	     cache->argnum != 2 && (
-	     (g1 == cache->geom1) ||
-	     (cache->geom1_size == VARSIZE(g1) && memcmp(cache->geom1, g1, cache->geom1_size) == 0)
-	     ))
+	if (g1 && cache->geom1 && cache->argnum != 2 && shared_gserialized_equal(g1, cache->geom1))
 	{
 		cache_hit = 1;
-		geom = cache->geom1;
-
+		geom = shared_gserialized_get(cache->geom1);
 	}
 	/* Cache hit on second argument */
-	else if ( g2 &&
-	          cache->argnum != 1 && (
-	          (g2 == cache->geom2) ||
-	          (cache->geom2_size == VARSIZE(g2) && memcmp(cache->geom2, g2, cache->geom2_size) == 0)
-	          ))
+	else if (g2 && cache->geom2 && cache->argnum != 1 && shared_gserialized_equal(g2, cache->geom2))
 	{
 		cache_hit = 2;
-		geom = cache->geom2;
+		geom = shared_gserialized_get(cache->geom2);
 	}
 	/* No cache hit. If we have a tree, free it. */
 	else
@@ -237,18 +227,17 @@ GetGeomCache(FunctionCallInfo fcinfo,
 	/* Argument one didn't match, so copy the new value in. */
 	if ( g1 && cache_hit != 1 )
 	{
-		if ( cache->geom1 ) pfree(cache->geom1);
-		cache->geom1_size = VARSIZE(g1);
-		cache->geom1 = MemoryContextAlloc(PostgisCacheContext(fcinfo), cache->geom1_size);
-		memcpy(cache->geom1, g1, cache->geom1_size);
+		if (cache->geom1)
+			shared_gserialized_unref(fcinfo, cache->geom1);
+		cache->geom1 = shared_gserialized_ref(fcinfo, g1);
 	}
+
 	/* Argument two didn't match, so copy the new value in. */
 	if ( g2 && cache_hit != 2 )
 	{
-		if ( cache->geom2 ) pfree(cache->geom2);
-		cache->geom2_size = VARSIZE(g2);
-		cache->geom2 = MemoryContextAlloc(PostgisCacheContext(fcinfo), cache->geom2_size);
-		memcpy(cache->geom2, g2, cache->geom2_size);
+		if (cache->geom2)
+			shared_gserialized_unref(fcinfo, cache->geom2);
+		cache->geom2 = shared_gserialized_ref(fcinfo, g2);
 	}
 
 	return NULL;
@@ -271,7 +260,7 @@ ToastCacheGet(FunctionCallInfo fcinfo)
 	return cache;
 }
 
-GSERIALIZED*
+SHARED_GSERIALIZED *
 ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
 {
 	Assert(argnum < ToastCacheSize);
@@ -292,7 +281,7 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
 	* https://www.postgresql.org/message-id/8196.1585870220@sss.pgh.pa.us
 	*/
 	if (!VARATT_IS_EXTERNAL_ONDISK(attr))
-		return (GSERIALIZED*)PG_DETOAST_DATUM(datum);
+		return shared_gserialized_new_nocache(datum);
 
 	/* Retrieve the unique keys for this object */
 	struct varatt_external ve;
@@ -307,9 +296,7 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
 			return arg->geom;
 
 		/* Take a copy into the upper context */
-		MemoryContext old_context = MemoryContextSwitchTo(PostgisCacheContext(fcinfo));
-		arg->geom = (GSERIALIZED*)PG_DETOAST_DATUM_COPY(datum);
-		MemoryContextSwitchTo(old_context);
+		arg->geom = shared_gserialized_new_cached(fcinfo, datum);
 		return arg->geom;
 	}
 	/* New object, clear our old copies and see if it */
@@ -317,11 +304,11 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
 	else
 	{
 		if (arg->geom)
-			pfree(arg->geom);
+			shared_gserialized_unref(fcinfo, arg->geom);
 		arg->valueid = valueid;
 		arg->toastrelid = toastrelid;
 		arg->geom = NULL;
-		return (GSERIALIZED*)PG_DETOAST_DATUM(datum);
+		return shared_gserialized_new_nocache(datum);
 	}
 }
 

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -141,7 +141,7 @@ GetGeomCache(FunctionCallInfo fcinfo,
 	MemoryContext old_context;
 	const GSERIALIZED *geom;
 	GenericCacheCollection* generic_cache = GetGenericCacheCollection(fcinfo);
-	int entry_number = cache_methods->entry_number;
+	uint32_t entry_number = cache_methods->entry_number;
 
 	Assert(entry_number >= 0);
 	Assert(entry_number < NUM_CACHE_ENTRIES);
@@ -178,16 +178,6 @@ GetGeomCache(FunctionCallInfo fcinfo,
 		{
 			cache_methods->GeomIndexFreer(cache);
 			cache->argnum = 0;
-		}
-		if ( cache->lwgeom1 )
-		{
-			lwgeom_free(cache->lwgeom1);
-			cache->lwgeom1 = 0;
-		}
-		if ( cache->lwgeom2 )
-		{
-			lwgeom_free(cache->lwgeom2);
-			cache->lwgeom2 = 0;
 		}
 	}
 

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -36,8 +36,8 @@
 MemoryContext PostgisCacheContext(FunctionCallInfo fcinfo);
 
 typedef struct {
-	uint32_t count;
 	GSERIALIZED *geom;
+	uint32_t count;
 } SHARED_GSERIALIZED;
 
 SHARED_GSERIALIZED *shared_gserialized_new_nocache(Datum d);
@@ -54,12 +54,10 @@ const GSERIALIZED *shared_gserialized_get(SHARED_GSERIALIZED *s);
 * to refer to.
 */
 typedef struct {
-	int                         type;
+	uint32_t type;
+	uint32 argnum;
 	SHARED_GSERIALIZED *geom1;
 	SHARED_GSERIALIZED *geom2;
-	LWGEOM*                     lwgeom1;
-	LWGEOM*                     lwgeom2;
-	int32                       argnum;
 } GeomCache;
 
 /*
@@ -110,7 +108,7 @@ PROJPortalCache;
 */
 typedef struct
 {
-	int entry_number; /* What kind of structure is this? */
+	uint32_t entry_number; /* What kind of structure is this? */
 	int (*GeomIndexBuilder)(const LWGEOM* lwgeom, GeomCache* cache); /* Build an index/tree and add it to your cache */
 	int (*GeomIndexFreer)(GeomCache* cache); /* Free the index/tree in your cache */
 	GeomCache* (*GeomCacheAllocator)(void); /* Allocate the kind of cache object you use (GeomCache+some extra space) */

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -35,6 +35,18 @@
 /* Returns the MemoryContext used to store the caches */
 MemoryContext PostgisCacheContext(FunctionCallInfo fcinfo);
 
+typedef struct {
+	uint32_t count;
+	GSERIALIZED *geom;
+} SHARED_GSERIALIZED;
+
+SHARED_GSERIALIZED *shared_gserialized_new_nocache(Datum d);
+SHARED_GSERIALIZED *shared_gserialized_new_cached(FunctionCallInfo fcinfo, Datum d);
+SHARED_GSERIALIZED *shared_gserialized_ref(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *ref);
+void shared_gserialized_unref(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *ref);
+bool shared_gserialized_equal(SHARED_GSERIALIZED *r1, SHARED_GSERIALIZED *r2);
+const GSERIALIZED *shared_gserialized_get(SHARED_GSERIALIZED *s);
+
 /*
 * A generic GeomCache just needs space for the cache type,
 * the cache keys (GSERIALIZED geometries), the key sizes,
@@ -43,10 +55,8 @@ MemoryContext PostgisCacheContext(FunctionCallInfo fcinfo);
 */
 typedef struct {
 	int                         type;
-	GSERIALIZED*                geom1;
-	GSERIALIZED*                geom2;
-	size_t                      geom1_size;
-	size_t                      geom2_size;
+	SHARED_GSERIALIZED *geom1;
+	SHARED_GSERIALIZED *geom2;
 	LWGEOM*                     lwgeom1;
 	LWGEOM*                     lwgeom2;
 	int32                       argnum;
@@ -112,8 +122,8 @@ typedef struct
 PROJPortalCache *GetPROJSRSCache(FunctionCallInfo fcinfo);
 GeomCache *GetGeomCache(FunctionCallInfo fcinfo,
 			const GeomCacheMethods *cache_methods,
-			const GSERIALIZED *g1,
-			const GSERIALIZED *g2);
+			SHARED_GSERIALIZED *g1,
+			SHARED_GSERIALIZED *g2);
 
 /******************************************************************************/
 
@@ -123,7 +133,7 @@ typedef struct
 {
 	Oid valueid;
 	Oid toastrelid;
-	GSERIALIZED *geom;
+	SHARED_GSERIALIZED *geom;
 } ToastCacheArgument;
 
 typedef struct
@@ -132,7 +142,7 @@ typedef struct
 	ToastCacheArgument arg[ToastCacheSize];
 } ToastCache;
 
-GSERIALIZED* ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum);
+SHARED_GSERIALIZED *ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum);
 
 /******************************************************************************/
 

--- a/libpgcommon/shared_gserialized.c
+++ b/libpgcommon/shared_gserialized.c
@@ -1,0 +1,98 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * PostGIS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PostGIS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************
+ *
+ * Copyright 2020 Raúl Marín
+ *
+ **********************************************************************/
+
+#include "lwgeom_cache.h"
+
+SHARED_GSERIALIZED *
+shared_gserialized_new_nocache(Datum d)
+{
+	SHARED_GSERIALIZED *s = palloc(sizeof(SHARED_GSERIALIZED));
+	s->count = 0;
+	s->geom = (GSERIALIZED *)PG_DETOAST_DATUM(d);
+	return s;
+}
+
+SHARED_GSERIALIZED *
+shared_gserialized_new_cached(FunctionCallInfo fcinfo, Datum d)
+{
+	SHARED_GSERIALIZED *s = MemoryContextAlloc(PostgisCacheContext(fcinfo), sizeof(SHARED_GSERIALIZED));
+	MemoryContext old_context = MemoryContextSwitchTo(PostgisCacheContext(fcinfo));
+	s->geom = (GSERIALIZED *)PG_DETOAST_DATUM_COPY(d);
+	MemoryContextSwitchTo(old_context);
+	s->count = 1;
+	return s;
+}
+
+SHARED_GSERIALIZED *
+shared_gserialized_ref(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *ref)
+{
+	if (MemoryContextContains(PostgisCacheContext(fcinfo), ref))
+	{
+		ref->count++;
+		return ref;
+	}
+	else
+	{
+		SHARED_GSERIALIZED *sg = MemoryContextAlloc(PostgisCacheContext(fcinfo), sizeof(SHARED_GSERIALIZED));
+		sg->count = 1;
+		sg->geom = MemoryContextAlloc(PostgisCacheContext(fcinfo), VARSIZE(ref->geom));
+		memcpy(sg->geom, ref->geom, VARSIZE(ref->geom));
+		return sg;
+	}
+}
+
+void
+shared_gserialized_unref(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *ref)
+{
+	if (MemoryContextContains(PostgisCacheContext(fcinfo), ref))
+	{
+		ref->count--;
+		if (!ref->count)
+		{
+			pfree(ref->geom);
+			pfree(ref);
+		}
+	}
+	else
+	{
+		pfree(ref->geom);
+		pfree(ref);
+	}
+}
+
+bool
+shared_gserialized_equal(SHARED_GSERIALIZED *r1, SHARED_GSERIALIZED *r2)
+{
+	if (r1->geom == r2->geom)
+		return true;
+	if (VARSIZE(r1->geom) != VARSIZE(r2->geom))
+		return false;
+	return memcmp(r1->geom, r2->geom, VARSIZE(r1->geom)) == 0;
+}
+
+const GSERIALIZED *
+shared_gserialized_get(SHARED_GSERIALIZED *s)
+{
+	return s->geom;
+}

--- a/postgis/geography_measurement_trees.c
+++ b/postgis/geography_measurement_trees.c
@@ -90,7 +90,7 @@ static GeomCacheMethods CircTreeCacheMethods =
 };
 
 static CircTreeGeomCache *
-GetCircTreeGeomCache(FunctionCallInfo fcinfo, const GSERIALIZED *g1, const GSERIALIZED *g2)
+GetCircTreeGeomCache(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *g1, SHARED_GSERIALIZED *g2)
 {
 	return (CircTreeGeomCache*)GetGeomCache(fcinfo, &CircTreeCacheMethods, g1, g2);
 }
@@ -155,12 +155,14 @@ CircTreePIP(const CIRC_NODE* tree1, const GSERIALIZED* g1, const POINT4D* in_poi
 
 static int
 geography_distance_cache_tolerance(FunctionCallInfo fcinfo,
-				   const GSERIALIZED *g1,
-				   const GSERIALIZED *g2,
+				   SHARED_GSERIALIZED *shared_g1,
+				   SHARED_GSERIALIZED *shared_g2,
 				   const SPHEROID *s,
 				   double tolerance,
 				   double *distance)
 {
+	const GSERIALIZED *g1 = shared_gserialized_get(shared_g1);
+	const GSERIALIZED *g2 = shared_gserialized_get(shared_g2);
 	CircTreeGeomCache* tree_cache = NULL;
 
 	int type1 = gserialized_get_type(g1);
@@ -173,7 +175,7 @@ geography_distance_cache_tolerance(FunctionCallInfo fcinfo,
 		return LW_FAILURE;
 
 	/* Fetch/build our cache, if appropriate, etc... */
-	tree_cache = GetCircTreeGeomCache(fcinfo, g1, g2);
+	tree_cache = GetCircTreeGeomCache(fcinfo, shared_g1, shared_g2);
 
 	/* OK, we have an index at the ready! Use it for the one tree argument and */
 	/* fill in the other tree argument */
@@ -250,8 +252,8 @@ geography_distance_cache_tolerance(FunctionCallInfo fcinfo,
 
 int
 geography_distance_cache(FunctionCallInfo fcinfo,
-			 const GSERIALIZED *g1,
-			 const GSERIALIZED *g2,
+			 SHARED_GSERIALIZED *g1,
+			 SHARED_GSERIALIZED *g2,
 			 const SPHEROID *s,
 			 double *distance)
 {
@@ -260,8 +262,8 @@ geography_distance_cache(FunctionCallInfo fcinfo,
 
 int
 geography_dwithin_cache(FunctionCallInfo fcinfo,
-			const GSERIALIZED *g1,
-			const GSERIALIZED *g2,
+			SHARED_GSERIALIZED *g1,
+			SHARED_GSERIALIZED *g2,
 			const SPHEROID *s,
 			double tolerance,
 			int *dwithin)

--- a/postgis/geography_measurement_trees.h
+++ b/postgis/geography_measurement_trees.h
@@ -27,14 +27,14 @@
 #include "lwgeom_cache.h"
 
 int geography_dwithin_cache(FunctionCallInfo fcinfo,
-			    const GSERIALIZED *g1,
-			    const GSERIALIZED *g2,
+			    SHARED_GSERIALIZED *g1,
+			    SHARED_GSERIALIZED *g2,
 			    const SPHEROID *s,
 			    double tolerance,
 			    int *dwithin);
 int geography_distance_cache(FunctionCallInfo fcinfo,
-			     const GSERIALIZED *g1,
-			     const GSERIALIZED *g2,
+			     SHARED_GSERIALIZED *g1,
+			     SHARED_GSERIALIZED *g2,
 			     const SPHEROID *s,
 			     double *distance);
 int geography_tree_distance(const GSERIALIZED* g1, const GSERIALIZED* g2, const SPHEROID* s, double tolerance, double* distance);

--- a/postgis/lwgeom_geos.h
+++ b/postgis/lwgeom_geos.h
@@ -35,7 +35,7 @@
 */
 
 GSERIALIZED *GEOS2POSTGIS(GEOSGeom geom, char want3d);
-GEOSGeometry * POSTGIS2GEOS(GSERIALIZED *g);
+GEOSGeometry *POSTGIS2GEOS(const GSERIALIZED *g);
 GEOSGeometry** ARRAY2GEOS(ArrayType* array, uint32_t nelems, int* is3d, int* srid);
 LWGEOM** ARRAY2LWGEOM(ArrayType* array, uint32_t nelems, int* is3d, int* srid);
 

--- a/postgis/lwgeom_geos_prepared.c
+++ b/postgis/lwgeom_geos_prepared.c
@@ -366,7 +366,7 @@ static GeomCacheMethods PrepGeomCacheMethods =
 * we need for this particular caching strategy.
 */
 PrepGeomCache *
-GetPrepGeomCache(FunctionCallInfo fcinfo, GSERIALIZED *g1, GSERIALIZED *g2)
+GetPrepGeomCache(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *g1, SHARED_GSERIALIZED *g2)
 {
 	return (PrepGeomCache*)GetGeomCache(fcinfo, &PrepGeomCacheMethods, g1, g2);
 }

--- a/postgis/lwgeom_geos_prepared.h
+++ b/postgis/lwgeom_geos_prepared.h
@@ -70,6 +70,6 @@ typedef struct {
 ** If you are only caching one argument (e.g., in contains) supply 0 as the
 ** value for pg_geom2.
 */
-PrepGeomCache *GetPrepGeomCache(FunctionCallInfo fcinfo, GSERIALIZED *pg_geom1, GSERIALIZED *pg_geom2);
+PrepGeomCache *GetPrepGeomCache(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *pg_geom1, SHARED_GSERIALIZED *pg_geom2);
 
 #endif /* LWGEOM_GEOS_PREPARED_H_ */

--- a/postgis/lwgeom_rtree.c
+++ b/postgis/lwgeom_rtree.c
@@ -429,7 +429,7 @@ static GeomCacheMethods RTreeCacheMethods =
 };
 
 RTREE_POLY_CACHE *
-GetRtreeCache(FunctionCallInfo fcinfo, GSERIALIZED *g1)
+GetRtreeCache(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *g1)
 {
 	RTreeGeomCache* cache = (RTreeGeomCache*)GetGeomCache(fcinfo, &RTreeCacheMethods, g1, NULL);
 	RTREE_POLY_CACHE* index = NULL;

--- a/postgis/lwgeom_rtree.h
+++ b/postgis/lwgeom_rtree.h
@@ -80,6 +80,6 @@ LWMLINE *RTreeFindLineSegments(RTREE_NODE *root, double value);
 * a pre-built index structure (RTREE_POLY_CACHE) if one exists. Otherwise
 * builds a new one and returns that.
 */
-RTREE_POLY_CACHE *GetRtreeCache(FunctionCallInfo fcinfo, GSERIALIZED *g1);
+RTREE_POLY_CACHE *GetRtreeCache(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *g1);
 
 #endif /* !defined _LWGEOM_RTREE_H */


### PR DESCRIPTION
Alternative to https://github.com/postgis/postgis/pull/559/

It's cleaner (I think/hope) but requires more changes.

```
explain analyze SELECT count(*), c.name    FROM countries c   JOIN places p   ON ST_Intersects(c.geom, p.geom)   GROUP BY c.name;
-- Before latency average = 627.031 ms
-- After latency average = 316.351 ms
-- Perf: 1.98x
```

It's based on the same principle, ToastCacheGetGeometry will return a SHARED_GSERIALIZED created either in the current context (if not toasted) or in the cache context (if toasted). Then GetGeomCache, will add a reference to that SHARED_GSERIALIZED (which will copy it into the cache context if needed).


Even though it's unused I've also applied the full modifications to ST_DistanceRectTreeCached.

Things look fine in the local environment, but the tests were already broken so not everything is executed.