### PR TITLE
Remove uninitialized variable warning

### DIFF
--- a/postgis/gserialized_estimate.c
+++ b/postgis/gserialized_estimate.c
@@ -2603,7 +2603,7 @@ Datum gserialized_estimated_extent(PG_FUNCTION_ARGS)
 	int16 attnum, idx_attnum;
 	Oid atttypid = InvalidOid;
 	char nsp_tbl[2*NAMEDATALEN+6];
-	char *tbl;
+	char *tbl = NULL;
 	Oid tbl_oid, idx_oid = 0;
 	ND_STATS *nd_stats;
 	GBOX *gbox = NULL;


### PR DESCRIPTION
I fixed a compilation issue related to an uninitialized variable. In our environment, this warning lead to an error.

Should I add the following switch 
-Wmaybe-uninitialized
to run_tests.sh / run_upgrade.sh