### PR TITLE
Avoid failed matrix run to cancel others

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   linux:
     name: "CI"
     strategy:
+      fail-fast: false
       matrix:
         ci:
         # Use the last stable releases to run more tests


### PR DESCRIPTION
In some cases it can be very useful to know the results of all architectures.