### PR TITLE
MVT improvements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PostGIS 3.1.0beta1
 2020/xx/xx
 Only tickets not included in 3.1.0alpha2
 
+* Breaking changes *
+  - #4737, Bump minimum protobuf-c requirement to 1.1.0 (Raúl Marín)
+
 * New features *
   - #4698, Add a precision parameter to ST_AsEWKT (Raúl Marín)
 
@@ -23,6 +26,8 @@ Only tickets not included in 3.1.0alpha2
            ST_BoundingDiagonal.
   - #4741, Don't use ST_PointInsideCircle if you need indexes, use ST_DWithin instead.
            Documentation adjusted (Darafei Praliaskouski)
+  - #4737, Improve performance and reduce memory usage in ST_AsMVT, especially in
+           queries involving parallelism (Raúl Marín)
 
 * Bug fixes *
   - #4691, Fix segfault during gist index creation with empty geometries (Raúl Marín)

--- a/configure.ac
+++ b/configure.ac
@@ -998,7 +998,7 @@ if test "$CHECK_PROTOBUF" != "no"; then
 	dnl Try pkgconfig first
 	if test -n "$PKG_CONFIG"; then
 		dnl Ensure libprotobuf-c is of minimum required version
-		PKG_CHECK_MODULES([PROTOBUFC], [libprotobuf-c >= 1.0.0], [
+		PKG_CHECK_MODULES([PROTOBUFC], [libprotobuf-c >= 1.1.0], [
 				PROTOBUF_CPPFLAGS="$PROTOBUFC_CFLAGS";
 				PROTOBUF_LDFLAGS="$PROTOBUFC_LIBS";
 			], [
@@ -1069,10 +1069,8 @@ if test "$CHECK_PROTOBUF" != "no"; then
         if test "$HAVE_PROTOBUF" = "yes"; then
 		AC_DEFINE([HAVE_LIBPROTOBUF], [1], [Define to 1 if libprotobuf-c is present])
 		AC_DEFINE_UNQUOTED([LIBPROTOBUF_VERSION], [$PROTOC_VERSION], [Numeric version number for libprotobuf-c])
-		if test $PROTOC_VERSION -ge 1001000; then
-			AC_DEFINE([HAVE_GEOBUF], [1], [Define to 1 if libprotobuf is >= 1.1])
-			HAVE_GEOBUF=yes
-		fi
+		AC_DEFINE([HAVE_GEOBUF], [1], [Define to 1 if geobuf is present])
+		HAVE_GEOBUF=yes
 	fi
 
     AC_SUBST([HAVE_PROTOBUF])

--- a/postgis/lwgeom_out_mvt.c
+++ b/postgis/lwgeom_out_mvt.c
@@ -129,12 +129,12 @@ Datum pgis_asmvt_transfn(PG_FUNCTION_ARGS)
 	elog(ERROR, "Missing libprotobuf-c");
 	PG_RETURN_NULL();
 #else
-	MemoryContext aggcontext;
+	MemoryContext aggcontext, old_context;
 	mvt_agg_context *ctx;
 
 	if (!AggCheckCallContext(fcinfo, &aggcontext))
 		elog(ERROR, "%s called in non-aggregate context", __func__);
-	MemoryContextSwitchTo(aggcontext);
+	old_context = MemoryContextSwitchTo(aggcontext);
 
 	if (PG_ARGISNULL(0)) {
 		ctx = palloc(sizeof(*ctx));
@@ -162,6 +162,8 @@ Datum pgis_asmvt_transfn(PG_FUNCTION_ARGS)
 
 	mvt_agg_transfn(ctx);
 	PG_FREE_IF_COPY(ctx->row, 1);
+
+	MemoryContextSwitchTo(old_context);
 	PG_RETURN_POINTER(ctx);
 #endif
 }

--- a/postgis/lwgeom_out_mvt.c
+++ b/postgis/lwgeom_out_mvt.c
@@ -184,11 +184,10 @@ Datum pgis_asmvt_finalfn(PG_FUNCTION_ARGS)
 	elog(ERROR, "Missing libprotobuf-c");
 	PG_RETURN_NULL();
 #else
-	MemoryContext aggcontext, oldcontext;
 	mvt_agg_context *ctx;
 	bytea *buf;
 	elog(DEBUG2, "%s called", __func__);
-	if (!AggCheckCallContext(fcinfo, aggcontext))
+	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "%s called in non-aggregate context", __func__);
 
 	if (PG_ARGISNULL(0))
@@ -199,7 +198,6 @@ Datum pgis_asmvt_finalfn(PG_FUNCTION_ARGS)
 	}
 
 	ctx = (mvt_agg_context *) PG_GETARG_POINTER(0);
-	oldcontext = MemoryContextSwitchTo(aggcontext);
 	buf = mvt_agg_finalfn(ctx);
 	PG_RETURN_BYTEA_P(buf);
 #endif

--- a/postgis/lwgeom_out_mvt.c
+++ b/postgis/lwgeom_out_mvt.c
@@ -184,10 +184,11 @@ Datum pgis_asmvt_finalfn(PG_FUNCTION_ARGS)
 	elog(ERROR, "Missing libprotobuf-c");
 	PG_RETURN_NULL();
 #else
+	MemoryContext aggcontext, oldcontext;
 	mvt_agg_context *ctx;
 	bytea *buf;
 	elog(DEBUG2, "%s called", __func__);
-	if (!AggCheckCallContext(fcinfo, NULL))
+	if (!AggCheckCallContext(fcinfo, aggcontext))
 		elog(ERROR, "%s called in non-aggregate context", __func__);
 
 	if (PG_ARGISNULL(0))
@@ -198,6 +199,7 @@ Datum pgis_asmvt_finalfn(PG_FUNCTION_ARGS)
 	}
 
 	ctx = (mvt_agg_context *) PG_GETARG_POINTER(0);
+	oldcontext = MemoryContextSwitchTo(aggcontext);
 	buf = mvt_agg_finalfn(ctx);
 	PG_RETURN_BYTEA_P(buf);
 #endif
@@ -225,7 +227,9 @@ Datum pgis_asmvt_serialfn(PG_FUNCTION_ARGS)
 
 	ctx = (mvt_agg_context *) PG_GETARG_POINTER(0);
 	result = mvt_ctx_serialize(ctx);
-	MemoryContextDelete(ctx->trans_context);
+	if (ctx->trans_context)
+		MemoryContextDelete(ctx->trans_context);
+	ctx->trans_context = NULL;
 	PG_RETURN_BYTEA_P(result);
 #endif
 }

