### PR TITLE
liblwgeom: Add NULL geometry check in lwgeom_simplify_in_place

### DIFF
--- a/liblwgeom/lwgeom.c
+++ b/liblwgeom/lwgeom.c
@@ -1893,6 +1893,13 @@ int
 lwgeom_simplify_in_place(LWGEOM *geom, double epsilon, int preserve_collapsed)
 {
 	int modified = LW_FALSE;
+
+	if (!geom)
+	{
+		lwerror("NULL geometry encountered");
+		return LW_FALSE;
+	}
+
 	switch (geom->type)
 	{
 		/* No-op! Cannot simplify points or triangles */


### PR DESCRIPTION
Prevent crash by checking for NULL geometry parameter and returning appropriate error message instead of dereferencing NULL pointer.