### PR TITLE
LTO enabled by default if supported; selecting ar, ranlib implementat…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,8 +26,15 @@ AC_CONFIG_MACRO_DIR([macros])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_PROG_INSTALL
 
-# Set default AR_FLAGS before libtool does
-: ${AR_FLAGS=rs}
+dnl Overwrite _LT_PROG_AR
+m4_pushdef([_LT_PROG_AR],
+  [: ${AR_FLAGS=rs}
+  PG_PROG_AR
+  PG_PROG_RANLIB
+  dnl Call original _LT_PROG_AR
+  m4_popdef([_LT_PROG_AR])
+  _LT_PROG_AR
+]) # _LT_PROG_AR
 
 dnl Invoke libtool: we do this as it is the easiest way to find the PIC
 dnl flags required to build liblwgeom
@@ -1168,6 +1175,9 @@ if test $ENABLE_DEBUG -eq 1; then
 else
     AC_DEFINE([PARANOIA_LEVEL], [0], [Disable use of memory checks])
     CPPFLAGS="-DNDEBUG $CPPFLAGS"
+
+    AC_LIBTOOL_COMPILER_OPTION([if $compiler supports -flto], [_cv_flto], [-flto], [], [CFLAGS="$CFLAGS -flto"], [])
+    AC_LIBTOOL_LINKER_OPTION([if $compiler supports -flto], [_cv_flto], [[-flto]], [LDFLAGS="$LDFLAGS -flto"])
 fi
 
 AC_DEFINE([POSTGIS_DEBUG_LEVEL], [0], [Define debug level. Default 0])

--- a/liblwgeom/varint.c
+++ b/liblwgeom/varint.c
@@ -140,6 +140,7 @@ varint_u64_decode(const uint8_t *the_start, const uint8_t *the_end, size_t *size
 		}
 	}
 	lwerror("%s: varint extends past end of buffer", __func__);
+	*size = 0;
 	return 0;
 }
 

--- a/macros/compiler-vendor.m4
+++ b/macros/compiler-vendor.m4
@@ -1,0 +1,56 @@
+dnl Selecting tool implementation based on compiler vendor
+
+dnl Wrap Autoconf check for whether GNU compiler is used
+AC_DEFUN([PG_LANG_COMPILER_GNU],
+[_AC_LANG_COMPILER_GNU])
+
+dnl Check if Clang compiler is used
+AC_DEFUN([PG_LANG_COMPILER_CLANG],
+[
+  AC_CACHE_CHECK([whether we are using Clang],
+    [ac_cv_[]_AC_LANG_ABBREV[]_compiler_clang],
+    [_AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[#ifndef __clang__
+      trigger error
+      #endif
+      ]])],
+      [pg_compiler_clang=yes],
+      [pg_compiler_clang=no])
+    ac_cv_[]_AC_LANG_ABBREV[]_compiler_clang=$pg_compiler_clang
+    ])
+  pg_compiler_clang=$ac_cv_[]_AC_LANG_ABBREV[]_compiler_clang
+])
+
+dnl Determine compiler vendor
+AC_DEFUN([PG_COMPILER_VENDOR],
+[
+  PG_LANG_COMPILER_CLANG
+  PG_LANG_COMPILER_GNU
+  pg_compiler_vendor=
+  if test "$pg_compiler_clang" = "yes"; then
+    pg_compiler_vendor="clang"
+  elif test "$ac_compiler_gnu" = "yes"; then
+    pg_compiler_vendor="gnu"
+  fi
+])
+
+dnl Select AR based on compiler
+AC_DEFUN([PG_PROG_AR],
+[
+  PG_COMPILER_VENDOR
+  case "$pg_compiler_vendor" in
+    "clang") AC_CHECK_TOOLS(AR, [llvm-ar ar], :) ;;
+    "gnu")   AC_CHECK_TOOLS(AR, [gcc-ar ar], :) ;;
+    *)       AC_CHECK_TOOL(AR, ar, :) ;;
+  esac
+])
+
+dnl Select RANLIB based on compiler
+AC_DEFUN([PG_PROG_RANLIB],
+[
+  PG_COMPILER_VENDOR
+  case "$pg_compiler_vendor" in
+    "clang") AC_CHECK_TOOLS(RANLIB, [llvm-ranlib ranlib], :) ;;
+    "gnu")   AC_CHECK_TOOLS(RANLIB, [gcc-ranlib ranlib], :) ;;
+    *)       AC_CHECK_TOOL(RANLIB, ranlib, :) ;;
+  esac
+])

--- a/raster/test/cunit/cu_raster_geometry.c
+++ b/raster/test/cunit/cu_raster_geometry.c
@@ -583,6 +583,7 @@ static void test_raster_get_pixel_bilinear() {
 	double ul_y = 0.0;
 	double scale_x = 1;
 	double scale_y = 1;
+	int err;
 
 	double xr, yr;
 	double igt[6];
@@ -623,14 +624,15 @@ static void test_raster_get_pixel_bilinear() {
 	rt_band_set_pixel(band, 1, 1, 40.0, NULL);
 
 
-	double value;
-	int nodata;
-	rt_band_get_pixel_bilinear(
+	double value = 0.0;
+	int nodata = 0;
+	err = rt_band_get_pixel_bilinear(
 		band,
 		xw, yw, // double xw, double yw,
 		&value, &nodata // double *r_value, int *r_nodata)
 		);
 
+	CU_ASSERT_EQUAL(err, ES_NONE);
 	printf("xw = %g, yw = %g, value = %g, nodata = %d\n", xr, yr, value, nodata);
 
 


### PR DESCRIPTION
…ion based on compiler vendor

Selecting `ar` (`llvm-ar`, `gcc-ar`) and `ranlib` (`llvg-ranlib`, `gcc-ranlib`) matching selected compiler for gcc and Clang.
This allows to enable LTO by default.