### PR TITLE
[FreeBSD][CI] Update and fix CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,10 +35,6 @@ task:
     # - name: 14-CURRENT
     #   freebsd_instance:
     #     image_family: freebsd-14-0-snap
-    - name: 13.1-RELEASE
+    - name: 13.2-RELEASE
       freebsd_instance:
-        image_family: freebsd-13-1
-   # - name: 12.3-RELEASE
-   #   freebsd_instance:
-   #     image_family: freebsd-12-3
-
+        image_family: freebsd-13-2


### PR DESCRIPTION
FreeBSD 12.3 uses Clang 10 by default. However, there is a new warning flags: -Wnocompound-token-split-by-macro. But, this FreeBSD version will be EOL at 2023-12-31. So it doesn't worth to fix it. rm is a good fix.

BTW, update FreeBSD 13 to 13.2.