### PR TITLE
Add AM support function (11) for BRIN OpClasses

### DIFF
--- a/postgis/brin_2d.c
+++ b/postgis/brin_2d.c
@@ -89,3 +89,30 @@ geom2d_brin_inclusion_add_value(PG_FUNCTION_ARGS)
 
 	PG_RETURN_BOOL(true);
 }
+
+
+PG_FUNCTION_INFO_V1(geom2d_brin_inclusion_merge);
+Datum
+geom2d_brin_inclusion_merge(PG_FUNCTION_ARGS)
+{
+	BOX2DF *box_key = (BOX2DF *) PG_GETARG_POINTER(0);
+	BOX2DF *box_geom = (BOX2DF *) PG_GETARG_POINTER(1);
+
+	/*
+	 * Check if the stored bounding box already contains the geometry's one.
+	 *
+	 * If not, enlarge the stored box2df to make it contains the current
+	 * geometry.
+	 */
+	if (!box2df_contains(box_key, box_geom))
+	{
+	    box_key->xmin = Min(box_key->xmin, box_geom->xmin);
+	    box_key->xmax = Max(box_key->xmax, box_geom->xmax);
+	    box_key->ymin = Min(box_key->ymin, box_geom->ymin);
+	    box_key->ymax = Max(box_key->ymax, box_geom->ymax);
+	}
+
+	PG_RETURN_POINTER(box_key);
+}
+
+

