### PR TITLE
getClosestEdge fails to use index

### DIFF
--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -3007,11 +3007,7 @@ cb_getClosestEdge( const LWT_BE_TOPOLOGY* topo, const LWPOINT* pt, uint64_t *num
 
   appendStringInfoString(sql, "SELECT ");
   addEdgeFields(sql, fields, 0);
-  appendStringInfo(sql, " FROM \"%s\".edge_data WHERE edge_id = COALESCE ( ", topo->name);
-  appendStringInfo(sql, "(SELECT  e1.edge_id FROM \"%s\".edge_data e1 WHERE geom && $1 ORDER BY e1.geom <-> $1 ASC, e1.edge_id LIMIT 1)", topo->name);
-  appendStringInfo(sql, ", ");
-  appendStringInfo(sql, "(SELECT  e1.edge_id FROM \"%s\".edge_data e1 ORDER BY e1.geom <-> $1 ASC, e1.edge_id LIMIT 1)", topo->name);
-  appendStringInfo(sql, " )");
+  appendStringInfo(sql, " FROM \"%s\".edge_data e1 ORDER BY e1.geom <-> $1 ASC LIMIT 1", topo->name);
 
   POSTGIS_DEBUGF(1, "cb_getClosestEdge query: %s", sql->data);
 

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -3007,7 +3007,11 @@ cb_getClosestEdge( const LWT_BE_TOPOLOGY* topo, const LWPOINT* pt, uint64_t *num
 
   appendStringInfoString(sql, "SELECT ");
   addEdgeFields(sql, fields, 0);
-  appendStringInfo(sql, " FROM \"%s\".edge_data ORDER BY geom <-> $1 ASC, edge_id ASC LIMIT 1", topo->name);
+  appendStringInfo(sql, " FROM \"%s\".edge_data WHERE edge_id = COALESCE ( ", topo->name);
+  appendStringInfo(sql, " (SELECT  edge_id FROM \"%s\".edge_data WHERE geom && $1 ORDER BY geom <-> $1 edge_id ASC LIMIT 1) ", topo->name);
+  appendStringInfo(sql, " , ");
+  appendStringInfo(sql, " (SELECT  edge_id FROM \"%s\".edge_data ORDER BY geom <-> $1 edge_id ASC LIMIT 1) ", topo->name);
+  appendStringInfo(sql, " ) ");
 
   POSTGIS_DEBUGF(1, "cb_getClosestEdge query: %s", sql->data);
 

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -3008,10 +3008,10 @@ cb_getClosestEdge( const LWT_BE_TOPOLOGY* topo, const LWPOINT* pt, uint64_t *num
   appendStringInfoString(sql, "SELECT ");
   addEdgeFields(sql, fields, 0);
   appendStringInfo(sql, " FROM \"%s\".edge_data WHERE edge_id = COALESCE ( ", topo->name);
-  appendStringInfo(sql, " (SELECT  edge_id FROM \"%s\".edge_data WHERE geom && $1 ORDER BY geom <-> $1 edge_id ASC LIMIT 1) ", topo->name);
-  appendStringInfo(sql, " , ");
-  appendStringInfo(sql, " (SELECT  edge_id FROM \"%s\".edge_data ORDER BY geom <-> $1 edge_id ASC LIMIT 1) ", topo->name);
-  appendStringInfo(sql, " ) ");
+  appendStringInfo(sql, "(SELECT  e1.edge_id FROM \"%s\".edge_data e1 WHERE geom && $1 ORDER BY e1.geom <-> $1 ASC, e1.edge_id LIMIT 1)", topo->name);
+  appendStringInfo(sql, ", ");
+  appendStringInfo(sql, "(SELECT  e1.edge_id FROM \"%s\".edge_data e1 ORDER BY e1.geom <-> $1 ASC, e1.edge_id LIMIT 1)", topo->name);
+  appendStringInfo(sql, " )");
 
   POSTGIS_DEBUGF(1, "cb_getClosestEdge query: %s", sql->data);
 


### PR DESCRIPTION
As the umber of edges increased in the database this part was consuming more and more time.

```
SELECT 

  (total_time / 1000 / 60) as total, 

  (total_time/calls) as avg,calls, 

  substring(replace(query, '  ', ' '),0,200) 

FROM pg_stat_statements 

ORDER BY 1 DESC 

LIMIT 100;





        total          |         avg          | calls |                                                                                                substring                                                                                                

------------------------+----------------------+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     126.96297004315011 |    6348.148502157505 |  1200 | SELECT edge_id,start_node,end_node,left_face,right_face,geom FROM "topo_ar5ngis_sysdata_webclient".edge_data ORDER BY geom <-> $1 ASC, edge_id ASC LIMIT 1



```

Here is the sample plan

```
EXPLAIN ANALYZE
SELECT
 edge_id,start_node,end_node,left_face,right_face,geom
FROM "topo_ar5ngis_sysdata_webclient".edge_data
ORDER BY geom <->
ST_SetSrid('POLYGON ((16.411088539068164 68.43083194373196, 16.411088539068164 68.457444977835, 16.465139252396938 68.457444977835, 16.465139252396938 68.43083194373196, 16.411088539068164 68.43083194373196))'::Geometry,4258)::geometry ASC,
edge_id ASC LIMIT 1
;





                                                                                                                          QUERY PLAN                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=2028441.01..2028441.13 rows=1 width=528) (actual time=4972.560..5439.936 rows=1 loops=1)
   ->  Gather Merge  (cost=2028441.01..2147814.75 rows=1023132 width=528) (actual time=4972.558..5439.932 rows=1 loops=1)
         Workers Planned: 2
         Workers Launched: 1
         ->  Sort  (cost=2027440.99..2028719.90 rows=511566 width=528) (actual time=4963.646..4963.647 rows=1 loops=2)
               Sort Key: ((geom <-> '0103000020A21000000100000005000000E50E37193D693040A81925C0921B5140E50E37193D69304054E14CC7461D51407821B55D1377304054E14CC7461D51407821B55D13773040A81925C0921B5140E50E37193D693040A81925C0921B5140'::geometry)), edge_id
               Sort Method: top-N heapsort  Memory: 25kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 25kB
               ->  Parallel Seq Scan on edge_data  (cost=0.00..2024883.16 rows=511566 width=528) (actual time=0.038..4722.584 rows=607531 loops=2)
 Planning Time: 0.158 ms
 Execution Time: 5439.985 ms
(11 rows)

Time: 5448.330 ms (00:05.448)


```

But using this new code it's many time faster.

```

 EXPLAIN ANALYZE
SELECT edge_id,start_node,end_node,left_face,right_face,geom 
FROM "topo_ar5ngis_sysdata_webclient".edge_data 
WHERE edge_id = COALESCE (
(SELECT  edge_id 
FROM "topo_ar5ngis_sysdata_webclient".edge_data 
WHERE geom && ST_SetSrid('POLYGON ((16.411088539068164 68.43083194373196, 16.411088539068164 68.457444977835, 16.465139252396938 68.457444977835, 16.465139252396938 68.43083194373196, 16.411088539068164 68.43083194373196))'::Geometry,4258)::geometry
ORDER BY geom <-> 
ST_SetSrid('POLYGON ((16.411088539068164 68.43083194373196, 16.411088539068164 68.457444977835, 16.465139252396938 68.457444977835, 16.465139252396938 68.43083194373196, 16.411088539068164 68.43083194373196))'::Geometry,4258)::geometry ASC, 
edge_id ASC LIMIT 1)
,
(SELECT  edge_id 
FROM "topo_ar5ngis_sysdata_webclient".edge_data 
ORDER BY geom <-> 
ST_SetSrid('POLYGON ((16.411088539068164 68.43083194373196, 16.411088539068164 68.457444977835, 16.465139252396938 68.457444977835, 16.465139252396938 68.43083194373196, 16.411088539068164 68.43083194373196))'::Geometry,4258)::geometry ASC, 
edge_id ASC LIMIT 1)
)
;
                                                                                                                                          QUERY PLAN                                                                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on edge_data  (cost=2325268.14..2325269.15 rows=1 width=524) (actual time=3.735..3.737 rows=1 loops=1)
   Recheck Cond: (edge_id = COALESCE($0, $2))
   Heap Blocks: exact=1
   InitPlan 1 (returns $0)
     ->  Limit  (cost=138.67..138.67 rows=1 width=12) (actual time=3.695..3.696 rows=1 loops=1)
           ->  Sort  (cost=138.67..138.81 rows=56 width=12) (actual time=3.694..3.694 rows=1 loops=1)
                 Sort Key: ((edge_data_1.geom <-> '0103000020A21000000100000005000000E50E37193D693040A81925C0921B5140E50E37193D69304054E14CC7461D51407821B55D1377304054E14CC7461D51407821B55D13773040A81925C0921B5140E50E37193D693040A81925C0921B5140'::geometry)), edge_data_1.edge_id
                 Sort Method: top-N heapsort  Memory: 25kB
                 ->  Index Scan using edge_gist on edge_data edge_data_1  (cost=0.41..138.39 rows=56 width=12) (actual time=0.172..3.487 rows=598 loops=1)
                       Index Cond: (geom && '0103000020A21000000100000005000000E50E37193D693040A81925C0921B5140E50E37193D69304054E14CC7461D51407821B55D1377304054E14CC7461D51407821B55D13773040A81925C0921B5140E50E37193D693040A81925C0921B5140'::geometry)
   InitPlan 2 (returns $2)
     ->  Limit  (cost=2325127.79..2325127.90 rows=1 width=12) (never executed)
           ->  Gather Merge  (cost=2325127.79..2499230.18 rows=1492202 width=12) (never executed)
                 Workers Planned: 2
                 Workers Launched: 0
                 ->  Sort  (cost=2324127.76..2325993.02 rows=746101 width=12) (never executed)
                       Sort Key: ((edge_data_2.geom <-> '0103000020A21000000100000005000000E50E37193D693040A81925C0921B5140E50E37193D69304054E14CC7461D51407821B55D1377304054E14CC7461D51407821B55D13773040A81925C0921B5140E50E37193D693040A81925C0921B5140'::geometry)), edge_data_2.edge_id
                       ->  Parallel Seq Scan on edge_data edge_data_2  (cost=0.00..2320397.26 rows=746101 width=12) (never executed)
   ->  Bitmap Index Scan on edge_data_pkey  (cost=0.00..1.56 rows=1 width=0) (actual time=3.724..3.724 rows=6 loops=1)
         Index Cond: (edge_id = COALESCE($0, $2))
 Planning Time: 0.419 ms
 Execution Time: 3.791 ms
(22 rows)

Time: 13.250 ms


```