### PR TITLE
loader: stop marking tiger geocoder for upgrade

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5948, [topology] Prevent MakeTopologyPrecise from erasing edges when
           grid size exceeds their extent (Darafei Praliaskouski)
  - #5959, Prevent histogram target overflow when analysing massive tables (Darafei Praliaskouski)
+ - GH-901, Stop loader upgrade helper from marking postgis_tiger_geocoder
+          for extension upgrade (Darafei Praliaskouski)
  - #4828, geometry_columns handles NOT VALID SRID checks without errors (Darafei Praliaskouski)
  - #6048, [raster] ST_Clip no longer crashes when clipping sparse band
           selections (Darafei Praliaskouski)

--- a/loader/postgis.pl
+++ b/loader/postgis.pl
@@ -232,8 +232,7 @@ BEGIN
       'postgis',
       'postgis_raster',
       'postgis_sfcgal',
-      'postgis_topology',
-      'postgis_tiger_geocoder'
+      'postgis_topology'
     );
     PERFORM postgis_extensions_upgrade();
   END IF;


### PR DESCRIPTION
## Summary

Covers a related hardening follow-up.

The loader upgrade helper no longer sets postgis_tiger_geocoder.extversion to ANY, because postgis_extensions_upgrade() no longer iterates that extension. This avoids leaving tiger geocoder metadata stale/corrupted after helper-driven upgrades.

## Release/Upgrade Notes

- Added a PostGIS 3.7.0 NEWS entry for https://github.com/postgis/postgis/pull/901.
- No extension upgrade SQL is needed: this changes the loader helper script behavior, not extension SQL definitions or catalog-visible objects.

## Verification

- `git diff --check`
- `perl -c loader/postgis.pl`
