### PR TITLE
Adjusted spelling of Neighbor and Behavior

### DIFF
--- a/doc/reference_operator.xml
+++ b/doc/reference_operator.xml
@@ -1918,7 +1918,7 @@ sphere for geographies.
 
 			<note><para>This operand will make use of 2D GiST indexes that may be available on the geometries.  It is different from other operators that use spatial indexes in that the spatial index is only used when the operator is in the ORDER BY clause.</para></note>
 			<note><para>Index only kicks in if one of the geometries is a constant (not in a subquery/cte).  e.g. 'SRID=3005;POINT(1011102 450541)'::geometry instead of a.geom</para></note>
-			<para>Refer to <ulink url="https://postgis.net/workshops/postgis-intro/knn.html">PostGIS workshop: Nearest-Neighbour Searching</ulink> for a detailed example.</para>
+			<para>Refer to <ulink url="https://postgis.net/workshops/postgis-intro/knn.html">PostGIS workshop: Nearest-Neighbor Searching</ulink> for a detailed example.</para>
 
 			 <para>Enhanced: 2.2.0 -- True KNN ("K nearest neighbor") behavior for geometry and geography for PostgreSQL 9.5+. Note for geography KNN is based on sphere rather than spheroid.  For PostgreSQL 9.4 and below, geography support is new but only supports centroid box.</para>
 			 <para>Changed: 2.2.0 -- For PostgreSQL 9.5 users, old Hybrid syntax may be slower, so you'll want to get rid of that hack if you are running your code only on PostGIS 2.2+ 9.5+.  See examples below.</para>

--- a/doc/reference_processing.xml
+++ b/doc/reference_processing.xml
@@ -95,7 +95,7 @@ This is only applicable to LINESTRING geometry and does not affect POINT or POLY
             It determines a planar spatial reference system that best fits the bounding box of the geography object
             (trying UTM, Lambert Azimuthal Equal Area (LAEA) North/South pole, and finally Mercator ).
             The buffer is computed in the planar space, and then transformed back to WGS84.
-            This may not produce the desired behaviour if the input object is much larger than a UTM zone or crosses the dateline
+            This may not produce the desired behavior if the input object is much larger than a UTM zone or crosses the dateline
             </para></note>
 
             <note><para>Buffer output is always a valid polygonal geometry.

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -6798,7 +6798,7 @@ WHERE rid = 2;
                         <paramdef choice="opt"><type>double precision </type> <parameter>gridy=NULL</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>skewx=0</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>skewy=0</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
 
@@ -6819,7 +6819,7 @@ WHERE rid = 2;
                         <funcdef>raster <function>ST_Resample</function></funcdef>
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef><type>raster </type> <parameter>ref</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                         <paramdef choice="opt"><type>boolean </type> <parameter>usescale=true</parameter></paramdef>
                     </funcprototype>
@@ -6829,7 +6829,7 @@ WHERE rid = 2;
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef><type>raster </type> <parameter>ref</parameter></paramdef>
                         <paramdef><type>boolean </type> <parameter>usescale</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
                 </funcsynopsis>
