### PR TITLE
std_pg_hash.c: fix cut/paste in IsInStdPortalCache

### DIFF
--- a/extensions/address_standardizer/std_pg_hash.c
+++ b/extensions/address_standardizer/std_pg_hash.c
@@ -226,8 +226,8 @@ IsInStdPortalCache(StdPortalCache *STDCache,  char *lextab, char *gaztab, char *
     for (i=0; i<STD_CACHE_ITEMS; i++) {
         StdCacheItem *ci = &STDCache->StdCache[i];
         if (ci->lextab && !strcmp(ci->lextab, lextab) &&
-            ci->lextab && !strcmp(ci->gaztab, gaztab) &&
-            ci->lextab && !strcmp(ci->rultab, rultab))
+            ci->gaztab && !strcmp(ci->gaztab, gaztab) &&
+            ci->rultab && !strcmp(ci->rultab, rultab))
                 return TRUE;
     }
 


### PR DESCRIPTION
ci->lextab is tested 3 times. I guess it's a cut/paste mistake and
should be replaced by the two other variables ci->gaztab and ci->rultab.