### PR TITLE
#1793 Remove ST_MemCollect aggregate

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #6052, [tiger_geocoder] Extension removed and moved to
           https://git.osgeo.org/postgis/postgis_tiger_geocoder (Regina Obe)
  - #6079, Remove support for GEOS < 3.10 (Sandro Santilli)
+ - #1793, Remove ST_MemCollect aggregate (Darafei Praliaskouski)
 
 * New Features *
 

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -4239,16 +4239,6 @@ CREATE OR REPLACE FUNCTION ST_Collect(geom1 geometry, geom2 geometry)
 	_COST_LOW;
 
 -- Availability: 1.2.2
--- Changed: 2.3.0 to support PostgreSQL 9.6
--- Changed: 2.3.1 to support PostgreSQL 9.6 parallel safe
-CREATE AGGREGATE ST_MemCollect(geometry)(
-	sfunc = ST_collect,
-	combinefunc = ST_collect,
-	parallel = safe,
-	stype = geometry
-	);
-
--- Availability: 1.2.2
 CREATE OR REPLACE FUNCTION ST_Collect(geometry[])
 	RETURNS geometry
 	AS 'MODULE_PATHNAME', 'LWGEOM_collect_garray'

--- a/postgis/postgis_after_upgrade.sql
+++ b/postgis/postgis_after_upgrade.sql
@@ -28,6 +28,7 @@ DROP AGGREGATE IF EXISTS st_geomunion(geometry);
 DROP AGGREGATE IF EXISTS accum_old(geometry);
 DROP AGGREGATE IF EXISTS st_accum_old(geometry);
 DROP AGGREGATE IF EXISTS st_accum(geometry); -- Dropped in 3.0.0
+DROP AGGREGATE IF EXISTS ST_MemCollect(geometry); -- Dropped in 3.7.0
 SELECT _postgis_drop_function_by_signature('pgis_geometry_accum_finalfn(internal)');
 
 DROP AGGREGATE IF EXISTS st_astwkb_agg(geometry, integer); -- temporarily introduced before 2.2.0 final


### PR DESCRIPTION
## Summary
- remove the existing `ST_MemCollect(geometry)` aggregate instead of documenting it
- keep `ST_Collect` and its C support functions unchanged
- drop old `ST_MemCollect(geometry)` during raw SQL and extension upgrades
- add a NEWS breaking-change entry

Closes #1793

## Validation
- `make -C postgis postgis.sql postgis_upgrade.sql`
- `make -C extensions postgis_extension_helper.sql && make -C extensions/postgis all`
- `make -C doc check-xml`
- `sudo -n make -C postgis install && sudo -n make -C extensions/postgis install`
- fresh `CREATE EXTENSION postgis` smoke: `to_regprocedure('st_memcollect(geometry)')` returns NULL
- raw SQL upgrade smoke: manually-created `ST_MemCollect(geometry)` is removed by `postgis/postgis_upgrade.sql`
- extension upgrade smoke: extension-owned manual `ST_MemCollect(geometry)` is removed by `ALTER EXTENSION postgis UPDATE TO 'ANY'; ALTER EXTENSION postgis UPDATE TO '3.7.0dev'`
- `git diff --check`
