### PR TITLE
liblwgeom: avoid size_t log formats for mingw

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,
           including guards for malformed TWKB reads and counts (Darafei Praliaskouski)
+ - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for
+          MinGW builds (Darafei Praliaskouski)
  - Build PostgreSQL extension modules with `-fno-semantic-interposition` when
           available so LTO can optimize same-DSO calls to exported PostGIS
           entry points directly instead of routing through the module PLT; in

--- a/liblwgeom/lwgeom_api.c
+++ b/liblwgeom/lwgeom_api.c
@@ -19,11 +19,9 @@
  **********************************************************************
  *
  * Copyright 2001-2006 Refractions Research Inc.
- * Copyright 2017 Darafei Praliaskouski <me@komzpa.net>
+ * Copyright 2017-2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
-
-
 
 #include "liblwgeom_internal.h"
 #include "lwgeom_log.h"
@@ -452,8 +450,8 @@ void printPA(POINTARRAY *pa)
 	else mflag = "";
 
 	lwnotice("      POINTARRAY%s{", mflag);
-	lwnotice("                 ndims=%i,   ptsize=%zu",
-	         FLAGS_NDIMS(pa->flags), ptarray_point_size(pa));
+	lwnotice(
+	    "                 ndims=%i,   ptsize=%lu", FLAGS_NDIMS(pa->flags), (unsigned long)ptarray_point_size(pa));
 	lwnotice("                 npoints = %u", pa->npoints);
 
 	for (t = 0; t < pa->npoints; t++)

--- a/liblwgeom/ptarray.c
+++ b/liblwgeom/ptarray.c
@@ -20,9 +20,9 @@
  *
  * Copyright (C) 2012-2021 Sandro Santilli <strk@kbt.io>
  * Copyright (C) 2001-2006 Refractions Research Inc.
+ * Copyright 2026 Darafei Praliaskouski
  *
  **********************************************************************/
-
 
 #include <stdio.h>
 #include <string.h>
@@ -533,13 +533,11 @@ ptarray_addPoint(const POINTARRAY *pa, uint8_t *p, size_t pdims, uint32_t where)
 	POINT4D pbuf;
 	size_t ptsize = ptarray_point_size(pa);
 
-	LWDEBUGF(3, "pa %p p %p size %zu where %u",
-	         pa, p, pdims, where);
+	LWDEBUGF(3, "pa %p p %p size %lu where %u", pa, p, (unsigned long)pdims, where);
 
 	if ( pdims < 2 || pdims > 4 )
 	{
-		lwerror("ptarray_addPoint: point dimension out of range (%zu)",
-		        pdims);
+		lwerror("ptarray_addPoint: point dimension out of range (%lu)", (unsigned long)pdims);
 		return NULL;
 	}
 


### PR DESCRIPTION
## Summary

- avoid `%zu` in liblwgeom logging/error wrappers reported by MinGW builds
- cast the affected `size_t` values to `unsigned long` and use `%lu` instead

Closes #6003

## Release / upgrade notes

- Added a `NEWS` entry under PostGIS 3.7.0 bug fixes for #6003.
- No database extension upgrade is needed: the change is in liblwgeom C logging/error formatting and does not modify SQL/catalog objects.

## Testing

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `git diff --check`
