### PR TITLE
Early exit if psql returns an error

### DIFF
--- a/regress/run_test.pl
+++ b/regress/run_test.pl
@@ -739,6 +739,10 @@ sub run_simple_test
           . " -c \"SET search_path TO public,$OPT_SCHEMA,topology\""
           . " -tXAq -f $sqlfile $DB > $outfile 2>&1";
 	my $rv = system($cmd);
+    if ( $rv ) {
+        fail "psql exited with an error", $outfile;
+        die;
+    }
 
 	# Check for ERROR lines
 	open(FILE, "$outfile");


### PR DESCRIPTION
Reduces the noise on backend crashes, like:
https://github.com/postgis/postgis/runs/3123818054?check_suite_focus=true