### PR TITLE
CI Update: FreeBSD 14.2 and macOS Sonoma

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,95 +1,114 @@
 task:
-  only_if: $CIRRUS_BRANCH =~ 'pull/.*'
+  #  only_if: $CIRRUS_BRANCH =~ 'pull/.*'
   name: FreeBSD
   alias: test-freebsd
-  #env:
-    #MAKE_FLAGS: -j 8
-
-  install_script:
-    - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
-    - ASSUME_ALWAYS_YES=yes pkg bootstrap -f
-    - pkg install -y
-        autoconf
-        automake
-        bison
-        cunit
-        docbook
-        gdal
-        geos
-        gmake
-        iconv
-        json-c
-        libtool
-        libxml2
-        libxslt
-        pcre
-        pkgconf
-        postgresql13-contrib
-        postgresql13-server
-        proj
-        protobuf-c
-        sfcgal
-    - projsync --system-directory --source-id us_noaa
-    - projsync --system-directory --source-id ch_swisstopo
-
+  env:
+    CIRRUS_CLONE_DEPTH: 1
+    CCACHE_DIR: "/tmp/ccache_dir"
+    NCPU: 8
+    MAKEJOBS: "-j${NCPU}"
+    CC: "ccache clang"
+    CXX: "ccache clang++"
+    CCACHE_MAXSIZE: 1
+    CCACHE_COMPRESS: 1
+    CCACHE_STATIC_PREFIX: "/usr/local"
+    CCACHE_NOSTATS: 1
+    CCACHE_TEMPDIR: "/tmp"
+    BASEFS: "${CIRRUS_WORKING_DIR}/test_bulk"
+  freebsd_cache:
+    folder: ${CCACHE_DIR}
+  pkg_bootstrap_script:
+    - |
+      sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+      ASSUME_ALWAYS_YES=yes pkg bootstrap -f
+  pkg_cache:
+    folder: /var/cache/pkg
+    populate_script:
+      pkg fetch -udy autoconf automake bison cunit docbook gdal geos gmake iconv json-c libtool libxml2 libxslt pcre2 pkgconf postgresql13-contrib postgresql13-server proj protobuf-c sfcgal
+  install_pkgs_script:
+    - |
+      env IGNORE_OSVERSION=yes pkg update -f
+      env IGNORE_OSVERSION=yes pkg install -y autoconf automake bison cunit docbook gdal geos gmake iconv json-c libtool libxml2 libxslt pcre2 pkgconf postgresql13-contrib postgresql13-server proj protobuf-c sfcgal
+      projsync --system-directory --source-id us_noaa
+      projsync --system-directory --source-id ch_swisstopo
+  ccache_setup_script:
+    - |
+      env IGNORE_OSVERSION=yes pkg install -y ccache-static
+      ccache --max-size=${CCACHE_MAXSIZE}
   patch_script:
-    # will be removed
-    - find . -name "*.pl" | xargs sed -i -r 's|/usr/bin/perl|/usr/bin/env perl|'
+    - |
+      find . -name "*.pl" | xargs sed -i -r 's|/usr/bin/perl|/usr/bin/env perl|'
   build_script:
-    - ./autogen.sh
-    - ./configure PKG_CONFIG=/usr/local/bin/pkgconf CFLAGS="-isystem /usr/local/include -Wall -fno-omit-frame-pointer -Werror" LDFLAGS="-L/usr/local/lib" --with-libiconv-prefix=/usr/local --without-gui --with-topology --without-raster  --with-sfcgal=/usr/local/bin/sfcgal-config --with-address-standardizer --with-protobuf
-    - service postgresql oneinitdb
-    - service postgresql onestart
-    - su postgres -c "createuser -s `whoami`"
-    - gmake || { service postgresql onestop; exit 1;}
-    - gmake check RUNTESTFLAGS="-v" || { service postgresql onestop; exit 1;}
-    - gmake install || { service postgresql onestop; exit 1;}
-    - gmake check RUNTESTFLAGS="-v --extension" || { service postgresql onestop; exit 1;}
-    - gmake check RUNTESTFLAGS="-v --extension --dumprestore" || { service postgresql onestop; exit 1;}
-    - service postgresql onestop
-
+    - |
+      ./autogen.sh
+      ./configure PKG_CONFIG=/usr/local/bin/pkgconf CFLAGS="-isystem /usr/local/include -Wall -fno-omit-frame-pointer -Werror" LDFLAGS="-L/usr/local/lib" --with-libiconv-prefix=/usr/local --without-gui --with-topology --without-raster --with-sfcgal=/usr/local/bin/sfcgal-config --with-address-standardizer --with-protobuf
+      service postgresql oneinitdb
+      service postgresql onestart
+      su postgres -c "createuser -s `whoami`"
+      gmake ${MAKEJOBS} || { service postgresql onestop; exit 1; }
+      gmake ${MAKEJOBS} install || { service postgresql onestop; exit 1; }
+      ccache -s
+  test_script:
+    - |
+      gmake ${MAKEJOBS} check RUNTESTFLAGS="-v --extension --dumprestore" || { service postgresql onestop; exit 1; }
+      service postgresql onestop
   freebsd_instance:
