### PR TITLE
MSVC Compat 1 v2: Reconcile attributes and math macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,6 +186,11 @@ case $host_os in
 esac
 AC_SUBST([MINGWBUILD])
 
+dnl
+dnl define _USE_MATH_DEFINES for Windows
+dnl
+AC_DEFINE([_USE_MATH_DEFINES], [], [Define to use math constants in MSVC])
+
 AC_PATH_PROG([CODESPELL], [codespell], [])
 if test "x$CODESPELL" = "x"; then
 	AC_MSG_WARN([codespell is not installed so spelling cannot be checked])

--- a/liblwgeom/lwgeom_config.h
+++ b/liblwgeom/lwgeom_config.h
@@ -1,0 +1,30 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * PostGIS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PostGIS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************
+ *
+ * Copyright 2025 Loïc Bartoletti <loic.bartoletti@oslandia.com>
+ *
+ **********************************************************************/
+
+
+#if defined(__GNUC__) || defined(__clang__)
+  #define PRINTF_FORMAT(fmt_index, args_index) __attribute__ ((format (printf, fmt_index, args_index)))
+#else
+  #define PRINTF_FORMAT(fmt_index, args_index)
+#endif

--- a/liblwgeom/lwgeom_geos.h
+++ b/liblwgeom/lwgeom_geos.h
@@ -23,9 +23,11 @@
  *
  **********************************************************************/
 
+#include "lwgeom_config.h"
+
 #if POSTGIS_GEOS_VERSION < 31300
 /* See https://github.com/libgeos/geos/pull/1097 */
-typedef void (*GEOSMessageHandler)(const char *fmt, ...) __attribute__ (( format(printf, 1, 2) ));
+typedef void (*GEOSMessageHandler)(const char *fmt, ...) PRINTF_FORMAT(1, 2);
 #endif
 
 #include "geos_c.h"
@@ -50,7 +52,7 @@ int union_dbscan(LWGEOM **geoms, uint32_t num_geoms, UNIONFIND *uf, double eps, 
 POINTARRAY* ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3d);
 
 extern char lwgeom_geos_errmsg[];
-extern void lwgeom_geos_error(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+extern void lwgeom_geos_error(const char* fmt, ...) PRINTF_FORMAT(1, 2);
 
 
 /*

--- a/liblwgeom/lwgeom_log.h
+++ b/liblwgeom/lwgeom_log.h
@@ -30,6 +30,7 @@
 #define LWGEOM_LOG_H 1
 
 #include <stdarg.h>
+#include "lwgeom_config.h"
 
 /*
  * Debug macros
@@ -126,7 +127,7 @@
  * For debugging, use LWDEBUG() or LWDEBUGF().
  * @ingroup logging
  */
-void lwnotice(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void lwnotice(const char *fmt, ...) PRINTF_FORMAT(1, 2);
 
 /**
  * Write a notice out to the error handler.
@@ -136,7 +137,7 @@ void lwnotice(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
  * For debugging, use LWDEBUG() or LWDEBUGF().
  * @ingroup logging
  */
-void lwerror(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void lwerror(const char *fmt, ...) PRINTF_FORMAT(1, 2);
 
 /**
  * Write a debug message out.
@@ -145,7 +146,7 @@ void lwerror(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
  * efficiency.
  * @ingroup logging
  */
-void lwdebug(int level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+void lwdebug(int level, const char *fmt, ...) PRINTF_FORMAT(2, 3);
 
 
 


### PR DESCRIPTION
This PR supersedes https://git.osgeo.org/gitea/postgis/postgis/pulls/208 and https://github.com/postgis/postgis/pull/777.

@ralian If I'm not mistaken, you don't need to include _USE_MATH_DEFINES in multiple files. It can be defined once globally. Could you test this PR? 
If the AC_DEFINE approach is not sufficient, you can define it by adding `CPPFLAGS="$CPPFLAGS -D_USE_MATH_DEFINES"`.

I'm also proposing an alternative version of the attribute macro that could be reused elsewhere in the codebase.