### PR TITLE
Reduce the size of the chunked HTML manual main table of contents

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -95,6 +95,7 @@ XSLTPROC_COMMONOPTS= \
 	--param section.label.includes.component.label 1 \
 	--param chunk.section.depth 0 \
 	--param generate.section.toc.level 2 \
+	--param toc.section.depth 1 \
 	--param funcsynopsis.style kr \
 	--param admon.graphics 1 \
 	--param admon.textlabel 0 \


### PR DESCRIPTION
Since [1] reference entries have been included in the main table of contents as level 2 information. Stop this by setting the TOC depth to 1.

[1]
acdfda8ec ("Convert PostGIS manual to DocBook 5.0", 2023-07-14)