### PR TITLE
remove gist decompress support function

### DIFF
--- a/postgis/geography.sql.in
+++ b/postgis/geography.sql.in
@@ -296,7 +296,9 @@ CREATE OPERATOR CLASS gist_geography_ops
 	FUNCTION        1        geography_gist_consistent (internal, geography, int4),
 	FUNCTION        2        geography_gist_union (bytea, internal),
 	FUNCTION        3        geography_gist_compress (internal),
+#if POSTGIS_PGSQL_VERSION < 110
 	FUNCTION        4        geography_gist_decompress (internal),
+#endif
 	FUNCTION        5        geography_gist_penalty (internal, internal, internal),
 	FUNCTION        6        geography_gist_picksplit (internal, internal),
 	FUNCTION        7        geography_gist_same (box2d, box2d, internal);

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -823,7 +823,9 @@ CREATE OPERATOR CLASS gist_geometry_ops_2d
 	FUNCTION        1        geometry_gist_consistent_2d (internal, geometry, int4),
 	FUNCTION        2        geometry_gist_union_2d (bytea, internal),
 	FUNCTION        3        geometry_gist_compress_2d (internal),
+#if POSTGIS_PGSQL_VERSION < 110
 	FUNCTION        4        geometry_gist_decompress_2d (internal),
+#endif
 	FUNCTION        5        geometry_gist_penalty_2d (internal, internal, internal),
 	FUNCTION        6        geometry_gist_picksplit_2d (internal, internal),
 	FUNCTION        7        geometry_gist_same_2d (geom1 geometry, geom2 geometry, internal);
@@ -1008,7 +1010,9 @@ CREATE OPERATOR CLASS gist_geometry_ops_nd
 	FUNCTION        1        geometry_gist_consistent_nd (internal, geometry, int4),
 	FUNCTION        2        geometry_gist_union_nd (bytea, internal),
 	FUNCTION        3        geometry_gist_compress_nd (internal),
+#if POSTGIS_PGSQL_VERSION < 110
 	FUNCTION        4        geometry_gist_decompress_nd (internal),
+#endif
 	FUNCTION        5        geometry_gist_penalty_nd (internal, internal, internal),
 	FUNCTION        6        geometry_gist_picksplit_nd (internal, internal),
 	FUNCTION        7        geometry_gist_same_nd (geometry, geometry, internal);


### PR DESCRIPTION
https://www.postgresql.org/message-id/flat/CAJEAwVELVx9gYscpE%3DBe6iJxvdW5unZ_LkcAaVNSeOwvdwtD%3DA%40mail.gmail.com

Decompress support function has become optional in gist since Postgres 11. This PR removes decompress for all gist implementation because they all are NOP in PostGIS. Also I observe 4-6% faster scan and build like mentioned in pgsql-hackers discussion.