### PR TITLE
ST_QuantizeCoordinates(): speed-up implementation

### DIFF
--- a/regress/core/quantize_coordinates.sql
+++ b/regress/core/quantize_coordinates.sql
@@ -11,4 +11,14 @@ SELECT 't5', ST_X(ST_QuantizeCoordinates('POINT (1.2345678 1.2345678)', 7, 4)) !
 -- Significant digits are preserved
 WITH input AS (SELECT ST_MakePoint(1.23456789012345, 0) AS geom)
 SELECT 't6', bool_and(abs(ST_X(geom)-ST_X(ST_QuantizeCoordinates(geom, i))) < pow(10, -i))
-FROM input, generate_series(1,15) AS i
+FROM input, generate_series(1,15) AS i;
+-- Test also negative precision
+WITH input AS (SELECT ST_MakePoint(-12345.6789012345, 0) AS geom)
+SELECT 't7', bool_and(abs(ST_X(geom)-ST_X(ST_QuantizeCoordinates(geom, i))) < pow(10, -i) AND abs(ST_X(geom)-ST_X(ST_QuantizeCoordinates(geom, i))) > pow(10, -i - 3))
+FROM input, generate_series(-4,10) AS i;
+-- Test NaN is preserved
+SELECT 't8', ST_X(ST_QuantizeCoordinates('POINT EMPTY', 7, 4)) IS NULL;
+-- Test that precision >= 18 fully preserves the number
+SELECT 't9', ST_X(ST_QuantizeCoordinates('POINT (1.234567890123456 0)', 18)) = ST_X('POINT (1.234567890123456 0)');
+-- Test very low precision
+SELECT 't10', abs(ST_X(ST_QuantizeCoordinates('POINT (1234567890123456 0)', -18)) - 1234567890123456) <= pow(10, 18);

--- a/regress/core/quantize_coordinates_expected
+++ b/regress/core/quantize_coordinates_expected
@@ -4,3 +4,7 @@ t3|t
 t4|t
 t5|t
 t6|t
+t7|t
+t8|t
+t9|t
+t10|t


### PR DESCRIPTION
We can completely avoid any floating-point computation by directly using the fact that the IEEE-754 representation of a floating point number contains the integral part of log2(abs(number)).
The improved trim_preserve_decimal_digits() function is ~ 7x times faster.