### PR TITLE
Coverage Cleaning with GEOS 3.14

### DIFF
--- a/doc/reference_coverage.xml
+++ b/doc/reference_coverage.xml
@@ -109,6 +109,7 @@ SELECT true = ALL (
       <para>
         <xref linkend="ST_IsValid"/>,
         <xref linkend="ST_CoverageUnion"/>,
+        <xref linkend="ST_CoverageClean"/>,
         <xref linkend="ST_CoverageSimplify"/>
       </para>
     </refsection>
@@ -212,7 +213,9 @@ SELECT id, ST_AsText(ST_CoverageSimplify(geom, 30) OVER ())
     <refsection>
       <title>See Also</title>
       <para>
-        <xref linkend="ST_CoverageInvalidEdges"/>
+        <xref linkend="ST_CoverageInvalidEdges"/>,
+        <xref linkend="ST_CoverageUnion"/>,
+        <xref linkend="ST_CoverageClean"/>
       </para>
     </refsection>
 
@@ -301,9 +304,90 @@ MULTIPOLYGON (((10 150, 80 190, 110 150, 140 80, 120 10, 10 10, 10 150), (50 60,
       <title>See Also</title>
       <para>
         <xref linkend="ST_CoverageInvalidEdges"/>,
+        <xref linkend="ST_CoverageSimplify"/>,
+        <xref linkend="ST_CoverageClean"/>,
         <xref linkend="ST_Union"/>
       </para>
     </refsection>
 
   </refentry>
+
+
+
+
+  <refentry xml:id="ST_CoverageClean">
+    <refnamediv>
+      <refname>ST_CoverageClean</refname>
+
+      <refpurpose>Computes a clean (edge matched, non-overlapping, gap-cleared) polygonal coverage, given a non-clean input.</refpurpose>
+    </refnamediv>
+
+    <refsynopsisdiv>
+      <funcsynopsis>
+        <funcprototype>
+          <funcdef>geometry <function>ST_CoverageClean</function></funcdef>
+          <paramdef><type>geometry winset</type>
+            <parameter>geom</parameter></paramdef>
+          <paramdef choice="opt"><type>float8 </type>
+            <parameter>snappingDistance = -1</parameter></paramdef>
+          <paramdef choice="opt"><type>float8 </type>
+            <parameter>gapMaximumWidth = 0</parameter></paramdef>
+          <paramdef choice="opt"><type>text </type>
+            <parameter>overlapMergeStrategy = 'MERGE_LONGEST_BORDER'</parameter></paramdef>
+        </funcprototype>
+      </funcsynopsis>
+    </refsynopsisdiv>
+
+    <refsection>
+      <title>Description</title>
+
+      <para>A window function which alters the edges of a polygonal coverage to ensure that none of the polygons overlap, that small gaps are snapped away, and that all shared edges are exactly identical. The result is a clean coverage that will pass validation tests like <xref linkend="ST_CoverageInvalidEdges"/></para>
+      <para>The <parameter>snappingDistance</parameter> controls the node snapping step, when nearby vertices are snapped together. The default setting (-1) applies an automatic snapping distance based on an analysis of the input. Set to 0.0 to turn off all snapping.</para>
+      <para>The <parameter>gapMaximumWidth</parameter> controls the cleaning of gaps between polygons. Gaps smaller than this tolerance will be closed.</para>
+      <para>The <parameter>overlapMergeStrategy</parameter> controls the algorithm used to determine which neighboring polygons to merge overlapping areas into.</para>
+      <para><code>MERGE_LONGEST_BORDER</code> chooses polygon with longest common border</para>
+      <para><code>MERGE_MAX_AREA</code> chooses polygon with maximum area</para>
+      <para><code>MERGE_MIN_AREA</code> chooses polygon with minimum area</para>
+      <para><code>MERGE_MIN_INDEX</code> chooses polygon with smallest input index</para>
+
+      <para role="availability" conformance="3.6.0">Availability: 3.6.0 - requires GEOS &gt;= 3.14.0</para>
+    </refsection>
+
+    <refsection>
+      <title>Examples</title>
+
+      <programlisting>-- Populate demo table
+CREATE TABLE example AS SELECT * FROM (VALUES
+  (1, 'POLYGON ((10 190, 30 160, 40 110, 100 70, 120 10, 10 10, 10 190))'::geometry),
+  (2, 'POLYGON ((100 190, 10 190, 30 160, 40 110, 50 80, 74 110.5, 100 130, 140 120, 140 160, 100 190))'::geometry),
+  (3, 'POLYGON ((140 190, 190 190, 190 80, 140 80, 140 190))'::geometry),
+  (4, 'POLYGON ((180 40, 120 10, 100 70, 140 80, 190 80, 180 40))'::geometry)
+) AS v(id, geom);
+
+-- Prove it is a dirty coverage
+SELECT ST_AsText(ST_CoverageInvalidEdges(geom) OVER ())
+  FROM example;
+
+-- Clean the coverage
+CREATE TABLE example_clean AS
+  SELECT id, ST_CoverageClean(geom) OVER () AS GEOM
+  FROM example;
+
+-- Prove it is a clean coverage
+SELECT ST_AsText(ST_CoverageInvalidEdges(geom) OVER ())
+  FROM example_clean;
+      </programlisting>
+    </refsection>
+
+    <refsection>
+      <title>See Also</title>
+      <para>
+        <xref linkend="ST_CoverageInvalidEdges"/>,
+        <xref linkend="ST_Union"/>
+        <xref linkend="ST_CoverageSimplify"/>
+      </para>
+    </refsection>
+
+  </refentry>
+
 </section>

--- a/postgis/lwgeom_window.c
+++ b/postgis/lwgeom_window.c
@@ -824,7 +824,7 @@ Datum ST_CoverageSimplify(PG_FUNCTION_ARGS)
 #if POSTGIS_GEOS_VERSION < 31200
 
 	lwpgerror("The GEOS version this PostGIS binary "
-		"was compiled against (%d) doesn't support "
+		"was compiled against (%d) not include "
 		"'GEOSCoverageSimplifyVW' function (3.12 or greater required)",
 		POSTGIS_GEOS_VERSION);
 	PG_RETURN_NULL();
@@ -844,7 +844,7 @@ Datum ST_CoverageInvalidEdges(PG_FUNCTION_ARGS)
 #if POSTGIS_GEOS_VERSION < 31200
 
 	lwpgerror("The GEOS version this PostGIS binary "
-		"was compiled against (%d) doesn't support "
+		"was compiled against (%d) does not include "
 		"'GEOSCoverageIsValid' function (3.12 or greater required)",
 		POSTGIS_GEOS_VERSION);
 	PG_RETURN_NULL();
@@ -863,8 +863,8 @@ Datum ST_CoverageClean(PG_FUNCTION_ARGS)
 #if POSTGIS_GEOS_VERSION < 31400
 
 	lwpgerror("The GEOS version this PostGIS binary "
-		"was compiled against (%d) doesn't support "
-		"'ST_CoverageClean' function (3.14 or greater required)",
+		"was compiled against (%d) not include "
+		"'GEOSCoverageClean' function (3.14 or greater required)",
 		POSTGIS_GEOS_VERSION);
 	PG_RETURN_NULL();
 

--- a/postgis/lwgeom_window.c
+++ b/postgis/lwgeom_window.c
@@ -696,7 +696,7 @@ coverage_window_calculation(PG_FUNCTION_ARGS, int mode)
 			if (!isnull) tolerance = DatumGetFloat8(d);
 
 			d = WinGetFuncArgCurrent(winobj, 2, &isnull);
-			if (!isnull) simplifyBoundary = DatumGetBool(d);
+			if (!isnull) simplifyBoundary = DatumGetFloat8(d);
 
 			/* GEOSCoverageSimplifyVW is "preserveBoundary" so we invert simplifyBoundary */
 			output = GEOSCoverageSimplifyVW(input, tolerance, !simplifyBoundary);
@@ -723,12 +723,19 @@ coverage_window_calculation(PG_FUNCTION_ARGS, int mode)
 			if (!isnull) snappingDistance = DatumGetFloat8(d);
 
 			d = WinGetFuncArgCurrent(winobj, 2, &isnull);
-			if (!isnull) gapMaximumWidth = DatumGetBool(d);
+			if (!isnull) gapMaximumWidth = DatumGetFloat8(d);
 
 			d = WinGetFuncArgCurrent(winobj, 3, &isnull);
 			// if (!isnull) overlapMergeStrategy = DatumGetInt32(d);
-			if (!isnull) overlapMergeStrategyText = DatumGetTextP(d);
-			overlapMergeStrategy = coverage_merge_strategy(text_to_cstring(overlapMergeStrategyText));
+			if (!isnull)
+			{
+				overlapMergeStrategyText = DatumGetTextP(d);
+				overlapMergeStrategy = coverage_merge_strategy(text_to_cstring(overlapMergeStrategyText));
+			}
+			else
+			{
+				overlapMergeStrategy = 0; /* Default to MERGE_LONGEST_BORDER */
+			}
 			if (overlapMergeStrategy < 0)
 			{
 				HANDLE_GEOS_ERROR("Invalid OverlapMergeStrategy");

--- a/postgis/lwgeom_window.c
+++ b/postgis/lwgeom_window.c
@@ -636,7 +636,7 @@ static int
 coverage_merge_strategy(const char *strategy)
 {
 	size_t stratLen = sizeof(overlapMergeStrategies) / sizeof(overlapMergeStrategies[0]);
-	for (uint32_t i = 0; i < stratLen; i++)
+	for (size_t i = 0; i < stratLen; i++)
 	{
 		if (strcasecmp(strategy, overlapMergeStrategies[i]) == 0)
 		{
@@ -825,7 +825,7 @@ Datum ST_CoverageSimplify(PG_FUNCTION_ARGS)
 
 	lwpgerror("The GEOS version this PostGIS binary "
 		"was compiled against (%d) doesn't support "
-		"'GEOSCoverageSimplifyVW' function (3.14 or greater required)",
+		"'GEOSCoverageSimplifyVW' function (3.12 or greater required)",
 		POSTGIS_GEOS_VERSION);
 	PG_RETURN_NULL();
 

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -4467,6 +4467,13 @@ CREATE OR REPLACE FUNCTION ST_CoverageInvalidEdges (geom geometry, tolerance flo
 	LANGUAGE 'c' IMMUTABLE STRICT WINDOW PARALLEL SAFE
 	_COST_HIGH;
 
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION ST_CoverageClean (geom geometry, snappingDistance float8 default -1.0, gapMaximumWidth float8 default 0.0, overlapMergeStrategy text default 'MERGE_LONGEST_BORDER')
+	RETURNS geometry
+	AS 'MODULE_PATHNAME', 'ST_CoverageClean'
+	LANGUAGE 'c' IMMUTABLE STRICT WINDOW PARALLEL SAFE
+	_COST_HIGH;
+
 --------------------------------------------------------------------------------
 
 -- Availability: 2.3.0


### PR DESCRIPTION
First draft of PostGIS exposure of new coverage cleaner.

API is a window function:
```
geometry ST_CoverageClean(
          geometry winset geom,
          float8  snappingDistance = -1,
          float8  gapMaximumWidth = 0,
          text  overlapMergeStrategy = 'MERGE_LONGEST_BORDER'
)
```