### PR TITLE
Tweak geodetic tolerance value to dodge another failure case. 

### DIFF
--- a/liblwgeom/cunit/cu_geodetic.c
+++ b/liblwgeom/cunit/cu_geodetic.c
@@ -1184,6 +1184,17 @@ static void test_lwgeom_distance_sphere(void)
 	spheroid_init(&s, 6378137.0, 6356752.314245179498);
 	s.a = s.b = s.radius;
 
+	/* Line/point #4835 */
+	lwg1 = lwgeom_from_wkt("LINESTRING (-166.11 68.875, 15.55 78.216667)", LW_PARSER_CHECK_NONE);
+	lwg2 = lwgeom_from_wkt("POINT (0 89.999)", LW_PARSER_CHECK_NONE);
+	d = lwgeom_distance_spheroid(lwg1, lwg2, &s, 0.0);
+	// printf("%12.9g\n", d);
+	// Wrong answer = 1310248.65
+	// Right answer = 25031.4956
+	CU_ASSERT_DOUBLE_EQUAL(d, 25031.4956, 0.1);
+	lwgeom_free(lwg1);
+	lwgeom_free(lwg2);
+
 	/* Line/line distance, 1 degree apart */
 	lwg1 = lwgeom_from_wkt("LINESTRING(-30 10, -20 5, -10 3, 0 1)", LW_PARSER_CHECK_NONE);
 	lwg2 = lwgeom_from_wkt("LINESTRING(-10 -5, -5 0, 5 0, 10 -5)", LW_PARSER_CHECK_NONE);

--- a/liblwgeom/lwgeodetic.c
+++ b/liblwgeom/lwgeodetic.c
@@ -702,7 +702,7 @@ edge_point_side(const GEOGRAPHIC_EDGE *e, const GEOGRAPHIC_POINT *p)
 	/* We expect the dot product of with normal with any vector in the plane to be zero */
 	w = dot_product(&normal, &pt);
 	LWDEBUGF(4,"dot product %.9g",w);
-	if ( FP_IS_ZERO(w) )
+	if (FP_IS_ZERO(w))
 	{
 		LWDEBUG(4, "point is on plane (dot product is zero)");
 		return 0;
@@ -816,7 +816,7 @@ int edge_point_in_cone(const GEOGRAPHIC_EDGE *e, const GEOGRAPHIC_POINT *p)
 	** for the test cases here.
 	** However, tuning the tolerance value feels like a dangerous hack.
 	** Fundamentally, the problem is that this test is so sensitive.
-	*/
+	 */
 
 	/* 1.1102230246251565404236316680908203125e-16 */
 

--- a/liblwgeom/lwgeodetic.h
+++ b/liblwgeom/lwgeodetic.h
@@ -40,7 +40,7 @@
 /* Override tolerance for geodetic */
 #ifdef FP_TOLERANCE
 #undef FP_TOLERANCE
-#define FP_TOLERANCE 1e-14
+#define FP_TOLERANCE 5e-14
 #endif
 
 extern int gbox_geocentric_slow;


### PR DESCRIPTION
Should bring double-double code in from GEOS to support higher precision work in geodetic code and avoid these issues. References #4835