### PR TITLE
Stringbuffer append double

### DIFF
--- a/liblwgeom/lwout_kml.c
+++ b/liblwgeom/lwout_kml.c
@@ -110,9 +110,7 @@ ptarray_to_kml2_sb(const POINTARRAY *pa, int precision, stringbuffer_t *sb)
 		for (j = 0; j < dims; j++)
 		{
 			if ( j ) stringbuffer_append_len(sb,",",1);
-			char coord[OUT_DOUBLE_BUFFER_SIZE];
-			int len = lwprint_double(d[j], precision, coord);
-			stringbuffer_append_len(sb, coord, len);
+			stringbuffer_append_double(sb, d[j], precision);
 		}
 	}
 	return LW_SUCCESS;

--- a/liblwgeom/lwout_wkt.c
+++ b/liblwgeom/lwout_wkt.c
@@ -86,7 +86,6 @@ static void ptarray_to_wkt_sb(const POINTARRAY *ptarray, stringbuffer_t *sb, int
 	/* OGC only includes X/Y */
 	uint32_t dimensions = 2;
 	uint32_t i, j;
-	char coord[OUT_DOUBLE_BUFFER_SIZE];
 
 	/* ISO and extended formats include all dimensions */
 	if ( variant & ( WKT_ISO | WKT_EXTENDED ) )
@@ -110,8 +109,7 @@ static void ptarray_to_wkt_sb(const POINTARRAY *ptarray, stringbuffer_t *sb, int
 			/* Spaces before every ordinate but the first */
 			if ( j > 0 )
 				stringbuffer_append_len(sb, " ", 1);
-			int len = lwprint_double(dbl_ptr[j], precision, coord);
-			stringbuffer_append_len(sb, coord, len);
+			stringbuffer_append_double(sb, dbl_ptr[j], precision);
 		}
 	}
 

--- a/liblwgeom/stringbuffer.h
+++ b/liblwgeom/stringbuffer.h
@@ -105,4 +105,11 @@ stringbuffer_append(stringbuffer_t *s, const char *a)
 	int alen = strlen(a); /* Length of string to append */
 	stringbuffer_append_len(s, a, alen);
 }
+
+inline static void
+stringbuffer_append_double(stringbuffer_t *s, double d, int precision)
+{
+	stringbuffer_makeroom(s, OUT_MAX_BYTES_DOUBLE);
+	s->str_end += lwprint_double(d, precision, s->str_end);
+}
 #endif /* _STRINGBUFFER_H */


### PR DESCRIPTION
Numbers: 3-5% improvement. Not much but it's something:

```
EXPLAIN ANALYZE Select ST_AsText(the_geom, 0) from benchmark_4c7214d90a79aa6760367a084a4d4a2f61fbe1c6cc4f7f9e76020;
-- Master (2020-07-28):  560.471 (8) / 482.554 (20) / 391.546 (0)
-- stringbuffer_append_double 13441: 544.986 (8) / 452.147 (20) / 374.633 (0)
-- Perf: 1.03x (8) / 1.067x (20) / 1.045x (0)
```

Trac: https://trac.osgeo.org/postgis/ticket/4729