### PR TITLE
liblwgeom: fix potential overlapping memory copying

### DIFF
--- a/liblwgeom/ptarray.c
+++ b/liblwgeom/ptarray.c
@@ -1852,7 +1852,7 @@ ptarray_simplify_in_place(POINTARRAY *pa, double tolerance, uint32_t minpts)
 	{
 		/* If there are 2 points remaining, it has to be first and last as
 		 * we added those at the start */
-		memcpy(pa->serialized_pointlist + pt_size * kept_it,
+		memmove(pa->serialized_pointlist + pt_size * kept_it,
 		       pa->serialized_pointlist + pt_size * (pa->npoints - 1),
 		       pt_size);
 	}


### PR DESCRIPTION
Using memcpy with overlapping memory regions is undefined behavior per C standard. Replace with memmove to safely handle the case when src and dst point to the same location