### PR TITLE
Fix shebangs in utils

### DIFF
--- a/utils/check_lang_enabled.sh
+++ b/utils/check_lang_enabled.sh
@@ -1,4 +1,3 @@
-
 #!/bin/sh
 
 usage() {

--- a/utils/check_tests_enabled.sh
+++ b/utils/check_tests_enabled.sh
@@ -1,4 +1,3 @@
-
 #!/bin/sh
 
 usage() {


### PR DESCRIPTION
Shebang need to be on the first line or the script will fail to execute on some systems:

    make: ./utils/check_tests_enabled.sh: No such file or directory
