### PR TITLE
Export MobilityDB PostGIS helper APIs

### DIFF
--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -29,6 +29,12 @@
 #ifndef _LIBLWGEOM_H
 #define _LIBLWGEOM_H 1
 
+#ifdef _WIN32
+#  define PGDLLEXPORT __declspec(dllexport)
+#else
+#  define PGDLLEXPORT
+#endif
+
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -29,10 +29,12 @@
 #ifndef _LIBLWGEOM_H
 #define _LIBLWGEOM_H 1
 
-#ifdef _WIN32
-#  define PGDLLEXPORT __declspec(dllexport)
-#else
-#  define PGDLLEXPORT
+#ifndef PGDLLEXPORT
+#  ifdef _WIN32
+#    define PGDLLEXPORT __declspec(dllexport)
+#  else
+#    define PGDLLEXPORT
+#  endif
 #endif
 
 #include <stdarg.h>
@@ -1765,7 +1767,7 @@ extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
 #if defined(HAVE_LIBJSON)
 /* Forward-declare to avoid exposing json-c headers in a public API */
 struct json_object;
-extern LWGEOM *parse_geojson(struct json_object *geojson, int *hasz);
+extern PGDLLEXPORT LWGEOM *parse_geojson(struct json_object *geojson, int *hasz);
 #endif /* HAVE_LIBJSON */
 
 /**
@@ -2271,6 +2273,8 @@ extern lwvarlena_t* lwgeom_to_wkt_varlena(const LWGEOM *geom, uint8_t variant, i
 *                (WKB_ISO, WKB_SFSQL, WKB_EXTENDED, WKB_NDR, WKB_XDR)
 */
 extern uint8_t* lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant);
+extern PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+extern PGDLLEXPORT uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
 extern lwvarlena_t* lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant);
 
 /**
@@ -2677,4 +2681,3 @@ int * lwgeom_cluster_kmeans(const LWGEOM **geoms, uint32_t n, uint32_t k, double
 #include "lwinline.h"
 
 #endif /* !defined _LIBLWGEOM_H  */
-

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1757,6 +1757,8 @@ extern lwvarlena_t* lwgeom_to_encoded_polyline(const LWGEOM *geom, int precision
 extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
 
 #if defined(HAVE_LIBJSON)
+/* Forward-declare to avoid exposing json-c headers in a public API */
+struct json_object;
 extern LWGEOM *parse_geojson(json_object *geojson, int *hasz)
 #endif /* HAVE_LIBJSON */
 

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1759,7 +1759,7 @@ extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
 #if defined(HAVE_LIBJSON)
 /* Forward-declare to avoid exposing json-c headers in a public API */
 struct json_object;
-extern LWGEOM *parse_geojson(json_object *geojson, int *hasz)
+extern LWGEOM *parse_geojson(json_object *geojson, int *hasz);
 #endif /* HAVE_LIBJSON */
 
 /**

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1759,7 +1759,7 @@ extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
 #if defined(HAVE_LIBJSON)
 /* Forward-declare to avoid exposing json-c headers in a public API */
 struct json_object;
-extern LWGEOM *parse_geojson(json_object *geojson, int *hasz);
+extern LWGEOM *parse_geojson(struct json_object *geojson, int *hasz);
 #endif /* HAVE_LIBJSON */
 
 /**

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1756,6 +1756,10 @@ extern lwvarlena_t* lwgeom_to_encoded_polyline(const LWGEOM *geom, int precision
  */
 extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
 
+#if defined(HAVE_LIBJSON)
+extern LWGEOM *parse_geojson(json_object *geojson, int *hasz)
+#endif /* HAVE_LIBJSON */
+
 /**
  * Create an LWGEOM object from an Encoded Polyline representation
  *

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -46,7 +46,7 @@
 #include <string.h>
 
 /* Prototype */
-LWGEOM *parse_geojson(json_object *geojson, int *hasz);
+PGDLLEXPORT LWGEOM *parse_geojson(json_object *geojson, int *hasz);
 
 static inline json_object *
 findMemberByName(json_object *poObj, const char *pszName)
@@ -359,7 +359,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 	return geom;
 }
 
-inline LWGEOM *
+LWGEOM *
 parse_geojson(json_object *geojson, int *hasz)
 {
 	json_object *type = NULL;

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -102,7 +102,7 @@ parse_coordinates(json_object *geojson)
 }
 
 
-inline int
+static inline int
 parse_geojson_coord(json_object *poObj, int *hasz, POINTARRAY *pa)
 {
 	POINT4D pt = {0, 0, 0, 0};
@@ -359,7 +359,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 	return geom;
 }
 
