### PR TITLE
Make ST_Relate DE-9IM inversion length-aware to prevent OOB access

### DIFF
--- a/postgis/lwgeom_geos_predicates.c
+++ b/postgis/lwgeom_geos_predicates.c
@@ -888,12 +888,27 @@ Datum coveredby(PG_FUNCTION_ARGS)
  *  to the GEOSPreparedRelatePattern function.
  */
 static void
-imInvert(char *im)
+imInvert(char *im, size_t len)
 {
 	char t;
-	t = im[1]; im[1] = im[3]; im[3] = t;
-	t = im[2]; im[2] = im[6]; im[6] = t;
-	t = im[5]; im[5] = im[7]; im[7] = t;
+	if (len > 3)
+	{
+		t = im[1];
+		im[1] = im[3];
+		im[3] = t;
+	}
+	if (len > 6)
+	{
+		t = im[2];
+		im[2] = im[6];
+		im[6] = t;
+	}
+	if (len > 7)
+	{
+		t = im[5];
+		im[5] = im[7];
+		im[7] = t;
+	}
 }
 #endif
 
@@ -910,7 +925,8 @@ Datum relate_pattern(PG_FUNCTION_ARGS)
 		PG_GETARG_DATUM(2), Int32GetDatum(9)));
 	char *im = text_to_cstring(imPtr);
 	int8_t result;
-	uint32_t i;
+	size_t im_len = strlen(im);
+	size_t i;
 #if POSTGIS_GEOS_VERSION >= 31300
 	PrepGeomCache *prep_cache;
 #endif
@@ -920,8 +936,8 @@ Datum relate_pattern(PG_FUNCTION_ARGS)
 	/*
 	** Need to make sure 't' and 'f' are upper-case before handing to GEOS
 	*/
-	for (i = 0; i < strlen(im); i++)
-		im[i] = toupper(im[i]);
+	for (i = 0; i < im_len; i++)
+		im[i] = toupper((unsigned char)im[i]);
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 
@@ -937,7 +953,7 @@ Datum relate_pattern(PG_FUNCTION_ARGS)
 		else
 		{
 			g = POSTGIS2GEOS(geom1);
-			imInvert(im);
+			imInvert(im, im_len);
 		}
 
 		if (!g) HANDLE_GEOS_ERROR("Geometry could not be converted to GEOS");


### PR DESCRIPTION
### Motivation
- A new `imInvert()` helper unconditionally indexed fixed DE-9IM positions, which can read/write past the end of short attacker-supplied pattern strings and cause out-of-bounds access in the GEOS prepared `ST_Relate` path. 
- The SQL input was only truncated to a maximum of 9 characters with `text_left(..., 9)` and no exact-length validation was performed, so short patterns could reach the inversion logic.

### Description
- Changed `imInvert(char *im)` to `imInvert(char *im, size_t len)` and made the three swaps conditional on `len` so only existing positions are accessed.  
- Cached the pattern length with `size_t im_len = strlen(im);` and passed it to `imInvert(im, im_len)`.  
- Normalized the pattern using `toupper((unsigned char)im[i])` to avoid undefined behavior for signed `char` values.  
- Modifications are confined to `postgis/lwgeom_geos_predicates.c` around the `relate_pattern` implementation and the inversion helper.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check errors.  
- Ran `git clang-format` / `git clang-format --diff --cached` and `clang-format` did not report further changes.  
- Attempted the full build bootstrap with `./autogen.sh` but it failed in this environment due to missing `aclocal`, so a full `./configure`/`make`/`make check` run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af52c323c8324a56044d42262cc31)