### PR TITLE
Fix NULL handling in ST_ClusterRelateWin to avoid NULL-dereference

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           dropping the tail (Darafei Praliaskouski)
  - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for
           MinGW builds (Darafei Praliaskouski)
+ - GH-886, ST_ClusterRelateWin validates NULL relate matrices before
+          detoasting them (Darafei Praliaskouski)
  - Build PostgreSQL extension modules with `-fno-semantic-interposition` when
           available so LTO can optimize same-DSO calls to exported PostGIS
           entry points directly instead of routing through the module PLT; in

--- a/postgis/lwgeom_window.c
+++ b/postgis/lwgeom_window.c
@@ -20,6 +20,7 @@
  *
  * Copyright 2016 Paul Ramsey <pramsey@cleverelephant.ca>
  * Copyright 2016 Daniel Baston <dbaston@gmail.com>
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
@@ -375,11 +376,22 @@ Datum ST_ClusterRelateWin(PG_FUNCTION_ARGS)
 		GEOSGeometry** geoms = palloc0(ngeoms * sizeof(GEOSGeometry*));
 		UNIONFIND* uf = UF_create(ngeoms);
 		char *matrix;
-		text *txtIm = DatumGetTextP(WinGetFuncArgCurrent(win_obj, 1, &matrix_is_null));
-		if (matrix_is_null || VARSIZE_ANY_EXHDR(txtIm) != 9)
+		/*
+		 * Window arguments must be checked for NULL before detoasting.
+		 * DatumGetTextP() is not allowed to inspect a NULL Datum.
+		 */
+		Datum matrix_datum = WinGetFuncArgCurrent(win_obj, 1, &matrix_is_null);
+		text *txtIm;
+
+		if (matrix_is_null)
 		{
-			elog(ERROR,"Invalid relate matrix provided");
-			PG_RETURN_NULL();
+			elog(ERROR, "Invalid relate matrix provided");
+		}
+
+		txtIm = DatumGetTextP(matrix_datum);
+		if (VARSIZE_ANY_EXHDR(txtIm) != 9)
+		{
+			elog(ERROR, "Invalid relate matrix provided");
 		}
 		matrix = text_to_cstring(txtIm);
 

--- a/regress/core/cluster_geos313.sql
+++ b/regress/core/cluster_geos313.sql
@@ -1,0 +1,8 @@
+CREATE TEMPORARY TABLE cluster_geos313_inputs (id int, geom geometry);
+INSERT INTO cluster_geos313_inputs VALUES
+(1, 'LINESTRING (0 0, 1 1)'),
+(2, 'LINESTRING (5 5, 4 4)');
+
+SELECT 'cluster_relate_null_matrix', ST_ClusterRelateWin(geom, NULL) OVER ()
+FROM cluster_geos313_inputs
+LIMIT 1;

--- a/regress/core/cluster_geos313_expected
+++ b/regress/core/cluster_geos313_expected
@@ -1,0 +1,1 @@
+ERROR:  Invalid relate matrix provided

--- a/regress/core/tests.mk.in
+++ b/regress/core/tests.mk.in
@@ -171,6 +171,11 @@ else
 		$(top_srcdir)/regress/core/concave_hull
 endif
 
+ifeq ($(shell expr "$(POSTGIS_GEOS_VERSION)" ">=" 31300),1)
+	TESTS += \
+		$(top_srcdir)/regress/core/cluster_geos313
+endif
+
 ifeq ($(shell expr "$(POSTGIS_GEOS_VERSION)" ">=" 31500),1)
 	TESTS += \
 		$(top_srcdir)/regress/core/geos315


### PR DESCRIPTION
Supersedes https://github.com/postgis/postgis/pull/877 using the `Komzpa/postgis` fork branch for review mechanics.

### Motivation

- `ST_ClusterRelateWin` previously detoasted the `relate_matrix` argument before checking whether the window-supplied datum was NULL, allowing a NULL `text` datum to be dereferenced and crash the backend.
- The change prevents a SQL caller from causing a backend crash by passing NULL as `relate_matrix` to the window function.

### Description

- Fetches the `relate_matrix` argument into a `Datum` via `WinGetFuncArgCurrent` and checks `matrix_is_null` before calling `DatumGetTextP`.
- Keeps the existing DE-9IM length validation after NULL validation and before `text_to_cstring`.
- Removes the unreachable `PG_RETURN_NULL()` statements after the `elog(ERROR)` paths noted by CodeRabbit.
- Adds a GEOS 3.13+ gated `core/cluster_geos313` regression for `ST_ClusterRelateWin(geom, NULL) OVER ()`; older GEOS CI lanes cannot execute this function.

### Release and Upgrade Notes

- Added a 3.7.0 `NEWS` entry for https://github.com/postgis/postgis/pull/886.
- No extension upgrade SQL is needed: the SQL declaration for `ST_ClusterRelateWin(geometry, text)` is unchanged and still points to the same C symbol, so installing the updated shared library picks up the fix.

### Testing

- Rebased on `postgis:master` at `63cbf4f069afebe50cb520b7abe6440c898842e9`.
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git clang-format --diff upstream/master -- postgis/lwgeom_window.c`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make -j32`
- `sudo -n make install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/cluster $(pwd)/regress/core/cluster_geos313"`

Coverage is covered by the queued GitHub coverage jobs; local validation used the focused regression lane for this window-function fix.
