### PR TITLE
sfcgal: fix regression gating and roof checks

### DIFF
--- a/sfcgal/regress/roofgeneration.sql
+++ b/sfcgal/regress/roofgeneration.sql
@@ -13,4 +13,10 @@ SELECT 'generic_hipped', ST_AsText(CG_GenerateRoof('POLYGON((0 0,4 0,4 4,0 4,0 0
 SELECT 'generic_flat', ST_AsText(CG_GenerateRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 'FLAT', 2.0, 30.0, 0));
 SELECT 'generic_gable_3d', ST_CoordDim(CG_GenerateRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 'GABLE', 2.0, 30.0, 0));
 SELECT 'generic_skillion_3d', ST_CoordDim(CG_GenerateRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 'SKILLION', 2.0, 30.0, 0));
+SELECT 'generic_gable_matches_specialized',
+  ST_AsText(CG_GenerateRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 'GABLE', 5.0, 15.0, 0)) =
+  ST_AsText(CG_GenerateGableRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 5.0, 15.0));
+SELECT 'generic_skillion_matches_specialized',
+  ST_AsText(CG_GenerateRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 'SKILLION', 5.0, 15.0, 0)) =
+  ST_AsText(CG_GenerateSkillionRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 5.0, 15.0, 0));
 SELECT 'invalid_type', CG_GenerateRoof('POLYGON((0 0,4 0,4 4,0 4,0 0))', 'DOME', 2.0, 30.0, 0);

--- a/sfcgal/regress/roofgeneration_expected
+++ b/sfcgal/regress/roofgeneration_expected
@@ -8,4 +8,6 @@ generic_hipped|POLYHEDRALSURFACE Z (((0 4 0,4 4 0,4 0 0,0 0 0,0 4 0)),((0 4 0,0 
 generic_flat|POLYHEDRALSURFACE Z (((0 0 0,0 4 0,4 4 0,4 0 0,0 0 0)),((0 0 2,4 0 2,4 4 2,0 4 2,0 0 2)),((0 0 0,0 0 2,0 4 2,0 4 0,0 0 0)),((0 4 0,0 4 2,4 4 2,4 4 0,0 4 0)),((4 4 0,4 4 2,4 0 2,4 0 0,4 4 0)),((4 0 0,4 0 2,0 0 2,0 0 0,4 0 0)))
 generic_gable_3d|3
 generic_skillion_3d|3
+generic_gable_matches_specialized|t
+generic_skillion_matches_specialized|t
 ERROR:  CG_GenerateRoof: unknown roof type 'DOME', expected FLAT, HIPPED, GABLE or SKILLION

--- a/sfcgal/regress/tests.mk.in
+++ b/sfcgal/regress/tests.mk.in
@@ -49,13 +49,15 @@ ifeq ($(shell expr "$(POSTGIS_SFCGAL_VERSION)" ">=" 20300),1)
 	TESTS += \
 		$(top_srcdir)/sfcgal/regress/alphashape_components.sql \
 		$(top_srcdir)/sfcgal/regress/roofgeneration.sql \
-		$(top_srcdir)/sfcgal/regress/polygonrepair.sql \
 		$(top_srcdir)/sfcgal/regress/approximatemedialaxis_projected.sql \
 		$(top_srcdir)/sfcgal/regress/nurbs.sql
-	ifeq ($(shell expr "$(POSTGIS_CGAL_VERSION)" ">=" 601),1)
-		TESTS += $(top_srcdir)/sfcgal/regress/polygonrepair_union.sql
-	else
-		TESTS += $(top_srcdir)/sfcgal/regress/polygonrepair_union_pre61.sql
+	ifeq ($(shell expr "$(POSTGIS_CGAL_VERSION)" ">=" 600),1)
+		TESTS += $(top_srcdir)/sfcgal/regress/polygonrepair.sql
+		ifeq ($(shell expr "$(POSTGIS_CGAL_VERSION)" ">=" 601),1)
+			TESTS += $(top_srcdir)/sfcgal/regress/polygonrepair_union.sql
+		else
+			TESTS += $(top_srcdir)/sfcgal/regress/polygonrepair_union_pre61.sql
+		endif
 	endif
 else
 	TESTS += \


### PR DESCRIPTION
Covers related hardening follow-ups:

- row 18: polygon repair regression tests are only selected when CGAL 6.0+ is available, matching the C guard
- row 19: generic CG_GenerateRoof is regression-checked against specialized roof wrappers with distinct height/slope values

Verification:
- git diff --check
- ./configure --without-raster --without-topology --with-sfcgal --without-protobuf --without-json
- perl ./utils/repo_revision.pl
- make -C liblwgeom -j32
- make -C libpgcommon -j32
- make -C sfcgal -j32
- ./config.status --file=sfcgal/regress/tests.mk:sfcgal/regress/tests.mk.in and inspected generated gates
