### PR TITLE
Fix typo in setting of INVMINDIST.

### DIFF
--- a/postgis/geography_measurement.c
+++ b/postgis/geography_measurement.c
@@ -45,7 +45,7 @@
 #define INVMINDIST 1.0e8
 #else
 /* round to 100 nm precision */
-#define INVMINDIST 1.0e9
+#define INVMINDIST 1.0e7
 #endif
 
 Datum geography_distance(PG_FUNCTION_ARGS);


### PR DESCRIPTION
This fixes an obvious typo since `100 nm = 100e-9 m = 1/1.0e7 m`.  This
only affects `!defined(PROJ_GEODESIC)` code which may not be active any
more.

However, to go back to the ticket #2168 that generated this `INVMINDIST`
hack...

The `defined(PROJ_GEODESIC)` code for geodesics is guaranteed to be
symmetric in the calculation of distances, i.e., `dist(A,B) = dist(B,A)`.  So it
would be better to avoid quantizing the distance calculation to fix a
non-existent problem.

Of course the length of a line string make change if it's reversed (just
from the properties of floating point addition).  However the hack is
still ill-advised.  If covers up the problem it most cases, but would
exacerbate it in a small fraction of cases.

I'm not making this change myself, because I'm not a direct user of
PostGIS.