### PR TITLE
explicitly setting compliler in makefiles before including PGXS

### DIFF
--- a/extensions/address_standardizer/Makefile.in
+++ b/extensions/address_standardizer/Makefile.in
@@ -199,6 +199,7 @@ distclean: clean
 
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 PERL = @PERL@
 

--- a/extensions/postgis/Makefile.in
+++ b/extensions/postgis/Makefile.in
@@ -154,6 +154,7 @@ distclean: clean
 
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 PERL = @PERL@
 

--- a/extensions/postgis_raster/Makefile.in
+++ b/extensions/postgis_raster/Makefile.in
@@ -127,6 +127,7 @@ distclean: clean
 
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 PERL = @PERL@
 

--- a/extensions/postgis_sfcgal/Makefile.in
+++ b/extensions/postgis_sfcgal/Makefile.in
@@ -101,6 +101,7 @@ distclean: clean
 
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 PERL = @PERL@
 

--- a/extensions/postgis_tiger_geocoder/Makefile.in
+++ b/extensions/postgis_tiger_geocoder/Makefile.in
@@ -232,6 +232,7 @@ distclean: clean
 
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 PERL=@PERL@
 

--- a/extensions/postgis_topology/Makefile.in
+++ b/extensions/postgis_topology/Makefile.in
@@ -106,6 +106,7 @@ distclean: clean
 
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 PERL=@PERL@
 

--- a/loader/Makefile.in
+++ b/loader/Makefile.in
@@ -19,6 +19,7 @@
 # 'all' and 'install' targets with the ones we really want to use below.
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 
 top_builddir = @top_builddir@

--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -166,6 +166,7 @@ PGXS := @PGXS@
 # NO_TEMP_INSTALL is a workaround for a 9.5dev bug. See:
 # http://www.postgresql.org/message-id/CAB7nPqTsR5o3g-fBi6jbsVdhfPiLFWQ_0cGU5=94Rv_8W3qvFA@mail.gmail.com
 NO_TEMP_INSTALL=yes
+CUSTOM_CC := $(CC)
 include $(PGXS)
 
 srcdir := @srcdir@

--- a/raster/rt_pg/Makefile.in
+++ b/raster/rt_pg/Makefile.in
@@ -97,6 +97,7 @@ PGXS := @PGXS@
 # NO_TEMP_INSTALL is a workaround for a 9.5dev bug. See:
 # http://www.postgresql.org/message-id/CAB7nPqTsR5o3g-fBi6jbsVdhfPiLFWQ_0cGU5=94Rv_8W3qvFA@mail.gmail.com
 NO_TEMP_INSTALL=yes
+CUSTOM_CC := $(CC)
 include $(PGXS)
 
 VPATH = @srcdir@

--- a/sfcgal/Makefile.in
+++ b/sfcgal/Makefile.in
@@ -78,6 +78,7 @@ PGXS := @PGXS@
 # NO_TEMP_INSTALL is a workaround for a 9.5dev bug. See:
 # http://www.postgresql.org/message-id/CAB7nPqTsR5o3g-fBi6jbsVdhfPiLFWQ_0cGU5=94Rv_8W3qvFA@mail.gmail.com
 NO_TEMP_INSTALL=yes
+CUSTOM_CC := $(CC)
 include $(PGXS)
 
 VPATH := @srcdir@

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -70,6 +70,7 @@ PGXS := @PGXS@
 # NO_TEMP_INSTALL is a workaround for a 9.5dev bug. See:
 # http://www.postgresql.org/message-id/CAB7nPqTsR5o3g-fBi6jbsVdhfPiLFWQ_0cGU5=94Rv_8W3qvFA@mail.gmail.com
 NO_TEMP_INSTALL=yes
+CUSTOM_CC := $(CC)
 include $(PGXS)
 
 VPATH := @srcdir@

--- a/utils/Makefile.in
+++ b/utils/Makefile.in
@@ -24,6 +24,7 @@ DATA_built=postgis_restore.pl
 # PGXS information
 PG_CONFIG := @PG_CONFIG@
 PGXS := @PGXS@
+CUSTOM_CC := $(CC)
 include $(PGXS)
 
 VPATH := @srcdir@


### PR DESCRIPTION
Fixes a mismatch between LTO versions when explicitly setting `CC` in `./configure` by overwriting `CC` set in PGXS `Makefile.global`