### PR TITLE
Avoid GMP overflow in topology ring orientation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -50,6 +50,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - GH-885, [topology] Avoid GMP overflow in ring orientation for very large
+          finite coordinates (Darafei Praliaskouski)
  - Build PostgreSQL extension modules with `-fno-semantic-interposition` when
           available so LTO can optimize same-DSO calls to exported PostGIS
           entry points directly instead of routing through the module PLT; in

--- a/liblwgeom/cunit/Makefile.in
+++ b/liblwgeom/cunit/Makefile.in
@@ -58,6 +58,7 @@ OBJS=	\
 	cu_split.o \
 	cu_stringbuffer.o \
 	cu_triangulate.o \
+	cu_topo.o \
 	cu_homogenize.o \
 	cu_force_dims.o \
 	cu_force_sfs.o \

--- a/liblwgeom/cunit/Makefile.in
+++ b/liblwgeom/cunit/Makefile.in
@@ -22,7 +22,7 @@ LIBTOOL = @LIBTOOL@
 CUNIT_LDFLAGS=@CUNIT_LDFLAGS@
 CUNIT_CPPFLAGS = -I$(srcdir)/.. -I$(builddir)/.. @CUNIT_CPPFLAGS@ @CPPFLAGS@
 CFLAGS=$(CUNIT_CPPFLAGS) @CFLAGS@
-LDFLAGS = @GEOS_LDFLAGS@ @PROJ_LDFLAGS@ $(CUNIT_LDFLAGS)
+LDFLAGS = @GEOS_LDFLAGS@ @PROJ_LDFLAGS@ @GMP_LIBS@ $(CUNIT_LDFLAGS)
 
 VPATH = $(srcdir)
 
@@ -108,7 +108,7 @@ endif
 
 # Build the main unit test executable
 cu_tester: ../liblwgeom.la $(OBJS) cu_tester.h
-	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS) -static ../liblwgeom.la @GMP_LIBS@
+	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS) -static ../liblwgeom.la
 
 # Command to build each of the .o files
 $(OBJS): %.o: %.c

--- a/liblwgeom/cunit/Makefile.in
+++ b/liblwgeom/cunit/Makefile.in
@@ -22,7 +22,8 @@ LIBTOOL = @LIBTOOL@
 CUNIT_LDFLAGS=@CUNIT_LDFLAGS@
 CUNIT_CPPFLAGS = -I$(srcdir)/.. -I$(builddir)/.. @CUNIT_CPPFLAGS@ @CPPFLAGS@
 CFLAGS=$(CUNIT_CPPFLAGS) @CFLAGS@
-LDFLAGS = @GEOS_LDFLAGS@ @PROJ_LDFLAGS@ @GMP_LIBS@ $(CUNIT_LDFLAGS)
+LDFLAGS = @GEOS_LDFLAGS@ @PROJ_LDFLAGS@ $(CUNIT_LDFLAGS)
+LIBLWGEOM_LDFLAGS = @GMP_LIBS@
 
 VPATH = $(srcdir)
 
@@ -108,7 +109,7 @@ endif
 
 # Build the main unit test executable
 cu_tester: ../liblwgeom.la $(OBJS) cu_tester.h
-	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS) -static ../liblwgeom.la
+	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS) -static ../liblwgeom.la $(LIBLWGEOM_LDFLAGS)
 
 # Command to build each of the .o files
 $(OBJS): %.o: %.c

--- a/liblwgeom/cunit/Makefile.in
+++ b/liblwgeom/cunit/Makefile.in
@@ -108,7 +108,7 @@ endif
 
 # Build the main unit test executable
 cu_tester: ../liblwgeom.la $(OBJS) cu_tester.h
-	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS) -static ../liblwgeom.la
+	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS) -static ../liblwgeom.la @GMP_LIBS@
 
 # Command to build each of the .o files
 $(OBJS): %.o: %.c

--- a/liblwgeom/cunit/cu_tester.c
+++ b/liblwgeom/cunit/cu_tester.c
@@ -72,6 +72,7 @@ extern void sfcgal_suite_setup(void);
 extern void split_suite_setup(void);
 extern void stringbuffer_suite_setup(void);
 extern void tree_suite_setup(void);
+extern void topo_suite_setup(void);
 extern void triangulate_suite_setup(void);
 extern void varint_suite_setup(void);
 extern void wkt_out_suite_setup(void);
