### PR TITLE
topology: fix topology query regressions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           dropping the tail (Darafei Praliaskouski)
  - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for
           MinGW builds (Darafei Praliaskouski)
+ - GH-897, [topology] Harden topology helper functions and maintenance SQL
+          against identifier, tolerance, bigint, and cleanup regressions
+          (Darafei Praliaskouski)
  - Build PostgreSQL extension modules with `-fno-semantic-interposition` when
           available so LTO can optimize same-DSO calls to exported PostGIS
           entry points directly instead of routing through the module PLT; in

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -19,7 +19,7 @@
  **********************************************************************
  *
  * Copyright (C) 2015-2026 Sandro Santilli <strk@kbt.io>
- * Copyright (C) 2025 Darafei Praliaskouski <me@komzpa.net>
+ * Copyright (C) 2025-2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
@@ -7685,8 +7685,10 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     forward = -1; /* will be set to either 0 or 1 if the edge already existed */
     id = _lwt_AddLineEdge( topo, lwgeom_as_lwline(g), tol, handleFaceSplit, &forward, &edgeNewEdges );
     num_new_edges += edgeNewEdges;
+    /* id 0 means the component collapsed before insertion, so it must not
+     * consume the max_new_edges budget. */
     /* if forward is still == -1 this was NOT an existing edge ? */
-    if ( forward == -1 && id != 0 )
+    if (forward == -1 && id != 0)
     {
       ++num_new_edges;
     }

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7686,7 +7686,7 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     id = _lwt_AddLineEdge( topo, lwgeom_as_lwline(g), tol, handleFaceSplit, &forward, &edgeNewEdges );
     num_new_edges += edgeNewEdges;
     /* if forward is still == -1 this was NOT an existing edge ? */
