### PR TITLE
gserialized1.c: fix a Null pointer dereference

### DIFF
--- a/liblwgeom/gserialized1.c
+++ b/liblwgeom/gserialized1.c
@@ -1465,8 +1465,11 @@ LWGEOM* lwgeom_from_gserialized1(const GSERIALIZED *g)
 
 	lwgeom = lwgeom_from_gserialized1_buffer(data_ptr, lwflags, &size);
 
-	if ( ! lwgeom )
+	if ( ! lwgeom ) 
+	{
 		lwerror("%s: unable create geometry", __func__); /* Ooops! */
+		return NULL;
+	}
 
 	lwgeom->type = lwtype;
 	lwgeom->flags = lwflags;


### PR DESCRIPTION
If lwgeom is NULL we write an error log thanks to lwerror.

However, lwgeom is used potentially NULL lines after.

This commit fix a potential crash returning NULL if lwgeom is NULL.