### PR TITLE
Speed up RASTER_Clip

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,7 @@ PostGIS 3.3.0dev
   - #4912, GiST: fix crash on STORAGE EXTERNAL for geography (Aliaksandr Kalenik)
   - ST_ConcaveHull GEOS 3.11+ native implementation (Paul Ramsey, Martin Davis)
   - GH678, Enable Link-Time Optimizations by default if supported (Sergei Shoulbakov)
+  - GH676, faster ST_Clip (Aliaksandr Kalenik)
 
  * New features *
   - #5116, Topology export/import scripts (Sandro Santilli)


### PR DESCRIPTION
These changes improve performance of raster clip by "inlining" of `rt_raster_iterator`. Although `rt_raster_iterator` is very useful generic function that allows to merge several rasters but as I discovered it's pretty inefficient in terms of memory usage when it comes to simple case like clipping (for example several separate allocations for every pixel in a band is pretty crazy). With this change I see 1.3x-1.7x speed up for my input data.