### PR TITLE
using ExecutorStart_hook to reset interrupt flags

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -41,6 +41,7 @@ PostGIS 3.3.0dev
    - #5100, Support for PostgreSQL 15 (atoi removal) (Laurenz Albe)
    - #5123, PG15 now exposes json types and functions, no need
     to include for PG15+ (Regina Obe)
+   - #5137, resetting interrupt flags before query execution (Sergei Shoulbakov)
 
 
 PostGIS 3.2.0 (Olivier Courtin Edition)

--- a/deps/wagyu/lwgeom_wagyu.cpp
+++ b/deps/wagyu/lwgeom_wagyu.cpp
@@ -264,3 +264,9 @@ lwgeom_wagyu_interruptRequest()
 {
 	mapbox::geometry::wagyu::interrupt_request();
 }
+
+void
+lwgeom_wagyu_interruptReset()
+{
+    mapbox::geometry::wagyu::interrupt_reset();
+}

--- a/deps/wagyu/lwgeom_wagyu.h
+++ b/deps/wagyu/lwgeom_wagyu.h
@@ -59,6 +59,11 @@ const char *libwagyu_version();
  */
 void lwgeom_wagyu_interruptRequest();
 
+/**
+ * Cancels request to stop processing.
+ */
+void lwgeom_wagyu_interruptReset();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fix for "interrupt handler called in wrong query" https://trac.osgeo.org/postgis/ticket/5137

Interrupt flags for Postgis, Wagyu and GEOS can be left set after query is executed, causing next query to be "interrupted".
PostgreSQL ExecutorStart hook allows to reset this flags before executing a query.