### PR TITLE
Fix syntax error in ST_TransformPipeline example

### DIFF
--- a/doc/reference_srs.xml
+++ b/doc/reference_srs.xml
@@ -7,7 +7,7 @@
    </abstract>
     </info>
 
-    
+
 
   <refentry xml:id="ST_InverseTransformPipeline">
     <refnamediv>
@@ -429,7 +429,7 @@ CREATE INDEX idx_geom_26986_parcels
     <programlisting>
 -- Forward direction
 SELECT ST_AsText(ST_TransformPipeline('SRID=4326;POINT(2 49)'::geometry,
-  'urn:ogc:def:coordinateOperation:EPSG::16031') AS utm_geom);
+  'urn:ogc:def:coordinateOperation:EPSG::16031')) AS utm_geom;
 
                   utm_geom
 --------------------------------------------


### PR DESCRIPTION
Don't know if this is the right procedure, but here is a small fix in the code example in the documentation of ST_TransformPipeline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the syntax for a function call related to coordinate transformation in database queries to ensure accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->