### PR TITLE
Enforce protobuf-c dependency

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ Only tickets not included in 3.1.0alpha2
 
 * Breaking changes *
   - #4737, Bump minimum protobuf-c requirement to 1.1.0 (Raúl Marín)
+           The configure step will now fail if the requirement isn't
+           met or explicitly disabled (--without-protobuf)
 
 * New features *
   - #4698, Add a precision parameter to ST_AsEWKT (Raúl Marín)

--- a/configure.ac
+++ b/configure.ac
@@ -979,8 +979,7 @@ dnl Detect if protobuf-c installed
 dnl ===========================================================================
 
 CHECK_PROTOBUF=yes
-HAVE_PROTOBUF=yes
-HAVE_GEOBUF=no
+HAVE_PROTOBUF=no
 
 AC_ARG_WITH([protobuf],
 	[AS_HELP_STRING([--without-protobuf], [build without protobuf-c support])],
@@ -989,6 +988,7 @@ AC_ARG_WITH([protobuf],
 dnl User didn't turn OFF protobuf support so...
 if test "$CHECK_PROTOBUF" != "no"; then
 
+	HAVE_PROTOBUF=yes
 	dnl Need to find libdir, incdir and protoc-c compiler
 
 	CPPFLAGS_SAVE="$CPPFLAGS"
@@ -1036,13 +1036,13 @@ if test "$CHECK_PROTOBUF" != "no"; then
 
 	dnl confirm that discovered/configured include path works
 	AC_CHECK_HEADER([protobuf-c/protobuf-c.h], [],
-		AC_MSG_RESULT([unable to find protobuf-c/protobuf-c.h using $CPPFLAGS])
+		AC_MSG_ERROR([unable to find protobuf-c/protobuf-c.h using CPPFLAGS. You can disable MVT and Geobuf support using --without-protobuf])
 		HAVE_PROTOBUF=no
 	)
 
 	dnl confirm that discovered/configured library path works
 	AC_CHECK_LIB([protobuf-c], [protobuf_c_message_init], [],
-		AC_MSG_RESULT([unable to link protobuf-c using $LDFLAGS])
+		AC_MSG_ERROR([unable to link protobuf-c using $LDFLAGS. You can disable MVT and Geobuf support using --without-protobuf])
 		HAVE_PROTOBUF=no
 	)
 
@@ -1052,6 +1052,9 @@ if test "$CHECK_PROTOBUF" != "no"; then
 
 	AC_MSG_CHECKING([protobuf-c version])
 	AC_PROTOBUFC_VERSION([PROTOC_VERSION])
+        if test ! "$PROTOC_VERSION" -ge 1001000; then
+                AC_MSG_ERROR("Old protobuf-c release found but 1.1.0 is required. You can disable MVT and Geobuf support using --without-protobuf")
+        fi
 	AC_MSG_RESULT([$PROTOC_VERSION])
 
 	CPPFLAGS="$CPPFLAGS_SAVE"
@@ -1061,7 +1064,7 @@ if test "$CHECK_PROTOBUF" != "no"; then
 	dnl confirm that protobuf compiler is available
 	AC_PATH_PROG(PROTOCC, protoc-c)
 	if test -z "$PROTOCC"; then
-		AC_MSG_RESULT([Cannot find protoc-c protobuf compiler on the PATH: $PATH])
+		AC_MSG_ERROR([Cannot find protoc-c protobuf compiler on the PATH: $PATH. You can disable MVT and Geobuf support using --without-protobuf])
 		HAVE_PROTOBUF=no
 	fi
 
@@ -1069,15 +1072,14 @@ if test "$CHECK_PROTOBUF" != "no"; then
         if test "$HAVE_PROTOBUF" = "yes"; then
 		AC_DEFINE([HAVE_LIBPROTOBUF], [1], [Define to 1 if libprotobuf-c is present])
 		AC_DEFINE_UNQUOTED([LIBPROTOBUF_VERSION], [$PROTOC_VERSION], [Numeric version number for libprotobuf-c])
-		AC_DEFINE([HAVE_GEOBUF], [1], [Define to 1 if geobuf is present])
-		HAVE_GEOBUF=yes
-	fi
+	else
+                AC_MSG_ERROR("Missing protobuf-c support. You can disable MVT and Geobuf support using --without-protobuf")
+        fi
 
-    AC_SUBST([HAVE_PROTOBUF])
-    AC_SUBST([HAVE_GEOBUF])
-    AC_SUBST([PROTOC_VERSION])
-    AC_SUBST([PROTOBUF_CPPFLAGS])
-    AC_SUBST([PROTOBUF_LDFLAGS])
+        AC_SUBST([HAVE_PROTOBUF])
+        AC_SUBST([PROTOC_VERSION])
+        AC_SUBST([PROTOBUF_CPPFLAGS])
+        AC_SUBST([PROTOBUF_LDFLAGS])
 
 fi
 

--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -58,10 +58,7 @@ SPGIST_OBJ= gserialized_spgist_2d.o gserialized_spgist_3d.o gserialized_spgist_n
 endif
 
 ifeq (@HAVE_PROTOBUF@,yes)
-PROTOBUF_OBJ = vector_tile.pb-c.o
-ifeq (@HAVE_GEOBUF@,yes)
-PROTOBUF_OBJ += geobuf.pb-c.o
-endif
+PROTOBUF_OBJ = vector_tile.pb-c.o geobuf.pb-c.o
 UTHASH_INCLUDE = -I../deps/uthash/include
 endif
 
@@ -231,10 +228,8 @@ geobuf.pb-c.c geobuf.pb-c.h: geobuf.proto
 ifeq (@HAVE_PROTOBUF@,yes)
 lwgeom_out_mvt.o: vector_tile.pb-c.h
 mvt.o: vector_tile.pb-c.h
-ifeq (@HAVE_GEOBUF@,yes)
 lwgeom_out_geobuf.o: geobuf.pb-c.h
 geobuf.o: geobuf.pb-c.h
-endif
 endif
 
 # Borrow the $libdir substitution from PGXS but customise by running the preprocessor

--- a/postgis/geobuf.c
+++ b/postgis/geobuf.c
@@ -26,7 +26,7 @@
 #include "geobuf.h"
 #include "pgsql_compat.h"
 
-#if defined HAVE_LIBPROTOBUF && defined HAVE_GEOBUF
+#if defined HAVE_LIBPROTOBUF
 
 #define FEATURES_CAPACITY_INITIAL 50
 #define MAX_PRECISION 1e6

--- a/postgis/geobuf.h
+++ b/postgis/geobuf.h
@@ -42,7 +42,7 @@
 #include "lwgeom_pg.h"
 #include "lwgeom_log.h"
 
-#if defined HAVE_LIBPROTOBUF && defined HAVE_GEOBUF
+#if defined HAVE_LIBPROTOBUF
 
 #include "geobuf.pb-c.h"
 

--- a/postgis/lwgeom_out_geobuf.c
+++ b/postgis/lwgeom_out_geobuf.c
@@ -45,8 +45,8 @@
 PG_FUNCTION_INFO_V1(pgis_asgeobuf_transfn);
 Datum pgis_asgeobuf_transfn(PG_FUNCTION_ARGS)
 {
-#if ! (defined HAVE_LIBPROTOBUF && defined HAVE_GEOBUF)
-	elog(ERROR, "ST_AsGeobuf: Missing libprotobuf-c >= version 1.1");
+#if !(defined HAVE_LIBPROTOBUF)
+	elog(ERROR, "ST_AsGeobuf: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	MemoryContext aggcontext;
@@ -82,8 +82,8 @@ Datum pgis_asgeobuf_transfn(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(pgis_asgeobuf_finalfn);
 Datum pgis_asgeobuf_finalfn(PG_FUNCTION_ARGS)
 {
-#if ! (defined HAVE_LIBPROTOBUF && defined HAVE_GEOBUF)
-	elog(ERROR, "ST_AsGeoBuf: Missing libprotobuf-c >= version 1.1");
+#if !(defined HAVE_LIBPROTOBUF)
+	elog(ERROR, "ST_AsGeobuf: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	uint8_t *buf;

--- a/postgis/lwgeom_out_mvt.c
+++ b/postgis/lwgeom_out_mvt.c
@@ -42,7 +42,7 @@ PG_FUNCTION_INFO_V1(ST_AsMVTGeom);
 Datum ST_AsMVTGeom(PG_FUNCTION_ARGS)
 {
 #ifndef HAVE_LIBPROTOBUF
-	elog(ERROR, "Missing libprotobuf-c");
+	elog(ERROR, "ST_AsMVTGeom: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	GBOX *bounds = NULL;
@@ -126,7 +126,7 @@ PG_FUNCTION_INFO_V1(pgis_asmvt_transfn);
 Datum pgis_asmvt_transfn(PG_FUNCTION_ARGS)
 {
 #ifndef HAVE_LIBPROTOBUF
-	elog(ERROR, "Missing libprotobuf-c");
+	elog(ERROR, "ST_AsMVT: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	MemoryContext aggcontext, old_context;
@@ -181,7 +181,7 @@ PG_FUNCTION_INFO_V1(pgis_asmvt_finalfn);
 Datum pgis_asmvt_finalfn(PG_FUNCTION_ARGS)
 {
 #ifndef HAVE_LIBPROTOBUF
-	elog(ERROR, "Missing libprotobuf-c");
+	elog(ERROR, "ST_AsMVT: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	mvt_agg_context *ctx;
@@ -207,7 +207,7 @@ PG_FUNCTION_INFO_V1(pgis_asmvt_serialfn);
 Datum pgis_asmvt_serialfn(PG_FUNCTION_ARGS)
 {
 #ifndef HAVE_LIBPROTOBUF
-	elog(ERROR, "Missing libprotobuf-c");
+	elog(ERROR, "ST_AsMVT: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	mvt_agg_context *ctx;
@@ -237,7 +237,7 @@ PG_FUNCTION_INFO_V1(pgis_asmvt_deserialfn);
 Datum pgis_asmvt_deserialfn(PG_FUNCTION_ARGS)
 {
 #ifndef HAVE_LIBPROTOBUF
-	elog(ERROR, "Missing libprotobuf-c");
+	elog(ERROR, "ST_AsMVT: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	MemoryContext aggcontext, oldcontext;
@@ -258,7 +258,7 @@ PG_FUNCTION_INFO_V1(pgis_asmvt_combinefn);
 Datum pgis_asmvt_combinefn(PG_FUNCTION_ARGS)
 {
 #ifndef HAVE_LIBPROTOBUF
-	elog(ERROR, "Missing libprotobuf-c");
+	elog(ERROR, "ST_AsMVT: Compiled without protobuf-c support");
 	PG_RETURN_NULL();
 #else
 	MemoryContext aggcontext, oldcontext;

--- a/postgis/postgis_libprotobuf.c
+++ b/postgis/postgis_libprotobuf.c
@@ -14,7 +14,7 @@
 PG_FUNCTION_INFO_V1(postgis_libprotobuf_version);
 Datum postgis_libprotobuf_version(PG_FUNCTION_ARGS)
 {
-#ifdef HAVE_PROTOBUF_C_VERSION
+#ifdef HAVE_LIBPROTOBUF
 	const char *ver = protobuf_c_version();
 	text *result = cstring_to_text(ver);
 	PG_RETURN_POINTER(result);

--- a/postgis_config.h.in
+++ b/postgis_config.h.in
@@ -41,14 +41,8 @@
 /* Define to 1 if libprotobuf-c is present */
 #undef HAVE_LIBPROTOBUF
 
-/* Define to 1 if protobuf_c_version() is present */
-#undef HAVE_PROTOBUF_C_VERSION
-
 /* Numeric version number for libprotobuf */
 #undef LIBPROTOBUF_VERSION
-
-/* Define to 1 if libprotobuf-c is >= version 1.1 */
-#undef HAVE_GEOBUF
 
 /* Define to 1 if libjson is present */
 #undef HAVE_LIBJSON

--- a/regress/core/Makefile.in
+++ b/regress/core/Makefile.in
@@ -227,11 +227,8 @@ ifeq (@HAVE_PROTOBUF@,yes)
 	# ST_AsMVT, ST_AsGeobuf
 	TESTS += \
 		mvt \
-		mvt_jsonb
-ifeq (@HAVE_GEOBUF@,yes)
-	TESTS += \
+		mvt_jsonb \
 		geobuf
-endif
 endif
 
 all install uninstall:


### PR DESCRIPTION
Unless explicitly disabled, enforce the dependency on libprotobuf-c >= 1.1.0.

Previously it would fail silently and disabled MVT support, which translated into end user complaints.