### PR TITLE
[SFCGAL] StraightSkeleton with distance

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,9 @@ To take advantage of all SFCGAL featurs, SFCGAL 1.5.0+ is needed.
   - #5659, ST_DFullyWithin behaviour has changed to
            be ST_Contains(ST_Buffer(A, R), B) (Paul Ramsey)
 
+* Deprecated signatures *
+  - GH-761, ST_StraightSkeleton => CG_StraightSkeleton (Loïc Bartoletti)
+
 * New Features *
 
   - #5055, add explicit <> geometry operator to prevent non-unique
@@ -56,8 +59,10 @@ To take advantage of all SFCGAL featurs, SFCGAL 1.5.0+ is needed.
             use style.css instead (Chris Mayo)
   - Faster implementation of point-in-poly cached index (Paul Ramsey)
   - Improve performance of ST_GeneratePoints (Paul Ramsey)
-  - #5361, ST_CurveN, ST_NumCurves and consistency in 
+  - #5361, ST_CurveN, ST_NumCurves and consistency in
            accessors on curved geometry (Paul Ramsey)
+  - GH-761, postgis_sfcgal: Add an optional parameter to CG_StraightSkeleton
+            (was ST_StraightSkeleton) to use m as a distance in result (Hannes Janetzek, Loïc Bartoletti)
 
 
 PostGIS 3.4.0

