### PR TITLE
raster/loader/Makefile.in: do not force static linking

### DIFF
--- a/raster/loader/Makefile.in
+++ b/raster/loader/Makefile.in
@@ -38,7 +38,7 @@ RASTER2PGSQL=raster2pgsql@EXESUFFIX@
 # PostgreSQL executable directory
 PGSQL_BINDIR=@PGSQL_BINDIR@
 
-LIBLWGEOM_LDFLAGS = -static $(top_builddir)/liblwgeom/liblwgeom.la
+LIBLWGEOM_LDFLAGS = $(top_builddir)/liblwgeom/liblwgeom.la
 LIBLWGEOM_CFLAGS = -I$(top_builddir)/liblwgeom -I$(top_srcdir)/liblwgeom
 LIBGDAL_CFLAGS=@LIBGDAL_CFLAGS@
 LIBGDAL_LDFLAGS=@LIBGDAL_LDFLAGS@


### PR DESCRIPTION
This is similar to commit
https://github.com/postgis/postgis/commit/98070faad220e12fcaed9a583a70a37c510b7c6b,
but applied to raster/loader. It ensures that if only shared variants
of the libraries are available, the link still works. If you force
-static and only shared variants of some of the libraries are
available, the link fails with "d: attempted static link of dynamic
object XYZ".

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>