### PR TITLE
Topology support for big int

### DIFF
--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1367,11 +1367,11 @@ ANALYZE themselves, to use updated statistics.
 					<funcprototype>
 						<funcdef>integer <function>CreateTopology</function></funcdef>
 						<paramdef><type>name </type> <parameter>topology_schema_name</parameter></paramdef>
-						<paramdef><type>integer </type> <parameter>srid</parameter></paramdef>
-						<paramdef><type>double precision </type> <parameter>prec</parameter></paramdef>
-						<paramdef><type>boolean </type> <parameter>hasz</parameter></paramdef>
-                        <paramdef><type>integer </type> <parameter>topoid</parameter></paramdef>
-                        <paramdef><type>boolean </type> <parameter>useslargeids</parameter></paramdef>
+						<paramdef choice="opt"><type>integer </type> <parameter>srid</parameter></paramdef>
+						<paramdef choice="opt"><type>double precision </type> <parameter>prec</parameter></paramdef>
+						<paramdef choice="opt"><type>boolean </type> <parameter>hasz</parameter></paramdef>
+                        <paramdef choice="opt"><type>integer </type> <parameter>topoid</parameter></paramdef>
+                        <paramdef choice="opt"><type>boolean </type> <parameter>useslargeids</parameter></paramdef>
 					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
@@ -1386,7 +1386,7 @@ ANALYZE themselves, to use updated statistics.
 				It returns the id of the topology.
 				</para>
 
- 				<para>The <varname>srid</varname> is the <link linkend="spatial_ref_sys">spatial reference system</link> SRID for the topology.
+ 				<para>The <varname>srid</varname> is the <link linkend="spatial_ref_sys">spatial reference system</link> SRID for the topology. The SRID defaults to -1 (unknown) if not specified.
 				</para>
 
 				<para>The tolerance <varname>prec</varname> is measured in the units of the spatial reference system.
@@ -1394,6 +1394,10 @@ ANALYZE themselves, to use updated statistics.
 				</para>
 
 				<para><varname>hasz</varname> defaults to false if not specified. </para>
+
+                <para><varname>topoid</varname> optional explicit identifier (allows deterministic topology id assignment, needs to be unique)</para>
+
+                <para><varname>useslargeids</varname> optional, defaults to false. If true, the topology will be created to support large ids (int8) for topology and primitive ids.</para>
 
                 <para>This is similar to the SQL/MM <xref linkend="ST_InitTopoGeo"/> but has more functionality.</para>
 

--- a/topology/sql/manage/AddTopoGeometryColumn.sql.in
+++ b/topology/sql/manage/AddTopoGeometryColumn.sql.in
@@ -36,7 +36,7 @@ DECLARE
   tbl varchar;
   sql TEXT;
 BEGIN
-  IF layerid IS NOT NULL and layerid < 0 THEN
+  IF layerid IS NOT NULL and layerid <= 0 THEN
     RAISE EXCEPTION 'Invalid Layer ID % (must be > 0)', layerid;
   END IF;
 
@@ -129,18 +129,7 @@ BEGIN
     || quote_literal(col) || ','
     || intlayertype || ');';
 
-  EXECUTE 'INSERT INTO '
-       'topology.layer(topology_id, '
-       'layer_id, level, child_id, schema_name, '
-       'table_name, feature_column, feature_type) '
-       'VALUES ('
-    || topoid || ','
-    || newlayer_id || ',' || COALESCE(newlevel, 0) || ','
-    || COALESCE(child::text, 'NULL') || ','
-    || quote_literal(schema) || ','
-    || quote_literal(tbl) || ','
-    || quote_literal(col) || ','
-    || intlayertype || ');';
+  EXECUTE sql;
 
   --
   -- Create a sequence for TopoGeometries in this new layer

--- a/topology/sql/manage/UpgradeTopology.sql.in
+++ b/topology/sql/manage/UpgradeTopology.sql.in
@@ -80,11 +80,11 @@ BEGIN
 		SELECT setval('%1$I.face_face_id_seq', %2$s);
 
 		ALTER TABLE %1$I.face
-    	ALTER COLUMN face_id SET DEFAULT nextval('%1$I.face_face_id_seq');
+      ALTER COLUMN face_id SET DEFAULT nextval('%1$I.face_face_id_seq');
 
 		-- Upgrade the edge_data table
