### PR TITLE
Handle MULTISURFACE without curves in st_simplifypreservetopology()

### DIFF
--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -513,11 +513,12 @@ LWGEOM2GEOS(const LWGEOM* lwgeom, uint8_t autofix)
 	case MULTIPOLYGONTYPE:
 	case TINTYPE:
 	case COLLECTIONTYPE:
+	case MULTISURFACETYPE: // a MULTISURFACE without any arcs, because if it had arcs it would have been converted to MULTIPOLYGON
 		if (lwgeom->type == MULTIPOINTTYPE)
 			geostype = GEOS_MULTIPOINT;
 		else if (lwgeom->type == MULTILINETYPE)
 			geostype = GEOS_MULTILINESTRING;
-		else if (lwgeom->type == MULTIPOLYGONTYPE)
+		else if (lwgeom->type == MULTIPOLYGONTYPE || lwgeom->type == MULTISURFACETYPE)
 			geostype = GEOS_MULTIPOLYGON;
 		else
 			geostype = GEOS_GEOMETRYCOLLECTION;


### PR DESCRIPTION
According to the documentation any geometry can be passed to st_simplifypreservetopology() 

Quote from https://postgis.net/docs/ST_SimplifyPreserveTopology.html
`Will actually do something only with (multi)lines and (multi)polygons but you can safely call it with any kind of geometry.`

but
`MultiSurface` generates an error

```
bgt_min=> select count(st_simplifypreservetopology(wkb_geometry,0.1)) from pand;
ERROR:  Unknown geometry type: 12 - MultiSurface
```

but

```
select st_simplifypreservetopology('SRID=4326;MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 0, 4 0, 4 4, 0 4, 0 0),(1 1, 3 3,
 3 1, 1 1)),((10 10, 14 12, 11 10, 10 10),(11 11, 11.5 11, 11 11.5, 11 11)))'::geometry,1);
``` 
works fine?

and

```
select st_simplifypreservetopology('MULTISURFACE(((178632.044 397744.007,178631.118 397743.786,178646.399 397679.574,178693.864 397690.889,178698.958 397669.487,178700.206 397669.784,178758.532 397683.689,178748.351 397726.468,178752.199 397727.384,178748.782 397741.904,178744.897 397740.98,178738.157 397769.303,178632.044 397744.007)))'::geometry,1);
```

fails

This PR adds `MULTISURFACETYPE` to the silently ignored types.