### PR TITLE
[CI][Cirrus] Fix and update FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,11 +19,11 @@ task:
     - service postgresql oneinitdb
     - service postgresql onestart
     - su postgres -c "createuser -s `whoami`"
-    - gmake -j8
-    - gmake -j8 check
-    - gmake -j8 install
-    - gmake -j8 check RUNTESTFLAGS="-v --extension"
-    - gmake -j8 check RUNTESTFLAGS="-v --dumprestore"
+    - gmake -j8 || { service postgresql onestop; exit 1;}
+    - gmake -j8 check || { service postgresql onestop; exit 1;}
+    - gmake -j8 install || { service postgresql onestop; exit 1;}
+    - gmake -j8 check RUNTESTFLAGS="-v --extension" || { service postgresql onestop; exit 1;}
+    - gmake -j8 check RUNTESTFLAGS="-v --dumprestore" || { service postgresql onestop; exit 1;}
     - service postgresql onestop
 
   freebsd_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,35 +1,42 @@
-# freebsd_instance:
-#   image: freebsd-12-2-release-amd64
-#   cpu: 8
-#   memory: 16G
+task:
+  only_if: $BRANCH != 'master'
+  name: FreeBSD
+  alias: test-freebsd
+  env:
+    MAKE_FLAGS: -j 8
 
-# task:
-#   only_if: $BRANCH != 'master'
-#   install_script:
-#     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
-#     - ASSUME_ALWAYS_YES=yes pkg bootstrap -f
-#     - pkg install -y bison postgresql12-server gmake libxml2 autoconf automake libtool pkgconf iconv pcre proj gdal sfcgal geos libxslt cunit protobuf-c json-c postgresql12-contrib
+  install_script:
+    - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f
+    - pkg install -y bison postgresql13-server gmake libxml2 autoconf automake libtool pkgconf iconv pcre proj gdal sfcgal geos libxslt cunit protobuf-c json-c postgresql13-contrib
 
-#   patch_script:
-#     # will be removed
-#     - find . -name "*.pl" | xargs sed -i -r 's|/usr/bin/perl|/usr/bin/env perl|'
-#   configure_script:
-#     - ./autogen.sh
-#     - ./configure PKG_CONFIG=/usr/local/bin/pkgconf CFLAGS="-isystem /usr/local/include -Wall -fno-omit-frame-pointer -Werror" LDFLAGS="-L/usr/local/lib" --with-libiconv-prefix=/usr/local --without-gui --without-interrupt-tests --with-topology --without-raster  --with-sfcgal=/usr/local/bin/sfcgal-config --with-address-standardizer --with-protobuf
-#     - service postgresql oneinitdb
-#     - service postgresql onestart
-#     - su -l postgres -c "createuser -s `whoami`"
-#   build_script:
-#     - gmake -j8
-#   check_script:
-#     - gmake -j8 check
-#     - gmake -j8 install
-#     - gmake -j8 check RUNTESTFLAGS="-v --extension"
-#     - gmake -j8 check RUNTESTFLAGS="-v --dumprestore"
-#   matrix:
-#     - name: freebsd12-amd64
-#       freebsd_instance:
-#           image: freebsd-12-2-release-amd64
-#     - name: freebsd13-amd64
-#       freebsd_instance:
-#           image: freebsd-13-0-release-amd64
+  patch_script:
+    # will be removed
+    - find . -name "*.pl" | xargs sed -i -r 's|/usr/bin/perl|/usr/bin/env perl|'
+  build_script:
+    - ./autogen.sh
+    - ./configure PKG_CONFIG=/usr/local/bin/pkgconf CFLAGS="-isystem /usr/local/include -Wall -fno-omit-frame-pointer -Werror" LDFLAGS="-L/usr/local/lib" --with-libiconv-prefix=/usr/local --without-gui --without-interrupt-tests --with-topology --without-raster  --with-sfcgal=/usr/local/bin/sfcgal-config --with-address-standardizer --with-protobuf
+    - service postgresql oneinitdb
+    - service postgresql onestart
+    - su postgres -c "createuser -s `whoami`"
+    - gmake -j8
+    - gmake -j8 check
+    - gmake -j8 install
+    - gmake -j8 check RUNTESTFLAGS="-v --extension"
+    - gmake -j8 check RUNTESTFLAGS="-v --dumprestore"
+    - service postgresql onestop
+
+  freebsd_instance:
+    cpu: 8
+    memory: 24g
+  matrix:
+    # - name: 14-CURRENT
+    #   freebsd_instance:
+    #     image_family: freebsd-14-0-snap
+    - name: 13.1-RELEASE
+      freebsd_instance:
+        image_family: freebsd-13-1
+    - name: 12.3-RELEASE
+      freebsd_instance:
+        image_family: freebsd-12-3
+


### PR DESCRIPTION
There was two problems:

- `strerror_l@FBSD_1.6` it was an ABI problem, the package are for 12.3 and the CI was still at 12.2
- the build didn't stop: it's a [cirrus problem](https://github.com/cirruslabs/cirrus-ci-docs/issues/910). I have to stop postgresql's service to release the CI – but have to use only one script parts to configure and build.