-  		-- Drop the edge view
-    	DROP VIEW IF EXISTS %1$I.edge;
+  	-- Drop the edge view
+    DROP VIEW IF EXISTS %1$I.edge;
 
 		ALTER TABLE %1$I.edge_data
     	ALTER COLUMN edge_id TYPE BIGINT;
@@ -164,40 +164,41 @@ BEGIN
 		);
 
 		-- Upgrade the node table
-	    ALTER TABLE %1$I.node
+	  ALTER TABLE %1$I.node
 	    ALTER COLUMN node_id TYPE BIGINT;
-		
-	    ALTER TABLE %1$I.node
+
+	  ALTER TABLE %1$I.node
 	    ALTER COLUMN node_id DROP DEFAULT;
 
-    	DROP SEQUENCE %1$I.node_node_id_seq;
+    DROP SEQUENCE %1$I.node_node_id_seq;
 
-    	CREATE SEQUENCE %1$I.node_node_id_seq AS BIGINT;
+    CREATE SEQUENCE %1$I.node_node_id_seq AS BIGINT;
 
 		SELECT setval('%1$I.node_node_id_seq', %4$s);
 
 		ALTER TABLE %1$I.node
     	ALTER COLUMN node_id SET DEFAULT nextval('%1$I.node_node_id_seq');
 
-	    ALTER TABLE %1$I.node
+	  ALTER TABLE %1$I.node
 	    ALTER COLUMN containing_face TYPE BIGINT;
 
 		-- Upgrade the relation table
-	    ALTER TABLE %1$I.relation
+	  ALTER TABLE %1$I.relation
 	    ALTER COLUMN topogeo_id TYPE BIGINT;
 
-	    ALTER TABLE %1$I.relation
+	  ALTER TABLE %1$I.relation
 	    ALTER COLUMN element_id TYPE BIGINT;
 
   		-- Update the topology table
-	    UPDATE topology.topology
-	    SET useslargeids = true
-	    WHERE id = topology.id;
-	$$,
-	toponame,
-	face_currval,
-	edge_currval,
-	node_currval
+	  UPDATE topology.topology
+	  SET useslargeids = true
+	  WHERE id = %5$s;
+    $$,
+    toponame,
+    face_currval,
+    edge_currval,
+    node_currval,
+    topo.id
   );
 
   --RAISE INFO '%', sql;

--- a/topology/sql/query/getfacebypoint.sql.in
+++ b/topology/sql/query/getfacebypoint.sql.in
@@ -37,7 +37,7 @@ $BODY$
 DECLARE
   rec RECORD;
   sql TEXT;
-  sideFaces INT8[];
+  sideFaces BIGINT[];
 BEGIN
 
   -- Check if any edge intersects the query circle

--- a/topology/test/load_large_topology.sql.in
+++ b/topology/test/load_large_topology.sql.in
@@ -195,5 +195,10 @@ SELECT NULL FROM setval('large_city_data.edge_data_edge_id_seq', 1000000000026);
 -- Set face minimum bounding rectangle
 UPDATE large_city_data.face set mbr = ST_SetSRID( ( select st_extent(geom) from large_city_data.edge where left_face = face_id or right_face = face_id ), @SRID@ ) where face_id != 0;
 
+-- Validate the loaded topology
+SELECT 'load_validation', *
+FROM ValidateTopology('large_city_data')
+WHERE error IS NOT NULL;
+
 END;
 


### PR DESCRIPTION
* Update c types to support int64 instead of int32 for IDs - face,edge,node,element,topogeo
* Modify the pre and post scripts including the restore, uninstall and upgrade script generators
* Upgrade core elements to support bigint - topoelement, topoelementarray and topogeometry
* Modify createtopogeom to support bigint including tests
* Modify createtopology - consolidate into single function and add large ids support
* Modified addtopogeomcolumn - added support for bigint including tests
* Modify topology query methods that need bigint
* Modify topology sql functions that require bigint for input or output (including tests)
* Modify validatetopology to support large ids. Also modified copytopology and topologysummary including tests
* Add dedicated tests for large id topologies
* Add topology.upgradetopology function
* Update NEWS