### PR TITLE
Avoid GMP overflow in topology ring orientation

### DIFF
--- a/liblwgeom/cunit/Makefile.in
+++ b/liblwgeom/cunit/Makefile.in
@@ -58,6 +58,7 @@ OBJS=	\
 	cu_split.o \
 	cu_stringbuffer.o \
 	cu_triangulate.o \
+	cu_topo.o \
 	cu_homogenize.o \
 	cu_force_dims.o \
 	cu_force_sfs.o \

--- a/liblwgeom/cunit/cu_tester.c
+++ b/liblwgeom/cunit/cu_tester.c
@@ -72,6 +72,7 @@ extern void sfcgal_suite_setup(void);
 extern void split_suite_setup(void);
 extern void stringbuffer_suite_setup(void);
 extern void tree_suite_setup(void);
+extern void topo_suite_setup(void);
 extern void triangulate_suite_setup(void);
 extern void varint_suite_setup(void);
 extern void wkt_out_suite_setup(void);
@@ -128,6 +129,7 @@ PG_SuiteSetup setupfuncs[] = {algorithms_suite_setup,
 			      stringbuffer_suite_setup,
 			      surface_suite_setup,
 			      tree_suite_setup,
+			      topo_suite_setup,
 			      triangulate_suite_setup,
 			      twkb_out_suite_setup,
 			      varint_suite_setup,

--- a/liblwgeom/cunit/cu_topo.c
+++ b/liblwgeom/cunit/cu_topo.c
@@ -1,0 +1,55 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU General Public Licence. See the COPYING file.
+ *
+ **********************************************************************/
+
+#include "CUnit/Basic.h"
+#include "CUnit/CUnit.h"
+
+#include "liblwgeom_internal.h"
+#include "topo/liblwgeom_topo.h"
+#include "cu_tester.h"
+
+static LWGEOM *
+lwgeom_from_text(const char *str)
+{
+	LWGEOM_PARSER_RESULT r;
+	if (LW_FAILURE == lwgeom_parse_wkt(&r, (char *)str, LW_PARSER_CHECK_NONE))
+		return NULL;
+	return r.geom;
+}
+
+static void
+test_lwt_IsTopoRingCCW_large_finite_coordinates(void)
+{
+	LWGEOM *geom = lwgeom_from_text("POLYGON((0 1e308,1e308 0,0 0,0 1e308))");
+	LWPOLY *poly;
+
+	CU_ASSERT_PTR_NOT_NULL(geom);
+	if (!geom)
+		return;
+
+	poly = lwgeom_as_lwpoly(geom);
+	CU_ASSERT_PTR_NOT_NULL(poly);
+	if (!poly)
+	{
+		lwgeom_free(geom);
+		return;
+	}
+
+	CU_ASSERT_EQUAL(lwt_IsTopoRingCCW(poly->rings[0]), LW_FALSE);
+
+	lwgeom_free(geom);
+}
+
+void
+topo_suite_setup(void)
+{
+	CU_pSuite suite = CU_add_suite("topology", NULL, NULL);
+	PG_ADD_TEST(suite, test_lwt_IsTopoRingCCW_large_finite_coordinates);
+}

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -38,6 +38,7 @@
 #include <gmp.h>
 
 #include <inttypes.h>
+#include <math.h>
 
 static bool
 _lwt_describe_point(const LWPOINT *pt, char *buf, size_t bufsize)
@@ -1888,27 +1889,49 @@ lwt_IsTopoRingCCW(const POINTARRAY *pa)
   const POINT2D *P3;
   mpf_t sum;
   mpf_t tmp;
-  double x0, x, y1, y2;
+  mpf_t x0;
+  mpf_t x;
+  mpf_t dy;
   uint32_t i;
   int ret;
 
   if (! pa || pa->npoints < 3 )
     return 0;
 
-  mpf_init2(sum, 64);
-  mpf_init2(tmp, 64);
-  mpf_set_d(sum, 0.0);
-
   P1 = getPoint2d_cp(pa, 0);
   P2 = getPoint2d_cp(pa, 1);
-  x0 = P1->x;
+
+  if (!isfinite(P1->x) || !isfinite(P1->y) || !isfinite(P2->x) || !isfinite(P2->y))
+	  return ptarray_isccw(pa);
+
+  mpf_init2(sum, 64);
+  mpf_init2(tmp, 64);
+  mpf_init2(x0, 64);
+  mpf_init2(x, 64);
+  mpf_init2(dy, 64);
+  mpf_set_d(sum, 0.0);
+  mpf_set_d(x0, P1->x);
+
   for ( i = 2; i < pa->npoints; i++ )
   {
     P3 = getPoint2d_cp(pa, i);
-    x = P2->x - x0;
-    y1 = P3->y;
-    y2 = P1->y;
-    mpf_set_d(tmp, x * (y2-y1));
+
+    if (!isfinite(P3->x) || !isfinite(P3->y))
+    {
+	    mpf_clear(dy);
+	    mpf_clear(x);
+	    mpf_clear(x0);
+	    mpf_clear(tmp);
+	    mpf_clear(sum);
+	    return ptarray_isccw(pa);
+    }
+
+    mpf_set_d(x, P2->x);
+    mpf_sub(x, x, x0);
+    mpf_set_d(dy, P1->y);
+    mpf_set_d(tmp, P3->y);
+    mpf_sub(dy, dy, tmp);
+    mpf_mul(tmp, x, dy);
     mpf_add(sum, sum, tmp);
     P1 = P2;
     P2 = P3;
@@ -1916,6 +1939,9 @@ lwt_IsTopoRingCCW(const POINTARRAY *pa)
 
   ret = mpf_cmp_ui(sum, 0) < 0;
 
+  mpf_clear(dy);
+  mpf_clear(x);
+  mpf_clear(x0);
   mpf_clear(tmp);
   mpf_clear(sum);
 


### PR DESCRIPTION
### Motivation
- The previous GMP-based ring orientation path computed the cross-product as a `double` before converting to `mpf_t`, which can overflow to ±Infinity for very large but finite coordinates and cause `mpf_set_d` to raise a floating-point exception and crash the PostgreSQL backend.
- The intent is to avoid turning large finite intermediate products into infinities passed to GMP while preserving the improved numeric robustness of the GMP path for normal inputs.

### Description
- Replace the double-product computation in `lwt_IsTopoRingCCW` with GMP arithmetic by introducing `mpf_t` variables for `x0`, `x`, and `dy`, using `mpf_set_d`/`mpf_sub`/`mpf_mul`/`mpf_add` so the product is formed inside GMP instead of as a `double` (file `liblwgeom/topo/lwgeom_topo.c`).
- Add `isfinite` guards that fall back to the legacy `ptarray_isccw` implementation when any ring vertex coordinate is non-finite to avoid passing infinities/NaNs to GMP (file `liblwgeom/topo/lwgeom_topo.c`).
- Include `<math.h>` and ensure proper `mpf_init2`/`mpf_clear` for the new GMP temporaries to avoid leaks (file `liblwgeom/topo/lwgeom_topo.c`).
- Add a CUnit regression test `liblwgeom/cunit/cu_topo.c` exercising a polygon with `1e308` coordinates that previously produced an infinite double product, and register the new test in the CUnit build by updating `liblwgeom/cunit/Makefile.in` and `liblwgeom/cunit/cu_tester.c`.

### Testing
- Ran `git diff --check` and project formatting checks which reported no issues, and `git clang-format` which made no formatting changes (success).
- Built and executed a minimal standalone GMP-based PoC compiled with `gcc -lgmp` which returned the expected orientation (`isccw=0`), demonstrating that the GMP arithmetic approach avoids the SIGFPE seen previously (success): `gcc -Wall -Wextra -Werror -o /tmp/toporing_ccw_gmp_fixed /tmp/toporing_ccw_gmp_fixed.c -lgmp && /tmp/toporing_ccw_gmp_fixed`.
- Attempted the repository test build `make -C liblwgeom/cunit cu_tester` but it failed in this environment because CUnit headers are not available, and `./autogen.sh` also cannot be run here due to a missing `aclocal` tool (environmental limitation, test not runnable here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2850c1119083248e4a4718efb52102)