--- a/doc/reference_sfcgal.xml
+++ b/doc/reference_sfcgal.xml
@@ -1258,7 +1258,7 @@ ST_GeomFromText('POLYHEDRALSURFACE Z( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
                 Return an approximate medial axis for the areal input based on
                 its straight skeleton. Uses an SFCGAL specific API when built against
                 a capable version (1.2.0+). Otherwise the function is just a wrapper
-                around ST_StraightSkeleton (slower case).
+                around CG_StraightSkeleton (slower case).
             </para>
 
             <para role="availability" conformance="2.2.0">Availability: 2.2.0</para>
@@ -1293,7 +1293,7 @@ ST_GeomFromText('POLYHEDRALSURFACE Z( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
         <refsection>
             <title>See Also</title>
 
-            <para><xref linkend="ST_StraightSkeleton"/></para>
+            <para><xref linkend="CG_StraightSkeleton"/></para>
         </refsection>
 
     </refentry>
@@ -1526,7 +1526,7 @@ ST_GeomFromText('POLYHEDRALSURFACE Z( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
         </refsection>
         <refsection>
             <title>See Also</title>
-            <para><xref linkend="ST_Extrude" />, <xref linkend="ST_StraightSkeleton" /></para>
+            <para><xref linkend="ST_Extrude" />, <xref linkend="CG_StraightSkeleton" /></para>
         </refsection>
 
     </refentry>
@@ -1854,6 +1854,72 @@ ST_GeomFromText('POLYHEDRALSURFACE Z( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
         </refsection>
     </refentry>
 
+    <refentry xml:id="CG_StraightSkeleton">
+        <refnamediv>
+            <refname>CG_StraightSkeleton</refname>
+
+            <refpurpose>Compute a straight skeleton from a geometry</refpurpose>
+        </refnamediv>
+
+        <refsynopsisdiv>
+            <funcsynopsis>
+                <funcprototype>
+                    <funcdef>geometry <function>CG_StraightSkeleton</function></funcdef>
+                    <paramdef><type>geometry</type> <parameter>geom</parameter></paramdef>
+                    <paramdef choice="opt"><type>boolean </type> <parameter>use_distance_as_m = false</parameter></paramdef>
+                </funcprototype>
+            </funcsynopsis>
+        </refsynopsisdiv>
+
+        <refsection>
+            <title>Description</title>
+
+            <para role="availability" conformance="3.5.0">Availability: 3.5.0</para>
+            <para role="sfcgal_requirement" conformance="1.3.8">Requires SFCGAL &gt;= 1.3.8 for option use_distance_as_m</para>
+            <para>&sfcgal_required;</para>
+            <para>&Z_support;</para>
+            <para>&P_support;</para>
+            <para>&T_support;</para>
+        </refsection>
+
+        <refsection><title>Examples</title>
+            <programlisting>SELECT CG_StraightSkeleton(ST_GeomFromText('POLYGON (( 190 190, 10 190, 10 10, 190 10, 190 20, 160 30, 60 30, 60 130, 190 140, 190 190 ))'));</programlisting>
+            <programlisting>ST_AsText(CG_StraightSkeleton('POLYGON((0 0,1 0,1 1,0 1,0 0))', true);</programlisting>
+            <screen>MULTILINESTRING M ((0 0 0,0.5 0.5 0.5),(1 0 0,0.5 0.5 0.5),(1 1 0,0.5 0.5 0.5),(0 1 0,0.5 0.5 0.5))</screen>
+
+            <informaltable>
+                <tgroup cols="2">
+                    <tbody>
+                        <row>
+                            <entry><para><informalfigure>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="images/st_straightskeleton01.png"/>
+                                            </imageobject>
+                                            <caption><para>Original polygon</para></caption>
+                                        </mediaobject>
+                                </informalfigure></para>
+                            </entry>
+                            <entry><para><informalfigure>
+                                        <mediaobject>
+                                            <imageobject>
+                                                <imagedata fileref="images/st_straightskeleton02.png"/>
+                                            </imageobject>
+                                            <caption><para>Straight Skeleton of polygon</para></caption>
+                                        </mediaobject>
+                                </informalfigure></para>
+                            </entry>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </informaltable>
+        </refsection>
+
+        <refsection>
+            <title>See Also</title>
+            <para><xref linkend="CG_ExtrudeStraightSkeleton" /></para>
+        </refsection>
+    </refentry>
 
     <refentry xml:id="ST_StraightSkeleton">
         <refnamediv>

--- a/liblwgeom/lwgeom_sfcgal.c
+++ b/liblwgeom/lwgeom_sfcgal.c
@@ -137,8 +137,9 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 	assert(geom);
 
 	int is_3d = sfcgal_geometry_is_3d(geom);
+#if POSTGIS_SFCGAL_VERSION >= 10308
 	int is_measured = sfcgal_geometry_is_measured(geom);
-
+#endif
 	switch (sfcgal_geometry_type_id(geom))
 	{
 	case SFCGAL_TYPE_POINT:
@@ -151,9 +152,10 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 			point.z = sfcgal_point_z(geom);
 		else if (want3d)
 			point.z = 0.0;
+#if POSTGIS_SFCGAL_VERSION >= 10308
 		if (is_measured)
 			point.m = sfcgal_point_m(geom);
-
+#endif
 		ptarray_set_point4d(pa, 0, &point);
 	}
 	break;
@@ -173,9 +175,10 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 				point.z = sfcgal_point_z(pt);
 			else if (want3d)
 				point.z = 0.0;
-                        if (is_measured)
-                                 point.m = sfcgal_point_m(pt);
-
+#if POSTGIS_SFCGAL_VERSION >= 10308
+			if (is_measured)
+				point.m = sfcgal_point_m(pt);
+#endif
 			ptarray_set_point4d(pa, i, &point);
 		}
 	}
@@ -195,9 +198,10 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 				point.z = sfcgal_point_z(pt);
 			else if (want3d)
 				point.z = 0.0;
+#if POSTGIS_SFCGAL_VERSION >= 10308
 			if (is_measured)
 				point.m = sfcgal_point_m(pt);
-
+#endif
 			ptarray_set_point4d(pa, i, &point);
 		}
 	}

--- a/liblwgeom/lwgeom_sfcgal.c
+++ b/liblwgeom/lwgeom_sfcgal.c
@@ -136,18 +136,23 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 
 	assert(geom);
 
+	int is_3d = sfcgal_geometry_is_3d(geom);
+	int is_measured = sfcgal_geometry_is_measured(geom);
+
 	switch (sfcgal_geometry_type_id(geom))
 	{
 	case SFCGAL_TYPE_POINT:
 	{
-		pa = ptarray_construct(want3d, 0, 1);
+		pa = ptarray_construct(want3d, is_measured, 1);
 		point.x = sfcgal_point_x(geom);
 		point.y = sfcgal_point_y(geom);
 
-		if (sfcgal_geometry_is_3d(geom))
+		if (is_3d)
 			point.z = sfcgal_point_z(geom);
 		else if (want3d)
 			point.z = 0.0;
+		if (is_measured)
+			point.m = sfcgal_point_m(geom);
 
 		ptarray_set_point4d(pa, 0, &point);
 	}
@@ -156,7 +161,7 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 	case SFCGAL_TYPE_LINESTRING:
 	{
 		npoints = sfcgal_linestring_num_points(geom);
-		pa = ptarray_construct(want3d, 0, npoints);
+		pa = ptarray_construct(want3d, is_measured, npoints);
 
 		for (i = 0; i < npoints; i++)
 		{
@@ -164,10 +169,12 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 			point.x = sfcgal_point_x(pt);
 			point.y = sfcgal_point_y(pt);
 
-			if (sfcgal_geometry_is_3d(geom))
+			if (is_3d)
 				point.z = sfcgal_point_z(pt);
 			else if (want3d)
 				point.z = 0.0;
+                        if (is_measured)
+                                 point.m = sfcgal_point_m(pt);
 
 			ptarray_set_point4d(pa, i, &point);
 		}
@@ -176,7 +183,7 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 
 	case SFCGAL_TYPE_TRIANGLE:
 	{
-		pa = ptarray_construct(want3d, 0, 4);
+		pa = ptarray_construct(want3d, is_measured, 4);
 
 		for (i = 0; i < 4; i++)
 		{
@@ -184,10 +191,12 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 			point.x = sfcgal_point_x(pt);
 			point.y = sfcgal_point_y(pt);
 
-			if (sfcgal_geometry_is_3d(geom))
+			if (is_3d)
 				point.z = sfcgal_point_z(pt);
 			else if (want3d)
 				point.z = 0.0;
+			if (is_measured)
+				point.m = sfcgal_point_m(pt);
 
 			ptarray_set_point4d(pa, i, &point);
 		}

--- a/liblwgeom/lwgeom_sfcgal.c
+++ b/liblwgeom/lwgeom_sfcgal.c
@@ -133,13 +133,17 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 	POINT4D point;
 	uint32_t i, npoints;
 	POINTARRAY *pa = NULL;
+	int is_3d;
+	int is_measured = 0;
 
 	assert(geom);
 
-	int is_3d = sfcgal_geometry_is_3d(geom);
+	is_3d = sfcgal_geometry_is_3d(geom);
+
 #if POSTGIS_SFCGAL_VERSION >= 10308
-	int is_measured = sfcgal_geometry_is_measured(geom);
+	is_measured = sfcgal_geometry_is_measured(geom);
 #endif
+
 	switch (sfcgal_geometry_type_id(geom))
 	{
 	case SFCGAL_TYPE_POINT:
@@ -152,10 +156,10 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 			point.z = sfcgal_point_z(geom);
 		else if (want3d)
 			point.z = 0.0;
-#if POSTGIS_SFCGAL_VERSION >= 10308
+
 		if (is_measured)
 			point.m = sfcgal_point_m(geom);
-#endif
+
 		ptarray_set_point4d(pa, 0, &point);
 	}
 	break;
@@ -175,10 +179,10 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 				point.z = sfcgal_point_z(pt);
 			else if (want3d)
 				point.z = 0.0;
-#if POSTGIS_SFCGAL_VERSION >= 10308
+
 			if (is_measured)
 				point.m = sfcgal_point_m(pt);
-#endif
+
 			ptarray_set_point4d(pa, i, &point);
 		}
 	}
@@ -198,10 +202,10 @@ ptarray_from_SFCGAL(const sfcgal_geometry_t *geom, int want3d)
 				point.z = sfcgal_point_z(pt);
 			else if (want3d)
 				point.z = 0.0;
-#if POSTGIS_SFCGAL_VERSION >= 10308
+
 			if (is_measured)
 				point.m = sfcgal_point_m(pt);
-#endif
+
 			ptarray_set_point4d(pa, i, &point);
 		}
 	}

