### PR TITLE
Upgrade path for address_standardizier_data_us and fix for upgrades as non-superuser via pgextwlist

### DIFF
--- a/extensions/address_standardizer/Makefile.in
+++ b/extensions/address_standardizer/Makefile.in
@@ -47,7 +47,7 @@ DATA_built = \
 
 all:  sql/address_standardizer.sql sql/address_standardizer--1.0--$(EXTVERSION).sql sql/$(EXTENSION)--$(EXTVERSION).sql sql/$(EXTENSION)--ANY--$(EXTVERSION).sql \
  sql/$(EXTENSION)_data_us.sql sql/address_standardizer--@POSTGIS_LIB_VERSION@.sql sql/$(EXTENSION)_data_us--@POSTGIS_LIB_VERSION@.sql  sql/$(EXTENSION)_data_us--$(EXTVERSION)--$(EXTVERSION)next.sql \
-sql/$(EXTENSION)_data_us--$(EXTVERSION)next--$(EXTVERSION).sql \
+sql/$(EXTENSION)_data_us--$(EXTVERSION)next--$(EXTVERSION).sql sql/$(EXTENSION)_data_us--ANY--$(EXTVERSION).sql \
 sql/test-init-extensions.sql sql/test-parseaddress.sql sql/test-standardize_address_1.sql sql/test-standardize_address_2.sql
 
 EXTRA_CLEAN = sql/
@@ -118,7 +118,20 @@ sql/$(EXTENSION)_data_us--$(EXTVERSION)next--$(EXTVERSION).sql: sql/$(EXTENSION)
 sql/$(EXTENSION)--ANY--$(EXTVERSION).sql: $(EXTENSION_UPGRADE_SCRIPTS)
 	cat $(EXTENSION_UPGRADE_SCRIPTS) > $@
 
+sql/$(EXTENSION)_data_us--ANY--$(EXTVERSION).sql: sql/$(EXTENSION)_data_us--$(EXTVERSION).sql
+	mkdir -p sql
+	cat $^ > $@
+
 include ../upgrade-paths-rules.mk
+
+install: install-upgrade-paths-data-us
+install-upgrade-paths-data-us:
+	# address_standardizer is already defined, we have to additionally create
+	# the upgrade path scripts for address_standardizer_data_us
+	tpl='$(EXTENSION)_data_us--ANY--$(EXTVERSION).sql'; \
+	for OLD_VERSION in $(UPGRADEABLE_VERSIONS); do \
+		ln -fs "$${tpl}" $(EXTDIR)/$(EXTENSION)_data_us--$$OLD_VERSION--$(EXTVERSION).sql; \
+	done
 
 mk-st-regexp: mk-st-regexp.pl
 	$(PERL) -c mk-st-regexp.pl


### PR DESCRIPTION
* address_standardizier_data_us: provide upgrade path scripts: for address standardizer_data_us so this extension can be upgraded and does not need to be dropped/recreated
* Convert _postgis_upgrade_info to a function -> we use pgextwlist and that sets a security context which prevents creating temporary tables (see e.g. https://github.com/dimitri/pgextwlist/issues/43)