### PR TITLE
Allow promoting column as an id in ST_AsGeoJsonRow

### DIFF
--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -623,6 +623,7 @@ F000000000000000000000000000000000000000000000000');
 				<paramdef choice="opt"><type>text </type> <parameter>geom_column=""</parameter></paramdef>
 				<paramdef choice="opt"><type>integer </type> <parameter>maxdecimaldigits=9</parameter></paramdef>
 				<paramdef choice="opt"><type>boolean </type> <parameter>pretty_bool=false</parameter></paramdef>
+                <paramdef choice="opt"><type>text </type> <parameter>id_column=''</parameter></paramdef>
 			</funcprototype>
 			<funcprototype>
 				<funcdef>text <function>ST_AsGeoJSON</function></funcdef>
@@ -703,6 +704,8 @@ Conversely, passing the parameter will save column type lookups.
 			  </itemizedlist>
 			</para>
 
+            <para>The <varname>id_column</varname> parameter is used to set the "id" member of the returned GeoJSON features. As per GeoJSON RFC, this SHOULD be used whenever a feature has a commonly used identifier, such as a primary key. When not specified, the produced features will not get an "id" member and any columns other than the geometry, including any potential keys, will just end up inside the feature’s "properties" member.</para>
+
             <para>The GeoJSON specification states that polygons are oriented using the Right-Hand Rule,
             and some clients require this orientation.
             This can be ensured by using <xref linkend="ST_ForcePolygonCCW"/>.
@@ -727,6 +730,7 @@ Conversely, passing the parameter will save column type lookups.
 			<para role="changed" conformance="2.0.0">Changed: 2.0.0 support default args and named args.</para>
 			<para role="changed" conformance="3.0.0">Changed: 3.0.0 support records as input</para>
 			<para role="changed" conformance="3.0.0">Changed: 3.0.0 output SRID if not EPSG:4326.</para>
+            <para role="changed" conformance="3.5.0">Changed: 3.5.0 allow specifying the column containing the feature id</para>
 			<para>&Z_support;</para>
 	  </refsection>
 
@@ -736,34 +740,20 @@ Conversely, passing the parameter will save column type lookups.
 <para>Generate a FeatureCollection:</para>
 <programlisting>SELECT json_build_object(
     'type', 'FeatureCollection',
-    'features', json_agg(ST_AsGeoJSON(t.*)::json)
+    'features', json_agg(ST_AsGeoJSON(t.*, id_column => 'id')::json)
     )
 FROM ( VALUES (1, 'one', 'POINT(1 1)'::geometry),
               (2, 'two', 'POINT(2 2)'),
               (3, 'three', 'POINT(3 3)')
      ) as t(id, name, geom);</programlisting>
