### PR TITLE
[CI][macOS]: disable protobuf

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,10 +79,9 @@ task:
         pkg-config
         postgresql@14
         proj
-        protobuf-c
         sfcgal
     - ./autogen.sh
-    - ./configure --without-gui --without-interrupt-tests --without-topology --without-raster  --with-sfcgal --with-address-standardizer --with-protobuf --with-pgconfig=/opt/homebrew/opt/postgresql@14/bin/pg_config
+    - ./configure --without-gui --without-interrupt-tests --without-topology --without-raster  --with-sfcgal --with-address-standardizer --without-protobuf --with-pgconfig=/opt/homebrew/opt/postgresql@14/bin/pg_config
     - brew services start postgresql@14
     - postgres -V
     - make -j8 || { brew services stop postgresql@14; exit 1;}


### PR DESCRIPTION
On macOS, [protobuf-c](https://formulae.brew.sh/formula/protobuf-c) uses [protobuf@26](https://formulae.brew.sh/formula/protobuf) whereas [protobuf@3](https://formulae.brew.sh/formula/protobuf@3) should be used.

Until a proper fix on *.proto file is applied, let's disable protobuf on macOS CI.