### PR TITLE
[macOS][CI] Add CI for macOS thanks to Cirrus-CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,3 +38,23 @@ task:
     - name: 13.2-RELEASE
       freebsd_instance:
         image_family: freebsd-13-2
+
+task:
+  name: macOS
+  alias: test-macos
+  test_script:
+    - brew update
+    - brew install autoconf automake libtool gpp pkg-config gdal geos json-c pcre2 postgresql@14 proj protobuf-c sfcgal cunit
+    - ./autogen.sh
+    - ./configure --without-gui --without-interrupt-tests --without-topology --without-raster  --with-sfcgal --with-address-standardizer --with-protobuf --with-pgconfig=/opt/homebrew/opt/postgresql@14/bin/pg_config
+    - brew services start postgresql@14
+    - postgres -V
+    - make -j8 || { brew services stop postgresql@14; exit 1;}
+    - make -j8 check || { brew services stop postgresql@14; exit 1;}
+    - brew services stop postgresql@14
+
+  matrix:
+    macos_instance:
+      image: ghcr.io/cirruslabs/macos-ventura-base:latest
+    macos_instance:
+      image: ghcr.io/cirruslabs/macos-monterey-base:latest


### PR DESCRIPTION
:tada: 

Finally, after a long break for me, I finished the macOs CI ; thanks to Cirrus.

However, I disabled the topology (cc @strk) build because of a strange error:

```
#/usr/bin/perl -0777 -ne 's/^(CREATE|ALTER) (CAST|OPERATOR|TYPE|TABLE|SCHEMA|DOMAIN|TRIGGER).*?;//msg;print;' topology.sql > topology_upgrade.sql.in
echo "BEGIN;" > topology_upgrade.sql
cat topology_before_upgrade.sql topology_upgrade.sql.in topology_after_upgrade.sql > topology_upgrade.sql
echo "COMMIT;" >> topology_upgrade.sql
9 warnings generated.
clang -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Werror=unguarded-availability-new -Wendif-labels -Wmissing-format-attribute -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -bundle -multiply_defined suppress -o postgis_topology-3.so postgis_topology.o -L/opt/homebrew/lib/postgresql@14  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -L/opt/homebrew/opt/openssl@1.1/lib -L/opt/homebrew/opt/readline/lib -L/opt/homebrew/Cellar/lz4/1.9.4/lib  -Wl,-dead_strip_dylibs   ../libpgcommon/libpgcommon.a ../liblwgeom/.libs/liblwgeom.a  -L/opt/homebrew/Cellar/geos/3.11.2/lib -lgeos_c -L/opt/homebrew/Cellar/proj/9.2.0/lib -lproj -L/opt/homebrew/Cellar/json-c/0.16/lib -ljson-c -L/opt/homebrew/Cellar/protobuf-c/1.4.1_1/lib -lprotobuf-c -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lxml2 -lz -lpthread -licucore -lm -L/opt/homebrew/Cellar/sfcgal/1.4.1_4/lib -lSFCGAL   -lm -L/opt/homebrew/Cellar/sfcgal/1.4.1_4/lib -lSFCGAL -bundle_loader /usr/local/bin/postgres
ld: file not found: /usr/local/bin/postgres
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [postgis_topology-3.so] Error 1
make: *** [all] Error 1
Stopping `postgresql@14`... (might take a while)
==> Successfully stopped `postgresql@14` (label: homebrew.mxcl.postgresql@14)
```