### PR TITLE
Fix NULL-pointer checks for gaztab and rultab in GetStdFromPortalCache

### DIFF
--- a/extensions/address_standardizer/std_pg_hash.c
+++ b/extensions/address_standardizer/std_pg_hash.c
@@ -251,8 +251,8 @@ GetStdFromPortalCache(StdPortalCache *STDCache,  char *lextab, char *gaztab, cha
     for (i=0; i<STD_CACHE_ITEMS; i++) {
         StdCacheItem *ci = &STDCache->StdCache[i];
         if (ci->lextab && !strcmp(ci->lextab, lextab) &&
-            ci->lextab && !strcmp(ci->gaztab, gaztab) &&
-            ci->lextab && !strcmp(ci->rultab, rultab))
+            ci->gaztab && !strcmp(ci->gaztab, gaztab) &&
+            ci->rultab && !strcmp(ci->rultab, rultab))
                 return STDCache->StdCache[i].std;
     }
 


### PR DESCRIPTION
Bad copy paste was potential reason of NULL pointer dereference

Fixes: c6091a4bb ("Prep to move address_standardizer into extensions folder")