### PR TITLE
gserialized.c: Fix an always true condition

### DIFF
--- a/liblwgeom/gserialized.c
+++ b/liblwgeom/gserialized.c
@@ -367,7 +367,7 @@ int gserialized_cmp(const GSERIALIZED *g1, const GSERIALIZED *g2)
 		{
 			if (bsz1 < bsz2)
 				return -1;
-                        return 1;
+			return 1;
 		}
 
 		/* If SRID is not equal, sort on it */

--- a/liblwgeom/gserialized.c
+++ b/liblwgeom/gserialized.c
@@ -367,8 +367,7 @@ int gserialized_cmp(const GSERIALIZED *g1, const GSERIALIZED *g2)
 		{
 			if (bsz1 < bsz2)
 				return -1;
-			else if (bsz1 > bsz2)
-				return 1;
+                        return 1;
 		}
 
 		/* If SRID is not equal, sort on it */


### PR DESCRIPTION
At line 366 we always check that bsz1 is different than bsz2. So, if
bsz1 is not inferior to bsz2, it always true than bsz1 is superior to
bsz2.
We could remove the else if part and return 1.