### PR TITLE
added -Z option to prevent tables from being  analyzed

### DIFF
--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -1677,6 +1677,16 @@ AVERYLONGCOLUMNNAME DBFFIELD2</programlisting>
         </para>
       </listitem>
     </varlistentry>
+    <varlistentry>
+      <term>-Z</term>
+      <listitem>
+        <para>
+          When used, this flag will prevent the generation of <code>ANALYZE</code> statements.
+          Without the -Z flag (default behaviour), the <code>ANALYZE</code> statements will
+          be generated.
+        </para>
+      </listitem>
+    </varlistentry>
   </variablelist>
 
   <para>

--- a/loader/shp2pgsql-cli.c
+++ b/loader/shp2pgsql-cli.c
@@ -68,6 +68,7 @@ usage()
 	printf(_( "  -X <tablespace> Specify the tablespace for the table's indexes.\n"
                   "      This applies to the primary key, and the spatial index if\n"
                   "      the -I flag is used.\n" ));
+	printf(_( "  -Z  Prevent tables from being analyzed.\n" ));
 	printf(_( "  -?  Display this help screen.\n" ));
 	printf( "\n" );
 	printf(_( "  An argument of `--' disables further option processing.\n" ));
@@ -102,7 +103,7 @@ main (int argc, char **argv)
 	set_loader_config_defaults(config);
 
 	/* Keep the flag list alphabetic so it's easy to see what's left. */
-	while ((c = pgis_getopt(argc, argv, "-acdeg:ikm:nps:t:wDGIN:ST:W:X:")) != EOF)
+	while ((c = pgis_getopt(argc, argv, "-acdeg:ikm:nps:t:wDGIN:ST:W:X:Z")) != EOF)
 	{
 		// can not do this inside the switch case
 		if ('-' == c)
@@ -123,6 +124,10 @@ main (int argc, char **argv)
 
 		case 'G':
 			config->geography = 1;
+			break;
+
+		case 'Z':
+			config->analyze = 0;
 			break;
 
 		case 'S':

--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -763,6 +763,7 @@ set_loader_config_defaults(SHPLOADERCONFIG *config)
 	config->quoteidentifiers = 0;
 	config->forceint4 = 0;
 	config->createindex = 0;
+	config->analyze = 1;
 	config->readshape = 1;
 	config->force_output = FORCE_OUTPUT_DISABLE;
 	config->encoding = strdup(ENCODING_DEFAULT);
@@ -1925,13 +1926,17 @@ ShpLoaderGetSQLFooter(SHPLOADERSTATE *state, char **strfooter)
 		stringbuffer_aprintf(sb, "COMMIT;\n");
 	}
 
-	/* Always ANALYZE the resulting table, for better stats */
-	stringbuffer_aprintf(sb, "ANALYZE ");
-	if (state->config->schema)
+
+	if(state->config->analyze)
 	{
-		stringbuffer_aprintf(sb, "\"%s\".", state->config->schema);
+		/* Always ANALYZE the resulting table, for better stats */
+		stringbuffer_aprintf(sb, "ANALYZE ");
+		if (state->config->schema)
+		{
+			stringbuffer_aprintf(sb, "\"%s\".", state->config->schema);
+		}
+		stringbuffer_aprintf(sb, "\"%s\";\n", state->config->table);
 	}
-	stringbuffer_aprintf(sb, "\"%s\";\n", state->config->table);
 
 	/* Copy the string buffer into a new string, destroying the string buffer */
 	ret = (char *)malloc(strlen((char *)stringbuffer_getstring(sb)) + 1);

--- a/loader/shp2pgsql-core.h
+++ b/loader/shp2pgsql-core.h
@@ -114,6 +114,9 @@ typedef struct shp_loader_config
 	/* 0 = no index, 1 = create index after load */
 	int createindex;
 
+    /* 0 = don't analyze tables , 1 = analyze tables */
+	int analyze;
+
 	/* 0 = load DBF file only, 1 = load everything */
 	int readshape;
 

--- a/regress/loader/PointWithSchema.opts
+++ b/regress/loader/PointWithSchema.opts
@@ -1,2 +1,2 @@
 # Test loading a table with a schema.
--g the_geom {regdir}/loader/PointWithSchema pgreg.loadedshp
+-Z -g the_geom {regdir}/loader/PointWithSchema pgreg.loadedshp


### PR DESCRIPTION
Adding a new flag called -Z . When used, this flag will prevent the generation of ANALYZE statements. Without the -Z flag (default behaviour), the ANALYZE statements will be generated.