@@ -6907,7 +6907,7 @@ FROM (
                         <funcdef>raster <function>ST_Rescale</function></funcdef>
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>scalexy</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
 
@@ -6916,7 +6916,7 @@ FROM (
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>scalex</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>scaley</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
 
@@ -6988,7 +6988,7 @@ SELECT ST_PixelWidth(ST_Rescale(ST_AddBand(ST_MakeEmptyRaster(100, 100, 0, 0, 0.
                         <funcdef>raster <function>ST_Reskew</function></funcdef>
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>skewxy</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
 
@@ -6997,7 +6997,7 @@ SELECT ST_PixelWidth(ST_Rescale(ST_AddBand(ST_MakeEmptyRaster(100, 100, 0, 0, 0.
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>skewx</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>skewy</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
 
@@ -7061,7 +7061,7 @@ SELECT ST_Rotation(ST_Reskew(ST_AddBand(ST_MakeEmptyRaster(100, 100, 0, 0, 0.001
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>gridx</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>gridy</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>scalex=DEFAULT 0</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>scaley=DEFAULT 0</parameter></paramdef>
@@ -7074,7 +7074,7 @@ SELECT ST_Rotation(ST_Reskew(ST_AddBand(ST_MakeEmptyRaster(100, 100, 0, 0, 0.001
                         <paramdef><type>double precision </type> <parameter>gridy</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>scalex</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>scaley</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
 
@@ -7084,7 +7084,7 @@ SELECT ST_Rotation(ST_Reskew(ST_AddBand(ST_MakeEmptyRaster(100, 100, 0, 0, 0.001
                         <paramdef><type>double precision </type> <parameter>gridx</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>gridy</parameter></paramdef>
                         <paramdef><type>double precision </type> <parameter>scalexy</parameter></paramdef>
-                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbour</parameter></paramdef>
+                        <paramdef choice="opt"><type>text </type> <parameter>algorithm=NearestNeighbor</parameter></paramdef>
                         <paramdef choice="opt"><type>double precision </type> <parameter>maxerr=0.125</parameter></paramdef>
                     </funcprototype>
 

--- a/doc/reference_srs.xml
+++ b/doc/reference_srs.xml
@@ -246,13 +246,13 @@ CREATE INDEX idx_geom_26986_parcels
 
 	  </refsection>
 	  <refsection>
-		<title>Configuring transformation behaviour</title>
+		<title>Configuring transformation behavior</title>
 			<para>Sometimes coordinate transformation involving a grid-shift
 				can fail, for example if PROJ.4 has not been built with
 				grid-shift files or the coordinate does not lie within the
 				range for which the grid shift is defined. By default, PostGIS
 				will throw an error if a grid shift file is not present, but
-				this behaviour can be configured on a per-SRID basis either
+				this behavior can be configured on a per-SRID basis either
 				by testing different <varname>to_proj</varname> values of
 				PROJ.4 text, or altering the <varname>proj4text</varname> value
 				within the <varname>spatial_ref_sys</varname> table.

--- a/doc/reference_trajectory.xml
+++ b/doc/reference_trajectory.xml
@@ -4,7 +4,7 @@
     <abstract>
 			<para>These functions support working with trajectories.
 			A trajectory is a linear geometry with increasing measures (M value) on each coordinate.
-			Spatio-temporal data can be modelled by using relative times (such as the epoch)
+			Spatio-temporal data can be modeled by using relative times (such as the epoch)
 			as the measure values.
 			</para>
     </abstract>

--- a/doc/reference_type.xml
+++ b/doc/reference_type.xml
@@ -5,14 +5,14 @@
     <para>This section lists the custom PostgreSQL
 		data types installed by PostGIS to represent spatial data.
     </para>
-    <para>Each data type describes its type casting behaviour.
+    <para>Each data type describes its type casting behavior.
 		A <ulink url="https://www.postgresql.org/docs/current/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS">type cast</ulink>
 		converts values of one data type into another type.
 		PostgreSQL allows defining casting behavior for custom types, along with the functions used to convert type values.
-		Casts can have <emphasis role="bold">automatic</emphasis> behaviour,
+		Casts can have <emphasis role="bold">automatic</emphasis> behavior,
 		which allows automatic conversion of a function argument to a type supported by the function.</para>
 		<para>
-		Some casts have <emphasis role="bold">explicit</emphasis> behaviour,
+		Some casts have <emphasis role="bold">explicit</emphasis> behavior,
 		which means the cast must be specified using the syntax <varname>CAST(myval As sometype)</varname>
 		or <varname>myval::sometype</varname>.
 		Explicit casting avoids the issue of ambiguous casts,
@@ -39,7 +39,7 @@
 				the two-dimensional enclosing box of a geometry or collection of geometries.
 				For example, the <xref linkend="ST_Extent" /> aggregate function returns a <varname>box2d</varname> object.</para>
 				<para>The representation contains the values <varname>xmin, ymin, xmax, ymax</varname>.
-				These are the minimum and maxium values of the X and Y extents.
+				These are the minimum and maximum values of the X and Y extents.
 				</para>
       </refsection>
 
@@ -58,7 +58,7 @@
 
       <refsection>
         <title>Description</title>
-        <para><varname>box3d</varname> is a postgis spatial data type used to represent
+        <para><varname>box3d</varname> is a PostGIS spatial data type used to represent
 				the three-dimensional enclosing box of a geometry or collection of geometries.
 				For example, the <xref linkend="ST_3DExtent" /> aggregate function returns a <varname>box3d</varname> object.
 				</para>

--- a/doc/reference_version.xml
+++ b/doc/reference_version.xml
@@ -14,7 +14,7 @@
 		<refname>PostGIS_Extensions_Upgrade</refname>
 
 		<refpurpose>
-Packages and upgrades postgis extensions (e.g. postgis_raster,
+Packages and upgrades PostGIS extensions (e.g. postgis_raster,
 postgis_topology, postgis_sfcgal) to latest available version.
     </refpurpose>
 	  </refnamediv>
@@ -32,12 +32,12 @@ postgis_topology, postgis_sfcgal) to latest available version.
 	  <refsection>
 		<title>Description</title>
 
-		<para>Packages and upgrades postgis extensions
+		<para>Packages and upgrades PostGIS extensions
 		to latest version. Only extensions you have installed in the
     database will be packaged and upgraded if needed.
-		Reports full postgis version and build configuration infos after.
+		Reports full PostGIS version and build configuration infos after.
     This is short-hand for doing multiple CREATE EXTENSION .. FROM
-    unpackaged and ALTER EXTENSION .. UPDATE for each postgis extension.
+    unpackaged and ALTER EXTENSION .. UPDATE for each PostGIS extension.
 		Currently only tries to upgrade extensions postgis,
     postgis_raster, postgis_sfcgal, postgis_topology, and postgis_tiger_geocoder.</para>
 
@@ -84,7 +84,7 @@ NOTICE:  Extension postgis_tiger_geocoder is not available or not packagable for
 	  <refnamediv>
 		<refname>PostGIS_Full_Version</refname>
 
-		<refpurpose>Reports full postgis version and build configuration
+		<refpurpose>Reports full PostGIS version and build configuration
 		infos.</refpurpose>
 	  </refnamediv>
 
@@ -101,7 +101,7 @@ NOTICE:  Extension postgis_tiger_geocoder is not available or not packagable for
 	  <refsection>
 		<title>Description</title>
 
-		<para>Reports full postgis version and build configuration
+		<para>Reports full PostGIS version and build configuration
 		infos. Also informs about synchronization between
 		libraries and scripts suggesting upgrades as needed.</para>
 	  </refsection>
@@ -491,7 +491,7 @@ postgis_liblwgeom_version
 	  <refnamediv>
 		<refname>PostGIS_Scripts_Installed</refname>
 
-		<refpurpose>Returns version of the postgis scripts installed in this
+		<refpurpose>Returns version of the PostGIS scripts installed in this
 			database.</refpurpose>
 	  </refnamediv>
 
@@ -508,7 +508,7 @@ postgis_liblwgeom_version
 	  <refsection>
 		<title>Description</title>
 
-		<para>Returns version of the postgis scripts installed in this
+		<para>Returns version of the PostGIS scripts installed in this
 			database.</para>
 
 		<note>
@@ -544,7 +544,7 @@ postgis_liblwgeom_version
 		<refname>PostGIS_Scripts_Released</refname>
 
 		<refpurpose>Returns the version number of the postgis.sql script
-		released with the installed postgis lib.</refpurpose>
+		released with the installed PostGIS lib.</refpurpose>
 	  </refnamediv>
 
 	  <refsynopsisdiv>
@@ -561,7 +561,7 @@ postgis_liblwgeom_version
 		<title>Description</title>
 
 		<para>Returns the version number of the postgis.sql script
-		released with the installed postgis lib.</para>
+		released with the installed PostGIS lib.</para>
 
 		<note>
 		  <para>Starting with version 1.1.0 this function returns the same

--- a/doc/reporting.xml
+++ b/doc/reporting.xml
@@ -10,7 +10,7 @@
     developers to reproduce it, so it would ideally contain a script
     triggering it and every information regarding the environment in which it
     was detected. Good enough info can be extracted running <code>SELECT
-    postgis_full_version()</code> [for postgis] and <code>SELECT
+    postgis_full_version()</code> [for PostGIS] and <code>SELECT
     version()</code> [for postgresql].</para>
 
     <para>If you aren't using the latest release, it's worth taking a look at

--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -38,7 +38,7 @@
     <emphasis role="bold">spatial reference system</emphasis>
     indicating the coordinate system in which it is embedded.
     See <xref linkend="spatial_ref_sys" />.
-    The spatial reference system is identifed by a SRID number.
+    The spatial reference system is identified by a SRID number.
     In <emphasis role="bold">planar</emphasis> reference systems the X and Y coordinates typically
     represent easting and northing,
     while in <emphasis role="bold">geodetic</emphasis> systems
@@ -74,7 +74,7 @@
 
     <sect3 id="LineString">
         <title>LineString</title>
-        <para>A LineString is a 1-dimensional line formed by a contigous sequence of line segments.
+        <para>A LineString is a 1-dimensional line formed by a contiguous sequence of line segments.
         Each line segment is defined by two points, with the end point of one segment
         forming the start point of the next segment.
         A LineString must have at least two points.
@@ -125,7 +125,7 @@
 
     <sect3 id="GeometryCollection">
         <title>GeometryCollection</title>
-        <para>A GeometryCollection is a heterogenous (mixed) collection of geometries.</para>
+        <para>A GeometryCollection is a heterogeneous (mixed) collection of geometries.</para>
         <programlisting>GEOMETRYCOLLECTION ( POINT(2 3), LINESTRING(2 3,3 4))</programlisting>
     </sect3>
 
@@ -1795,7 +1795,7 @@ AVERYLONGCOLUMNNAME DBFFIELD2</programlisting>
       <listitem>
         <para>
           When used, this flag will prevent the generation of <code>ANALYZE</code> statements.
-          Without the -Z flag (default behaviour), the <code>ANALYZE</code> statements will
+          Without the -Z flag (default behavior), the <code>ANALYZE</code> statements will
           be generated.
         </para>
       </listitem>

--- a/doc/using_postgis_query.xml
+++ b/doc/using_postgis_query.xml
@@ -466,7 +466,7 @@ WHERE a.geom &amp;&amp; b.geom
     the bounding box operators
     (of which the most commonly used is <xref linkend="geometry_overlaps" />;
     see <xref linkend="operators-bbox" /> for the full list)
-    and the distance operators used in nearest-neighbour queries
+    and the distance operators used in nearest-neighbor queries
     (the most common being <xref linkend="geometry_distance_knn" />;
     see <xref linkend="operators-distance" /> for the full list.)
     </para>

--- a/doc/using_raster_dataman.xml
+++ b/doc/using_raster_dataman.xml
@@ -11,7 +11,7 @@
         The <varname>raster2pgsql</varname> is a raster loader executable that loads GDAL supported raster formats into sql suitable for loading into a PostGIS raster table.
         It is capable of loading folders of raster files as well as creating overviews of rasters. </para>
     <para>Since the raster2pgsql is compiled as part of PostGIS most often (unless you compile your own GDAL library), the raster types supported
-	by the executable will be the same as those compiled in the GDAL dependency library.  To get a list of raster types your particular raster2pgsql supports use the <varname>-G</varname> switch.  These should be the same as those provided by your PostGIS install documented here  <xref linkend="RT_ST_GDALDrivers" /> if you are using the same gdal library for both.</para>
+	by the executable will be the same as those compiled in the GDAL dependency library.  To get a list of raster types your particular raster2pgsql supports use the <varname>-G</varname> switch.  These should be the same as those provided by your PostGIS install documented here  <xref linkend="RT_ST_GDALDrivers" /> if you are using the same GDAL library for both.</para>
     <note>
 	<para>The older version of this tool was a python script.  The executable has replaced the python script.  If you still find the need for the Python script
         Examples of the python one can be found at <ulink url="http://trac.osgeo.org/gdal/wiki/frmts_wtkraster.html">GDAL PostGIS Raster Driver Usage</ulink>.
@@ -619,7 +619,7 @@ AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';</programlisting
    </sect1>
    <sect1 id="RT_Raster_Applications">
 		<title>Building Custom Applications with PostGIS Raster</title>
-		<para>The fact that PostGIS raster provides you with SQL functions to render rasters in known image formats gives  you a lot of optoins for rendering them.
+		<para>The fact that PostGIS raster provides you with SQL functions to render rasters in known image formats gives  you a lot of options for rendering them.
 		For example you can use OpenOffice / LibreOffice for rendering as demonstrated in <ulink url="http://www.postgresonline.com/journal/archives/244-Rendering-PostGIS-Raster-graphics-with-LibreOffice-Base-Reports.html">Rendering PostGIS Raster graphics with LibreOffice Base Reports</ulink>.  In addition you can use a wide variety of languages as demonstrated in this section.</para>
 		<sect2 id="RT_PHP_Output">
 			<title>PHP Example Outputting using ST_AsPNG in concert with other raster functions</title>


### PR DESCRIPTION
One hyperlink with neighbour was not changed and release_notes.xml did not have behaviour changed.  NB many raster functions allow a NearestNeighbor (english or american spelling) parameter.  That note remains as is.