### PR TITLE
Fix NULL handling in ST_ClusterRelateWin to avoid NULL-dereference

### DIFF
--- a/postgis/lwgeom_window.c
+++ b/postgis/lwgeom_window.c
@@ -375,8 +375,17 @@ Datum ST_ClusterRelateWin(PG_FUNCTION_ARGS)
 		GEOSGeometry** geoms = palloc0(ngeoms * sizeof(GEOSGeometry*));
 		UNIONFIND* uf = UF_create(ngeoms);
 		char *matrix;
-		text *txtIm = DatumGetTextP(WinGetFuncArgCurrent(win_obj, 1, &matrix_is_null));
-		if (matrix_is_null || VARSIZE_ANY_EXHDR(txtIm) != 9)
+		Datum matrix_datum = WinGetFuncArgCurrent(win_obj, 1, &matrix_is_null);
+		text *txtIm;
+
+		if (matrix_is_null)
+		{
+			elog(ERROR, "Invalid relate matrix provided");
+			PG_RETURN_NULL();
+		}
+
+		txtIm = DatumGetTextP(matrix_datum);
+		if (VARSIZE_ANY_EXHDR(txtIm) != 9)
 		{
 			elog(ERROR,"Invalid relate matrix provided");
 			PG_RETURN_NULL();


### PR DESCRIPTION
### Motivation
- `ST_ClusterRelateWin` previously detoasted the `relate_matrix` argument before checking whether the window-supplied datum was NULL, allowing a NULL `text` datum to be dereferenced and crash the backend.
- The change prevents a low-privileged SQL caller from causing a backend crash by passing NULL as `relate_matrix` to the window function.

### Description
- Modified `postgis/lwgeom_window.c` in `ST_ClusterRelateWin` to fetch the `relate_matrix` argument into a `Datum` via `WinGetFuncArgCurrent` and store it in `matrix_datum` before any detoast.
- Added an explicit `matrix_is_null` check immediately after fetching the `Datum` and before calling `DatumGetTextP` to avoid dereferencing a NULL varlena pointer.
- Preserved the existing DE-9IM validation by keeping the `VARSIZE_ANY_EXHDR(... ) != 9` check after the NULL validation and before `text_to_cstring`.

### Testing
- Ran `git diff --cached --check` which reported no index warnings or whitespace errors (success).
- Ran `git clang-format --diff HEAD -- postgis/lwgeom_window.c` / format checks which reported no further formatting changes (success).
- Attempted `./autogen.sh` in this environment but it failed due to missing `aclocal` so a full build/regression run could not be executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a290dd878fc8324bf939bee76ff7b13)