### PR TITLE
sfcgal: Adapt to SFCGAL 2.1 API changes

### DIFF
--- a/liblwgeom/lwgeom_sfcgal.c
+++ b/liblwgeom/lwgeom_sfcgal.c
@@ -26,12 +26,12 @@
 #include <stdio.h>
 
 #if POSTGIS_SFCGAL_VERSION >= 20100
-#define sfcgal_triangulated_surface_num_triangles(g) sfcgal_geometry_num_geometries((g))
-#define sfcgal_triangulated_surface_triangle_n(g,i)  sfcgal_geometry_get_geometry_n((g), (i))
-#define sfcgal_polyhedral_surface_num_polygons(g)    sfcgal_geometry_num_geometries((g))
-#define sfcgal_polyhedral_surface_polygon_n(g,i)     sfcgal_geometry_get_geometry_n((g), (i))
+#define sfcgal_triangulated_surface_num_triangles(g) sfcgal_triangulated_surface_num_patchs((g))
+#define sfcgal_triangulated_surface_triangle_n(g,i)  sfcgal_triangulated_surface_patch_n((g), (i))
+#define sfcgal_polyhedral_surface_num_polygons(g)    sfcgal_polyhedral_surface_num_patchs((g))
+#define sfcgal_polyhedral_surface_polygon_n(g,i)     sfcgal_polyhedral_surface_patch_n((g), (i))
 #define sfcgal_geometry_collection_num_geometries(g) sfcgal_geometry_num_geometries((g))
-#define sfcgal_geometry_collection_geometry_n(g,i)   sfcgal_geometry_get_geometry_n((g), (i))
+#define sfcgal_polyhedral_surface_add_polygon(g, p) sfcgal_polyhedral_surface_add_patch((g), (p))
 #endif
 
 


### PR DESCRIPTION
`PolyhedralSurface` and `TriangulatedSurface` are now correctly considered as one geometry instead of sometimes a collection of polygons or triangles.

Some C API calls introduced during SFCGAL 2.1 development have been renamed to reflect that change.

See: https://gitlab.com/sfcgal/SFCGAL/-/merge_requests/461