### PR TITLE
libpgcommon: qualify pg_class in SRID lookup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -160,6 +160,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           for extension upgrade (Darafei Praliaskouski)
  - #6080, Avoid out-of-bounds hex WKB lookup for high-bit input bytes
           (Darafei Praliaskouski)
+ - GH-895, Qualify pg_class lookup during SRID/PROJ validation
+          (Darafei Praliaskouski)
  - #4828, geometry_columns handles NOT VALID SRID checks without errors (Darafei Praliaskouski)
  - #6048, [raster] ST_Clip no longer crashes when clipping sparse band
           selections (Darafei Praliaskouski)

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -184,10 +184,11 @@ GetProjStringsSPI(int32_t srid)
 	 * resolve standard codes from its own database.
 	 */
 	Oid nsp_oid = POSTGIS_CONSTANTS ? POSTGIS_CONSTANTS->install_nsp_oid : InvalidOid;
-	snprintf(proj_spi_buffer, spibufferlen,
-	         "SELECT 1 FROM pg_class "
-	         "WHERE relname = 'spatial_ref_sys' AND relnamespace = %u",
-	         nsp_oid);
+	snprintf(proj_spi_buffer,
+		 spibufferlen,
+		 "SELECT 1 FROM pg_catalog.pg_class "
+		 "WHERE relname = 'spatial_ref_sys' AND relnamespace = %u",
+		 nsp_oid);
 	spi_result = SPI_execute(proj_spi_buffer, true, 1);
 	bool srs_exists = (spi_result == SPI_OK_SELECT && SPI_processed > 0);
 


### PR DESCRIPTION
## Summary

Qualify the `pg_class` catalog lookup used before querying `spatial_ref_sys` during SRID/PROJ lookup. This keeps the preflight check on the real PostgreSQL catalog even if a caller changes `search_path` so that another schema precedes `pg_catalog`.

## CSV finding covered

- Unqualified pg_class lookup enables SRID validation bypass.

## Release/Upgrade Notes

- Added a PostGIS 3.7.0 NEWS entry for https://github.com/postgis/postgis/pull/895.
- No extension upgrade SQL is needed: SQL definitions and catalog-visible objects are unchanged; this is libpgcommon runtime behavior.

## Current state

- Rebased on `postgis:master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`.
- Current head: `f46ed7d7a8be7bc25d2338d18d2c393d33125b63`.
- GitHub readback after push: draft PR, `MERGEABLE`, approved, no review threads; CI checks are queued/pending.
- Gitea search found no matching active mirror PR for `895` or `fix-srid-pg-class-lookup`.

## Tests

- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- libpgcommon/lwgeom_transform.c NEWS`
- `./utils/check_news.sh .`
- `make -C libpgcommon -j32`
