### PR TITLE
[CI] Bessie32, fix gcc rpath

### DIFF
--- a/ci/bessie32/postgis_regress.sh
+++ b/ci/bessie32/postgis_regress.sh
@@ -6,7 +6,7 @@ set -e
 sh autogen.sh
 CC=gcc11  \
 CXX=g++11 \
-CXXFLAGS="-O2 -pipe  -fstack-protector-strong -Wl,-rpath=/usr/local/lib/gcc8  -nostdinc++ -isystem /usr/include/c++/v1 -Wl,-rpath=/usr/local/lib/gcc11" \
+CXXFLAGS="-O2 -pipe  -fstack-protector-strong -Wl,-rpath=/usr/local/lib/gcc11  -nostdinc++ -isystem /usr/include/c++/v1 -Wl,-rpath=/usr/local/lib/gcc11" \
 CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-trunc" \
 export PATH=${PATH}:/usr/local:/usr/local/lib:/usr/local/bin
 sh autogen.sh


### PR DESCRIPTION
rpath was still with gcc v8.