### PR TITLE
Fix typo in ST_Touches math expression

### DIFF
--- a/doc/reference_relationship.xml
+++ b/doc/reference_relationship.xml
@@ -1724,7 +1724,7 @@ SELECT pat.name AS relationship, pat.val AS pattern,
     since points do not have a boundary.</para>
 
     <para>In mathematical terms:
-    <emphasis>ST_Touches(A, B) ⇔ (Int(A) ⋂ Int(B) ≠ ∅) ∧ (A ⋂ B ≠ ∅) </emphasis></para>
+    <emphasis>ST_Touches(A, B) ⇔ (Int(A) ⋂ Int(B) = ∅) ∧ (A ⋂ B ≠ ∅) </emphasis></para>
 
     <para>This relationship holds if the DE-9IM Intersection Matrix for the two geometries matches one of:</para>
 


### PR DESCRIPTION
I believe this fixes a typo, as the current expression says that the interiors _do_ intersect.