### PR TITLE
.gitignore .deps/ .Po build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ config.guess
 config.sub
 config.status
 configure
+.deps/
 doc/html/postgis-*
 doc/images
 doc/html/images/generator


### PR DESCRIPTION
Saw these artifacts show up as untracked after performing a simple make.  Doesn't seem like it is something only my setup would be generating so put it in the project .gitignore

https://trac.osgeo.org/postgis/ticket/5972#ticket