-<screen>{"type" : "FeatureCollection", "features" : [{"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "properties": {"id": 1, "name": "one"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[2,2]}, "properties": {"id": 2, "name": "two"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[3,3]}, "properties": {"id": 3, "name": "three"}}]}</screen>
+<screen>{"type" : "FeatureCollection", "features" : [{"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "id": 1, "properties": {"name": "one"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[2,2]}, "id": 2, "properties": {"name": "two"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[3,3]}, "id": 3, "properties": {"name": "three"}}]}</screen>
 
 <para>Generate a Feature:</para>
-		<programlisting>SELECT ST_AsGeoJSON(t.*)
+		<programlisting>SELECT ST_AsGeoJSON(t.*, id_column => 'id')
 FROM (VALUES (1, 'one', 'POINT(1 1)'::geometry)) AS t(id, name, geom);</programlisting>
 <screen>                                                  st_asgeojson
 -----------------------------------------------------------------------------------------------------------------
- {"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "properties": {"id": 1, "name": "one"}}
-</screen>
-
-<para>An alternate way to generate Features with an <varname>id</varname> property
-is to use JSONB functions and operators:</para>
-		<programlisting>SELECT jsonb_build_object(
-    'type',       'Feature',
-    'id',         id,
-    'geometry',   ST_AsGeoJSON(geom)::jsonb,
-    'properties', to_jsonb( t.* ) - 'id' - 'geom'
-    ) AS json
-FROM (VALUES (1, 'one', 'POINT(1 1)'::geometry)) AS t(id, name, geom);</programlisting>
-<screen>                                                  json
------------------------------------------------------------------------------------------------------------------
- {"id": 1, "type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"name": "one"}}
+ {"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "id": 1, "properties": {"name": "one"}}
 </screen>
 
 <para>Don't forget to transform your data to WGS84 longitude, latitude to conform with the GeoJSON specification:</para>

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -5053,7 +5053,8 @@ CREATE OR REPLACE FUNCTION ST_AsGeoJson(geom geometry, maxdecimaldigits integer 
 	_COST_MEDIUM;
 
 -- Availability: 3.0.0
-CREATE OR REPLACE FUNCTION ST_AsGeoJson(r record, geom_column text DEFAULT '', maxdecimaldigits integer DEFAULT 9, pretty_bool bool DEFAULT false)
+-- Changed: 3.5.0 add id_column='' parameter
+CREATE OR REPLACE FUNCTION ST_AsGeoJson(r record, geom_column text DEFAULT '', maxdecimaldigits integer DEFAULT 9, pretty_bool bool DEFAULT false, id_column text DEFAULT '')
 	RETURNS text
 	AS 'MODULE_PATHNAME','ST_AsGeoJsonRow'
 	LANGUAGE 'c' STABLE STRICT PARALLEL SAFE

--- a/postgis/postgis_before_upgrade.sql
+++ b/postgis/postgis_before_upgrade.sql
@@ -173,3 +173,9 @@ BEGIN
 END;
 $$;
 
+-- FUNCTION ST_AsGeoJson added `id_column` optional argument in 3.5.0.
+SELECT _postgis_drop_function_by_identity
+	(
+	'ST_AsGeoJson',
+	'r record, geom_column text, maxdecimaldigits integer, pretty_bool boolean'
+	);

--- a/regress/core/out_geojson.sql
+++ b/regress/core/out_geojson.sql
@@ -35,6 +35,9 @@ SELECT 'gj03', i, to_json(g.*) AS rj3
 SELECT 'gj04', i, to_jsonb(g.*) AS rj4
 	FROM g ORDER BY i;
 
+SELECT 'gj05', i, ST_AsGeoJSON(g.*, id_column => 'i') AS gj5
+	FROM g ORDER BY i;
+
 SELECT '4695', ST_ASGeoJSON(a.*) FROM
 (
     SELECT 1 as v, ST_SetSRID(ST_Point(0,1),2227) as g

--- a/regress/core/out_geojson_expected
+++ b/regress/core/out_geojson_expected
@@ -27,4 +27,11 @@ gj04|4|{"d": "2004-04-04", "f": 4.4, "g": {"type": "GeometryCollection", "geomet
 gj04|5|{"d": "2005-05-05", "f": 5.5, "g": {"type": "Point", "coordinates": []}, "i": 5, "t": "five"}
 gj04|6|{"d": "2006-06-06", "f": 6.6, "g": null, "i": 6, "t": "six"}
 gj04|7|{"d": "2007-07-07", "f": 7.7, "g": {"type": "GeometryCollection", "geometries": [{"type": "Point", "coordinates": []}, {"type": "Point", "coordinates": [1, 2]}]}, "i": 7, "t": "seven"}
+gj05|1|{"type": "Feature", "geometry": {"type":"Point","coordinates":[42,42]}, "id": 1, "properties": {"f": 1.1, "t": "one", "d": "2001-01-01"}}
+gj05|2|{"type": "Feature", "geometry": {"type":"LineString","coordinates":[[42,42],[45,45]]}, "id": 2, "properties": {"f": 2.2, "t": "two", "d": "2002-02-02"}}
+gj05|3|{"type": "Feature", "geometry": {"type":"Polygon","coordinates":[[[42,42],[45,45],[45,42],[42,42]]]}, "id": 3, "properties": {"f": 3.3, "t": "three", "d": "2003-03-03"}}
+gj05|4|{"type": "Feature", "geometry": {"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[42,42]}]}, "id": 4, "properties": {"f": 4.4, "t": "four", "d": "2004-04-04"}}
+gj05|5|{"type": "Feature", "geometry": {"type":"Point","coordinates":[]}, "id": 5, "properties": {"f": 5.5, "t": "five", "d": "2005-05-05"}}
+gj05|6|{"type": "Feature", "geometry": {"type": null}, "id": 6, "properties": {"f": 6.6, "t": "six", "d": "2006-06-06"}}
+gj05|7|{"type": "Feature", "geometry": {"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[]},{"type":"Point","coordinates":[1,2]}]}, "id": 7, "properties": {"f": 7.7, "t": "seven", "d": "2007-07-07"}}
 4695|{"type": "Feature", "geometry": {"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:2227"}},"coordinates":[0,1]}, "properties": {"v": 1}}


### PR DESCRIPTION
As per GeoJSON RFC, the id should go directly to the feature object rather than to properties:

> If a Feature has a commonly used identifier, that identifier SHOULD be included as a member of the Feature object with the name "id"

Let’s add an argument that will allow designating a column as an identifier so that people do not have to tediously build the JSON object manually.

References https://trac.osgeo.org/postgis/ticket/5596