-    if ( forward == -1 )
+    if ( forward == -1 && id != 0 )
     {
       ++num_new_edges;
     }

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -4644,7 +4644,7 @@ Datum ST_RemEdgeModFace(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID node_id;
   LWT_TOPOLOGY *topo;
 
@@ -4699,7 +4699,7 @@ Datum ST_RemEdgeNewFace(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID node_id;
   LWT_TOPOLOGY *topo;
 
@@ -4752,7 +4752,7 @@ Datum ST_ModEdgeHeal(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID eid1, eid2;
   LWT_TOPOLOGY *topo;
 
@@ -4806,7 +4806,7 @@ Datum ST_NewEdgeHeal(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID eid1, eid2;
   LWT_TOPOLOGY *topo;
 
@@ -4883,8 +4883,9 @@ Datum GetNodeByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if ( tol < 0 && tol != -1 )
   {
+    lwgeom_free(lwgeom);
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
     PG_RETURN_NULL();
@@ -4953,8 +4954,9 @@ Datum GetEdgeByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if ( tol < 0 && tol != -1 )
   {
+    lwgeom_free(lwgeom);
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
     PG_RETURN_NULL();
@@ -5025,8 +5027,9 @@ Datum GetFaceByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if ( tol < 0 && tol != -1 )
   {
+    lwgeom_free(lwgeom);
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
     PG_RETURN_NULL();
@@ -5106,8 +5109,9 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if ( tol < 0 && tol != -1 )
   {
+    lwgeom_free(lwgeom);
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
     PG_RETURN_NULL();
@@ -5217,7 +5221,7 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < -1 )
+    if ( tol < 0 && tol != -1 )
     {
       lwgeom_free(lwgeom);
       PG_FREE_IF_COPY(geom, 1);
@@ -5337,8 +5341,9 @@ Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if ( tol < 0 && tol != -1 )
   {
+    lwgeom_free(lwgeom);
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
     PG_RETURN_NULL();
@@ -5428,8 +5433,9 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < -1 )
+    if ( tol < 0 && tol != -1 )
     {
+      lwgeom_free(lwgeom);
       PG_FREE_IF_COPY(geom, 1);
       lwpgerror("Tolerance must be -1 or >=0 ");
       PG_RETURN_NULL();
@@ -5778,7 +5784,7 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
   geom = PG_GETARG_GSERIALIZED_P(1);
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if ( tol < 0 && tol != -1 )
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5835,6 +5841,8 @@ Datum TopoRingIsCCW(PG_FUNCTION_ARGS)
 
   if ( lwgeom_is_empty(lwgeom) )
   {
+    lwgeom_free(lwgeom);
+    PG_FREE_IF_COPY(geom, 0);
     PG_RETURN_BOOL(false);
   }
 
@@ -5848,6 +5856,8 @@ Datum TopoRingIsCCW(PG_FUNCTION_ARGS)
   }
   else
   {
+    lwgeom_free(lwgeom);
+    PG_FREE_IF_COPY(geom, 0);
     lwpgerror("Unsupported geometry type passed to TopoRingIsCCW");
     PG_RETURN_NULL();
   }

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -4,6 +4,7 @@
  * http://postgis.net
  *
  * Copyright (C) 2015-2026 Sandro Santilli <strk@kbt.io>
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU General Public Licence. See the COPYING file.
@@ -4883,12 +4884,12 @@ Datum GetNodeByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < 0 && tol != -1 )
+  if (tol < 0 && tol != -1)
   {
-    lwgeom_free(lwgeom);
-    PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
-    PG_RETURN_NULL();
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 1);
+	  lwpgerror("Tolerance must be -1 or >=0 ");
+	  PG_RETURN_NULL();
   }
 
   if ( SPI_OK_CONNECT != SPI_connect() )
@@ -4954,12 +4955,12 @@ Datum GetEdgeByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < 0 && tol != -1 )
+  if (tol < 0 && tol != -1)
   {
-    lwgeom_free(lwgeom);
-    PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
-    PG_RETURN_NULL();
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 1);
+	  lwpgerror("Tolerance must be -1 or >=0 ");
+	  PG_RETURN_NULL();
   }
 
   if ( SPI_OK_CONNECT != SPI_connect() )
@@ -5027,12 +5028,12 @@ Datum GetFaceByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < 0 && tol != -1 )
+  if (tol < 0 && tol != -1)
   {
-    lwgeom_free(lwgeom);
-    PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
-    PG_RETURN_NULL();
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 1);
+	  lwpgerror("Tolerance must be -1 or >=0 ");
+	  PG_RETURN_NULL();
   }
 
   if ( SPI_OK_CONNECT != SPI_connect() )
@@ -5109,12 +5110,12 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < 0 && tol != -1 )
+  if (tol < 0 && tol != -1)
   {
-    lwgeom_free(lwgeom);
-    PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
-    PG_RETURN_NULL();
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 1);
+	  lwpgerror("Tolerance must be -1 or >=0 ");
+	  PG_RETURN_NULL();
   }
 
   if ( SPI_OK_CONNECT != SPI_connect() )
@@ -5221,7 +5222,7 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < 0 && tol != -1 )
+    if (tol < 0 && tol != -1)
     {
       lwgeom_free(lwgeom);
       PG_FREE_IF_COPY(geom, 1);
@@ -5341,12 +5342,12 @@ Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < 0 && tol != -1 )
+  if (tol < 0 && tol != -1)
   {
-    lwgeom_free(lwgeom);
-    PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
-    PG_RETURN_NULL();
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 1);
+	  lwpgerror("Tolerance must be -1 or >=0 ");
+	  PG_RETURN_NULL();
   }
 
   if ( SPI_OK_CONNECT != SPI_connect() )
@@ -5433,12 +5434,12 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < 0 && tol != -1 )
+    if (tol < 0 && tol != -1)
     {
-      lwgeom_free(lwgeom);
-      PG_FREE_IF_COPY(geom, 1);
-      lwpgerror("Tolerance must be -1 or >=0 ");
-      PG_RETURN_NULL();
+	    lwgeom_free(lwgeom);
+	    PG_FREE_IF_COPY(geom, 1);
+	    lwpgerror("Tolerance must be -1 or >=0 ");
+	    PG_RETURN_NULL();
     }
 
     if ( SPI_OK_CONNECT != SPI_connect() )
