### PR TITLE
Fix SFCGAL visibility empty input handling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,
           including guards for malformed TWKB reads and counts (Darafei Praliaskouski)
+ - GH-888, [sfcgal] Avoid stale detoasted geometry access in
+          CG_Visibility empty-input handling for SFCGAL < 2.2
+          (Darafei Praliaskouski)
  - Build PostgreSQL extension modules with `-fno-semantic-interposition` when
           available so LTO can optimize same-DSO calls to exported PostGIS
           entry points directly instead of routing through the module PLT; in

--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -19,6 +19,7 @@
  **********************************************************************
  *
  * Copyright 2012-2020 Oslandia <infos@oslandia.com>
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
@@ -1232,21 +1233,29 @@ sfcgal_visibility_point(PG_FUNCTION_ARGS)
 	input0 = PG_GETARG_GSERIALIZED_P(0);
 	srid = gserialized_get_srid(input0);
 	input1 = PG_GETARG_GSERIALIZED_P(1);
-	polygon = POSTGIS2SFCGALGeometry(input0);
-	PG_FREE_IF_COPY(input0, 0);
-	point = POSTGIS2SFCGALGeometry(input1);
-	PG_FREE_IF_COPY(input1, 1);
 
 #if POSTGIS_SFCGAL_VERSION < 20200
+	/*
+	 * SFCGAL < 2.2 needs PostGIS to preserve the empty-input result.
+	 * Check this before converting and freeing detoasted inputs, because
+	 * gserialized_is_empty() must not inspect a freed copy.
+	 */
 	if (gserialized_is_empty(input0) || gserialized_is_empty(input1))
 	{
 		result = sfcgal_polygon_create();
 		output = SFCGALGeometry2POSTGIS(result, 0, srid);
 		sfcgal_geometry_delete(result);
 
+		PG_FREE_IF_COPY(input0, 0);
+		PG_FREE_IF_COPY(input1, 1);
 		PG_RETURN_POINTER(output);
 	}
 #endif
+
+	polygon = POSTGIS2SFCGALGeometry(input0);
+	PG_FREE_IF_COPY(input0, 0);
+	point = POSTGIS2SFCGALGeometry(input1);
+	PG_FREE_IF_COPY(input1, 1);
 
 	result = sfcgal_geometry_visibility_point(polygon, point);
 	sfcgal_geometry_delete(polygon);
@@ -1282,23 +1291,32 @@ sfcgal_visibility_segment(PG_FUNCTION_ARGS)
 	srid = gserialized_get_srid(input0);
 	input1 = PG_GETARG_GSERIALIZED_P(1);
 	input2 = PG_GETARG_GSERIALIZED_P(2);
-	polygon = POSTGIS2SFCGALGeometry(input0);
-	PG_FREE_IF_COPY(input0, 0);
-	pointA = POSTGIS2SFCGALGeometry(input1);
-	PG_FREE_IF_COPY(input1, 1);
-	pointB = POSTGIS2SFCGALGeometry(input2);
-	PG_FREE_IF_COPY(input2, 2);
 
 #if POSTGIS_SFCGAL_VERSION < 20200
+	/*
+	 * SFCGAL < 2.2 needs PostGIS to preserve the empty-input result.
+	 * Check this before converting and freeing detoasted inputs, because
+	 * gserialized_is_empty() must not inspect a freed copy.
+	 */
 	if (gserialized_is_empty(input0) || gserialized_is_empty(input1) || gserialized_is_empty(input2))
 	{
 		result = sfcgal_polygon_create();
 		output = SFCGALGeometry2POSTGIS(result, 0, srid);
 		sfcgal_geometry_delete(result);
 
+		PG_FREE_IF_COPY(input0, 0);
+		PG_FREE_IF_COPY(input1, 1);
+		PG_FREE_IF_COPY(input2, 2);
 		PG_RETURN_POINTER(output);
 	}
 #endif
+
+	polygon = POSTGIS2SFCGALGeometry(input0);
+	PG_FREE_IF_COPY(input0, 0);
+	pointA = POSTGIS2SFCGALGeometry(input1);
+	PG_FREE_IF_COPY(input1, 1);
+	pointB = POSTGIS2SFCGALGeometry(input2);
+	PG_FREE_IF_COPY(input2, 2);
 
 	result = sfcgal_geometry_visibility_segment(polygon, pointA, pointB);
 	sfcgal_geometry_delete(polygon);


### PR DESCRIPTION
Supersedes https://github.com/postgis/postgis/pull/882 using the `Komzpa/postgis` fork branch for review mechanics.

### Motivation

- Avoid stale access to detoasted geometry arguments in the SFCGAL-backed `CG_Visibility` empty-input compatibility path for builds against SFCGAL < 2.2.
- Preserve the existing behavior that returns an empty polygon for empty inputs while keeping resource management correct for toasted or compressed `geometry` arguments.

### Description

- Moves the `gserialized_is_empty(...)` checks for both `sfcgal_visibility_point` and `sfcgal_visibility_segment` so they run before converting inputs to SFCGAL geometries and before freeing detoasted input copies.
- Frees any detoasted input copies on the empty-input early-return path before returning the constructed empty polygon.
- Leaves the non-empty conversion and cleanup path unchanged.

### Release and Upgrade Notes

- Added a 3.7.0 `NEWS` entry for https://github.com/postgis/postgis/pull/888.
- No extension upgrade SQL is needed because the `CG_Visibility` SQL declarations and C symbols are unchanged; installing the updated `postgis_sfcgal-3` shared library picks up the fix.

### Testing

- `git diff --check`
- `make -C sfcgal -j32`
- `sudo -n make -C sfcgal install`
- `make -C sfcgal/regress check RUNTESTFLAGS='--extension' TESTS='visibility'`

The focused regression passed on local SFCGAL 2.3.0, including the upgrade-mode rerun. That validates current public behavior; the fixed compatibility branch is compiled for SFCGAL < 2.2.
