### PR TITLE
Add cirrus_ci for FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,8 +5,8 @@ freebsd_instance:
 
 task:
   install_script:
-    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f ; pkg upgrade -y
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f
     - pkg install -y bison postgresql12-server gmake libxml2 autoconf automake libtool pkgconf iconv pcre proj gdal sfcgal geos libxslt cunit protobuf-c json-c postgresql12-contrib
 
   patch_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,41 @@
+freebsd_instance:
+  image: freebsd-12-2-release-amd64
+  cpu: 8
+  memory: 16G
+
+task:
+  timeout_in: 320m
+  sysinfo_script:
+    - mount
+    - df -h
+    - sysctl hw.model hw.ncpu hw.physmem
+    - freebsd-version
+
+  install_script:
+    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f ; pkg upgrade -y
+    - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+    - pkg install -y bison postgresql12-server gmake libxml2 autoconf automake libtool pkgconf iconv pcre proj gdal sfcgal geos libxslt cunit protobuf-c json-c postgresql12-contrib
+
+  patch_script:
+    # will be removed
+    - find . -name "*.pl" | xargs sed -i -r 's|/usr/bin/perl|/usr/bin/env perl|'
+  configure_script:
+    - ./autogen.sh
+    - ./configure PKG_CONFIG=/usr/local/bin/pkgconf CFLAGS="-isystem /usr/local/include -Wall -fno-omit-frame-pointer -Werror" LDFLAGS="-L/usr/local/lib" --with-libiconv-prefix=/usr/local --without-gui --without-interrupt-tests --with-topology --with-gdalconfig=/usr/local/bin/gdal-config --with-sfcgal=/usr/local/bin/sfcgal-config --with-address-standardizer --with-protobuf
+    - service postgresql oneinitdb
+    - service postgresql onestart
+    - su -l postgres -c "createuser -s `whoami`"
+  build_script:
+    - gmake -j8
+  check_script:
+    - gmake -j8 check
+    - gmake -j8 install
+    - gmake -j8 check RUNTESTFLAGS="-v --extension"
+    - gmake -j8 check RUNTESTFLAGS="-v --dumprestore"
+  matrix:
+    - name: freebsd12-amd64
+      freebsd_instance:
+          image: freebsd-12-2-release-amd64
+    - name: freebsd13-amd64
+      freebsd_instance:
+          image: freebsd-13-0-release-amd64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,13 +4,6 @@ freebsd_instance:
   memory: 16G
 
 task:
-  timeout_in: 320m
-  sysinfo_script:
-    - mount
-    - df -h
-    - sysctl hw.model hw.ncpu hw.physmem
-    - freebsd-version
-
   install_script:
     - ASSUME_ALWAYS_YES=yes pkg bootstrap -f ; pkg upgrade -y
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf


### PR DESCRIPTION
@robe2 [Cirrus ci] is a service that provides similar services as travis, GH action and many others BUT with [FreeBSD support](https://cirrus-ci.org/guide/FreeBSD/)

As I'm the postgis maintainer on FreeBSD, I have several scripts to test and deploy releases. For postgis, we have already bessie/bessie32 as a CI, but in this CI, I use latest pkg. I init this CI for myself, but if it can be useful for the project feel free to adopt it, or I keep it for me :)

Regards