--- a/postgis/lwgeom_out_mvt.c
+++ b/postgis/lwgeom_out_mvt.c
@@ -152,8 +152,9 @@ Datum pgis_asmvt_transfn(PG_FUNCTION_ARGS)
 		else
 			ctx->id_name = NULL;
 
-		//		MemoryContextSwitchTo(old_context);
-		//		old_context = MemoryContextSwitchTo(ctx->transf_context);
+		ctx->trans_context = AllocSetContextCreate(aggcontext, "MVT transfn", ALLOCSET_DEFAULT_SIZES);
+
+		MemoryContextSwitchTo(ctx->trans_context);
 		mvt_agg_init_context(ctx);
 		MemoryContextSwitchTo(old_context);
 	} else {
@@ -164,8 +165,7 @@ Datum pgis_asmvt_transfn(PG_FUNCTION_ARGS)
 		elog(ERROR, "%s: parameter row cannot be other than a rowtype", __func__);
 	ctx->row = PG_GETARG_HEAPTUPLEHEADER(1);
 
-	//		old_context = MemoryContextSwitchTo(ctx->transf_context);
-	old_context = MemoryContextSwitchTo(aggcontext);
+	old_context = MemoryContextSwitchTo(ctx->trans_context);
 	mvt_agg_transfn(ctx);
 	MemoryContextSwitchTo(old_context);
 
@@ -211,6 +211,7 @@ Datum pgis_asmvt_serialfn(PG_FUNCTION_ARGS)
 	PG_RETURN_NULL();
 #else
 	mvt_agg_context *ctx;
+	bytea *result;
 	elog(DEBUG2, "%s called", __func__);
 	if (!AggCheckCallContext(fcinfo, NULL))
 		elog(ERROR, "%s called in non-aggregate context", __func__);
@@ -223,7 +224,9 @@ Datum pgis_asmvt_serialfn(PG_FUNCTION_ARGS)
 	}
 
 	ctx = (mvt_agg_context *) PG_GETARG_POINTER(0);
