### PR TITLE
Fix SFCGAL visibility empty input handling

### DIFF
--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -1232,10 +1232,6 @@ sfcgal_visibility_point(PG_FUNCTION_ARGS)
 	input0 = PG_GETARG_GSERIALIZED_P(0);
 	srid = gserialized_get_srid(input0);
 	input1 = PG_GETARG_GSERIALIZED_P(1);
-	polygon = POSTGIS2SFCGALGeometry(input0);
-	PG_FREE_IF_COPY(input0, 0);
-	point = POSTGIS2SFCGALGeometry(input1);
-	PG_FREE_IF_COPY(input1, 1);
 
 #if POSTGIS_SFCGAL_VERSION < 20200
 	if (gserialized_is_empty(input0) || gserialized_is_empty(input1))
@@ -1244,9 +1240,16 @@ sfcgal_visibility_point(PG_FUNCTION_ARGS)
 		output = SFCGALGeometry2POSTGIS(result, 0, srid);
 		sfcgal_geometry_delete(result);
 
+		PG_FREE_IF_COPY(input0, 0);
+		PG_FREE_IF_COPY(input1, 1);
 		PG_RETURN_POINTER(output);
 	}
 #endif
+
+	polygon = POSTGIS2SFCGALGeometry(input0);
+	PG_FREE_IF_COPY(input0, 0);
+	point = POSTGIS2SFCGALGeometry(input1);
+	PG_FREE_IF_COPY(input1, 1);
 
 	result = sfcgal_geometry_visibility_point(polygon, point);
 	sfcgal_geometry_delete(polygon);
@@ -1282,12 +1285,6 @@ sfcgal_visibility_segment(PG_FUNCTION_ARGS)
 	srid = gserialized_get_srid(input0);
 	input1 = PG_GETARG_GSERIALIZED_P(1);
 	input2 = PG_GETARG_GSERIALIZED_P(2);
-	polygon = POSTGIS2SFCGALGeometry(input0);
-	PG_FREE_IF_COPY(input0, 0);
-	pointA = POSTGIS2SFCGALGeometry(input1);
-	PG_FREE_IF_COPY(input1, 1);
-	pointB = POSTGIS2SFCGALGeometry(input2);
-	PG_FREE_IF_COPY(input2, 2);
 
 #if POSTGIS_SFCGAL_VERSION < 20200
 	if (gserialized_is_empty(input0) || gserialized_is_empty(input1) || gserialized_is_empty(input2))
@@ -1296,9 +1293,19 @@ sfcgal_visibility_segment(PG_FUNCTION_ARGS)
 		output = SFCGALGeometry2POSTGIS(result, 0, srid);
 		sfcgal_geometry_delete(result);
 
+		PG_FREE_IF_COPY(input0, 0);
+		PG_FREE_IF_COPY(input1, 1);
+		PG_FREE_IF_COPY(input2, 2);
 		PG_RETURN_POINTER(output);
 	}
 #endif
+
+	polygon = POSTGIS2SFCGALGeometry(input0);
+	PG_FREE_IF_COPY(input0, 0);
+	pointA = POSTGIS2SFCGALGeometry(input1);
+	PG_FREE_IF_COPY(input1, 1);
+	pointB = POSTGIS2SFCGALGeometry(input2);
+	PG_FREE_IF_COPY(input2, 2);
 
 	result = sfcgal_geometry_visibility_segment(polygon, pointA, pointB);
 	sfcgal_geometry_delete(polygon);


### PR DESCRIPTION
### Motivation
- Eliminate a use-after-free and associated memory leak in the SFCGAL-backed `CG_Visibility` implementations for builds against SFCGAL < 2.2.0 by ensuring tests for empty input geometries do not dereference freed detoasted copies.
- Preserve the existing behavior that returns an empty polygon for empty inputs while ensuring correct resource management for toasted/compressed `geometry` arguments.

### Description
- Move `gserialized_is_empty(...)` checks to occur immediately after obtaining the `GSERIALIZED *` arguments and before any conversions or `PG_FREE_IF_COPY(...)` calls for both `sfcgal_visibility_point` and `sfcgal_visibility_segment` in `sfcgal/lwgeom_sfcgal.c`.
- On the empty-input early-return path, free any detoasted input copies with `PG_FREE_IF_COPY(...)` before returning the constructed empty polygon to avoid leaks.
- Keep the conversion to SFCGAL geometry and subsequent `PG_FREE_IF_COPY(...)` calls for the normal (non-empty) execution path unchanged, and apply the same fix to both the point and segment overloads.

### Testing
- Ran staged-diff and formatting checks with `git diff --cached --check` and `git clang-format --diff --staged`, both of which completed without reported formatting failures.
- Attempted the build preparation scripts (`./autogen.sh`) which failed in this environment due to a missing `aclocal` binary, preventing a full build or regression test run.
- Attempted targeted `make`/`make`-in-directory invocations which failed because the tree is unconfigured and no `Makefile`/targets were present prior to running `configure` in this environment.
- No full `make check` or runtime regression tests were run due to the above environment limitations, so behavioral verification is limited to static checks and source inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2abe0f7e50832493bdfb77cdf9ff85)