### PR TITLE
doc(sfcgal): Fix CG_ApproximateMedialAxis regarding 3d geometries

### DIFF
--- a/doc/reference_sfcgal.xml
+++ b/doc/reference_sfcgal.xml
@@ -1778,8 +1778,9 @@ ST_GeomFromText('POLYHEDRALSURFACE Z( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),
             </para>
 
             <para role="availability" conformance="3.5.0">Availability: 3.5.0</para>
+            <note><para>This function ignores the Z dimension.
+It always gives a 2D result even when used on a 3D geometry.</para></note>
             <para>&sfcgal_required;</para>
-            <para>&Z_support;</para>
             <para>&P_support;</para>
             <para>&T_support;</para>
         </refsection>


### PR DESCRIPTION
CG_ApproximateMedialAxis ignores the Z dimension and always gives a 2D result.


cc @lbartoletti 