### PR TITLE
Fix KMeans parameter name

### DIFF
--- a/doc/reference_cluster.xml
+++ b/doc/reference_cluster.xml
@@ -291,16 +291,22 @@ FROM testdata;
 	  <refsynopsisdiv>
 		<funcsynopsis>
 		  <funcprototype>
-			<funcdef>integer <function>ST_ClusterKMeans</function></funcdef>
-
-			<paramdef><type>geometry winset </type>
-			<parameter>geom</parameter></paramdef>
-
-			<paramdef><type>integer </type>
-			<parameter>number_of_clusters</parameter></paramdef>
-
-            <paramdef><type>float </type>
-			<parameter>max_radius</parameter></paramdef>
+            <funcdef>integer <function>ST_ClusterKMeans</function></funcdef>
+    
+            <paramdef>
+              <type>geometry winset </type>
+              <parameter>geom</parameter>
+            </paramdef>
+    
+            <paramdef>
+              <type>integer </type>
+              <parameter>k</parameter>
+            </paramdef>
+    
+            <paramdef>
+              <type>float8 </type>
+              <parameter>max_radius</parameter>
+            </paramdef>
 		  </funcprototype>
 		</funcsynopsis>
 	  </refsynopsisdiv>


### PR DESCRIPTION
The `k` argument was mis-named as `number_of_clusters` for the `K`-Means cluster function.

Passing named arguments with `number_of_clusters` failed, the correct syntax is:

```sql
SELECT id, ST_ClusterKMeans(geom, k => 10, max_radius => 1000), ...
```

This PR fixes the inaccurate name in the docs.