--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -423,19 +423,15 @@ sfcgal_straight_skeleton(PG_FUNCTION_ARGS)
 	sfcgal_geometry_t *geom;
 	sfcgal_geometry_t *result;
 	srid_t srid;
-	int distance_in_m;
+
 	sfcgal_postgis_init();
 
 	input = PG_GETARG_GSERIALIZED_P(0);
-	distance_in_m = PG_GETARG_BOOL(1);
 	srid = gserialized_get_srid(input);
 	geom = POSTGIS2SFCGALGeometry(input);
 	PG_FREE_IF_COPY(input, 0);
 
-	if (distance_in_m)
-		result = sfcgal_geometry_straight_skeleton_distance_in_m(geom);
-	else
-		result = sfcgal_geometry_straight_skeleton(geom);
+	result = sfcgal_geometry_straight_skeleton(geom);
 	sfcgal_geometry_delete(geom);
 
 	output = SFCGALGeometry2POSTGIS(result, 0, srid);

--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -423,6 +423,34 @@ sfcgal_straight_skeleton(PG_FUNCTION_ARGS)
 	sfcgal_geometry_t *geom;
 	sfcgal_geometry_t *result;
 	srid_t srid;
+	int distance_in_m;
+	sfcgal_postgis_init();
+
+	input = PG_GETARG_GSERIALIZED_P(0);
+	distance_in_m = PG_GETARG_BOOL(1);
+	srid = gserialized_get_srid(input);
+	geom = POSTGIS2SFCGALGeometry(input);
+	PG_FREE_IF_COPY(input, 0);
+
+	if (distance_in_m)
+		result = sfcgal_geometry_straight_skeleton_distance_in_m(geom);
+	else
+		result = sfcgal_geometry_straight_skeleton(geom);
+	sfcgal_geometry_delete(geom);
+
+	output = SFCGALGeometry2POSTGIS(result, 0, srid);
+	sfcgal_geometry_delete(result);
+
+	PG_RETURN_POINTER(output);
+}
+
+PG_FUNCTION_INFO_V1(sfcgal_straight_skeleton_distance_in_m);
+Datum sfcgal_straight_skeleton_distance_in_m(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *input, *output;
+	sfcgal_geometry_t *geom;
+	sfcgal_geometry_t *result;
+	srid_t srid;
 
 	sfcgal_postgis_init();
 
@@ -431,7 +459,7 @@ sfcgal_straight_skeleton(PG_FUNCTION_ARGS)
 	geom = POSTGIS2SFCGALGeometry(input);
 	PG_FREE_IF_COPY(input, 0);
 
-	result = sfcgal_geometry_straight_skeleton(geom);
+	result = sfcgal_geometry_straight_skeleton_distance_in_m(geom);
 	sfcgal_geometry_delete(geom);
 
 	output = SFCGALGeometry2POSTGIS(result, 0, srid);

--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -123,6 +123,7 @@ Datum sfcgal_union3D(PG_FUNCTION_ARGS);
 Datum sfcgal_volume(PG_FUNCTION_ARGS);
 Datum sfcgal_extrude(PG_FUNCTION_ARGS);
 Datum sfcgal_straight_skeleton(PG_FUNCTION_ARGS);
+Datum sfcgal_straight_skeleton_distance_in_m(PG_FUNCTION_ARGS);
 Datum sfcgal_approximate_medial_axis(PG_FUNCTION_ARGS);
 Datum sfcgal_is_planar(PG_FUNCTION_ARGS);
 Datum sfcgal_orientation(PG_FUNCTION_ARGS);
@@ -443,6 +444,14 @@ sfcgal_straight_skeleton(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(sfcgal_straight_skeleton_distance_in_m);
 Datum sfcgal_straight_skeleton_distance_in_m(PG_FUNCTION_ARGS)
 {
+#if POSTGIS_SFCGAL_VERSION < 10308
+	lwpgerror("The SFCGAL version this PostGIS binary "
+	          "was compiled against (%d) doesn't support "
+	          "'sfcgal_straight_skeleton_distance_in_m' "
+	          "function (1.3.8+ required)",
+	          POSTGIS_SFCGAL_VERSION);
+	          PG_RETURN_NULL();
+#else /* POSTGIS_SFCGAL_VERSION >= 10308 */
 	GSERIALIZED *input, *output;
 	sfcgal_geometry_t *geom;
 	sfcgal_geometry_t *result;
@@ -462,6 +471,7 @@ Datum sfcgal_straight_skeleton_distance_in_m(PG_FUNCTION_ARGS)
 	sfcgal_geometry_delete(result);
 
 	PG_RETURN_POINTER(output);
+#endif
 }
 
 PG_FUNCTION_INFO_V1(sfcgal_approximate_medial_axis);

--- a/sfcgal/regress/regress_sfcgal.sql
+++ b/sfcgal/regress/regress_sfcgal.sql
@@ -28,8 +28,8 @@ SELECT 'ST_ForceLHR', ST_AsText(ST_ForceLHR('POLYGON((0 0,0 1,1 1,1 0,0 0))'));
 SELECT 'ST_Orientation_1', ST_Orientation(ST_ForceLHR('POLYGON((0 0,0 1,1 1,1 0,0 0))'));
 SELECT 'ST_Orientation_2', ST_Orientation(ST_ForceRHR('POLYGON((0 0,0 1,1 1,1 0,0 0))'));
 SELECT 'ST_MinkowskiSum', ST_AsText(ST_MinkowskiSum('LINESTRING(0 0,4 0)','POLYGON((0 0,1 0,1 1,0 1,0 0))'));
-SELECT 'ST_StraightSkeleton', ST_AsText(ST_StraightSkeleton('POLYGON((1 1,2 1,2 2,1 2,1 1))'));
-SELECT 'ST_StraightSkeletonUseMDistance',
+SELECT 'CG_StraightSkeleton', ST_AsText(CG_StraightSkeleton('POLYGON((1 1,2 1,2 2,1 2,1 1))'));
+SELECT 'CG_StraightSkeletonUseMDistance',
 CASE WHEN postgis_sfcgal_version() >= '1.3.8'
 THEN
 	ST_AsText(CG_StraightSkeleton('POLYGON((0 0,1 0,1 1,0 1,0 0))', true))

--- a/sfcgal/regress/regress_sfcgal.sql
+++ b/sfcgal/regress/regress_sfcgal.sql
@@ -30,7 +30,7 @@ SELECT 'ST_Orientation_2', ST_Orientation(ST_ForceRHR('POLYGON((0 0,0 1,1 1,1 0,
 SELECT 'ST_MinkowskiSum', ST_AsText(ST_MinkowskiSum('LINESTRING(0 0,4 0)','POLYGON((0 0,1 0,1 1,0 1,0 0))'));
 SELECT 'CG_StraightSkeleton', ST_AsText(CG_StraightSkeleton('POLYGON((1 1,2 1,2 2,1 2,1 1))'));
 SELECT 'CG_StraightSkeletonUseMDistance',
-CASE WHEN postgis_sfcgal_version() >= '1.3.8'
+CASE WHEN string_to_array(postgis_sfcgal_version(), '.')::int[] >= string_to_array('1.3.8', '.')::int[]
 THEN
 	ST_AsText(CG_StraightSkeleton('POLYGON((0 0,1 0,1 1,0 1,0 0))', true))
 ELSE

--- a/sfcgal/regress/regress_sfcgal.sql
+++ b/sfcgal/regress/regress_sfcgal.sql
@@ -29,6 +29,14 @@ SELECT 'ST_Orientation_1', ST_Orientation(ST_ForceLHR('POLYGON((0 0,0 1,1 1,1 0,
 SELECT 'ST_Orientation_2', ST_Orientation(ST_ForceRHR('POLYGON((0 0,0 1,1 1,1 0,0 0))'));
 SELECT 'ST_MinkowskiSum', ST_AsText(ST_MinkowskiSum('LINESTRING(0 0,4 0)','POLYGON((0 0,1 0,1 1,0 1,0 0))'));
 SELECT 'ST_StraightSkeleton', ST_AsText(ST_StraightSkeleton('POLYGON((1 1,2 1,2 2,1 2,1 1))'));
+SELECT 'ST_StraightSkeletonUseMDistance',
+CASE WHEN postgis_sfcgal_version() >= '1.3.8'
+THEN
+	ST_AsText(CG_StraightSkeleton('POLYGON((0 0,1 0,1 1,0 1,0 0))', true))
+ELSE
+	-- export result directly
+	'MULTILINESTRING M ((0 0 0,0.5 0.5 0.5),(1 0 0,0.5 0.5 0.5),(1 1 0,0.5 0.5 0.5),(0 1 0,0.5 0.5 0.5))'
+END;
 SELECT 'ST_ConstrainedDelaunayTriangles', ST_AsText(ST_ConstrainedDelaunayTriangles('GEOMETRYCOLLECTION(POINT(0 0), POLYGON((2 2, 2 -2, 4 0, 2 2)))'));
 SELECT 'postgis_sfcgal_noop', ST_NPoints(postgis_sfcgal_noop(ST_Buffer('POINT(0 0)', 5)));
 SELECT 'ST_3DConvexHull', ST_3DArea(ST_3DConvexHull('MULTIPOINTZ(0 0 5, 1 5 3, 5 7 6, 9 5 3 , 5 7 5, 6 3 5)'))::numeric(10,4);

--- a/sfcgal/regress/regress_sfcgal_expected
+++ b/sfcgal/regress/regress_sfcgal_expected
@@ -9,6 +9,7 @@ ST_Orientation_1|-1
 ST_Orientation_2|1
 ST_MinkowskiSum|MULTIPOLYGON(((0 0,1 0,5 0,5 1,4 1,0 1,0 0)))
 ST_StraightSkeleton|MULTILINESTRING((1 1,1.5 1.5),(2 1,1.5 1.5),(2 2,1.5 1.5),(1 2,1.5 1.5))
+ST_StraightSkeletonUseMDistance|MULTILINESTRING M ((0 0 0,0.5 0.5 0.5),(1 0 0,0.5 0.5 0.5),(1 1 0,0.5 0.5 0.5),(0 1 0,0.5 0.5 0.5))
 ST_ConstrainedDelaunayTriangles|TIN(((4 0,2 2,2 -2,4 0)),((2 2,0 0,2 -2,2 2)))
 postgis_sfcgal_noop|33
 ST_3DConvexHull|80.9227

--- a/sfcgal/regress/regress_sfcgal_expected
+++ b/sfcgal/regress/regress_sfcgal_expected
@@ -8,8 +8,8 @@ ST_ForceLHR|POLYGON((0 0,1 0,1 1,0 1,0 0))
 ST_Orientation_1|-1
 ST_Orientation_2|1
 ST_MinkowskiSum|MULTIPOLYGON(((0 0,1 0,5 0,5 1,4 1,0 1,0 0)))
-ST_StraightSkeleton|MULTILINESTRING((1 1,1.5 1.5),(2 1,1.5 1.5),(2 2,1.5 1.5),(1 2,1.5 1.5))
-ST_StraightSkeletonUseMDistance|MULTILINESTRING M ((0 0 0,0.5 0.5 0.5),(1 0 0,0.5 0.5 0.5),(1 1 0,0.5 0.5 0.5),(0 1 0,0.5 0.5 0.5))
+CG_StraightSkeleton|MULTILINESTRING((1 1,1.5 1.5),(2 1,1.5 1.5),(2 2,1.5 1.5),(1 2,1.5 1.5))
+CG_StraightSkeletonUseMDistance|MULTILINESTRING M ((0 0 0,0.5 0.5 0.5),(1 0 0,0.5 0.5 0.5),(1 1 0,0.5 0.5 0.5),(0 1 0,0.5 0.5 0.5))
 ST_ConstrainedDelaunayTriangles|TIN(((4 0,2 2,2 -2,4 0)),((2 2,0 0,2 -2,2 2)))
 postgis_sfcgal_noop|33
 ST_3DConvexHull|80.9227

--- a/sfcgal/sfcgal.sql.in
+++ b/sfcgal/sfcgal.sql.in
@@ -194,11 +194,14 @@ CREATE OR REPLACE FUNCTION CG_StraightSkeleton(geometry, use_m_as_distance boole
        COST 100;
 
 -- Availability: 2.1.0
+-- Deprecation in 3.1.0
 CREATE OR REPLACE FUNCTION ST_StraightSkeleton(geometry)
-       RETURNS geometry
-       AS 'SELECT @extschema@.CG_StraightSkeleton($1, false)'
-			 LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
-       COST 100;
+RETURNS geometry AS $$
+	SELECT @extschema@._postgis_deprecate(
+		'ST_StraightSkeleton', 'CG_StraightSkeleton', '3.1.0');
+	SELECT @extschema@.CG_StraightSkeleton($1, false);
+$$
+LANGUAGE 'sql' IMMUTABLE SECURITY INVOKER;
 
 -- Availability: 2.2.0
 CREATE OR REPLACE FUNCTION ST_ApproximateMedialAxis(geometry)

--- a/sfcgal/sfcgal.sql.in
+++ b/sfcgal/sfcgal.sql.in
@@ -186,6 +186,13 @@ CREATE OR REPLACE FUNCTION ST_MinkowskiSum(geometry, geometry)
        LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
        COST 100;
 
+-- Availability: 3.4.0
+CREATE OR REPLACE FUNCTION ST_StraightSkeletonDistanceInM(geometry)
+       RETURNS geometry
+       AS 'MODULE_PATHNAME','sfcgal_straight_skeleton_distance_in_m'
+       LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+       COST 100;
+
 -- Availability: 2.1.0
 CREATE OR REPLACE FUNCTION ST_StraightSkeleton(geometry)
        RETURNS geometry

--- a/sfcgal/sfcgal.sql.in
+++ b/sfcgal/sfcgal.sql.in
@@ -186,18 +186,18 @@ CREATE OR REPLACE FUNCTION ST_MinkowskiSum(geometry, geometry)
        LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
        COST 100;
 
--- Availability: 3.4.0
-CREATE OR REPLACE FUNCTION ST_StraightSkeletonDistanceInM(geometry)
+-- Availability: 3.5.0
+CREATE OR REPLACE FUNCTION CG_StraightSkeleton(geometry, use_m_as_distance boolean DEFAULT false)
        RETURNS geometry
-       AS 'MODULE_PATHNAME','sfcgal_straight_skeleton_distance_in_m'
+       AS 'MODULE_PATHNAME','sfcgal_straight_skeleton'
        LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
        COST 100;
 
 -- Availability: 2.1.0
 CREATE OR REPLACE FUNCTION ST_StraightSkeleton(geometry)
        RETURNS geometry
-       AS 'MODULE_PATHNAME','sfcgal_straight_skeleton'
-       LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+       AS 'SELECT @extschema@.CG_StraightSkeleton($1, false)'
+			 LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
        COST 100;
 
 -- Availability: 2.2.0


### PR DESCRIPTION
Supersedes #730

- Add test, documentation
- Rename function to CG_StraightSkeleton
- Use only one method for StraightSkeleton with or without use_m_as_distance
- Rewrite and deprecate ST_StraightSkeleton as a SQL alias
- Create a NEWS entry

Thanks to @hjanetzek