### PR TITLE
liblwgeom: fix signed hex WKB lookup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5948, [topology] Prevent MakeTopologyPrecise from erasing edges when
           grid size exceeds their extent (Darafei Praliaskouski)
  - #5959, Prevent histogram target overflow when analysing massive tables (Darafei Praliaskouski)
+ - #6080, Avoid out-of-bounds hex WKB lookup for high-bit input bytes
+          (Darafei Praliaskouski)
  - #4828, geometry_columns handles NOT VALID SRID checks without errors (Darafei Praliaskouski)
  - #6048, [raster] ST_Clip no longer crashes when clipping sparse band
           selections (Darafei Praliaskouski)

--- a/liblwgeom/cunit/cu_in_wkb.c
+++ b/liblwgeom/cunit/cu_in_wkb.c
@@ -212,6 +212,10 @@ static void test_wkb_in_multisurface(void) {}
 
 static void test_wkb_in_malformed(void)
 {
+	char highbit_hex[3] = {(char)0xff, '0', '\0'};
+
+	cu_wkb_malformed_in(highbit_hex);
+
 	/* OSSFUXX */
 	cu_wkb_malformed_in("0000000008200000002020202020202020");
 

--- a/liblwgeom/lwin_wkb.c
+++ b/liblwgeom/lwin_wkb.c
@@ -105,8 +105,8 @@ uint8_t* bytes_from_hexbytes(const char *hexbuf, size_t hexsize)
 
 	for( i = 0; i < hexsize/2; i++ )
 	{
-		h1 = hex2char[(int)hexbuf[2*i]];
-		h2 = hex2char[(int)hexbuf[2*i+1]];
+		h1 = hex2char[(uint8_t)hexbuf[2*i]];
+		h2 = hex2char[(uint8_t)hexbuf[2*i+1]];
 		if( h1 > 15 )
 			lwerror("Invalid hex character (%c) encountered", hexbuf[2*i]);
 		if( h2 > 15 )


### PR DESCRIPTION
## Summary

- cast hex input bytes to `uint8_t` before indexing the hex lookup table
- add a malformed WKB regression with a high-bit input byte

Closes https://trac.osgeo.org/postgis/ticket/6080

## Release/Upgrade Notes

- Added a PostGIS 3.7.0 NEWS entry for #6080.
- No extension upgrade SQL is needed: SQL definitions and catalog-visible objects are unchanged; this is liblwgeom parser behavior plus CUnit coverage.

## Testing

- `git diff --check`
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `./liblwgeom/cunit/cu_tester test_wkb_in_malformed`