@@ -128,6 +129,7 @@ PG_SuiteSetup setupfuncs[] = {algorithms_suite_setup,
 			      stringbuffer_suite_setup,
 			      surface_suite_setup,
 			      tree_suite_setup,
+			      topo_suite_setup,
 			      triangulate_suite_setup,
 			      twkb_out_suite_setup,
 			      varint_suite_setup,

--- a/liblwgeom/cunit/cu_topo.c
+++ b/liblwgeom/cunit/cu_topo.c
@@ -1,0 +1,55 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU General Public Licence. See the COPYING file.
+ *
+ **********************************************************************/
+
+#include "CUnit/Basic.h"
+#include "CUnit/CUnit.h"
+
+#include "liblwgeom_internal.h"
+#include "topo/liblwgeom_topo.h"
+#include "cu_tester.h"
+
+static LWGEOM *
+lwgeom_from_text(const char *str)
+{
+	LWGEOM_PARSER_RESULT r;
+	if (LW_FAILURE == lwgeom_parse_wkt(&r, (char *)str, LW_PARSER_CHECK_NONE))
+		return NULL;
+	return r.geom;
+}
+
+static void
+test_lwt_IsTopoRingCCW_large_finite_coordinates(void)
+{
+	LWGEOM *geom = lwgeom_from_text("POLYGON((0 1e308,1e308 0,0 0,0 1e308))");
+	LWPOLY *poly;
+
+	CU_ASSERT_PTR_NOT_NULL(geom);
+	if (!geom)
+		return;
+
+	poly = lwgeom_as_lwpoly(geom);
+	CU_ASSERT_PTR_NOT_NULL(poly);
+	if (!poly)
+	{
+		lwgeom_free(geom);
+		return;
+	}
+
+	CU_ASSERT_EQUAL(lwt_IsTopoRingCCW(poly->rings[0]), LW_FALSE);
+
+	lwgeom_free(geom);
+}
+
+void
+topo_suite_setup(void)
+{
+	CU_pSuite suite = CU_add_suite("topology", NULL, NULL);
+	PG_ADD_TEST(suite, test_lwt_IsTopoRingCCW_large_finite_coordinates);
+}

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -38,6 +38,7 @@
 #include <gmp.h>
 
 #include <inttypes.h>
+#include <math.h>
 
 static bool
 _lwt_describe_point(const LWPOINT *pt, char *buf, size_t bufsize)
@@ -1888,27 +1889,49 @@ lwt_IsTopoRingCCW(const POINTARRAY *pa)
   const POINT2D *P3;
   mpf_t sum;
   mpf_t tmp;
-  double x0, x, y1, y2;
+  mpf_t x0;
+  mpf_t x;
+  mpf_t dy;
   uint32_t i;
   int ret;
 
   if (! pa || pa->npoints < 3 )
     return 0;
 
-  mpf_init2(sum, 64);
-  mpf_init2(tmp, 64);
-  mpf_set_d(sum, 0.0);
-
   P1 = getPoint2d_cp(pa, 0);
   P2 = getPoint2d_cp(pa, 1);
-  x0 = P1->x;
+
+  if (!isfinite(P1->x) || !isfinite(P1->y) || !isfinite(P2->x) || !isfinite(P2->y))
+	  return ptarray_isccw(pa);
+
+  mpf_init2(sum, 64);
+  mpf_init2(tmp, 64);
+  mpf_init2(x0, 64);
+  mpf_init2(x, 64);
+  mpf_init2(dy, 64);
+  mpf_set_d(sum, 0.0);
+  mpf_set_d(x0, P1->x);
+
   for ( i = 2; i < pa->npoints; i++ )
   {
     P3 = getPoint2d_cp(pa, i);
-    x = P2->x - x0;
-    y1 = P3->y;
-    y2 = P1->y;
-    mpf_set_d(tmp, x * (y2-y1));
+
+    if (!isfinite(P3->x) || !isfinite(P3->y))
+    {
+	    mpf_clear(dy);
+	    mpf_clear(x);
+	    mpf_clear(x0);
+	    mpf_clear(tmp);
+	    mpf_clear(sum);
+	    return ptarray_isccw(pa);
+    }
+
+    mpf_set_d(x, P2->x);
+    mpf_sub(x, x, x0);
+    mpf_set_d(dy, P1->y);
+    mpf_set_d(tmp, P3->y);
+    mpf_sub(dy, dy, tmp);
+    mpf_mul(tmp, x, dy);
     mpf_add(sum, sum, tmp);
     P1 = P2;
     P2 = P3;
@@ -1916,6 +1939,9 @@ lwt_IsTopoRingCCW(const POINTARRAY *pa)
 
   ret = mpf_cmp_ui(sum, 0) < 0;
 
+  mpf_clear(dy);
+  mpf_clear(x);
+  mpf_clear(x0);
   mpf_clear(tmp);
   mpf_clear(sum);
 


### PR DESCRIPTION
### Motivation

- Avoid a floating-point exception in the GMP-based topology ring orientation path when very large finite coordinates make an intermediate double product overflow before being passed to GMP.
- Preserve the GMP path for finite inputs while falling back to the legacy orientation path for non-finite coordinates.

### Description

- Compute the orientation product inside GMP rather than multiplying as a double first.
- Guard non-finite coordinates before calling `mpf_set_d`.
- Add a CUnit regression for large finite coordinates.
- Link the CUnit test binary with GMP after `liblwgeom` so static-link style jobs resolve the GMP symbols correctly.

### Release / upgrade notes

- Added a 3.7.0 `NEWS` entry for https://github.com/postgis/postgis/pull/885.
- No SQL upgrade file is needed: this changes liblwgeom C code and CUnit coverage only, so existing databases pick up the fix when the updated shared library is installed.

### Testing

- `git diff --check`
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `./liblwgeom/cunit/cu_tester topology`
