### PR TITLE
Include <math.h> for isnan

### DIFF
--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -15,6 +15,8 @@
 
 #include "../postgis_config.h"
 
+#include <math.h> /* for isnan */
+
 #include "shp2pgsql-core.h"
 #include "../liblwgeom/liblwgeom.h"
 #include "../liblwgeom/lwgeom_log.h" /* for LWDEBUG macros */


### PR DESCRIPTION
This avoids an implicit function declaration and a build failure with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
