### PR TITLE
raster: honor registered interrupts in GDAL progress

### DIFF
--- a/raster/rt_core/rt_gdal.c
+++ b/raster/rt_core/rt_gdal.c
@@ -68,6 +68,9 @@ rt_util_gdal_progress_func(double dfComplete, const char *pszMessage, void *pPro
 	(void)dfComplete;
 	(void)pszMessage;
 
+	if (_lwgeom_interrupt_callback)
+		(*_lwgeom_interrupt_callback)();
+
 	if (_lwgeom_interrupt_requested)
 	{
 		// rtwarn("%s interrupted at %g", (const char*)pProgressArg, dfComplete);
@@ -307,4 +310,3 @@ int rt_raster_gdal_contour(
 	/* Done */
 	return TRUE;
 }
-

--- a/raster/rt_pg/rtpostgis.c
+++ b/raster/rt_pg/rtpostgis.c
@@ -161,6 +161,8 @@ rtpg_interrupt_liblwgeom_callback(void)
 		lwgeom_request_interrupt();
 }
 
+static lwinterrupt_callback *prev_liblwgeom_interrupt_callback = NULL;
+
 
 #ifndef __GNUC__
 # define __attribute__ (x)
@@ -727,7 +729,8 @@ _PG_init(void) {
 
 	/* Install liblwgeom handlers */
 	pg_install_lwgeom_handlers();
-	lwgeom_register_interrupt_callback(rtpg_interrupt_liblwgeom_callback);
+	prev_liblwgeom_interrupt_callback =
+		lwgeom_register_interrupt_callback(rtpg_interrupt_liblwgeom_callback);
 
 	/* Install rtcore handlers */
 	rt_set_handlers_options(rt_pg_alloc, rt_pg_realloc, rt_pg_free,
@@ -860,6 +863,9 @@ _PG_fini(void) {
 
 	elog(NOTICE, "Goodbye from PostGIS Raster %s", POSTGIS_VERSION);
 
+	lwgeom_register_interrupt_callback(prev_liblwgeom_interrupt_callback);
+	prev_liblwgeom_interrupt_callback = NULL;
+
 	/* Clean up */
 	pfree(env_postgis_gdal_enabled_drivers);
 	pfree(boot_postgis_gdal_enabled_drivers);
@@ -872,5 +878,3 @@ _PG_fini(void) {
 	/* Revert back to old context */
 	MemoryContextSwitchTo(old_context);
 }
-
-

--- a/raster/rt_pg/rtpostgis.c
+++ b/raster/rt_pg/rtpostgis.c
@@ -137,6 +137,7 @@
 #include "utils/builtins.h"
 #include "utils/memutils.h"
 #include "utils/elog.h"
+#include "miscadmin.h"
 
 /* PostGIS */
 #include "postgis_config.h"
@@ -148,6 +149,17 @@
 /* PostGIS Raster */
 #include "rtpostgis.h"
 #include "rtpg_internal.h"
+
+static void
+rtpg_interrupt_liblwgeom_callback(void)
+{
+#ifdef WIN32
+	if (UNBLOCKED_SIGNAL_QUEUE())
+		pgwin32_dispatch_queued_signals();
+#endif
+	if (QueryCancelPending || ProcDiePending)
+		lwgeom_request_interrupt();
+}
 
 
 #ifndef __GNUC__
@@ -715,6 +727,7 @@ _PG_init(void) {
 
 	/* Install liblwgeom handlers */
 	pg_install_lwgeom_handlers();
+	lwgeom_register_interrupt_callback(rtpg_interrupt_liblwgeom_callback);
 
 	/* Install rtcore handlers */
 	rt_set_handlers_options(rt_pg_alloc, rt_pg_realloc, rt_pg_free,
@@ -859,6 +872,5 @@ _PG_fini(void) {
 	/* Revert back to old context */
 	MemoryContextSwitchTo(old_context);
 }
-
 
 


### PR DESCRIPTION
Covers a related hardening follow-up.

The raster GDAL progress callback now invokes the registered liblwgeom interrupt callback before checking the interrupt flag, so backend PostgreSQL cancel/death state can be reflected in long-running GDAL operations without adding PostgreSQL dependencies to raster core.

Verification:
- git diff --check
- ./configure --with-raster --without-topology --without-sfcgal --without-protobuf --without-json
- perl ./utils/repo_revision.pl
- make -C liblwgeom -j32
- make -C raster -j32
- make -C raster/test/cunit cu_tester -j32
- ./raster/test/cunit/cu_tester gdal
