### PR TITLE
Support for 3D in K-Means.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,7 @@ Only tickets not included in 3.1.0alpha1
 * New features *
   - #4656, Cast a geojson_text::geometry for implicit GeoJSON ingestion (Raúl Marín)
   - #4687, Expose GEOS MaximumInscribedCircle (Paul Ramsey)
-  -
+  - #4710, ST_ClusterKMeans now works with 3D geometries (Darafei Praliaskouski)
 
 * Enhancements *
   - #4675, topology.GetRingEdges now implemented in C (Sandro Santilli)

--- a/doc/reference_cluster.xml
+++ b/doc/reference_cluster.xml
@@ -233,8 +233,9 @@ GEOMETRYCOLLECTION(LINESTRING(6 6,7 7))
       <para>Returns 2D distance based
         <ulink url="https://en.wikipedia.org/wiki/K-means_clustering">K-means</ulink>
         cluster number for each input geometry. The distance used for clustering is the
-        distance between the centroids of the geometries.
+        distance between the centroids for 2D geometries, and distance between bounding box centers for 3D geometries.
       </para>
+      <para>Enhanced: 3.1.0 Support for 3D geometries</para>
       <para>Availability: 2.3.0</para>
     </refsection>
 
@@ -245,7 +246,7 @@ GEOMETRYCOLLECTION(LINESTRING(6 6,7 7))
 SELECT lpad((row_number() over())::text,3,'0') As parcel_id, geom,
 ('{residential, commercial}'::text[])[1 + mod(row_number()OVER(),2)] As type
 FROM
-    ST_Subdivide(ST_Buffer('LINESTRING(40 100, 98 100, 100 150, 60 90)'::geometry,
+    ST_Subdivide(ST_Buffer('SRID=3857;LINESTRING(40 100, 98 100, 100 150, 60 90)'::geometry,
     40, 'endcap=square'),12) As geom;
 </programlisting>
 
@@ -305,6 +306,27 @@ FROM parcels;
    0 | 002       | residential
    2 | 006       | residential
 (7 rows)</programlisting>
+
+
+		    <programlisting> -- Clustering points around antimeridian can be done in 3D XYZ CRS, EPSG:4978:
+
+SELECT ST_ClusterKMeans(ST_Transform(ST_Force3D(geom), 4978), 3) over () AS cid, parcel_id, type
+FROM parcels;
+-- result
+┌─────┬───────────┬─────────────┐
+│ cid │ parcel_id │    type     │
+├─────┼───────────┼─────────────┤
+│   1 │ 001       │ commercial  │
+│   2 │ 002       │ residential │
+│   0 │ 003       │ commercial  │
+│   1 │ 004       │ residential │
+│   0 │ 005       │ commercial  │
+│   2 │ 006       │ residential │
+│   0 │ 007       │ commercial  │
+└─────┴───────────┴─────────────┘
+(7 rows)
+</programlisting>
+
 
     </refsection>
 

--- a/liblwgeom/cunit/cu_algorithm.c
+++ b/liblwgeom/cunit/cu_algorithm.c
@@ -1726,7 +1726,7 @@ static void test_kmeans(void)
 		}
 	}
 
-	r = lwgeom_cluster_2d_kmeans((const LWGEOM **)geoms, N, num_clusters);
+	r = lwgeom_cluster_kmeans((const LWGEOM **)geoms, N, num_clusters);
 
 	// for (i = 0; i < k; i++)
 	// {

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -2512,7 +2512,7 @@ LWGEOM* lwgeom_voronoi_diagram(const LWGEOM* g, const GBOX* env, double toleranc
 * @param ngeoms the number of elements in the array
 * @param k the number of clusters to calculate
 */
-int * lwgeom_cluster_2d_kmeans(const LWGEOM **geoms, uint32_t ngeoms, uint32_t k);
+int * lwgeom_cluster_kmeans(const LWGEOM **geoms, uint32_t ngeoms, uint32_t k);
 
 #include "lwinline.h"
 

--- a/liblwgeom/lwinline.h
+++ b/liblwgeom/lwinline.h
@@ -40,6 +40,16 @@ distance2d_sqr_pt_pt(const POINT2D *p1, const POINT2D *p2)
 	return hside * hside + vside * vside;
 }
 
