### PR TITLE
Prevent OOB reads in GIDX BRIN merge by checking dimensionality

### DIFF
--- a/postgis/brin_nd.c
+++ b/postgis/brin_nd.c
@@ -17,6 +17,8 @@ static Datum gidx_brin_inclusion_add_value(
 
 static GIDX * gidx_brin_inclusion_merge(
 	GIDX *gidx_key, GIDX *gidx_geom);
+static bool gidx_brin_inclusion_mergeable(
+	GIDX *gidx_key, GIDX *gidx_geom);
 
 /*
  * As for the GiST case, geographies are converted into GIDX before
@@ -195,6 +197,9 @@ gidx_brin_inclusion_add_value(__attribute__((__unused__)) BrinDesc *bdesc,
 static GIDX *
 gidx_brin_inclusion_merge(GIDX *gidx_key, GIDX *gidx_geom)
 {
+	if (!gidx_brin_inclusion_mergeable(gidx_key, gidx_geom))
+		return gidx_key;
+
 	if (!gidx_contains(gidx_key, gidx_geom))
 	{
 		for (uint32_t i = 0; i < GIDX_NDIMS(gidx_key); i++)
@@ -211,6 +216,12 @@ gidx_brin_inclusion_merge(GIDX *gidx_key, GIDX *gidx_geom)
 	return gidx_key;
 }
 
+static bool
+gidx_brin_inclusion_mergeable(GIDX *gidx_key, GIDX *gidx_geom)
+{
+	return GIDX_NDIMS(gidx_key) == GIDX_NDIMS(gidx_geom);
+}
+
 PG_FUNCTION_INFO_V1(geog_brin_inclusion_merge);
 Datum geog_brin_inclusion_merge(PG_FUNCTION_ARGS)
 {
@@ -218,6 +229,15 @@ Datum geog_brin_inclusion_merge(PG_FUNCTION_ARGS)
 	GIDX *geom = (GIDX *) PG_GETARG_POINTER(1);
 
 	PG_RETURN_POINTER(gidx_brin_inclusion_merge(key, geom));
+}
+
+PG_FUNCTION_INFO_V1(geog_brin_inclusion_mergeable);
+Datum geog_brin_inclusion_mergeable(PG_FUNCTION_ARGS)
+{
+	GIDX *key = (GIDX *) PG_GETARG_POINTER(0);
+	GIDX *geom = (GIDX *) PG_GETARG_POINTER(1);
+
+	PG_RETURN_BOOL(gidx_brin_inclusion_mergeable(key, geom));
 }
 
 PG_FUNCTION_INFO_V1(geom3d_brin_inclusion_merge);
@@ -229,6 +249,15 @@ Datum geom3d_brin_inclusion_merge(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(gidx_brin_inclusion_merge(key, geom));
 }
 
+PG_FUNCTION_INFO_V1(geom3d_brin_inclusion_mergeable);
+Datum geom3d_brin_inclusion_mergeable(PG_FUNCTION_ARGS)
+{
+	GIDX *key = (GIDX *) PG_GETARG_POINTER(0);
+	GIDX *geom = (GIDX *) PG_GETARG_POINTER(1);
+
+	PG_RETURN_BOOL(gidx_brin_inclusion_mergeable(key, geom));
+}
+
 PG_FUNCTION_INFO_V1(geom4d_brin_inclusion_merge);
 Datum geom4d_brin_inclusion_merge(PG_FUNCTION_ARGS)
 {
@@ -236,6 +265,15 @@ Datum geom4d_brin_inclusion_merge(PG_FUNCTION_ARGS)
 	GIDX *geom = (GIDX *) PG_GETARG_POINTER(1);
 
 	PG_RETURN_POINTER(gidx_brin_inclusion_merge(key, geom));
+}
+
+PG_FUNCTION_INFO_V1(geom4d_brin_inclusion_mergeable);
+Datum geom4d_brin_inclusion_mergeable(PG_FUNCTION_ARGS)
+{
+	GIDX *key = (GIDX *) PG_GETARG_POINTER(0);
+	GIDX *geom = (GIDX *) PG_GETARG_POINTER(1);
+
+	PG_RETURN_BOOL(gidx_brin_inclusion_mergeable(key, geom));
 }
 
 

--- a/postgis/geography_brin.sql.in
+++ b/postgis/geography_brin.sql.in
@@ -65,6 +65,12 @@ RETURNS internal
         AS 'MODULE_PATHNAME','geog_brin_inclusion_merge'
         LANGUAGE 'c' PARALLEL SAFE;
 
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION geog_brin_inclusion_mergeable(internal, internal)
+RETURNS boolean
+        AS 'MODULE_PATHNAME','geog_brin_inclusion_mergeable'
+        LANGUAGE 'c' PARALLEL SAFE;
+
 -- Availability: 2.3.0
 CREATE OPERATOR CLASS brin_geography_inclusion_ops
   DEFAULT FOR TYPE geography
@@ -74,6 +80,7 @@ CREATE OPERATOR CLASS brin_geography_inclusion_ops
     FUNCTION      3        brin_inclusion_consistent(internal, internal, internal),
     FUNCTION      4        brin_inclusion_union(internal, internal, internal),
     FUNCTION      11       geog_brin_inclusion_merge(internal, internal),
+    FUNCTION      12       geog_brin_inclusion_mergeable(internal, internal),
     OPERATOR      3        &&(geography, geography),
     OPERATOR      3        &&(geography, gidx),
     OPERATOR      3        &&(gidx, geography),

--- a/postgis/postgis_brin.sql.in
+++ b/postgis/postgis_brin.sql.in
@@ -210,6 +210,12 @@ RETURNS internal
 AS 'MODULE_PATHNAME','geom3d_brin_inclusion_merge'
 LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
 
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION geom3d_brin_inclusion_mergeable(internal, internal)
+RETURNS boolean
+AS 'MODULE_PATHNAME','geom3d_brin_inclusion_mergeable'
+LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
+
 -- Availability: 2.3.0
 CREATE OR REPLACE FUNCTION geom4d_brin_inclusion_add_value(internal, internal, internal, internal)
 RETURNS boolean
@@ -220,6 +226,12 @@ LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
 CREATE OR REPLACE FUNCTION geom4d_brin_inclusion_merge(internal, internal)
 RETURNS internal
 AS 'MODULE_PATHNAME','geom4d_brin_inclusion_merge'
+LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
+
+-- Availability: 3.6.0
+CREATE OR REPLACE FUNCTION geom4d_brin_inclusion_mergeable(internal, internal)
+RETURNS boolean
+AS 'MODULE_PATHNAME','geom4d_brin_inclusion_mergeable'
 LANGUAGE 'c' PARALLEL SAFE _COST_DEFAULT;
 
 -- Availability: 2.3.0
@@ -259,6 +271,7 @@ CREATE OPERATOR CLASS brin_geometry_inclusion_ops_3d
     FUNCTION      3        brin_inclusion_consistent(internal, internal, internal),
     FUNCTION      4        brin_inclusion_union(internal, internal, internal),
     FUNCTION      11       geom3d_brin_inclusion_merge(internal, internal),
+    FUNCTION      12       geom3d_brin_inclusion_mergeable(internal, internal),
     OPERATOR      3        &&&(geometry, geometry),
     OPERATOR      3        &&&(geometry, gidx),
     OPERATOR      3        &&&(gidx, geometry),
@@ -278,6 +291,7 @@ CREATE OPERATOR CLASS brin_geometry_inclusion_ops_4d
     FUNCTION      3        brin_inclusion_consistent(internal, internal, internal),
     FUNCTION      4        brin_inclusion_union(internal, internal, internal),
     FUNCTION      11       geom4d_brin_inclusion_merge(internal, internal),
+    FUNCTION      12       geom4d_brin_inclusion_mergeable(internal, internal),
     OPERATOR      3        &&&(geometry, geometry),
     OPERATOR      3        &&&(geometry, gidx),
     OPERATOR      3        &&&(gidx, geometry),


### PR DESCRIPTION
### Motivation
- The new BRIN merge path for GIDX-backed summaries could read past a shorter GIDX when merging mixed-dimension summaries, causing out-of-bounds reads or corrupted BRIN summaries. 
- The existing `add_value` path already treated differing GIDX dimensions as unmergeable, but the merge helper lacked an equivalent check. 
- The change aims to make BRIN merge behavior defensively consistent with `add_value` and avoid native memory-safety issues reachable from BRIN operations.

### Description
- Add a `gidx_brin_inclusion_mergeable(GIDX *gidx_key, GIDX *gidx_geom)` helper that returns whether the two GIDX objects have the same number of dimensions. 
- Guard `gidx_brin_inclusion_merge()` with the new helper to return early when dimensionality differs so the merge loop never indexes non-existent dimensions. 
- Expose boolean wrappers for the helper as BRIN support functions and register them as support proc 12 in the GIDX-backed opclass SQL for geography, 3D geometry, and 4D geometry. 
- Changes touch `postgis/brin_nd.c`, `postgis/postgis_brin.sql.in`, and `postgis/geography_brin.sql.in` and otherwise preserve existing behavior for matching-dimension merges.

### Testing
- Ran `git diff --check` which reported no whitespace or patch issues and succeeded. 
- Attempted a full build with `make -j"$(nproc)"` but the tree requires a prior `./configure` run so the build did not proceed. 
- Attempted `./autogen.sh && ./configure --without-raster` but the environment lacked `aclocal`/automake and installing build tools failed due to network/proxy restrictions, so compilation and runtime regression tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b463d53408324acd16489e33a932d)