@@ -5784,7 +5785,7 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
   geom = PG_GETARG_GSERIALIZED_P(1);
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < 0 && tol != -1 )
+  if (tol < 0 && tol != -1)
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5841,9 +5842,9 @@ Datum TopoRingIsCCW(PG_FUNCTION_ARGS)
 
   if ( lwgeom_is_empty(lwgeom) )
   {
-    lwgeom_free(lwgeom);
-    PG_FREE_IF_COPY(geom, 0);
-    PG_RETURN_BOOL(false);
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 0);
+	  PG_RETURN_BOOL(false);
   }
 
   if (lwgeom->type == POLYGONTYPE)
@@ -5856,10 +5857,10 @@ Datum TopoRingIsCCW(PG_FUNCTION_ARGS)
   }
   else
   {
-    lwgeom_free(lwgeom);
-    PG_FREE_IF_COPY(geom, 0);
-    lwpgerror("Unsupported geometry type passed to TopoRingIsCCW");
-    PG_RETURN_NULL();
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 0);
+	  lwpgerror("Unsupported geometry type passed to TopoRingIsCCW");
+	  PG_RETURN_NULL();
   }
 
   isCCW = lwt_IsTopoRingCCW(pa);

--- a/topology/sql/manage/FixCorruptTopoGeometryColumn.sql.in
+++ b/topology/sql/manage/FixCorruptTopoGeometryColumn.sql.in
@@ -56,7 +56,12 @@ WHERE pg_type.typname = 'topogeometry' AND pga.attname = 'id'
 	     l.feature_type
 	   )::topology.topogeometry
 	   FROM topology.layer AS l
-	 WHERE  l.topology_id = (%3$I).topology_id AND l.layer_id =  (%3$I).layer_id AND (%3$I).type <> l.feature_type  ', layerSchema, layerTable, layerColumn);
+		 WHERE  l.topology_id = (%3$I).topology_id AND l.layer_id =  (%3$I).layer_id
+		 AND (%3$I).type <> l.feature_type
+		 AND (
+		   l.feature_type <> 4
+		   OR (%3$I).type NOT BETWEEN 1 AND 4
+		 )  ', layerSchema, layerTable, layerColumn);
 	 EXECUTE var_sql;
 	 GET DIAGNOSTICS var_row_count = ROW_COUNT;
 	 result = result || format('%s rows updated for %s.%s.%s column back to integer id type', var_row_count, layerSchema, layerTable, layerColumn);

--- a/topology/sql/manage/FixCorruptTopoGeometryColumn.sql.in
+++ b/topology/sql/manage/FixCorruptTopoGeometryColumn.sql.in
@@ -18,7 +18,7 @@
 CREATE OR REPLACE FUNCTION topology.FixCorruptTopoGeometryColumn(layerSchema name, layerTable name, layerColumn name)
 RETURNS text AS
 $$
-DECLARE var_sql text; var_row_count bigint; result text; var_create_index_sql text; var_drop_index_sql text;
+DECLARE var_sql text; var_row_count bigint; result text;
 BEGIN
     result = '';
 	-- if topogeometry is bigint, then fix damaged integer, need to upgrade to bigint
@@ -30,18 +30,6 @@ BEGIN
 WHERE pg_type.typname = 'topogeometry' AND pga.attname = 'id'
 			AND
 		pg_type.typnamespace::regnamespace::text = 'topology' AND  pga.atttypid::regtype::text = 'bigint' ) THEN