--- a/postgis/geography_brin.sql.in
+++ b/postgis/geography_brin.sql.in
@@ -54,8 +54,15 @@ CREATE OPERATOR && (
 --------------------------------
 
 -- Availability: 2.3.0
-CREATE OR REPLACE FUNCTION geog_brin_inclusion_add_value(internal, internal, internal, internal) RETURNS boolean
+CREATE OR REPLACE FUNCTION geog_brin_inclusion_add_value(internal, internal, internal, internal)
+RETURNS boolean
         AS 'MODULE_PATHNAME','geog_brin_inclusion_add_value'
+        LANGUAGE 'c';
+
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION geog_brin_inclusion_merge(internal, internal)
+RETURNS internal
+        AS 'MODULE_PATHNAME','geog_brin_inclusion_merge'
         LANGUAGE 'c';
 
 -- Availability: 2.3.0
@@ -66,6 +73,7 @@ CREATE OPERATOR CLASS brin_geography_inclusion_ops
     FUNCTION      2        geog_brin_inclusion_add_value(internal, internal, internal, internal),
     FUNCTION      3        brin_inclusion_consistent(internal, internal, internal),
     FUNCTION      4        brin_inclusion_union(internal, internal, internal),
+    FUNCTION      11       geog_brin_inclusion_merge(internal, internal),
     OPERATOR      3        &&(geography, geography),
     OPERATOR      3        &&(geography, gidx),
     OPERATOR      3        &&(gidx, geography),

--- a/postgis/postgis_brin.sql.in
+++ b/postgis/postgis_brin.sql.in
@@ -192,16 +192,34 @@ RETURNS boolean
 AS 'MODULE_PATHNAME','geom2d_brin_inclusion_add_value'
 LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
 
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION geom2d_brin_inclusion_merge(internal, internal)
+RETURNS internal
+AS 'MODULE_PATHNAME','geom2d_brin_inclusion_merge'
+LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
+
 -- Availability: 2.3.0
 CREATE OR REPLACE FUNCTION geom3d_brin_inclusion_add_value(internal, internal, internal, internal)
 RETURNS boolean
 AS 'MODULE_PATHNAME','geom3d_brin_inclusion_add_value'
 LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
 
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION geom3d_brin_inclusion_merge(internal, internal)
+RETURNS internal
+AS 'MODULE_PATHNAME','geom3d_brin_inclusion_merge'
+LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
+
 -- Availability: 2.3.0
 CREATE OR REPLACE FUNCTION geom4d_brin_inclusion_add_value(internal, internal, internal, internal)
 RETURNS boolean
 AS 'MODULE_PATHNAME','geom4d_brin_inclusion_add_value'
+LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
+
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION geom4d_brin_inclusion_merge(internal, internal)
+RETURNS internal
+AS 'MODULE_PATHNAME','geom4d_brin_inclusion_merge'
 LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
 
 -- Availability: 2.3.0
@@ -212,6 +230,7 @@ CREATE OPERATOR CLASS brin_geometry_inclusion_ops_2d
     FUNCTION      2        geom2d_brin_inclusion_add_value(internal, internal, internal, internal),
     FUNCTION      3        brin_inclusion_consistent(internal, internal, internal),
     FUNCTION      4        brin_inclusion_union(internal, internal, internal),
+    FUNCTION      11       geom2d_brin_inclusion_merge(internal, internal),
     OPERATOR      3         &&(box2df, box2df),
     OPERATOR      3         &&(box2df, geometry),
     OPERATOR      3         &&(geometry, box2df),
@@ -226,6 +245,7 @@ CREATE OPERATOR CLASS brin_geometry_inclusion_ops_2d
     OPERATOR      8        @(geometry, geometry),
   STORAGE box2df;
 
+
 		-------------
 		-- 3D case --
 		-------------
@@ -238,6 +258,7 @@ CREATE OPERATOR CLASS brin_geometry_inclusion_ops_3d
     FUNCTION      2        geom3d_brin_inclusion_add_value(internal, internal, internal, internal),
     FUNCTION      3        brin_inclusion_consistent(internal, internal, internal),
     FUNCTION      4        brin_inclusion_union(internal, internal, internal),
+    FUNCTION      11       geom3d_brin_inclusion_merge(internal, internal),
     OPERATOR      3        &&&(geometry, geometry),
     OPERATOR      3        &&&(geometry, gidx),
     OPERATOR      3        &&&(gidx, geometry),
@@ -256,6 +277,7 @@ CREATE OPERATOR CLASS brin_geometry_inclusion_ops_4d
     FUNCTION      2        geom4d_brin_inclusion_add_value(internal, internal, internal, internal),
     FUNCTION      3        brin_inclusion_consistent(internal, internal, internal),
     FUNCTION      4        brin_inclusion_union(internal, internal, internal),
+    FUNCTION      11       geom4d_brin_inclusion_merge(internal, internal),
     OPERATOR      3        &&&(geometry, geometry),
     OPERATOR      3        &&&(geometry, gidx),
     OPERATOR      3        &&&(gidx, geometry),


### PR DESCRIPTION
References #5564. Supports parallel BRIN build on PG17+ and in general should fix some longstanding low-probability crash cases related to BRIN.

For new installs, the `CREATE OPERATOR CLASS` has the new support function entry. For upgrades, removing and re-creating the opclass would remote any existing BRIN indexes. It is possible to insert the new support function into `pg_amproc`, as long as you can pull the `old` numbers for the `geometry` type, the support function itself, and the operator family. For example here's some `INSERT` statements.

```sql
insert into pg_amproc (amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
select 
	pg_opfamily.oid as amprocfamily, 
	pg_type.oid as amproclefttype,
	pg_type.oid as amprocrighttype,
	11 as amprocnum,
	pg_proc.oid::regproc as amproc
from pg_proc, pg_type, pg_opfamily
where pg_proc.proname = 'geom2d_brin_inclusion_merge'
and pg_type.typname = 'geometry'
and pg_opfamily.opfname = 'brin_geometry_inclusion_ops_2d';

insert into pg_amproc (amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
select 
	pg_opfamily.oid as amprocfamily, 
	pg_type.oid as amproclefttype,
	pg_type.oid as amprocrighttype,
	11 as amprocnum,
	pg_proc.oid::regproc as amproc
from pg_proc, pg_type, pg_opfamily
where pg_proc.proname = 'geom3d_brin_inclusion_merge'
and pg_type.typname = 'geometry'
and pg_opfamily.opfname = 'brin_geometry_inclusion_ops_3d';

insert into pg_amproc (amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
select 
	pg_opfamily.oid as amprocfamily, 
	pg_type.oid as amproclefttype,
	pg_type.oid as amprocrighttype,
	11 as amprocnum,
	pg_proc.oid::regproc as amproc
from pg_proc, pg_type, pg_opfamily
where pg_proc.proname = 'geom4d_brin_inclusion_merge'
and pg_type.typname = 'geometry'
and pg_opfamily.opfname = 'brin_geometry_inclusion_ops_4d';

insert into pg_amproc (amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
select 
	pg_opfamily.oid as amprocfamily, 
	pg_type.oid as amproclefttype,
	pg_type.oid as amprocrighttype,
	11 as amprocnum,
	pg_proc.oid::regproc as amproc
from pg_proc, pg_type, pg_opfamily
where pg_proc.proname = 'geog_brin_inclusion_merge'
and pg_type.typname = 'geography'
and pg_opfamily.opfname = 'brin_geography_inclusion_ops';
```

On a new install, you can take a look at what the `pg_amproc` entries are *expected* to be with the following SQL.

```sql
select pg_amproc.* 
from pg_opfamily
join pg_amproc
on pg_amproc.amprocfamily = pg_opfamily.oid
where pg_opfamily.opfname = 'brin_geometry_inclusion_ops_2d';

select pg_amproc.* 
from pg_opfamily
join pg_amproc
on pg_amproc.amprocfamily = pg_opfamily.oid
where pg_opfamily.opfname = 'brin_geometry_inclusion_ops_3d';

select pg_amproc.* 
from pg_opfamily
join pg_amproc
on pg_amproc.amprocfamily = pg_opfamily.oid
where pg_opfamily.opfname = 'brin_geometry_inclusion_ops_4d';

select pg_amproc.* 
from pg_opfamily
join pg_amproc
on pg_amproc.amprocfamily = pg_opfamily.oid
where pg_opfamily.opfname = 'brin_geography_inclusion_ops';
```