### PR TITLE
Fix null pointer dereference in ST_AsGeoJsonRow()

### DIFF
--- a/postgis/lwgeom_out_geojson.c
+++ b/postgis/lwgeom_out_geojson.c
@@ -91,7 +91,7 @@ ST_AsGeoJsonRow(PG_FUNCTION_ARGS)
 	text        *id_column_text = PG_GETARG_TEXT_P(4);
 	StringInfo	result;
 	char        *geom_column = text_to_cstring(geom_column_text);
-	char        *id_column = text_to_cstring(id_column_text);
+	char        *id_column = id_column_text == NULL ? "" : text_to_cstring(id_column_text);
 	Oid geom_oid = InvalidOid;
 	Oid geog_oid = InvalidOid;
 


### PR DESCRIPTION
If extension is created before 3.5 and the actual postgis-3.so is from 3.5 or newer, we experience crash when ST_AsGeoJsonRow() is called.

Crash happens because of ST_AsGeoJsonRow() expects to get id_column value as an empty string, however this parameter doesn't exist in old version of the function:
```sql
-- Availability: 3.0.0
-- Changed: 3.5.0 add id_column='' parameter
-- Replaces ST_AsGeoJson(record, text, integer, bool) deprecated in 3.5.0
CREATE OR REPLACE FUNCTION ST_AsGeoJson(r record, geom_column text DEFAULT '', maxdecimaldigits integer DEFAULT 9, pretty_bool boolean DEFAULT false, id_column text DEFAULT '')
    RETURNS text
    AS 'MODULE_PATHNAME','ST_AsGeoJsonRow'
    LANGUAGE 'c' STABLE STRICT PARALLEL SAFE
    _COST_MEDIUM;
```
As a result, we receive NULL and text_to_cstring(NULL) call results in segfault.