-	PG_RETURN_BYTEA_P(mvt_ctx_serialize(ctx));
+	result = mvt_ctx_serialize(ctx);
+	MemoryContextDelete(ctx->trans_context);
+	PG_RETURN_BYTEA_P(result);
 #endif
 }
 

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -1367,7 +1367,7 @@ vectortile_layer_combine(VectorTile__Tile__Layer *layer, VectorTile__Tile__Layer
 {
 	const uint32_t key_offset = layer->n_keys;
 	const uint32_t value_offset = layer->n_values;
-	//	const uint32_t feature_offset = layer->n_features;
+	const uint32_t feature_offset = layer->n_features;
 
 	layer->keys = repalloc(layer->keys, sizeof(char *) * (layer->n_keys + layer2->n_keys));
 	memcpy(&layer->keys[key_offset], layer2->keys, sizeof(char *) * layer2->n_keys);
@@ -1378,11 +1378,11 @@ vectortile_layer_combine(VectorTile__Tile__Layer *layer, VectorTile__Tile__Layer
 	memcpy(&layer->values[value_offset], layer2->values, sizeof(VectorTile__Tile__Value *) * layer2->n_values);
 	layer->n_values += layer2->n_values;
 
-	//	layer->features =
-	//	    repalloc(layer->features, sizeof(VectorTile__Tile__Feature *) * (layer->n_features +
-	//layer2->n_features)); 	memcpy(&layer->features[feature_offset], layer2->features, sizeof(char *) *
-	//layer2->n_features); 	layer->n_features += layer2->n_features; 	for (uint32_t i = feature_offset; i <
-	//layer->n_features; i += 2)
+	layer->features =
+	    repalloc(layer->features, sizeof(VectorTile__Tile__Feature *) * (layer->n_features + layer2->n_features));
+	memcpy(&layer->features[feature_offset], layer2->features, sizeof(char *) * layer2->n_features);
+	layer->n_features += layer2->n_features;
+	//	for (uint32_t i = feature_offset; i < layer->n_features; i += 2)
 	//	{
 	//		layer->features[i] += key_offset;
 	//		layer->features[i + 1] += value_offset;

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -1409,7 +1409,7 @@ tile_value_copy(const VectorTile__Tile__Value *value)
 {
 	VectorTile__Tile__Value *nvalue = palloc(sizeof(VectorTile__Tile__Value));
 	memcpy(nvalue, value, sizeof(VectorTile__Tile__Value));
-	if (value->string_value)
+	if (value->test_oneof_case == VECTOR_TILE__TILE__VALUE__TEST_ONEOF_STRING_VALUE)
 		nvalue->string_value = pstrdup(value->string_value);
 	return nvalue;
 }

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -183,7 +183,6 @@ static void encode_point(mvt_agg_context *ctx, LWPOINT *point)
 {
 	VectorTile__Tile__Feature *feature = ctx->feature;
 	feature->type = VECTOR_TILE__TILE__GEOM_TYPE__POINT;
-	feature->has_type = 1;
 	feature->n_geometry = 3;
 	feature->geometry = palloc(sizeof(*feature->geometry) * 3);
 	encode_ptarray_initial(ctx, MVT_POINT, point->point, feature->geometry);
@@ -196,7 +195,6 @@ static void encode_mpoint(mvt_agg_context *ctx, LWMPOINT *mpoint)
 	// NOTE: inefficient shortcut LWMPOINT->LWLINE
 	LWLINE *lwline = lwline_from_lwmpoint(mpoint->srid, mpoint);
 	feature->type = VECTOR_TILE__TILE__GEOM_TYPE__POINT;
-	feature->has_type = 1;
 	c = 1 + lwline->points->npoints * 2;
 	feature->geometry = palloc(sizeof(*feature->geometry) * c);
 	feature->n_geometry = encode_ptarray_initial(ctx, MVT_POINT,
@@ -208,7 +206,6 @@ static void encode_line(mvt_agg_context *ctx, LWLINE *lwline)
 	size_t c;
 	VectorTile__Tile__Feature *feature = ctx->feature;
 	feature->type = VECTOR_TILE__TILE__GEOM_TYPE__LINESTRING;
-	feature->has_type = 1;
 	c = 2 + lwline->points->npoints * 2;
 	feature->geometry = palloc(sizeof(*feature->geometry) * c);
 	feature->n_geometry = encode_ptarray_initial(ctx, MVT_LINE,
@@ -222,7 +219,6 @@ static void encode_mline(mvt_agg_context *ctx, LWMLINE *lwmline)
 	size_t c = 0, offset = 0;
 	VectorTile__Tile__Feature *feature = ctx->feature;
 	feature->type = VECTOR_TILE__TILE__GEOM_TYPE__LINESTRING;
-	feature->has_type = 1;
 	for (i = 0; i < lwmline->ngeoms; i++)
 		c += 2 + lwmline->geoms[i]->points->npoints * 2;
 	feature->geometry = palloc(sizeof(*feature->geometry) * c);
@@ -240,7 +236,6 @@ static void encode_poly(mvt_agg_context *ctx, LWPOLY *lwpoly)
 	size_t c = 0, offset = 0;
 	VectorTile__Tile__Feature *feature = ctx->feature;
 	feature->type = VECTOR_TILE__TILE__GEOM_TYPE__POLYGON;
-	feature->has_type = 1;
 	for (i = 0; i < lwpoly->nrings; i++)
 		c += 3 + ((lwpoly->rings[i]->npoints - 1) * 2);
 	feature->geometry = palloc(sizeof(*feature->geometry) * c);
@@ -259,7 +254,6 @@ static void encode_mpoly(mvt_agg_context *ctx, LWMPOLY *lwmpoly)
 	LWPOLY *poly;
 	VectorTile__Tile__Feature *feature = ctx->feature;
 	feature->type = VECTOR_TILE__TILE__GEOM_TYPE__POLYGON;
-	feature->has_type = 1;
 	for (i = 0; i < lwmpoly->ngeoms; i++)
 		for (j = 0; poly = lwmpoly->geoms[i], j < poly->nrings; j++)
 			c += 3 + ((poly->rings[j]->npoints - 1) * 2);
@@ -1261,7 +1255,6 @@ void mvt_agg_init_context(mvt_agg_context *ctx)
 	vector_tile__tile__layer__init(layer);
 	layer->version = 2;
 	layer->name = ctx->name;
-	layer->has_extent = 1;
 	layer->extent = ctx->extent;
 	layer->features = palloc (ctx->features_capacity *
 		sizeof(*layer->features));
@@ -1430,7 +1423,6 @@ tile_feature_copy(const VectorTile__Tile__Feature *feature, int key_offset, int 
 	/* Copy settings straight over */
 	nfeature->has_id = feature->has_id;
 	nfeature->id = feature->id;
-	nfeature->has_type = feature->has_type;
 	nfeature->type = feature->type;
 
 	/* Copy tags over, offsetting indexes so they match the dictionaries */
@@ -1469,7 +1461,6 @@ vectortile_layer_combine(const VectorTile__Tile__Layer *layer1, const VectorTile
 	/* Take globals from layer1 */
 	layer->version = layer1->version;
 	layer->name = pstrdup(layer1->name);
-	layer->has_extent = layer1->has_extent;
 	layer->extent = layer1->extent;
 
 	/* Copy keys into new layer */

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -1365,28 +1365,28 @@ mvt_agg_context * mvt_ctx_deserialize(const bytea *ba)
 static VectorTile__Tile__Layer *
 vectortile_layer_combine(VectorTile__Tile__Layer *layer, VectorTile__Tile__Layer *layer2)
 {
-	const uint32_t key_offset = layer->n_keys;
-	const uint32_t value_offset = layer->n_values;
-	const uint32_t feature_offset = layer->n_features;
-
-	layer->keys = repalloc(layer->keys, sizeof(char *) * (layer->n_keys + layer2->n_keys));
-	memcpy(&layer->keys[key_offset], layer2->keys, sizeof(char *) * layer2->n_keys);
-	layer->n_keys += layer2->n_keys;
-
-	layer->values =
-	    repalloc(layer->values, sizeof(VectorTile__Tile__Value *) * (layer->n_values + layer2->n_values));
-	memcpy(&layer->values[value_offset], layer2->values, sizeof(VectorTile__Tile__Value *) * layer2->n_values);
-	layer->n_values += layer2->n_values;
-
-	layer->features =
-	    repalloc(layer->features, sizeof(VectorTile__Tile__Feature *) * (layer->n_features + layer2->n_features));
-	memcpy(&layer->features[feature_offset], layer2->features, sizeof(char *) * layer2->n_features);
-	layer->n_features += layer2->n_features;
-	for (uint32_t i = feature_offset; i < layer->n_features; i += 2)
-	{
-		layer->features[i] += key_offset;
-		layer->features[i + 1] += value_offset;
-	}
+//	const uint32_t key_offset = layer->n_keys;
+//	const uint32_t value_offset = layer->n_values;
+//	const uint32_t feature_offset = layer->n_features;
+//
+//	layer->keys = repalloc(layer->keys, sizeof(char *) * (layer->n_keys + layer2->n_keys));
+//	memcpy(&layer->keys[key_offset], layer2->keys, sizeof(char *) * layer2->n_keys);
+//	layer->n_keys += layer2->n_keys;
+//
+//	layer->values =
+//	    repalloc(layer->values, sizeof(VectorTile__Tile__Value *) * (layer->n_values + layer2->n_values));
+//	memcpy(&layer->values[value_offset], layer2->values, sizeof(VectorTile__Tile__Value *) * layer2->n_values);
+//	layer->n_values += layer2->n_values;
+//
+//	layer->features =
+//	    repalloc(layer->features, sizeof(VectorTile__Tile__Feature *) * (layer->n_features + layer2->n_features));
+//	memcpy(&layer->features[feature_offset], layer2->features, sizeof(char *) * layer2->n_features);
+//	layer->n_features += layer2->n_features;
+//	for (uint32_t i = feature_offset; i < layer->n_features; i += 2)
+//	{
+//		layer->features[i] += key_offset;
+//		layer->features[i + 1] += value_offset;
+//	}
 
 	return layer;
 }

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -418,7 +418,7 @@ static VectorTile__Tile__Value *create_value()
 		for (kv = ctx->hash; kv != NULL; kv=kv->hh.next) \
 		{ \
 			VectorTile__Tile__Value *value = create_value(); \
-			value->hasfield = 1; \
+			value->test_oneof_case = hasfield; \
 			value->valuefield = kv->valuefield; \
 			values[kv->id] = value; \
 		} \
@@ -437,18 +437,19 @@ static void encode_values(mvt_agg_context *ctx)
 	{
 		VectorTile__Tile__Value *value = create_value();
 		value->string_value = kv->string_value;
+		value->test_oneof_case = VECTOR_TILE__TILE__VALUE__TEST_ONEOF_STRING_VALUE;
 		values[kv->id] = value;
 	}
 	MVT_CREATE_VALUES(mvt_kv_float_value,
-		float_values_hash, has_float_value, float_value);
+		float_values_hash, VECTOR_TILE__TILE__VALUE__TEST_ONEOF_FLOAT_VALUE, float_value);
 	MVT_CREATE_VALUES(mvt_kv_double_value,
-		double_values_hash, has_double_value, double_value);
+		double_values_hash, VECTOR_TILE__TILE__VALUE__TEST_ONEOF_DOUBLE_VALUE, double_value);
 	MVT_CREATE_VALUES(mvt_kv_uint_value,
-		uint_values_hash, has_uint_value, uint_value);
+		uint_values_hash, VECTOR_TILE__TILE__VALUE__TEST_ONEOF_UINT_VALUE, uint_value);
 	MVT_CREATE_VALUES(mvt_kv_sint_value,
-		sint_values_hash, has_sint_value, sint_value);
+		sint_values_hash, VECTOR_TILE__TILE__VALUE__TEST_ONEOF_SINT_VALUE, sint_value);
 	MVT_CREATE_VALUES(mvt_kv_bool_value,
-		bool_values_hash, has_bool_value, bool_value);
+		bool_values_hash, VECTOR_TILE__TILE__VALUE__TEST_ONEOF_BOOL_VALUE, bool_value);
 
 	POSTGIS_DEBUGF(3, "encode_values n_values: %d", ctx->values_hash_i);
 	ctx->layer->n_values = ctx->values_hash_i;

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -1365,13 +1365,13 @@ mvt_agg_context * mvt_ctx_deserialize(const bytea *ba)
 static VectorTile__Tile__Layer *
 vectortile_layer_combine(VectorTile__Tile__Layer *layer, VectorTile__Tile__Layer *layer2)
 {
-//	const uint32_t key_offset = layer->n_keys;
+	const uint32_t key_offset = layer->n_keys;
 //	const uint32_t value_offset = layer->n_values;
 //	const uint32_t feature_offset = layer->n_features;
-//
-//	layer->keys = repalloc(layer->keys, sizeof(char *) * (layer->n_keys + layer2->n_keys));
-//	memcpy(&layer->keys[key_offset], layer2->keys, sizeof(char *) * layer2->n_keys);
-//	layer->n_keys += layer2->n_keys;
+
+	layer->keys = repalloc(layer->keys, sizeof(char *) * (layer->n_keys + layer2->n_keys));
+	memcpy(&layer->keys[key_offset], layer2->keys, sizeof(char *) * layer2->n_keys);
+	layer->n_keys += layer2->n_keys;
 //
 //	layer->values =
 //	    repalloc(layer->values, sizeof(VectorTile__Tile__Value *) * (layer->n_values + layer2->n_values));

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -389,6 +389,8 @@ static void encode_values(mvt_agg_context *ctx)
 	ctx->layer->n_values = ctx->values_hash_i;
 	ctx->layer->values = values;
 
+	/* Since the tupdesc is part of Postgresql cache, we need to ensure we release it when we
+	 * are done with it */
 	ReleaseTupleDesc(ctx->column_cache.tupdesc);
 	memset(&ctx->column_cache, 0, sizeof(ctx->column_cache));
 

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -1366,27 +1366,27 @@ static VectorTile__Tile__Layer *
 vectortile_layer_combine(VectorTile__Tile__Layer *layer, VectorTile__Tile__Layer *layer2)
 {
 	const uint32_t key_offset = layer->n_keys;
-//	const uint32_t value_offset = layer->n_values;
-//	const uint32_t feature_offset = layer->n_features;
+	const uint32_t value_offset = layer->n_values;
+	//	const uint32_t feature_offset = layer->n_features;
 
 	layer->keys = repalloc(layer->keys, sizeof(char *) * (layer->n_keys + layer2->n_keys));
 	memcpy(&layer->keys[key_offset], layer2->keys, sizeof(char *) * layer2->n_keys);
 	layer->n_keys += layer2->n_keys;
-//
-//	layer->values =
-//	    repalloc(layer->values, sizeof(VectorTile__Tile__Value *) * (layer->n_values + layer2->n_values));
-//	memcpy(&layer->values[value_offset], layer2->values, sizeof(VectorTile__Tile__Value *) * layer2->n_values);
-//	layer->n_values += layer2->n_values;
-//
-//	layer->features =
-//	    repalloc(layer->features, sizeof(VectorTile__Tile__Feature *) * (layer->n_features + layer2->n_features));
-//	memcpy(&layer->features[feature_offset], layer2->features, sizeof(char *) * layer2->n_features);
-//	layer->n_features += layer2->n_features;
-//	for (uint32_t i = feature_offset; i < layer->n_features; i += 2)
-//	{
-//		layer->features[i] += key_offset;
-//		layer->features[i + 1] += value_offset;
-//	}
+
+	layer->values =
+	    repalloc(layer->values, sizeof(VectorTile__Tile__Value *) * (layer->n_values + layer2->n_values));
+	memcpy(&layer->values[value_offset], layer2->values, sizeof(VectorTile__Tile__Value *) * layer2->n_values);
+	layer->n_values += layer2->n_values;
+
+	//	layer->features =
+	//	    repalloc(layer->features, sizeof(VectorTile__Tile__Feature *) * (layer->n_features +
+	//layer2->n_features)); 	memcpy(&layer->features[feature_offset], layer2->features, sizeof(char *) *
+	//layer2->n_features); 	layer->n_features += layer2->n_features; 	for (uint32_t i = feature_offset; i <
+	//layer->n_features; i += 2)
+	//	{
+	//		layer->features[i] += key_offset;
+	//		layer->features[i + 1] += value_offset;
+	//	}
 
 	return layer;
 }

--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -1256,8 +1256,7 @@ void mvt_agg_init_context(mvt_agg_context *ctx)
 	layer->version = 2;
 	layer->name = ctx->name;
 	layer->extent = ctx->extent;
-	layer->features = palloc (ctx->features_capacity *
-		sizeof(*layer->features));
+	layer->features = palloc(ctx->features_capacity * sizeof(*layer->features));
 
 	ctx->layer = layer;
 }

--- a/postgis/mvt.h
+++ b/postgis/mvt.h
@@ -56,27 +56,43 @@ typedef struct mvt_column_cache
 
 typedef struct mvt_agg_context
 {
+	/* Temporal memory context using during during pgis_asmvt_transfn and deleted after
+	 * pgis_asmvt_serialfn. This is to have a faster and simpler way to delete the temporal
+	 * objects in parallel runs */
 	MemoryContext trans_context;
 	char *name;
 	uint32_t extent;
+
+	/* Name and position of the property that sets the feature id */
 	char *id_name;
 	uint32_t id_index;
+
+	/* Name and position of the property that sets the feature geometry */
 	char *geom_name;
 	uint32_t geom_index;
+
 	HeapTupleHeader row;
 	VectorTile__Tile__Feature *feature;
 	VectorTile__Tile__Layer *layer;
 	VectorTile__Tile *tile;
 	size_t features_capacity;
+
+	/* Hash table holding the feature keys */
 	struct mvt_kv_key *keys_hash;
+
+	/* Hash tables holding the feature values, one per type */
 	struct mvt_kv_value *string_values_hash;
 	struct mvt_kv_value *float_values_hash;
 	struct mvt_kv_value *double_values_hash;
 	struct mvt_kv_value *uint_values_hash;
 	struct mvt_kv_value *sint_values_hash;
 	struct mvt_kv_value *bool_values_hash;
+
+	/* Total number of values stored (for all combined value hash tables) */
 	uint32_t values_hash_i;
+	/* Total number of keys stored */
 	uint32_t keys_hash_i;
+
 	uint32_t row_columns;
 	mvt_column_cache column_cache;
 } mvt_agg_context;

--- a/postgis/mvt.h
+++ b/postgis/mvt.h
@@ -69,12 +69,12 @@ typedef struct mvt_agg_context
 	VectorTile__Tile *tile;
 	size_t features_capacity;
 	struct mvt_kv_key *keys_hash;
-	struct mvt_kv_string_value *string_values_hash;
-	struct mvt_kv_float_value *float_values_hash;
-	struct mvt_kv_double_value *double_values_hash;
-	struct mvt_kv_uint_value *uint_values_hash;
-	struct mvt_kv_sint_value *sint_values_hash;
-	struct mvt_kv_bool_value *bool_values_hash;
+	struct mvt_kv_value *string_values_hash;
+	struct mvt_kv_value *float_values_hash;
+	struct mvt_kv_value *double_values_hash;
+	struct mvt_kv_value *uint_values_hash;
+	struct mvt_kv_value *sint_values_hash;
+	struct mvt_kv_value *bool_values_hash;
 	uint32_t values_hash_i;
 	uint32_t keys_hash_i;
 	uint32_t row_columns;

--- a/postgis/mvt.h
+++ b/postgis/mvt.h
@@ -56,6 +56,7 @@ typedef struct mvt_column_cache
 
 typedef struct mvt_agg_context
 {
+	MemoryContext trans_context;
 	char *name;
 	uint32_t extent;
 	char *id_name;

--- a/postgis/vector_tile.proto
+++ b/postgis/vector_tile.proto
@@ -17,16 +17,15 @@ message Tile {
         // Variant type encoding
         // The use of values is described in section 4.1 of the specification
         message Value {
-                // Exactly one of these values must be present in a valid message
-                optional string string_value = 1;
-                optional float float_value = 2;
-                optional double double_value = 3;
-                optional int64 int_value = 4;
-                optional uint64 uint_value = 5;
-                optional sint64 sint_value = 6;
-                optional bool bool_value = 7;
-
-                extensions 8 to max;
+            oneof test_oneof {
+                string string_value = 1;
+                float float_value = 2;
+                double double_value = 3;
+                int64 int_value = 4;
+                uint64 uint_value = 5;
+                sint64 sint_value = 6;
+                bool bool_value = 7;
+            }
         }
 
         // Features are described in section 4.2 of the specification

--- a/postgis/vector_tile.proto
+++ b/postgis/vector_tile.proto
@@ -16,6 +16,7 @@ message Tile {
 
         // Variant type encoding
         // The use of values is described in section 4.1 of the specification
+        // PostGIS: Made oneof (protobuf-c 1.1+ required) to reduce memory usage
         message Value {
             oneof test_oneof {
                 string string_value = 1;
@@ -39,7 +40,8 @@ message Tile {
                 repeated uint32 tags = 2 [ packed = true ];
 
                 // The type of geometry stored in this feature.
-                optional GeomType type = 3 [ default = UNKNOWN ];
+                // PostGIS: Made mandatory
+                required GeomType type = 3 [ default = UNKNOWN ];
 
                 // Contains a stream of commands and parameters (vertices).
                 // A detailed description on geometry encoding is located in
@@ -66,9 +68,8 @@ message Tile {
                 // Dictionary encoding for values
                 repeated Value values = 4;
 
-                // Although this is an "optional" field it is required by the specification.
-                // See https://github.com/mapbox/vector-tile-spec/issues/47
-                optional uint32 extent = 5 [ default = 4096 ];
+                // PostGIS: Made mandatory (see https://github.com/mapbox/vector-tile-spec/issues/47)
+                required uint32 extent = 5 [ default = 4096 ];
 
                 extensions 16 to max;
         }


### PR DESCRIPTION
- Reduce memory usage (raises protobuf-c requirement to 1.1).
- Improves performance when merging tiles (from parallel queries).
- Uses protobuf values to reduce the number of transformations and memory usage.
- Uses a temporal context when transforming data (reading rows) to have a fast way of cleaning up memory before the parallel process starts.
- Processes texts and cstrings with each known reading functions instead of the `OidOutputFunctionCall` fallback.
- Avoids multiple hash function calls when a value is not found in the hash table (once for the lookup and once for the insertion).