### PR TITLE
CodeQL: Enable SFCGAL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: |
           sudo apt-get update
-          sudo apt-get install -y g++ autoconf automake libgeos-dev libproj-dev libgdal-dev libjson-c-dev gettext libxml2-dev postgresql-server-dev-16 postgresql-client-16 libprotobuf-c-dev libprotoc-dev protobuf-c-compiler clang-19
+          sudo apt-get install -y g++ autoconf automake libgeos-dev libproj-dev libgdal-dev libjson-c-dev libsfcgal-dev gettext libxml2-dev postgresql-server-dev-16 postgresql-client-16 libprotobuf-c-dev libprotoc-dev protobuf-c-compiler clang-19
 
     - name: Build
       run: |


### PR DESCRIPTION
Add libsfcgal-dev to enable CodeQL to analyze the SFCGAL part as well.