### PR TITLE
Disable forced static linking of liblwgeom

### DIFF
--- a/loader/Makefile.in
+++ b/loader/Makefile.in
@@ -44,7 +44,7 @@ ICONV_CFLAGS=@ICONV_CFLAGS@
 
 # liblwgeom
 LIBLWGEOM=../liblwgeom/liblwgeom.la
-LDFLAGS += -static $(LIBLWGEOM)
+LDFLAGS += $(LIBLWGEOM)
 
 # GTK includes and libraries
 GTK_CFLAGS = @GTK_CFLAGS@ @IGE_MAC_CFLAGS@


### PR DESCRIPTION
In case of shared libs build fails:
ld: cannot find -lgeos_c
ld: attempted static link of dynamic object `/usr/lib/libproj.so'