### PR TITLE
MSVC Compat 1: Reconcile attributes and math macros

### DIFF
--- a/liblwgeom/liblwgeom_internal.h
+++ b/liblwgeom/liblwgeom_internal.h
@@ -40,6 +40,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <float.h>
+
+#ifdef _MSC_VER
+	#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 
 #if HAVE_IEEEFP_H

--- a/liblwgeom/lwgeom_geos.h
+++ b/liblwgeom/lwgeom_geos.h
@@ -25,7 +25,11 @@
 
 #if POSTGIS_GEOS_VERSION < 31300
 /* See https://github.com/libgeos/geos/pull/1097 */
-typedef void (*GEOSMessageHandler)(const char *fmt, ...) __attribute__ (( format(printf, 1, 0) ));
+typedef void (*GEOSMessageHandler)(const char *fmt, ...)
+#ifdef __GNUC__
+	__attribute__ (( format(printf, 1, 0) ))
+#endif
+;
 #endif
 
 #include "geos_c.h"

--- a/liblwgeom/lwgeom_log.h
+++ b/liblwgeom/lwgeom_log.h
@@ -126,7 +126,11 @@
  * For debugging, use LWDEBUG() or LWDEBUGF().
  * @ingroup logging
  */
-void lwnotice(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void lwnotice(const char *fmt, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 1, 2)))
+#endif
+;
 
 /**
  * Write a notice out to the error handler.
@@ -136,7 +140,11 @@ void lwnotice(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
  * For debugging, use LWDEBUG() or LWDEBUGF().
  * @ingroup logging
  */
-void lwerror(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void lwerror(const char *fmt, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 1, 2)))
+#endif
+;
 
 /**
  * Write a debug message out.
@@ -145,7 +153,11 @@ void lwerror(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
  * efficiency.
  * @ingroup logging
  */
-void lwdebug(int level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+void lwdebug(int level, const char *fmt, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 2, 3)))
+#endif
+;
 
 
 

--- a/postgis/geography_centroid.c
+++ b/postgis/geography_centroid.c
@@ -26,6 +26,9 @@
 
 #include "../postgis_config.h"
 
+#ifdef _MSC_VER
+	#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 
 #include "liblwgeom.h"         /* For standard geometry types. */

--- a/postgis/geography_measurement.c
+++ b/postgis/geography_measurement.c
@@ -28,7 +28,11 @@
 
 #include "../postgis_config.h"
 
+#ifdef _MSC_VER
+	#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
+
 #include <float.h>
 #include <string.h>
 #include <stdio.h>

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -35,7 +35,11 @@
 #include "liblwgeom_internal.h"
 #include "lwgeom_pg.h"
 
+#ifdef _MSC_VER
+	#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
+
 #include <float.h>
 #include <string.h>
 #include <stdio.h>

--- a/postgis/lwgeom_spheroid.c
+++ b/postgis/lwgeom_spheroid.c
@@ -25,8 +25,11 @@
 
 #include "postgres.h"
 
-
+#ifdef _MSC_VER
+	#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
+
 #include <float.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
- Define _USE_MATH_DEFINES on MSVC wherever constants like M_PI are needed
- Do not allow use of format attribute outside of GCC