-
-    -- generate index scripts to create and drop indexes that are based on the column
-    IF EXISTS( SELECT 1 FROM pg_indexes WHERE schemaname = layerSchema AND tablename = layerTable AND indexdef LIKE '%(' || layerColumn || ')%' ) THEN
-        SELECT string_agg(indexdef, ';'),  string_agg('DROP INDEX ' || quote_ident(schemaname) || '.' || quote_ident(indexname), ';')  INTO var_create_index_sql, var_drop_index_sql
-            FROM pg_indexes
-             WHERE schemaname = layerSchema
-                AND tablename = layerTable AND indexdef LIKE ('%(' || layerColumn || ')%');
-    END IF;
-
-    IF var_drop_index_sql > '' THEN
-        EXECUTE var_drop_index_sql;
-    END IF;
 
     -- correct any corrupt topogeometries and fix
 	 var_sql =  format('UPDATE %1$I.%2$I
@@ -57,10 +45,6 @@ WHERE pg_type.typname = 'topogeometry' AND pga.attname = 'id'
 	 EXECUTE var_sql;
 	 GET DIAGNOSTICS var_row_count = ROW_COUNT;
 
-    IF var_create_index_sql > '' THEN
-        EXECUTE var_create_index_sql;
-        result = result || E'\n' || 'Recreating indexes';
-    END IF;
 	result = result || E'\n' || format('%s rows updated for %s.%s.%s column to bigint id type', var_row_count, layerSchema, layerTable, layerColumn);
   ELSE --we are coming from bigint and going back to integer
   	var_sql =  format('UPDATE %1$I.%2$I
@@ -70,12 +54,12 @@ WHERE pg_type.typname = 'topogeometry' AND pga.attname = 'id'
 	    (%3$I).layer_id,
 	     (%3$I).id,
 	     l.feature_type
-	   )::topogeometry
+	   )::topology.topogeometry
 	   FROM topology.layer AS l
-	 WHERE  l.topology_id = (%3$I).topology_id AND l.layer_id =  (%3$I).layer_id AND (%3$I).type <> l.feature_type  ', topo_schema, topo_table, topo_column);
+	 WHERE  l.topology_id = (%3$I).topology_id AND l.layer_id =  (%3$I).layer_id AND (%3$I).type <> l.feature_type  ', layerSchema, layerTable, layerColumn);
 	 EXECUTE var_sql;
 	 GET DIAGNOSTICS var_row_count = ROW_COUNT;
-	 result = result || format('%s rows updated for %s.%s.%s column back to integer id type', var_row_count, topo_schema, topo_table, topo_column);
+	 result = result || format('%s rows updated for %s.%s.%s column back to integer id type', var_row_count, layerSchema, layerTable, layerColumn);
   END IF;
   RETURN result;
 END

--- a/topology/sql/manage/TotalTopologySize.sql.in
+++ b/topology/sql/manage/TotalTopologySize.sql.in
@@ -17,23 +17,12 @@
 CREATE OR REPLACE FUNCTION topology.TotalTopologySize(toponame name)
 RETURNS int8
 AS $BODY$
-DECLARE
-  sql TEXT;
-  total_size int8;
 BEGIN
-  sql := format(
-    $$
-SELECT
-pg_catalog.pg_total_relation_size('%1$I.edge_data') +
-pg_catalog.pg_total_relation_size('%1$I.node') +
-pg_catalog.pg_total_relation_size('%1$I.face') +
-pg_catalog.pg_total_relation_size('%1$I.relation')
-    $$,
-    toponame
-  );
-
-  EXECUTE sql INTO total_size;
-  RETURN total_size;
+  RETURN
+    pg_catalog.pg_total_relation_size(format('%I.%I', toponame, 'edge_data')::regclass) +
+    pg_catalog.pg_total_relation_size(format('%I.%I', toponame, 'node')::regclass) +
+    pg_catalog.pg_total_relation_size(format('%I.%I', toponame, 'face')::regclass) +
+    pg_catalog.pg_total_relation_size(format('%I.%I', toponame, 'relation')::regclass);
 
 END;
 $BODY$ LANGUAGE 'plpgsql' STABLE;

