### PR TITLE
Expose ST_OrderingEquals as planner equality

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -72,6 +72,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
+          (Darafei Praliaskouski)
+ - GH-875, Allow ST_OrderingEquals joins to use hash and merge join plans
+          (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/postgis/gserialized_supportfn.c
+++ b/postgis/gserialized_supportfn.c
@@ -34,6 +34,7 @@
 #include "nodes/nodeFuncs.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/optimizer.h"
+#include "parser/parse_oper.h"
 #include "parser/parse_func.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
@@ -327,6 +328,55 @@ Datum postgis_index_supportfn(PG_FUNCTION_ARGS)
 	 * is installed is part of the search path (Trac #4739)
 	 */
 	postgis_initialize_cache();
+
+	if (IsA(rawreq, SupportRequestSimplify))
+	{
+		SupportRequestSimplify *req = (SupportRequestSimplify *)rawreq;
+		FuncExpr *clause = req->fcall;
+		IndexableFunction idxfn = {NULL, 0, 0, 0, 0};
+
+		if (needsSpatialIndex(clause->funcid, &idxfn) && idxfn.index == ST_ORDERINGEQUALS_IDX &&
+		    list_length(clause->args) == 2)
+		{
+			Node *leftarg = linitial(clause->args);
+			Node *rightarg = lsecond(clause->args);
+			Oid leftdatatype = exprType(leftarg);
+			Oid rightdatatype = exprType(rightarg);
+			Oid eqoproid = InvalidOid;
+			bool hashable = false;
+
+			if (leftdatatype != rightdatatype)
+				PG_RETURN_POINTER((Node *)NULL);
+
+			/* Keep constant predicates on the spatial index support path below. */
+			if (!contain_var_clause(leftarg) || !contain_var_clause(rightarg))
+				PG_RETURN_POINTER((Node *)NULL);
+
+			if (contain_volatile_functions(leftarg) || contain_volatile_functions(rightarg))
+				PG_RETURN_POINTER((Node *)NULL);
+
+			/* ST_OrderingEquals uses the same gserialized_cmp equality as the = operator. */
+			get_sort_group_operators(leftdatatype, false, true, false, NULL, &eqoproid, NULL, &hashable);
+
+			if (!OidIsValid(eqoproid))
+				PG_RETURN_POINTER((Node *)NULL);
+
+			/*
+			 * Do not add a bbox-equality conjunct here. Exact serialized equality can
+			 * match non-finite coordinates that box2df equality rejects, so adding ~=
+			 * would make the simplification narrower than ST_OrderingEquals.
+			 */
+			ret = (Node *)make_opclause(eqoproid,
+						    BOOLOID,
+						    false,
+						    (Expr *)leftarg,
+						    (Expr *)rightarg,
+						    InvalidOid,
+						    clause->inputcollid);
+
+			PG_RETURN_POINTER(ret);
+		}
+	}
 
 	if (IsA(rawreq, SupportRequestSelectivity))
 	{

--- a/regress/core/regress_index.sql
+++ b/regress/core/regress_index.sql
@@ -25,6 +25,22 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION qplan_has(q text, pattern text) RETURNS boolean
+LANGUAGE 'plpgsql' AS
+$$
+DECLARE
+  exp TEXT;
+BEGIN
+  FOR exp IN EXECUTE 'EXPLAIN ' || q
+  LOOP
+    IF exp ~ pattern THEN
+      RETURN true;
+    END IF;
+  END LOOP;
+  RETURN false;
+END;
+$$;
+
 -- GiST index
 
 CREATE INDEX quick_gist on test using gist (the_geom);
@@ -113,12 +129,82 @@ SELECT 'expr &&', id, estimate_error(
   'select num from test where st_centroid(the_geom) && ' || box, tol )
   FROM sample_queries ORDER BY id;
 
+SELECT 'st_orderingequals_idx',
+  qnodes('select * from test where ST_OrderingEquals(the_geom, ST_MakePoint(0,0))');
+
+CREATE TABLE st_orderingequals_volatile_calls (num integer);
+INSERT INTO st_orderingequals_volatile_calls VALUES (0);
+
+CREATE OR REPLACE FUNCTION st_orderingequals_volatile_geom(g geometry)
+RETURNS geometry
+LANGUAGE 'plpgsql' VOLATILE AS $$
+BEGIN
+  UPDATE st_orderingequals_volatile_calls SET num = num + 1;
+  RETURN g;
+END;
+$$;
+
+SELECT 'st_orderingequals_volatile_count', count(*)
+FROM (VALUES (ST_MakePoint(0,0))) AS q(g)
+JOIN test t ON ST_OrderingEquals(st_orderingequals_volatile_geom(t.the_geom), q.g);
+
+SELECT 'st_orderingequals_volatile', num FROM st_orderingequals_volatile_calls;
+
+DROP FUNCTION st_orderingequals_volatile_geom(geometry);
+DROP TABLE st_orderingequals_volatile_calls;
+
+CREATE SCHEMA st_orderingequals_search_path;
+CREATE FUNCTION st_orderingequals_search_path.geometry_bbox_false(geometry, geometry)
+RETURNS boolean
+LANGUAGE 'sql' IMMUTABLE AS 'SELECT false';
+CREATE OPERATOR st_orderingequals_search_path.~= (
+  LEFTARG = geometry,
+  RIGHTARG = geometry,
+  PROCEDURE = st_orderingequals_search_path.geometry_bbox_false,
+  COMMUTATOR = '~='
+);
+
+SET search_path = st_orderingequals_search_path, public;
+SELECT 'st_orderingequals_qualified_bbox', count(*)
+FROM (VALUES (ST_MakePoint(0,0))) AS g1(g)
+JOIN (VALUES (ST_MakePoint(0,0))) AS g2(g)
+  ON ST_OrderingEquals(g1.g, g2.g);
+RESET search_path;
+
+DROP OPERATOR st_orderingequals_search_path.~= (geometry, geometry);
+DROP FUNCTION st_orderingequals_search_path.geometry_bbox_false(geometry, geometry);
+DROP SCHEMA st_orderingequals_search_path;
+
+WITH geoms AS (SELECT ST_MakePoint(0, 'NaN'::float8) AS g)
+SELECT 'st_orderingequals_nan_bbox', ST_OrderingEquals(g, g), g = g, g ~= g
+FROM geoms;
+
+SELECT 'st_orderingequals_nan_join', count(*)
+FROM (VALUES (ST_MakePoint(0, 'NaN'::float8))) AS g1(g)
+JOIN (VALUES (ST_MakePoint(0, 'NaN'::float8))) AS g2(g)
+  ON ST_OrderingEquals(g1.g, g2.g);
+
+-- ST_OrderingEquals is exact geometry equality, so the planner should see
+-- the hash/merge-joinable geometry operator instead of only a function filter.
+set enable_nestloop = off;
+SELECT 'st_orderingequals_join',
+  qplan_has(
+    'SELECT t1.num FROM test t1, test t2 WHERE t1.num > t2.num AND ST_OrderingEquals(t1.the_geom, t2.the_geom)',
+    '(Hash|Merge) Join'
+  ),
+  qplan_has(
+    'SELECT t1.num FROM test t1, test t2 WHERE t1.num > t2.num AND ST_OrderingEquals(t1.the_geom, t2.the_geom)',
+    'Nested Loop'
+  );
+set enable_nestloop = on;
+
 DROP TABLE test;
 DROP TABLE test_gist_idx_2d;
 DROP TABLE sample_queries;
 
 DROP FUNCTION estimate_error(text, int);
 
+DROP FUNCTION qplan_has(text, text);
 DROP FUNCTION qnodes(text);
 
 set enable_indexscan = on;

--- a/regress/core/regress_index_expected
+++ b/regress/core/regress_index_expected
@@ -22,4 +22,11 @@ expr &&|1|5+-5:true
 expr &&|2|912+-60:true
 expr &&|3|12505+-500:true
 expr &&|4|50000+-600:true
+st_orderingequals_idx|Index Scan
+st_orderingequals_volatile_count|0
+st_orderingequals_volatile|50000
+st_orderingequals_qualified_bbox|1
+st_orderingequals_nan_bbox|t|t|f
+st_orderingequals_nan_join|1
+st_orderingequals_join|t|f
 _st_sortablehash|0|768602608280535040|768602608280535040


### PR DESCRIPTION
## Summary

`ST_OrderingEquals(a, b)` is exact geometry equality: its C implementation quickly reaches the same `gserialized_cmp(...) == 0` comparison used by the geometry `=` operator. However, when it appears as a join predicate PostgreSQL only sees an opaque function call, so duplicate-detection queries can fall back to nested-loop joins even though the equivalent `a = b` predicate is hash/merge-joinable.

This adds a `SupportRequestSimplify` path to `postgis_index_supportfn` for `ST_OrderingEquals` when both arguments contain Vars. In that case the planner can see the type's equality operator and produce hash/merge joins. Constant predicates are left alone so the existing spatial index support path still injects the `~=` index condition plus the exact `ST_OrderingEquals` filter.

The variable-join simplification intentionally does not add `~=` as a mandatory conjunct. Exact serialized equality can still match geometries whose box fields contain `NaN`, while `box2df_equals` treats those box fields as unequal, so adding bbox equality would make the simplified predicate narrower than `ST_OrderingEquals`.

## Release / upgrade notes

- Added a `NEWS` entry under PostGIS 3.7.0 enhancements for https://github.com/postgis/postgis/pull/875.
- No extension upgrade SQL is needed: the existing `ST_OrderingEquals` SQL declaration already uses `SUPPORT postgis_index_supportfn`, and this patch only changes the loaded C behavior behind that existing support function.

## Current state

- Rebased on `postgis:master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`.
- Current head: `8cca5da369e58ed0a2d25779670d226d6260789e`.
- GitHub readback after push: draft PR, `MERGEABLE`, no unresolved current review threads; CI checks are queued/pending.
- No matching Gitea mirror PR was found for `875`, `OrderingEquals`, or `st-orderingequals`.

## Tests

- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- postgis/gserialized_supportfn.c regress/core/regress_index.sql regress/core/regress_index_expected NEWS`
- `./utils/check_news.sh .`
- `make -C postgis -j32`
- `make -C extensions/postgis -j32`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `POSTGIS_TOP_BUILD_DIR=$(pwd) perl regress/run_test.pl --extension --verbose regress/core/regress_index`

The normal `make -C regress check ...` wrapper was blocked locally by a missing generated `regress/dumper/tests.mk` include in this checkout. The direct `run_test.pl` invocation above ran the same targeted `regress/core/regress_index` test against the installed extension and passed `regress_index` plus uninstall.

The regression now checks the join plan families and review-risk cases:

- `ST_OrderingEquals(d1.geom, d2.geom)` in Julien Monticolo's duplicate-check query shape can plan as a hash/merge-joinable equality predicate.
- Constant `ST_OrderingEquals(the_geom, ST_MakePoint(...))` predicates still exercise the existing spatial index support path.
- Volatile geometry arguments are not simplified into duplicated operator clauses.
- Caller `search_path` shadowing of `~=` does not affect the equality-only simplification.
- A `POINT(0 NaN)` pair verifies that `ST_OrderingEquals` and `geometry =` can be true while `~=` is false, and the variable-join simplification preserves that exact-equality result.

Local coverage reports were not generated for this planner support-function edit; the PR keeps focused regression coverage local and leaves the broader coverage jobs to CI.
