### PR TITLE
fix PG_FREE_IF_COPY macro parameter position

### DIFF
--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -394,7 +394,7 @@ Datum LWGEOM_asX3D(PG_FUNCTION_ARGS)
 	if (option & LW_X3D_USE_GEOCOORDS) {
 		if (lwgeom->srid != 4326)
 		{
-			PG_FREE_IF_COPY(geom, 0);
+			PG_FREE_IF_COPY(geom, 1);
 			/** TODO: we need to support UTM and other coordinate systems supported by X3D eventually
 			http://www.web3d.org/documents/specifications/19775-1/V3.2/Part01/components/geodata.html#t-earthgeoids **/
 			elog(ERROR, "Only SRID 4326 is supported for geocoordinates.");

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -3659,7 +3659,7 @@ Datum ST_ModEdgeSplit(PG_FUNCTION_ARGS)
   node_id = lwt_ModEdgeSplit(topo, edge_id, pt, 0);
   POSTGIS_DEBUG(1, "lwt_ModEdgeSplit returned");
   lwgeom_free(lwgeom);
-  PG_FREE_IF_COPY(geom, 3);
+  PG_FREE_IF_COPY(geom, 2);
   lwt_FreeTopology(topo);
 
   if ( node_id == -1 )
@@ -3729,7 +3729,7 @@ Datum ST_NewEdgesSplit(PG_FUNCTION_ARGS)
   node_id = lwt_NewEdgesSplit(topo, edge_id, pt, 0);
   POSTGIS_DEBUG(1, "lwt_NewEdgesSplit returned");
   lwgeom_free(lwgeom);
-  PG_FREE_IF_COPY(geom, 3);
+  PG_FREE_IF_COPY(geom, 2);
   lwt_FreeTopology(topo);
 
   if ( node_id == -1 )


### PR DESCRIPTION
The second parameter of the `PG_FREE_IF_COPY` macro is the position of the argument, but an incorrect argument position is specified here.