+inline static double
+distance3d_sqr_pt_pt(const POINT3D *p1, const POINT3D *p2)
+{
+	double hside = p2->x - p1->x;
+	double vside = p2->y - p1->y;
+	double zside = p2->z - p1->z;
+
+	return hside * hside + vside * vside + zside * zside;
+}
+
 /*
  * Size of point represeneted in the POINTARRAY
  * 16 for 2d, 24 for 3d, 32 for 4d
@@ -94,7 +104,7 @@ getPoint2d_cp(const POINTARRAY *pa, uint32_t n)
 }
 
 /**
- * Returns a POINT2D pointer into the POINTARRAY serialized_ptlist,
+ * Returns a POINT3D pointer into the POINTARRAY serialized_ptlist,
  * suitable for reading from. This is very high performance
  * and declared const because you aren't allowed to muck with the
  * values, only read them.
@@ -106,7 +116,7 @@ getPoint3d_cp(const POINTARRAY *pa, uint32_t n)
 }
 
 /**
- * Returns a POINT2D pointer into the POINTARRAY serialized_ptlist,
+ * Returns a POINT4D pointer into the POINTARRAY serialized_ptlist,
  * suitable for reading from. This is very high performance
  * and declared const because you aren't allowed to muck with the
  * values, only read them.

--- a/postgis/lwgeom_window.c
+++ b/postgis/lwgeom_window.c
@@ -232,7 +232,7 @@ Datum ST_ClusterKMeans(PG_FUNCTION_ARGS)
 		}
 
 		/* Calculate k-means on the list! */
-		r = lwgeom_cluster_2d_kmeans((const LWGEOM **)geoms, N, k);
+		r = lwgeom_cluster_kmeans((const LWGEOM **)geoms, N, k);
 
 		/* Clean up */
 		for (i = 0; i < N; i++)

--- a/regress/core/cluster.sql
+++ b/regress/core/cluster.sql
@@ -44,7 +44,7 @@ SELECT '#3612b', ST_ClusterDBSCAN(ST_Point(1,1), 20.1, 5) OVER();
 
 
 -- ST_ClusterKMeans
