### PR TITLE
enable 2d sortsupport function for postgres >= 15

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,7 @@ PostGIS 3.3.0dev
   - ST_ConcaveHull GEOS 3.11+ native implementation (Paul Ramsey, Martin Davis)
   - #4574, GH678, #5121 Enable Link-Time Optimizations using --enable-lto (Sergei Shoulbakov)
   - GH676, faster ST_Clip (Aliaksandr Kalenik)
+  - Fast GiST index build is enabled by default for PostgreSQL 15+ (Sergei Shoulbakov)
 
  * New features *
   - #5116, Topology export/import scripts (Sandro Santilli)

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -823,9 +823,13 @@ CREATE OPERATOR CLASS gist_geometry_ops_2d
 	OPERATOR        13       <-> FOR ORDER BY pg_catalog.float_ops,
 	OPERATOR        14       <#> FOR ORDER BY pg_catalog.float_ops,
 --
--- Note at 3.2: Sort support in bulk indexing not included in the
--- default opclass due to performance degredation in query
--- may be enabled in future versions.
+-- Sort support in bulk indexing not included in the default
+-- opclass for PostgreSQL versions <15 due to query performance
+-- degradation caused by GiST index page overlap.
+-- Since PostgreSQL 15 sorting build uses picksplit function to
+-- find better partitioning for index records. This allows to
+-- build indices performing similarly to those produced by default
+-- method while still reducing index build time significantly.
 --
 -- To enable sortsupport:
 --   alter operator family gist_geometry_ops_2d using gist
@@ -836,10 +840,9 @@ CREATE OPERATOR CLASS gist_geometry_ops_2d
 --   alter operator family gist_geometry_ops_2d using gist
 --     drop function 11 (geometry);
 --
--- #if POSTGIS_PGSQL_VERSION >= 140
---	FUNCTION        11       geometry_gist_sortsupport_2d (internal),
--- #endif
---
+#if POSTGIS_PGSQL_VERSION >= 150
+	FUNCTION        11       geometry_gist_sortsupport_2d (internal),
+#endif
 	FUNCTION        8        geometry_gist_distance_2d (internal, geometry, int4),
 	FUNCTION        1        geometry_gist_consistent_2d (internal, geometry, int4),
 	FUNCTION        2        geometry_gist_union_2d (bytea, internal),


### PR DESCRIPTION
PostgreSQL 15 uses opclass' `picksplit` function to find better partitioning for index records when building GiST index using sorted build method. This produces indices performing similarly to those built by default method while reducing build time by approx. 40%.

Previously `sortsupport` function had to be removed from `gist_geometry_ops_2d` opclass due to performance degradation: https://lists.osgeo.org/pipermail/postgis-devel/2021-November/029225.html

Postgres patch addressing this issue: https://commitfest.postgresql.org/36/3488/, please see Emails link for more details and benchmarking results.