-static inline LWGEOM *
+inline LWGEOM *
 parse_geojson(json_object *geojson, int *hasz)
 {
 	json_object *type = NULL;

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -46,7 +46,7 @@
 #include <string.h>
 
 /* Prototype */
-static LWGEOM *parse_geojson(json_object *geojson, int *hasz);
+LWGEOM *parse_geojson(json_object *geojson, int *hasz);
 
 static inline json_object *
 findMemberByName(json_object *poObj, const char *pszName)
@@ -102,7 +102,7 @@ parse_coordinates(json_object *geojson)
 }
 
 
-static inline int
+inline int
 parse_geojson_coord(json_object *poObj, int *hasz, POINTARRAY *pa)
 {
 	POINT4D pt = {0, 0, 0, 0};

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -359,7 +359,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 	return geom;
 }
 
-LWGEOM *
+PGDLLEXPORT LWGEOM *
 parse_geojson(json_object *geojson, int *hasz)
 {
 	json_object *type = NULL;

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -29,8 +29,8 @@
 #include "liblwgeom_internal.h"
 #include "lwgeom_log.h"
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
-static size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
 
 /*
 * Look-up table for hex writer
@@ -672,7 +672,7 @@ static uint8_t* lwcollection_to_wkb_buf(const LWCOLLECTION *col, uint8_t *buf, u
 /*
 * GEOMETRY
 */
-static size_t
+size_t
 lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 {
 	size_t size = 0;
@@ -736,7 +736,7 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 
 /* TODO handle the TRIANGLE type properly */
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
 {
 
 	/* Do not simplify empties when outputting to canonical form */

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -29,8 +29,8 @@
 #include "liblwgeom_internal.h"
 #include "lwgeom_log.h"
 
-uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
-size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+PGDLLEXPORT uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
 
 /*
 * Look-up table for hex writer
@@ -672,7 +672,7 @@ static uint8_t* lwcollection_to_wkb_buf(const LWCOLLECTION *col, uint8_t *buf, u
 /*
 * GEOMETRY
 */
-size_t
+PGDLLEXPORT size_t
 lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 {
 	size_t size = 0;
@@ -736,7 +736,7 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 
 /* TODO handle the TRIANGLE type properly */
 
-uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+PGDLLEXPORT uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
 {
 
 	/* Do not simplify empties when outputting to canonical form */

--- a/liblwgeom/lwunionfind.c
+++ b/liblwgeom/lwunionfind.c
@@ -147,7 +147,9 @@ UF_get_collapsed_cluster_ids(UNIONFIND *uf, const uint8_t *is_in_cluster)
 {
 	uint32_t* ordered_components = UF_ordered_by_cluster(uf);
 	uint32_t* new_ids = lwalloc(uf->N * sizeof(uint32_t));
-	memset(new_ids, 0xFF, uf->N * sizeof(uint32_t)); /* set all to UINT32_MAX */
+	// memset(new_ids, 0xFF, uf->N * sizeof(uint32_t)); /* set all to UINT32_MAX */
+  for (int i = 0; i < uf->N; i++)
+    new_ids[i] = UINT32_MAX;
 	uint32_t last_old_id, current_new_id, i;
 	uint8_t encountered_cluster = LW_FALSE;
 

--- a/liblwgeom/lwunionfind.c
+++ b/liblwgeom/lwunionfind.c
@@ -154,6 +154,7 @@ UF_get_collapsed_cluster_ids(UNIONFIND *uf, const uint8_t *is_in_cluster)
 	for (i = 0; i < uf->N; i++)
 	{
 		uint32_t j = ordered_components[i];
+		new_ids[j] = -1;
 		if (!is_in_cluster || is_in_cluster[j])
 		{
 			uint32_t current_old_id = UF_find(uf, j);

--- a/liblwgeom/lwunionfind.c
+++ b/liblwgeom/lwunionfind.c
@@ -147,6 +147,7 @@ UF_get_collapsed_cluster_ids(UNIONFIND *uf, const uint8_t *is_in_cluster)
 {
 	uint32_t* ordered_components = UF_ordered_by_cluster(uf);
 	uint32_t* new_ids = lwalloc(uf->N * sizeof(uint32_t));
+	memset(new_ids, 0xFF, uf->N * sizeof(uint32_t)); /* set all to UINT32_MAX */
 	uint32_t last_old_id, current_new_id, i;
 	uint8_t encountered_cluster = LW_FALSE;
 
@@ -154,7 +155,6 @@ UF_get_collapsed_cluster_ids(UNIONFIND *uf, const uint8_t *is_in_cluster)
 	for (i = 0; i < uf->N; i++)
 	{
 		uint32_t j = ordered_components[i];
-		new_ids[j] = -1;
 		if (!is_in_cluster || is_in_cluster[j])
 		{
 			uint32_t current_old_id = UF_find(uf, j);

--- a/liblwgeom/lwunionfind.c
+++ b/liblwgeom/lwunionfind.c
@@ -147,9 +147,7 @@ UF_get_collapsed_cluster_ids(UNIONFIND *uf, const uint8_t *is_in_cluster)
 {
 	uint32_t* ordered_components = UF_ordered_by_cluster(uf);
 	uint32_t* new_ids = lwalloc(uf->N * sizeof(uint32_t));
-	// memset(new_ids, 0xFF, uf->N * sizeof(uint32_t)); /* set all to UINT32_MAX */
-  for (int i = 0; i < uf->N; i++)
-    new_ids[i] = UINT32_MAX;
+	memset(new_ids, 0xFF, uf->N * sizeof(uint32_t)); /* set all to UINT32_MAX */
 	uint32_t last_old_id, current_new_id, i;
 	uint8_t encountered_cluster = LW_FALSE;
 

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -262,7 +262,7 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
  * Could return SRS as short one (i.e EPSG:4326)
  * or as long one: (i.e urn:ogc:def:crs:EPSG::4326)
  */
-static char *
+char *
 getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
 {
 	static const uint16_t max_query_size = 512;

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -262,7 +262,7 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
  * Could return SRS as short one (i.e EPSG:4326)
  * or as long one: (i.e urn:ogc:def:crs:EPSG::4326)
  */
-char *
+PGDLLEXPORT const char *
 getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
 {
 	static const uint16_t max_query_size = 512;
@@ -356,7 +356,8 @@ GetSRSCacheBySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
 		arg->short_mode = short_crs;
 		if (arg->srs)
 			pfree(arg->srs);
-		arg->srs = getSRSbySRID(fcinfo, srid, short_crs);
+		/* getSRSbySRID exposes an immutable API, but the cache owns this copy. */
+		arg->srs = (char *)getSRSbySRID(fcinfo, srid, short_crs);
 	}
 	return arg->srs;
 }

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -136,3 +136,5 @@ typedef struct {
 
 int32_t GetSRIDCacheBySRS(FunctionCallInfo fcinfo, const char *srs);
 
+PGDLLEXPORT
+char *getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -137,4 +137,4 @@ typedef struct {
 int32_t GetSRIDCacheBySRS(FunctionCallInfo fcinfo, const char *srs);
 
 PGDLLEXPORT
-char *getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);
+const char *getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);

--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -327,7 +327,11 @@ sfcgal_tesselate(PG_FUNCTION_ARGS)
 	geom = POSTGIS2SFCGALGeometry(input);
 	PG_FREE_IF_COPY(input, 0);
 
+#if POSTGIS_SFCGAL_VERSION >= 20300
+	result = sfcgal_geometry_tessellate(geom);
+#else
 	result = sfcgal_geometry_tesselate(geom);
+#endif
 	sfcgal_geometry_delete(geom);
 
 	output = SFCGALGeometry2POSTGIS(result, 0, srid);


### PR DESCRIPTION
Replacement for #826 because the original MobilityDB fork branch has `maintainerCanModify=false` and cannot be repaired in-place from this repository.

Carries the original MobilityDB `static` branch changes rebased onto current `master`, then adds one maintainer-owned fix commit on top:

- declares and exports `parse_geojson`, `lwgeom_to_wkb_size`, and `lwgeom_to_wkb_buf` through `liblwgeom.h.in` and matching definitions for external consumers / Windows builds, without redefining PostgreSQL's `PGDLLEXPORT` when included after `postgres.h`;
- keeps `getSRSbySRID()` const-correct in the public cache API while preserving the owned mutable cache slot internally;
- restores the `lwunionfind` sentinel initialization to the compact `memset(..., 0xFF, ...)` form;
- keeps `sfcgal_tesselate` building with SFCGAL 2.3+ by using the non-deprecated `sfcgal_geometry_tessellate` spelling when available.

Validation run locally on this rebased branch:

- `./autogen.sh`
- `./configure`
- `make -C liblwgeom -B -j2`
- `make -C libpgcommon -B -j2`
- `nm -g --defined-only liblwgeom/.libs/liblwgeom.a | rg 'parse_geojson|lwgeom_to_wkb_size|lwgeom_to_wkb_buf'`
- `nm -g --defined-only libpgcommon/libpgcommon.a | rg 'GetSRSCacheBySRID|getSRSbySRID'`
- `git diff --check`

Supersedes/continues #826 and keeps the original author changes visible in this branch.



