### PR TITLE
Add POSTGIS_DEBUG_LEVEL define to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1129,6 +1129,8 @@ else
     CPPFLAGS="-DNDEBUG $CPPFLAGS"
 fi
 
+AC_DEFINE([POSTGIS_DEBUG_LEVEL], [0], [Define debug level. Default 0])
+
 dnl ===========================================================================
 dnl Allow the developer to disable the automatic updates of postgis_revision.h
 dnl with --without-phony-revision


### PR DESCRIPTION
In case of using autoreconf "#define POSTGIS_DEBUG_LEVEL 0" is removed from postgis_config.h.in so build failed with undefined POSTGIS_DEBUG_LEVEL.