### PR TITLE
Add test case gml namespace, missing will cause a warning.

### DIFF
--- a/doc/reference_input.xml
+++ b/doc/reference_input.xml
@@ -1585,7 +1585,8 @@ SELECT ST_AsText(ST_GeomFromGeoHash('9qqj7nmxncgyy4d0dbxqz0', 10));
 		<title>Examples - A single geometry with srsName</title>
 		<programlisting><![CDATA[
 SELECT ST_GeomFromGML($$
-    <gml:LineString srsName="EPSG:4269">
+    <gml:LineString xmlns:gml="http://www.opengis.net/gml" 
+			srsName="EPSG:4269">
         <gml:coordinates>
             -71.16028,42.258729 -71.160837,42.259112 -71.161143,42.25932
         </gml:coordinates>
@@ -1619,7 +1620,7 @@ $$);
 		<title>Examples - Polyhedral Surface</title>
 		<programlisting><![CDATA[
 SELECT ST_AsEWKT(ST_GeomFromGML('
-<gml:PolyhedralSurface>
+<gml:PolyhedralSurface xmlns:gml="http://www.opengis.net/gml">
 <gml:polygonPatches>
   <gml:PolygonPatch>
     <gml:exterior>


### PR DESCRIPTION
gml does not add the namespace when converting, which causes libxml2 to throw a warning.
postgis 3.4.0
CGAL 5.4.5
PROJ="8.2.1
LIBXML="2.9.11"
LIBJSON="0.15"


2023-11-10 12:18:36.706 CST [23404] LOG:  execute <unnamed>: SET SESSION search_path TO 'public'
namespace warning : Namespace prefix gml is not defined
    <gml:LineString srsName="EPSG:4269">
                                       ^
2023-11-10 12:18:36.715 CST [23404] LOG:  execute <unnamed>: SELECT ST_GeomFromGML($$
            <gml:LineString srsName="EPSG:4269">
                <gml:coordinates>
                    -71.16028,42.258729 -71.160837,42.259112 -71.161143,42.25932
                </gml:coordinates>
            </gml:LineString>
        $$)


reference https://www.ogc.org/standard/gml/
 《 5.1 XML namespaces 》

All components of the GML schema are defined in the namespace with the identifier "http://www.opengis.net/gml/3.2", for which the prefix gml or the default namespace is used within this International Standard.


2023-11-10 12:29:49.619 CST [23404] LOG:  execute <unnamed>: SELECT ST_GeomFromGML($$
            <gml:LineString xmlns:gml="http://www.opengis.net/gml"
                                srsName="EPSG:4269">
                <gml:coordinates>
                    -71.16028,42.258729 -71.160837,42.259112 -71.161143,42.25932
                </gml:coordinates>
            </gml:LineString>
        $$)

