### PR TITLE
raster: add ST_Union band type regression

### DIFF
--- a/raster/test/regress/rt_union.sql
+++ b/raster/test/regress/rt_union.sql
@@ -76,6 +76,52 @@ FROM (
 ) foo
 ORDER BY uniontype, y, x;
 
+WITH v(rast) AS (
+	VALUES (
+		ST_AddBand(
+			ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 10, 0),
+			2, '16BUI', 300, 0
+		)
+	), (
+		ST_AddBand(
+			ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 20, 0),
+			2, '16BUI', 400, 0
+		)
+	)
+), u AS (
+	SELECT ST_Union(rast, ARRAY[ROW(1, 'SUM'), ROW(2, 'MAX')]::unionarg[]) AS rast
+	FROM v
+)
+SELECT
+	'ticket-5317-array',
+	ST_BandPixelType(rast, 1),
+	ST_Value(rast, 1, 1, 1),
+	ST_BandPixelType(rast, 2),
+	ST_Value(rast, 2, 1, 1)
+FROM u;
+
+WITH v(rast) AS (
+	VALUES (
+		ST_AddBand(
+			ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 10, 0),
+			2, '16BUI', 300, 0
+		)
+	), (
+		ST_AddBand(
+			ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 20, 0),
+			2, '16BUI', 400, 0
+		)
+	)
+), u AS (
+	SELECT ST_Union(rast, 2, 'MAX') AS rast
+	FROM v
+)
+SELECT
+	'ticket-5317-band',
+	ST_BandPixelType(rast, 1),
+	ST_Value(rast, 1, 1, 1)
+FROM u;
+
 TRUNCATE raster_union_out;
 TRUNCATE raster_union_in;
 

--- a/raster/test/regress/rt_union_expected
+++ b/raster/test/regress/rt_union_expected
@@ -52,6 +52,8 @@ SUM|2|2|3
 SUM|3|2|2
 SUM|2|3|2
 SUM|3|3|2
+ticket-5317-array|8BUI|30|16BUI|400
+ticket-5317-band|16BUI|400
 NOTICE:  No pixels found for band 1
 COUNT|1|1|1
 COUNT|2|1|1


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/5317

## Summary
- Add regression coverage so multi-band raster unions keep each band's pixel type when later bands use a wider class than band 1.
- Cover both forms mentioned in the ticket:
  - `ST_Union(rast, ARRAY[ROW(...)]::unionarg[])`
  - `ST_Union(rast, band, uniontype)`

## Release / upgrade notes
- No `NEWS` entry is needed: this PR adds regression coverage only and does not change user-facing behavior.
- No database extension upgrade is needed: no SQL/catalog objects change.

## Current branch
- Base: `postgis/postgis` `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- Head: `be75f1e94293bbbc68ec187fb6ac9ece870ee6a1`

## Validation
- `make -C raster/test/regress check RUNTESTFLAGS='--extension --raster --verbose' TESTS="$(pwd)/raster/test/regress/rt_union"`; the harness also ran the raster upgrade pass because `--upgrade` was not explicitly supplied
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- raster/test/regress/rt_union.sql raster/test/regress/rt_union_expected`

GitHub CI has been queued for this refreshed head.
