### PR TITLE
raster: Fix memory overallocation

### DIFF
--- a/raster/rt_pg/rtpg_geometry.c
+++ b/raster/rt_pg/rtpg_geometry.c
@@ -1534,7 +1534,7 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 			options = (char **) repalloc(options, sizeof(char *) * options_len);
 		}
 
-		options[options_len - 1] = palloc(sizeof(char*) * (strlen("ALL_TOUCHED=TRUE") + 1));
+		options[options_len - 1] = palloc(sizeof(char) * (strlen("ALL_TOUCHED=TRUE") + 1));
 		strcpy(options[options_len - 1], "ALL_TOUCHED=TRUE");
 	}
 

--- a/raster/rt_pg/rtpg_mapalgebra.c
+++ b/raster/rt_pg/rtpg_mapalgebra.c
@@ -3300,7 +3300,7 @@ Datum RASTER_clip(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(5) && PG_GETARG_BOOL(5) == TRUE){
 			options_len = options_len + 1;
 			options = (char **) palloc(sizeof(char *) * options_len);
-			options[options_len - 1] = palloc(sizeof(char*) * (strlen("ALL_TOUCHED=TRUE") + 1));
+			options[options_len - 1] = palloc(sizeof(char) * (strlen("ALL_TOUCHED=TRUE") + 1));
 		 	strcpy(options[options_len - 1], "ALL_TOUCHED=TRUE");
 	}
 


### PR DESCRIPTION
Replace sizeof(char *) with strlen()+1 for string allocation, eliminating 8x memory overallocation on 64-bit platforms.

Found by PostgresPro