### PR TITLE
raster: restore ST_Intersects wrapper inlining

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,7 +24,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
 
 
-PostGIS 3.7.0beta1
+PostGIS 3.7.0alpha1
 2026/07/05
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.

--- a/NEWS
+++ b/NEWS
@@ -24,7 +24,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
 
 
-PostGIS 3.7.0alpha1
+PostGIS 3.7.0beta1
 2026/07/05
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -164,7 +164,7 @@ CREATE OR REPLACE FUNCTION st_envelope(raster)
 CREATE OR REPLACE FUNCTION st_convexhull(raster)
     RETURNS geometry
     AS 'MODULE_PATHNAME','RASTER_convex_hull'
-    LANGUAGE 'c' IMMUTABLE STRICT
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
     COST 300;
 
 CREATE OR REPLACE FUNCTION st_minconvexhull(
@@ -6032,13 +6032,13 @@ CREATE OR REPLACE FUNCTION st_intersects(rast1 raster, nband1 integer, rast2 ras
 	RETURNS boolean
 	AS $$ SELECT $1 OPERATOR(@extschema@.&&) $3 AND CASE WHEN $2 IS NULL OR $4 IS NULL THEN @extschema@._st_intersects(@extschema@.st_convexhull($1), @extschema@.st_convexhull($3)) ELSE @extschema@._st_intersects($1, $2, $3, $4) END $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE
-	COST 1000;
+	_COST_DEFAULT;
 
 CREATE OR REPLACE FUNCTION st_intersects(rast1 raster, rast2 raster)
 	RETURNS boolean
 	AS $$ SELECT @extschema@.st_intersects($1, NULL::integer, $2, NULL::integer) $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE
-	COST 1000;
+	_COST_DEFAULT;
 
 -----------------------------------------------------------------------
 -- ST_Intersects(geometry, raster)
@@ -6077,7 +6077,7 @@ CREATE OR REPLACE FUNCTION st_intersects(geom geometry, rast raster, nband integ
 	RETURNS boolean AS
 	$$ SELECT $1 OPERATOR(@extschema@.&&) $2::@extschema@.geometry AND @extschema@._st_intersects($1, $2, $3); $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE
-	COST 1000;
+	_COST_DEFAULT;
 
 -----------------------------------------------------------------------
 -- ST_Intersects(raster, geometry)
@@ -6087,13 +6087,13 @@ CREATE OR REPLACE FUNCTION st_intersects(rast raster, geom geometry, nband integ
 	RETURNS boolean
 	AS $$ SELECT $1::@extschema@.geometry OPERATOR(@extschema@.&&) $2 AND @extschema@._st_intersects($2, $1, $3) $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE
-	COST 1000;
+	_COST_DEFAULT;
 
 CREATE OR REPLACE FUNCTION st_intersects(rast raster, nband integer, geom geometry)
 	RETURNS boolean
 	AS $$ SELECT $1::@extschema@.geometry OPERATOR(@extschema@.&&) $3 AND @extschema@._st_intersects($3, $1, $2) $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE
-	COST 1000;
+	_COST_DEFAULT;
 
 -----------------------------------------------------------------------
 -- ST_Overlaps(raster, raster)

--- a/raster/test/regress/rt_intersects.sql
+++ b/raster/test/regress/rt_intersects.sql
@@ -431,5 +431,44 @@ FROM raster_intersects_rast r1
 CROSS JOIN raster_intersects_geom g1
 WHERE r1.rid = 2;
 
+CREATE INDEX raster_intersects_geom_idx ON raster_intersects_geom USING gist (geom);
+ANALYZE raster_intersects_rast (rid);
+ANALYZE raster_intersects_geom (geom);
+SET enable_seqscan = off;
+
+CREATE OR REPLACE FUNCTION raster_intersects_plan_has(query text, pattern text)
+	RETURNS boolean AS $$
+	DECLARE
+		exp text;
+	BEGIN
+		IF current_setting('server_version_num')::integer >= 140000 THEN
+			PERFORM set_config('enable_memoize', 'off', true);
+		END IF;
+
+		FOR exp IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query LOOP
+			IF exp ~ pattern THEN
+				RETURN TRUE;
+			END IF;
+		END LOOP;
+		RETURN FALSE;
+	END;
+	$$ LANGUAGE 'plpgsql';
+
+SELECT
+	'#4463.1',
+	raster_intersects_plan_has(
+		'SELECT g1.gid FROM raster_intersects_geom g1 JOIN raster_intersects_rast r1 ON ST_Intersects(g1.geom, r1.rast) WHERE r1.rid = 0',
+		'Index Cond: .*geom && .*r1[.]rast.*geometry'
+	);
+
+SELECT
+	'#4463.2',
+	raster_intersects_plan_has(
+		'SELECT g1.gid FROM raster_intersects_geom g1 JOIN raster_intersects_rast r1 ON ST_Intersects(r1.rast, g1.geom) WHERE r1.rid = 0',
+		'Index Cond: .*geom && .*r1[.]rast.*geometry'
+	);
+
+RESET enable_seqscan;
+DROP FUNCTION raster_intersects_plan_has(text, text);
 DROP TABLE IF EXISTS raster_intersects_rast;
 DROP TABLE IF EXISTS raster_intersects_geom;

--- a/raster/test/regress/rt_intersects_expected
+++ b/raster/test/regress/rt_intersects_expected
@@ -234,3 +234,5 @@
 2.6|2|44|ST_MultiPolygon|t
 2.6|2|45|ST_MultiPolygon|t
 2.6|2|46|ST_MultiPolygon|t
+#4463.1|t
+#4463.2|t


### PR DESCRIPTION
Summary:
- Lower the cost of raster `ST_Intersects` SQL wrappers so PostgreSQL can inline them again.
- Keep the expensive `_st_intersects` implementation functions at their existing cost.
- Mark `st_convexhull(raster)` parallel-safe so the exposed raster-to-geometry cast does not suppress parallel plans.
- Add plan regressions proving both geometry/raster argument orders expose the `&&` index condition.
- Add a NEWS entry for https://trac.osgeo.org/postgis/ticket/4463.

Release / upgrade notes:
- NEWS records the bug fix for https://trac.osgeo.org/postgis/ticket/4463.
- Raster SQL declarations are updated in `raster/rt_pg/rtpostgis.sql.in`; raster extension upgrade SQL is generated from the SQL sources during the normal extension build.

Current base/head:
- Base: `4e470f1534795ae4a4c52ad5ad35b8744af9d708` (`upstream/master`)
- Head: `a8d3b45331eb71a2018fca9a27439021ab524ca5`

Validation:
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
- `git clang-format --diff upstream/master -- raster/rt_pg/rtpostgis.sql.in raster/test/regress/rt_intersects.sql`
- `./utils/check_news.sh .`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make -C liblwgeom -j32`
- `make -C libpgcommon -j32`
- `make -C postgis -j32`
- `make -C raster -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C raster install`
- `sudo -n make -C extensions/postgis_raster install`
- `make -C raster/test/regress check RUNTESTFLAGS="--extension --raster --verbose" TESTS="$(pwd)/raster/test/regress/rt_intersects"`
- Catalog smoke in a temporary database: `st_convexhull(raster)` has `proparallel = s`

Note: top-level `make postgis_revision.h` still trips on this local worktree's missing generated `regress/dumper/tests.mk`, but `/usr/bin/perl ./utils/repo_revision.pl` wrote the revision file and the targeted subtree builds plus raster regression passed on the rebuilt/installed artifacts.

Closes https://trac.osgeo.org/postgis/ticket/4463