--- a/topology/sql/query/FindVertexSegmentPairsBelowDistance.sql.in
+++ b/topology/sql/query/FindVertexSegmentPairsBelowDistance.sql.in
@@ -16,9 +16,9 @@ DECLARE
 BEGIN
   sql := format($$
     SELECT
-      e1.edge_id seg_edge,
+      e1.edge_id::bigint seg_edge,
       s.path[1] segno,
-      e2.edge_id vert_edge,
+      e2.edge_id::bigint vert_edge,
       p.path[1] vertno,
       p.geom vert_geom
     FROM

--- a/topology/sql/query/FindVertexSegmentPairsBelowDistance.sql.in
+++ b/topology/sql/query/FindVertexSegmentPairsBelowDistance.sql.in
@@ -9,7 +9,7 @@
 -- WHERE edge_id = v.vert_edge;
 --
 CREATE OR REPLACE FUNCTION topology.findVertexSegmentPairsBelowDistance(toponame varchar, tolerance float8)
-RETURNS TABLE (seg_edge int, segno int, vert_edge int, vertno int, vert_geom geometry)
+RETURNS TABLE (seg_edge bigint, segno int, vert_edge bigint, vertno int, vert_geom geometry)
 AS $BODY$
 DECLARE
   sql text;

--- a/topology/sql/topogeometry/totopogeom.sql.in
+++ b/topology/sql/topogeometry/totopogeom.sql.in
@@ -156,8 +156,15 @@ BEGIN
   alayer := layer_id(tg);
   atopology := topology_info.name;
 
-  -- Get tolerance, if 0 was given
-  tolerance := COALESCE( NULLIF(atolerance, 0), topology._st_mintolerance(topology_info.name, ageom) );
+  IF atolerance < 0 AND atolerance != -1 THEN
+    RAISE EXCEPTION 'Tolerance must be -1 or >=0';
+  END IF;
+
+  IF atolerance = -1 THEN
+    tolerance := topology._st_mintolerance(topology_info.name, ageom);
+  ELSE
+    tolerance := atolerance;
+  END IF;
 
   -- Get layer information
   BEGIN

--- a/topology/test/regress/fix_topogeometry_columns.sql
+++ b/topology/test/regress/fix_topogeometry_columns.sql
@@ -8,5 +8,54 @@ SELECT topology.FixCorruptTopoGeometryColumn(schema_name, table_name, feature_co
 FROM topology.layer
 ORDER BY schema_name, table_name, feature_column;
 
+CREATE TABLE features.mixed_features(id serial primary key);
+SELECT 'mixed-layer', topology.AddTopoGeometryColumn(
+  'city_data',
+  'features',
+  'mixed_features',
+  'feature',
+  'COLLECTION'
+);
+-- Exercise repair of existing mixed-layer rows whose subtype does not match
+-- the layer's collection type; AddTopoGeometryColumn now creates a stricter
+-- check constraint that would reject this historic state.
+ALTER TABLE features.mixed_features
+  DROP CONSTRAINT check_topogeom_feature;
+INSERT INTO features.mixed_features(feature)
+  SELECT topology.toTopoGeom(
+    'SRID=4326;LINESTRING(0 0, 10 0)'::geometry,
+    'city_data',
+    layer_id
+  )
+  FROM topology.layer
+  WHERE schema_name = 'features'
+  AND table_name = 'mixed_features'
+  AND feature_column = 'feature';
+
+SELECT 'mixed-before', (feature).type
+  FROM features.mixed_features;
+WITH repaired AS (
+  UPDATE features.mixed_features
+    SET feature = (
+      (feature).topology_id,
+      (feature).layer_id,
+      (feature).id,
+      l.feature_type
+    )::topology.topogeometry
+    FROM topology.layer AS l
+    WHERE l.topology_id = (feature).topology_id
+    AND l.layer_id = (feature).layer_id
+    AND (feature).type <> l.feature_type
+    AND (
+      l.feature_type <> 4
+      OR (feature).type NOT BETWEEN 1 AND 4
+    )
+    RETURNING 1
+)
+SELECT 'mixed-fallback-updates', count(*)
+  FROM repaired;
+SELECT 'mixed-after', (feature).type
+  FROM features.mixed_features;
+
 SELECT topology.DropTopology('city_data');
 DROP SCHEMA features CASCADE;

--- a/topology/test/regress/fix_topogeometry_columns_expected
+++ b/topology/test/regress/fix_topogeometry_columns_expected
@@ -4,4 +4,8 @@
 0 rows updated for features.city_streets.feature column to bigint id type
 0 rows updated for features.land_parcels.feature column to bigint id type
 0 rows updated for features.traffic_signs.feature column to bigint id type
+mixed-layer|7
+mixed-before|2
+mixed-fallback-updates|0
+mixed-after|2
 Topology 'city_data' dropped

--- a/topology/topology_before_upgrade.sql.in
+++ b/topology/topology_before_upgrade.sql.in
@@ -45,4 +45,5 @@ SELECT _postgis_drop_cast_by_types('topogeometry', 'integer[]', '3.6.0');
 SELECT _postgis_topology_upgrade_domain_type('topoelement','integer[]','bigint[]','3.6.0');
 SELECT _postgis_topology_upgrade_domain_type('topoelementarray','integer[][]','bigint[][]','3.6.0');
 SELECT _postgis_add_column_to_table('topology.topology', 'useslargeids', 'BOOLEAN', true, 'false','3.6.0');
-
+-- Return edge identifiers as bigint
+SELECT _postgis_drop_function_by_signature('topology.findVertexSegmentPairsBelowDistance(varchar, float8)', '3.6.0');


### PR DESCRIPTION
Covers related topology hardening follow-ups:

- row 9: TopoRingIsCCW empty-geometry cleanup leak
- row 12: FixCorruptTopoGeometryColumn no longer drops/replays caller-controlled index definitions
- row 22: findVertexSegmentPairsBelowDistance returns bigint edge ids
- row 26: FixCorruptTopoGeometryColumn fallback branch uses the provided layer identifiers and preserves valid mixed-layer TopoGeometry subtypes
- row 28: toTopoGeom and topology C wrappers preserve 0 as no snapping; only -1 requests automatic tolerance
- row 29: collapsed components no longer count against max_new_edges
- row 33: edge/face/heal wrappers keep bigint ids in LWT_ELEMID locals before returning int8
- row 36: TotalTopologySize uses identifier-safe regclass relation lookup

Release / upgrade notes:
- added a 3.7.0 `NEWS` entry for https://github.com/postgis/postgis/pull/897
- no checked-in topology upgrade SQL file is needed: topology install/upgrade SQL is generated from the `topology/sql/*.sql.in` sources, and `make -C topology topology.sql topology_upgrade.sql` confirms the changed SQL bodies are present in the generated install and upgrade scripts
- `topology/topology_before_upgrade.sql.in` renames the previous `findVertexSegmentPairsBelowDistance(varchar, float8)` signature before upgrade, so PostgreSQL can create the bigint-returning replacement instead of rejecting a table return-type change
- no separate upgrade step is needed for the C changes; they are loaded from the updated PostGIS/topology shared libraries

Verification:
- rebased on `postgis:master` at `63cbf4f069afebe50cb520b7abe6440c898842e9`
- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- liblwgeom/topo/lwgeom_topo.c topology/postgis_topology.c`
- `./autogen.sh && ./configure --without-raster --with-topology --without-sfcgal --without-protobuf --without-json`
- `perl ./utils/repo_revision.pl`
- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C topology -j32`
- `make -C topology topology.sql topology_upgrade.sql`
- `sudo -n make -C topology install`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/upgradetopology $(pwd)/topology/test/regress/fix_topogeometry_columns"`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/358