-select '#4100a', count(distinct result) from (SELECT ST_ClusterKMeans(foo1.the_geom, 3)OVER()  As result
+select '#4100a', count(distinct result) from (SELECT ST_ClusterKMeans(foo1.the_geom, 3) OVER()  As result
   FROM ((SELECT ST_Collect(geom)  As the_geom
 		FROM (VALUES ( ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON(((-71.0821 42.3036 2,-71.0822 42.3036 2,-71.082 42.3038 2,-71.0819 42.3037 2,-71.0821 42.3036 2)))') ),
 	( ST_GeomFromEWKT('SRID=4326;POLYGON((-71.1261 42.2703 1,-71.1257 42.2703 1,-71.1257 42.2701 1,-71.126 42.2701 1,-71.1261 42.2702 1,-71.1261 42.2703 1))') ) ) As g(geom) CROSS JOIN generate_series(1,3) As i GROUP BY i )) As foo1 LIMIT 10) kmeans;
@@ -60,3 +60,15 @@ select '#4101a', count(distinct result) from (SELECT ST_ClusterKMeans(foo1.the_g
 			UNION ALL SELECT ST_GeomFromText('MULTILINESTRING EMPTY',4326) As the_geom ) ) As foo1 LIMIT 10) kmeans;
 
 select '#4101b', count(distinct cid) from (select ST_ClusterKMeans(geom,2) over () as cid from (values ('POINT EMPTY'::geometry), ('POINT EMPTY')) g(geom)) kmeans;
+
+select '3d_support-1', count(distinct cid) from (select ST_ClusterKMeans(geom,2) over () as cid from (values ('POINT(0 0 1)'::geometry), ('POINT(0 0 5)'), ('POINT(0 0 7)')) g(geom)) kmeans;
+select '3d_support-2', count(distinct cid) from (select ST_ClusterKMeans(geom,2) over () as cid from (values ('LINESTRING(0 0 1, 0 0 -1)'::geometry), ('POINT(0 0 5)'), ('POINT(0 0 7)')) g(geom)) kmeans;
+select '3d_support-3', count(distinct cid) from (select ST_ClusterKMeans(geom,2) over () as cid from (values ('LINESTRING(0 0, 0 0)'::geometry), ('POINT(0 0)'), ('POINT(0 0)')) g(geom)) kmeans;
+
+-- check that null and empty is handled in the clustering
+select '#4071', count(distinct a), count(distinct b), count(distinct c)  from
+(select
+	ST_ClusterKMeans(geom, 1) over () a,
+	ST_ClusterKMeans(geom, 2) over () b,
+	ST_ClusterKMeans(geom, 3) over () c
+from (values (null::geometry), ('POINT(1 1)'), ('POINT EMPTY'), ('POINT(0 0)'), ('POINT(4 4)')) as g (geom)) z;

--- a/regress/core/cluster_expected
+++ b/regress/core/cluster_expected
@@ -34,7 +34,12 @@ NOTICE:  kmeans_init: there are at least 3 duplicate inputs, number of output cl
 #4100a|1
 NOTICE:  kmeans_init: there are at least 2 duplicate inputs, number of output clusters may be less than you requested
 #4100b|1
-NOTICE:  lwgeom_cluster_2d_kmeans: number of non-empty geometries is less than the number of clusters requested, not all clusters will get data
+NOTICE:  lwgeom_cluster_kmeans: number of non-empty geometries (0) is less than the number of clusters (3) requested, not all clusters will get data
 #4101a|1
-NOTICE:  lwgeom_cluster_2d_kmeans: number of non-empty geometries is less than the number of clusters requested, not all clusters will get data
+NOTICE:  lwgeom_cluster_kmeans: number of non-empty geometries (0) is less than the number of clusters (2) requested, not all clusters will get data
 #4101b|1
+3d_support-1|2
+3d_support-2|2
+NOTICE:  kmeans_init: there are at least 3 duplicate inputs, number of output clusters may be less than you requested
+3d_support-3|1
+#4071|2|3|4

--- a/regress/core/lwgeom_regress.sql
+++ b/regress/core/lwgeom_regress.sql
@@ -219,14 +219,6 @@ group by cid
 order by count(*)
 limit 1;
 
--- check that null and empty is handled in the clustering
-select '#4071', count(distinct a), count(distinct b), count(distinct c)  from
-(select
-	ST_ClusterKMeans(geom, 1) over () a,
-	ST_ClusterKMeans(geom, 2) over () b,
-	ST_ClusterKMeans(geom, 3) over () c
-from (values (null::geometry), ('POINT(1 1)'), ('POINT EMPTY'), ('POINT(0 0)'), ('POINT(4 4)')) as g (geom)) z;
-
 -- typmod checks
 select 'typmod_point_4326', geometry_typmod_out(geometry_typmod_in('{Point,4326}'));
 select 'typmod_point_0', geometry_typmod_out(geometry_typmod_in('{Point,0}'));

--- a/regress/core/lwgeom_regress_expected
+++ b/regress/core/lwgeom_regress_expected
@@ -43,7 +43,6 @@ ERROR:  Empty geometry
 ST_Angle_2_lines|4.712389
 #3965|25|25
 #3971|t
-#4071|2|3|4
 typmod_point_4326|(Point,4326)
 typmod_point_0|(Point)
 NOTICE:  SRID value -1 converted to the officially unknown SRID value 0


### PR DESCRIPTION
Closes #4710.

Paving the way for XMeans: remove pointers-to-pointers, sanitize nulls upon input and not on each step, check for convergence during update_r and not by comparing cluster id's to backup. 