### PR TITLE
minor change to st_asmvt doc

### DIFF
--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1277,8 +1277,8 @@ SELECT (ST_AsLatLonText('POINT (-302.2342342 -792.32498)'));
 		</para>
 
 		<para>
-		Tiles with multiple layers
-		can be created by concatenating multiple calls to this function	using <varname>||</varname>.
+		Tiles with multiple layers can be created by concatenating multiple calls to this function
+		using <varname>||</varname> or <varname>STRING_AGG</varname>.
 		</para>
 
 		<important>


### PR DESCRIPTION
The `||` operator implies concatenation of one row, but in many cases each row represents a separate layer - thus better to mention `STRING_AGG` as an alternative, and help those less familiar with SQL.

P.S. I am not certain if I need to run some doc regeneration for other files in `/po` dir.