-    cpu: 8
-    memory: 24g
+    cpu: ${NCPU}
+    memory: 24G
   matrix:
-    # - name: 14-CURRENT
-    #   freebsd_instance:
-    #     image_family: freebsd-14-0-snap
-    - name: 13.2-RELEASE
+    - name: 14.2-RELEASE
       freebsd_instance:
-        image_family: freebsd-13-2
+        image_family: freebsd-14-2
 
 task:
   name: macOS
   alias: test-macos
-  test_script:
-    - brew update
-    - brew install
-        autoconf
-        automake
-        cunit
-        docbook
-        docbook-xsl
-        gdal
-        geos
-        gpp
-        json-c
-        libtool
-        pcre2
-        pkg-config
-        postgresql@14
-        proj
-        sfcgal
-    - ./autogen.sh
-    - ./configure --without-gui --without-interrupt-tests --without-topology --without-raster  --with-sfcgal --with-address-standardizer --without-protobuf --with-pgconfig=/opt/homebrew/opt/postgresql@14/bin/pg_config
-    - brew services start postgresql@14
-    - postgres -V
-    - make -j8 || { brew services stop postgresql@14; exit 1;}
-    - make -j8 check || { brew services stop postgresql@14; exit 1;}
-    - brew services stop postgresql@14
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
 
-  matrix:
-    macos_instance:
-      image: ghcr.io/cirruslabs/macos-ventura-base:latest
-  #  macos_instance:
-  #    image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  env:
+    CC: "ccache clang"
+    CXX: "ccache clang++"
+    CCACHE_DIR: "$HOME/.ccache"
+    CCACHE_MAXSIZE: 1
+    PG: "17"
+    HOMEBREW_PREFIX: "/opt/homebrew"
+    PATH: "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:${HOMEBREW_PREFIX}/opt/ccache/libexec:$PATH"
+
+  setup_script:
+    - |
+      brew update
+      brew install ccache autoconf automake libtool pkg-config gdal geos icu4c json-c libpq libxml2 pcre2 proj protobuf-c sfcgal cunit docbook docbook-xsl postgresql@${PG} gettext
+      brew link --force gettext
+      ccache --max-size=$CCACHE_MAXSIZE
+      sudo ln -sfn ${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/postgres /usr/local/bin/postgres
+
+  test_script:
+    - |
+      export PGCONFIG="${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/pg_config"
+      export CFLAGS="-I${HOMEBREW_PREFIX}/opt/gettext/include \
+                     -I${HOMEBREW_PREFIX}/opt/postgresql@${PG}/include \
+                     -I${HOMEBREW_PREFIX}/include -Wno-nullability-completeness"
+      export LDFLAGS="-L${HOMEBREW_PREFIX}/opt/gettext/lib \
+                      -L${HOMEBREW_PREFIX}/opt/postgresql@${PG}/lib"
+      export CXXFLAGS="-std=c++17"
+
+      ./autogen.sh
+      ./configure --without-gui \
+                  --without-interrupt-tests \
+                  --with-topology \
+                  --without-raster \
+                  --with-sfcgal \
+                  --with-address-standardizer \
+                  --with-protobuf \
+                  --with-pgconfig=${PGCONFIG}
+
+      brew services start postgresql@${PG}
+      make -j$(sysctl -n hw.logicalcpu) || { brew services stop postgresql@${PG}; exit 1; }
+      make -j$(sysctl -n hw.logicalcpu) check || { brew services stop postgresql@${PG}; exit 1; }
+      brew services stop postgresql@${PG}
+
+  macos_cache:
+    folders: ${CCACHE_DIR}
+
+  upload_caches: macos


### PR DESCRIPTION
Small "early year" update. I've rewritten the CI configurations with better step separation for clarity. I've attempted to apply some optimizations and improvements.

FreeBSD:
- Upgrade to FreeBSD 14.2
- Added ccache and cache configuration
- Optimized parallel builds
- Move pcre to pcre2

macOS:
- Update to macOS Sonoma
- Upgrade to PostgreSQL 17
- Add ccache and some flags
- Add with-topology and protobuf support