### PR TITLE
Remove GEOS geometry validation from RT_ST_DumpAsPolygons

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PostGIS 3.3.0dev
   - Drop support for PostgreSQL 9.6 and 10 (Regina Obe)
   - Change output for WKT MULTIPOINT. All points now
     wrapped in parens. (Even Roualt)
+  - GH674, geometry validation and fixing is disabled for ST_DumpAsPolygons
+    so it works faster but might produce invalid polygons.
 
  * Enhancements *
   - #2861, Add index on topology.node(containing_face) speeding up


### PR DESCRIPTION
I would like to remove geometry validation from RT_ST_DumpAsPolygons and I see several reasons to do that:
- Removing GEOS validation and geometry fix calls makes RT_ST_DumpAsPolygons work 2.5x-3x faster for my data
- Since time this function was written GDAL seem to be improved and do better job at producing valid polygons

Also there will still be an option to call ST_MakeValid on output but performance of RT_ST_DumpAsPolygons itself will be better.