### PR TITLE
Clarify standards support in introduction

### DIFF
--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -19,19 +19,28 @@
   <section xml:id="standards_support">
 	<title>Standards Support</title>
 
-	<para>PostGIS implements parts of the
-	<link xlink:href="https://www.ogc.org/standard/sfa/">OGC Simple Features Access</link>
-	and <link xlink:href="https://www.iso.org/standard/60343.html">SQL/MM Spatial</link>
-	standards.  The geometry type, the Well-Known Text (WKT) and Well-Known
-	Binary (WKB) input/output functions, and many spatial accessors,
-	constructors, predicates, and processing functions follow those standards
-	where the manual marks them as OGC or SQL/MM compliant.</para>
+	<para>This manual marks individual functions as compliant with spatial
+	standards so users can tell which behavior is portable and which behavior is
+	a PostGIS extension.  PostGIS implements the
+	<link xlink:href="https://www.ogc.org/standard/sfs/">OGC Simple Features
+	for SQL</link> model, including the geometry type, Well-Known Text (WKT),
+	Well-Known Binary (WKB), and the common spatial accessors, constructors,
+	predicates, and processing functions.  PostGIS also implements many
+	<link xlink:href="https://www.iso.org/standard/60343.html">SQL/MM Spatial</link>
+	types and functions.</para>
 
-	<para>PostGIS also includes widely used extensions beyond those standards.
-	Examples include Extended WKT (EWKT) and Extended WKB (EWKB), SRID metadata
-	in those extended formats, geography, raster, topology, curved geometry,
-	polyhedral surface, TIN, and many analysis functions.  These extensions are
-	documented individually, but should not be read as OGC or SQL/MM
+	<para>PostGIS supports geometry families defined by later standards,
+	including SQL/MM curved geometry and OGC Simple Features Access 1.2
+	PolyhedralSurface, Triangle, and TIN.  Support for these geometry families
+	is function-specific, and each function page documents the supported input
+	types and conformance level.</para>
+
+	<para>PostGIS also includes widely used extensions and integrations.
+	Examples of PostGIS extensions include Extended WKT (EWKT), Extended WKB
+	(EWKB), SRID metadata in those extended formats, geography, and raster.
+	PostGIS also supports input and output exchange formats defined by other
+	standards, such as GeoJSON, GML, and KML.  These features are documented
+	individually and should not be read as OGC Simple Features or SQL/MM
 	requirements unless the specific function or format says so.</para>
 
 	<para>When the implementation intentionally differs from a standard, or when

--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -16,6 +16,30 @@
   surfaces, networks), data source for desktop user interface tools for viewing and editing
   GIS data, and web-based access tools.</para>
 
+  <section xml:id="standards_support">
+	<title>Standards Support</title>
+
+	<para>PostGIS implements parts of the
+	<link xlink:href="https://www.ogc.org/standard/sfa/">OGC Simple Features Access</link>
+	and <link xlink:href="https://www.iso.org/standard/60343.html">SQL/MM Spatial</link>
+	standards.  The geometry type, the Well-Known Text (WKT) and Well-Known
+	Binary (WKB) input/output functions, and many spatial accessors,
+	constructors, predicates, and processing functions follow those standards
+	where the manual marks them as OGC or SQL/MM compliant.</para>
+
+	<para>PostGIS also includes widely used extensions beyond those standards.
+	Examples include Extended WKT (EWKT) and Extended WKB (EWKB), SRID metadata
+	in those extended formats, geography, raster, topology, curved geometry,
+	polyhedral surface, TIN, and many analysis functions.  These extensions are
+	documented individually, but should not be read as OGC or SQL/MM
+	requirements unless the specific function or format says so.</para>
+
+	<para>When the implementation intentionally differs from a standard, or when
+	a standard leaves behavior ambiguous, the relevant function page describes
+	the PostGIS behavior.  The <xref linkend="PostGIS_Special_Functions_Index"/>
+	chapter summarizes SQL/MM compliance and geometry-type support across
+	functions.</para>
+  </section>
 
   <section xml:id="psc">
 	<title>Project Steering Committee</title>


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/2563

## Summary
- Clarify that PostGIS documents standards support by function and feature area instead of claiming blanket conformance to whole standards.
- Separate OGC Simple Features / SQL-MM support from PostGIS extension areas such as geography, raster, and EWKT/EWKB metadata.
- Mention common exchange formats such as GeoJSON, GML, KML, and X3D as supported formats rather than core conformance claims.

## Current branch
- Base: `postgis/postgis` `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- Head: `0a1e203f4b775c2d5b05912c0a1fd09195486b5e`

## Validation
- `make -C doc html`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- doc/introduction.xml`

GitHub CI has been queued for this refreshed head. Existing review threads are resolved and outdated on the current head.
