### PR TITLE
topology: optionally snap existing edges when adding lines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 * New Features *
 
  - [topology] FindVertexSegmentPairsBelowDistance function (Sandro Santilli)
+ - #6034, [topology] Add snap_edges parameter to TopoGeo_AddLinestring
+          (Darafei Praliaskouski)
  - ST_CoverageEdges, returns MultiLinestring of distinct shared edges in
           polygonal coverage (Paul Ramsey)
  - ST_MinimumSpanningTree, window function to calculate MST (Paul Ramsey)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1738,6 +1738,7 @@ Adds a linestring to an existing topology using a tolerance and possibly splitti
 						<paramdef><type>geometry </type> <parameter>aline</parameter></paramdef>
 						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
 						<paramdef choice="opt"><type>int </type> <parameter>max_edges</parameter></paramdef>
+						<paramdef choice="opt"><type>boolean </type> <parameter>snap_edges</parameter></paramdef>
 					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
@@ -1767,6 +1768,12 @@ uncovered or resulting from split of existing edges) may be limited
 by the <varname>max_edges</varname> parameter.
                 </para>
 
+                <para>
+The <varname>snap_edges</varname> parameter may be set to true to
+snap existing edges to vertices of the input line before adding the
+line.
+                </para>
+
                 <note><para>
 Updating statistics about topologies being loaded via this function is
 up to caller, see <xref linkend="Topology_StatsManagement"/>.
@@ -1776,6 +1783,7 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
                 <para role="availability" conformance="2.0.0">Availability: 2.0.0</para>
                 <para role="enhanced" conformance="3.2.0">Enhanced: 3.2.0 added support for returning signed identifier.</para>
                 <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for limiting the number of new edges created in the topology.</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for snapping existing edges to input line vertices.</para>
 			</refsection>
 
 

--- a/liblwgeom/topo/liblwgeom_topo.h
+++ b/liblwgeom/topo/liblwgeom_topo.h
@@ -1064,13 +1064,16 @@ LWT_ELEMID lwt_AddPoint(LWT_TOPOLOGY* topo, LWPOINT* point, double tol);
  *                  line to be split into. 0 for no limits.
  *                  An error will be returned if number of edges would
  *                  exceed this number.
+ * @param snap_existing_edges
+ *                  Allow snapping existing edges to incoming line vertices.
  *
  * @return an array of <nedges> edge identifiers that sewed together
  *         will build up the input linestring (after snapping). Caller
  *         will need to free the array using lwfree(), if not null.
  */
 LWT_ELEMID* lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol,
-                        int* nedges, int max_edges);
+                        int* nedges, int max_edges,
+                        int snap_existing_edges);
 
 /**
  * Adds a linestring to the topology without determining generated faces

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -905,14 +905,16 @@ _lwt_CheckEdgeCrossing( LWT_TOPOLOGY* topo,
 
 static int
 _lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
+                          LWT_ELEMID edge_id,
                           LWT_ELEMID start_node, LWT_ELEMID end_node,
                           LWLINE *oldedge, LWLINE *newedge )
 {
   GBOX mbox;
+  LWT_ISO_EDGE *edges;
   LWT_ISO_NODE *nodes;
   const GBOX *edgebox;
   POINTARRAY *motion_range = NULL;
-  uint64_t i, numnodes;
+  uint64_t i, numnodes, numedges;
   int isclosed = start_node == end_node;
 
   lwgeom_add_bbox(lwline_as_lwgeom(newedge));
@@ -1020,8 +1022,97 @@ _lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
       return 1;
     }
   }
-  if (motion_range) ptarray_free(motion_range);
   if (nodes) _lwt_release_nodes(nodes, numnodes);
+
+  if (motion_range)
+  {
+    LWLINE *motion_bounds;
+    LWGEOM *motion_poly_bare;
+    LWGEOM *motion_poly;
+    GEOSGeometry *motion_poly_g;
+
+    initGEOS(lwnotice, lwgeom_geos_error);
+
+    motion_bounds = lwline_construct(topo->srid, NULL, motion_range);
+    motion_range = NULL;
+    motion_poly_bare = (LWGEOM *)lwpoly_from_lwlines(motion_bounds, 0, NULL);
+    motion_poly = lwgeom_make_valid(motion_poly_bare);
+    lwgeom_free(motion_poly_bare);
+
+    motion_poly_g = LWGEOM2GEOS(motion_poly, 0);
+    lwgeom_free(motion_poly);
+    if (!motion_poly_g)
+    {
+      lwerror("Could not convert edge motion range to GEOS: %s", lwgeom_geos_errmsg);
+      return -1;
+    }
+
+    edges = lwt_be_getEdgeWithinBox2D(topo, &mbox, &numedges,
+                                      LWT_COL_EDGE_ALL, 0);
+    LWDEBUGF(1, "lwt_be_getEdgeWithinBox2D returned %" PRIu64 " edges", numedges);
+    if (numedges == UINT64_MAX)
+    {
+      GEOSGeom_destroy(motion_poly_g);
+      PGTOPO_BE_ERROR();
+      return -1;
+    }
+
+    for (i=0; i<numedges; ++i)
+    {
+      LWT_ISO_EDGE *edge = &(edges[i]);
+      GEOSGeometry *edge_g;
+      char *relate;
+      int match;
+
+      if (edge->edge_id == edge_id) continue;
+
+      if (!edge->geom)
+      {
+        GEOSGeom_destroy(motion_poly_g);
+        _lwt_release_edges(edges, numedges);
+        lwerror("Edge %" LWTFMT_ELEMID " has NULL geometry!", edge->edge_id);
+        return -1;
+      }
+
+      edge_g = LWGEOM2GEOS(lwline_as_lwgeom(edge->geom), 0);
+      if (!edge_g)
+      {
+        GEOSGeom_destroy(motion_poly_g);
+        _lwt_release_edges(edges, numedges);
+        lwerror("Could not convert edge geometry to GEOS: %s", lwgeom_geos_errmsg);
+        return -1;
+      }
+
+      relate = GEOSRelate(motion_poly_g, edge_g);
+      GEOSGeom_destroy(edge_g);
+      if (!relate)
+      {
+        GEOSGeom_destroy(motion_poly_g);
+        _lwt_release_edges(edges, numedges);
+        lwerror("GEOSRelate error: %s", lwgeom_geos_errmsg);
+        return -1;
+      }
+
+      match = GEOSRelatePatternMatch(relate, "FF*F*****");
+      GEOSFree(relate);
+      if (match == 2)
+      {
+        GEOSGeom_destroy(motion_poly_g);
+        _lwt_release_edges(edges, numedges);
+        lwerror("GEOSRelatePatternMatch error: %s", lwgeom_geos_errmsg);
+        return -1;
+      }
+      if (!match)
+      {
+        GEOSGeom_destroy(motion_poly_g);
+        _lwt_release_edges(edges, numedges);
+        return 1;
+      }
+    }
+    if (edges) _lwt_release_edges(edges, numedges);
+    GEOSGeom_destroy(motion_poly_g);
+  }
+  if (motion_range) ptarray_free(motion_range);
 
   return 0;
 }
@@ -1078,6 +1169,94 @@ _lwt_EdgeGeomsCollide( LWLINE *edge1, LWLINE *edge2 )
   GEOSGeom_destroy(edge1gg);
 
   return collision;
+}
+
+static int
+_lwt_EdgeMoveWillHitStagedEdges( LWLINE *oldedge, LWLINE *newedge,
+                                 LWLINE **staged_edges,
+                                 int staged_edge_count )
+{
+  POINTARRAY *motion_range;
+  POINTARRAY *reverse_newedge;
+  LWLINE *motion_bounds;
+  LWGEOM *motion_poly_bare;
+  LWGEOM *motion_poly;
+  GEOSGeometry *motion_poly_g;
+  int i;
+
+  if ( ptarray_is_closed_2d(oldedge->points) )
+    return 0;
+
+  motion_range = ptarray_clone_deep(oldedge->points);
+  reverse_newedge = ptarray_clone_deep(newedge->points);
+  ptarray_reverse_in_place(reverse_newedge);
+  ptarray_append_ptarray(motion_range, reverse_newedge, 0);
+  ptarray_free(reverse_newedge);
+
+  if ( ! ptarray_is_closed_2d(motion_range) || motion_range->npoints <= 3 )
+  {
+    ptarray_free(motion_range);
+    return 0;
+  }
+
+  initGEOS(lwnotice, lwgeom_geos_error);
+
+  motion_bounds = lwline_construct(oldedge->srid, NULL, motion_range);
+  motion_poly_bare = (LWGEOM *)lwpoly_from_lwlines(motion_bounds, 0, NULL);
+  motion_poly = lwgeom_make_valid(motion_poly_bare);
+  lwgeom_free(motion_poly_bare);
+
+  motion_poly_g = LWGEOM2GEOS(motion_poly, 0);
+  lwgeom_free(motion_poly);
+  if ( ! motion_poly_g )
+  {
+    lwerror("Could not convert edge motion range to GEOS: %s", lwgeom_geos_errmsg);
+    return -1;
+  }
+
+  for (i = 0; i < staged_edge_count; i++)
+  {
+    GEOSGeometry *edge_g;
+    char *relate;
+    int match;
+
+    if ( ! staged_edges[i] )
+      continue;
+
+    edge_g = LWGEOM2GEOS(lwline_as_lwgeom(staged_edges[i]), 0);
+    if ( ! edge_g )
+    {
+      GEOSGeom_destroy(motion_poly_g);
+      lwerror("Could not convert staged edge geometry to GEOS: %s", lwgeom_geos_errmsg);
+      return -1;
+    }
+
+    relate = GEOSRelate(motion_poly_g, edge_g);
+    GEOSGeom_destroy(edge_g);
+    if ( ! relate )
+    {
+      GEOSGeom_destroy(motion_poly_g);
+      lwerror("GEOSRelate error: %s", lwgeom_geos_errmsg);
+      return -1;
+    }
+
+    match = GEOSRelatePatternMatch(relate, "FF*F*****");
+    GEOSFree(relate);
+    if (match == 2)
+    {
+      GEOSGeom_destroy(motion_poly_g);
+      lwerror("GEOSRelatePatternMatch error: %s", lwgeom_geos_errmsg);
+      return -1;
+    }
+    if ( ! match )
+    {
+      GEOSGeom_destroy(motion_poly_g);
+      return 1;
+    }
+  }
+
+  GEOSGeom_destroy(motion_poly_g);
+  return 0;
 }
 
 static int
@@ -2072,6 +2251,14 @@ _lwt_FindAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID node, edgeend *data,
 }
 
 static int
+_lwt_RingWindingWithReplacement(LWT_TOPOLOGY *topo,
+                                LWT_ELEMID replace_edge_id,
+                                LWLINE *replace_edge,
+                                LWT_ELEMID *signed_edge_ids,
+                                uint64_t num_signed_edge_ids,
+                                int *isccw);
+
+static int
 _lwt_EdgeMoveWillChangeAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID edge_id,
                                       LWT_ELEMID start_node, LWT_ELEMID end_node,
                                       LWT_ELEMID face_left, LWT_ELEMID face_right,
@@ -2101,7 +2288,38 @@ _lwt_EdgeMoveWillChangeAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID edge_id,
       face_left != face_right &&
       span_pre.nextCW == span_pre.nextCCW &&
       epan_pre.nextCW == epan_pre.nextCCW)
-    return 1;
+  {
+    uint64_t num_signed_edge_ids;
+    LWT_ELEMID *signed_edge_ids;
+    int old_isccw;
+    int new_isccw;
+
+    signed_edge_ids = lwt_be_getRingEdges(topo, edge_id, &num_signed_edge_ids, 0);
+    if (!signed_edge_ids)
+    {
+      PGTOPO_BE_ERROR();
+      return -1;
+    }
+
+    if (_lwt_RingWindingWithReplacement(topo, edge_id, oldedge,
+                                        signed_edge_ids, num_signed_edge_ids,
+                                        &old_isccw) < 0)
+    {
+      lwfree(signed_edge_ids);
+      return -1;
+    }
+    if (_lwt_RingWindingWithReplacement(topo, edge_id, newedge,
+                                        signed_edge_ids, num_signed_edge_ids,
+                                        &new_isccw) < 0)
+    {
+      lwfree(signed_edge_ids);
+      return -1;
+    }
+    lwfree(signed_edge_ids);
+
+    if (old_isccw != new_isccw)
+      return 1;
+  }
 
   if ( _lwt_InitEdgeEndByLine(&span_post, &epan_post, newedge, &p1, &p2) )
     return -1;
@@ -2357,6 +2575,112 @@ _lwt_MakeRingShell(LWT_TOPOLOGY *topo, LWT_ELEMID *signed_edge_ids, uint64_t num
   LWPOLY* shell = lwpoly_construct(0, 0, 1, points);
 
   return shell;
+}
+
+static int
+_lwt_RingWindingWithReplacement(LWT_TOPOLOGY *topo,
+                                LWT_ELEMID replace_edge_id,
+                                LWLINE *replace_edge,
+                                LWT_ELEMID *signed_edge_ids,
+                                uint64_t num_signed_edge_ids,
+                                int *isccw)
+{
+  LWT_ELEMID *edge_ids;
+  uint64_t numedges, j, i;
+  LWT_ISO_EDGE *ring_edges;
+  POINTARRAY *full_ring_pa = NULL;
+
+  numedges = 0;
+  edge_ids = lwalloc(sizeof(LWT_ELEMID)*num_signed_edge_ids);
+  for (i=0; i<num_signed_edge_ids; ++i)
+  {
+    LWT_ELEMID absid = llabs(signed_edge_ids[i]);
+    int found = 0;
+    for (j=0; j<numedges; ++j)
+    {
+      if (edge_ids[j] == absid)
+      {
+        found = 1;
+        break;
+      }
+    }
+    if (!found)
+      edge_ids[numedges++] = absid;
+  }
+
+  i = numedges;
+  ring_edges = lwt_be_getEdgeById(topo, edge_ids, &i,
+                                  LWT_COL_EDGE_EDGE_ID|LWT_COL_EDGE_GEOM);
+  lwfree(edge_ids);
+  if (i == UINT64_MAX)
+  {
+    PGTOPO_BE_ERROR();
+    return -1;
+  }
+  else if (i != numedges)
+  {
+    _lwt_release_edges(ring_edges, i);
+    lwerror("Unexpected error: %" LWTFMT_ELEMID
+      " edges found when expecting %" PRIu64, i, numedges);
+    return -1;
+  }
+
+  for (i=0; i<num_signed_edge_ids; ++i)
+  {
+    LWT_ELEMID eid = signed_edge_ids[i];
+    LWT_ELEMID abseid = llabs(eid);
+    LWLINE *edge = NULL;
+    POINTARRAY *epa;
+
+    if (abseid == replace_edge_id)
+      edge = replace_edge;
+    else
+    {
+      for (j=0; j<numedges; ++j)
+      {
+        if (ring_edges[j].edge_id == abseid)
+        {
+          edge = ring_edges[j].geom;
+          break;
+        }
+      }
+    }
+    if (edge == NULL)
+    {
+      if (full_ring_pa) ptarray_free(full_ring_pa);
+      _lwt_release_edges(ring_edges, numedges);
+      lwerror("missing edge that was found in ring edges loop");
+      return -1;
+    }
+
+    if (full_ring_pa == NULL)
+    {
+      full_ring_pa = ptarray_clone_deep(edge->points);
+      if (eid < 0) ptarray_reverse_in_place(full_ring_pa);
+    }
+    else if (eid < 0)
+    {
+      epa = ptarray_clone_deep(edge->points);
+      ptarray_reverse_in_place(epa);
+      ptarray_append_ptarray(full_ring_pa, epa, 0);
+      ptarray_free(epa);
+    }
+    else
+      ptarray_append_ptarray(full_ring_pa, edge->points, 0);
+  }
+  _lwt_release_edges(ring_edges, numedges);
+
+  if (!ptarray_is_closed_2d(full_ring_pa))
+  {
+    ptarray_free(full_ring_pa);
+    lwerror("Corrupted topology: ring of edge %" LWTFMT_ELEMID
+            " is geometrically not-closed", signed_edge_ids[0]);
+    return -1;
+  }
+
+  *isccw = lwt_IsTopoRingCCW(full_ring_pa);
+  ptarray_free(full_ring_pa);
+  return 0;
 }
 
 /*
@@ -7877,6 +8201,7 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
 
         /* Avoid staging snaps that lwt_ChangeEdgeGeom would reject. */
         move_collision = _lwt_EdgeMoveWillHitNode(topo,
+                                                 edge_id,
                                                  nearby_start_node[i],
                                                  nearby_end_node[i],
                                                  edgeline,
@@ -7909,6 +8234,13 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
           if ( ! snapped_edges[j] ) continue;
           edge_collision = _lwt_EdgeGeomsCollide(snapped_edges[j], snappedline);
           if ( edge_collision ) break;
+        }
+        if ( ! edge_collision )
+        {
+          edge_collision = _lwt_EdgeMoveWillHitStagedEdges(edgeline,
+                                                           snappedline,
+                                                           snapped_edges,
+                                                           i);
         }
         if ( edge_collision )
         {

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -19,7 +19,7 @@
  **********************************************************************
  *
  * Copyright (C) 2015-2026 Sandro Santilli <strk@kbt.io>
- * Copyright (C) 2025 Darafei Praliaskouski <me@komzpa.net>
+ * Copyright (C) 2025-2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
@@ -1036,6 +1036,7 @@ _lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
     motion_bounds = lwline_construct(topo->srid, NULL, motion_range);
     motion_range = NULL;
     motion_poly_bare = (LWGEOM *)lwpoly_from_lwlines(motion_bounds, 0, NULL);
+    lwline_free(motion_bounds);
     motion_poly = lwgeom_make_valid(motion_poly_bare);
     lwgeom_free(motion_poly_bare);
 
@@ -1176,35 +1177,66 @@ _lwt_EdgeMoveWillHitStagedEdges( LWLINE *oldedge, LWLINE *newedge,
                                  LWLINE **staged_edges,
                                  int staged_edge_count )
 {
-  POINTARRAY *motion_range;
-  POINTARRAY *reverse_newedge;
-  LWLINE *motion_bounds;
-  LWGEOM *motion_poly_bare;
+  POINTARRAY *motion_range = NULL;
   LWGEOM *motion_poly;
   GEOSGeometry *motion_poly_g;
   int i;
 
   if ( ptarray_is_closed_2d(oldedge->points) )
-    return 0;
-
-  motion_range = ptarray_clone_deep(oldedge->points);
-  reverse_newedge = ptarray_clone_deep(newedge->points);
-  ptarray_reverse_in_place(reverse_newedge);
-  ptarray_append_ptarray(motion_range, reverse_newedge, 0);
-  ptarray_free(reverse_newedge);
-
-  if ( ! ptarray_is_closed_2d(motion_range) || motion_range->npoints <= 3 )
   {
-    ptarray_free(motion_range);
-    return 0;
+    LWGEOM *oldpoly_bare;
+    LWGEOM *oldpoly;
+    LWGEOM *newpoly_bare;
+    LWGEOM *newpoly;
+
+    if ( oldedge->points->npoints < 4 || newedge->points->npoints < 4 ||
+         ! ptarray_is_closed_2d(newedge->points) )
+      return 0;
+
+    oldpoly_bare = (LWGEOM *)lwpoly_from_lwlines(oldedge, 0, NULL);
+    oldpoly = lwgeom_make_valid(oldpoly_bare);
+    lwgeom_free(oldpoly_bare);
+
+    newpoly_bare = (LWGEOM *)lwpoly_from_lwlines(newedge, 0, NULL);
+    newpoly = lwgeom_make_valid(newpoly_bare);
+    lwgeom_free(newpoly_bare);
+
+    motion_poly = lwgeom_symdifference(oldpoly, newpoly);
+    lwgeom_free(oldpoly);
+    lwgeom_free(newpoly);
+    if ( ! motion_poly )
+    {
+      lwerror("Could not build closed edge motion range");
+      return -1;
+    }
+  }
+  else
+  {
+    POINTARRAY *reverse_newedge;
+    LWLINE *motion_bounds;
+    LWGEOM *motion_poly_bare;
+
+    motion_range = ptarray_clone_deep(oldedge->points);
+    reverse_newedge = ptarray_clone_deep(newedge->points);
+    ptarray_reverse_in_place(reverse_newedge);
+    ptarray_append_ptarray(motion_range, reverse_newedge, 0);
+    ptarray_free(reverse_newedge);
+
+    if ( ! ptarray_is_closed_2d(motion_range) || motion_range->npoints <= 3 )
+    {
+      ptarray_free(motion_range);
+      return 0;
+    }
+
+    motion_bounds = lwline_construct(oldedge->srid, NULL, motion_range);
+    motion_range = NULL;
+    motion_poly_bare = (LWGEOM *)lwpoly_from_lwlines(motion_bounds, 0, NULL);
+    lwline_free(motion_bounds);
+    motion_poly = lwgeom_make_valid(motion_poly_bare);
+    lwgeom_free(motion_poly_bare);
   }
 
   initGEOS(lwnotice, lwgeom_geos_error);
-
-  motion_bounds = lwline_construct(oldedge->srid, NULL, motion_range);
-  motion_poly_bare = (LWGEOM *)lwpoly_from_lwlines(motion_bounds, 0, NULL);
-  motion_poly = lwgeom_make_valid(motion_poly_bare);
-  lwgeom_free(motion_poly_bare);
 
   motion_poly_g = LWGEOM2GEOS(motion_poly, 0);
   lwgeom_free(motion_poly);

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -911,6 +911,7 @@ _lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
   GBOX mbox;
   LWT_ISO_NODE *nodes;
   const GBOX *edgebox;
+  POINTARRAY *motion_range = NULL;
   uint64_t i, numnodes;
   int isclosed = start_node == end_node;
 
@@ -963,6 +964,24 @@ _lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
     PGTOPO_BE_ERROR();
     return -1;
   }
+
+  if (!isclosed)
+  {
+    POINTARRAY *reverse_newedge;
+
+    motion_range = ptarray_clone_deep(oldedge->points);
+    reverse_newedge = ptarray_clone_deep(newedge->points);
+    ptarray_reverse_in_place(reverse_newedge);
+    ptarray_append_ptarray(motion_range, reverse_newedge, 0);
+    ptarray_free(reverse_newedge);
+
+    if (!ptarray_is_closed_2d(motion_range) || motion_range->npoints <= 3)
+    {
+      ptarray_free(motion_range);
+      motion_range = NULL;
+    }
+  }
+
   for (i=0; i<numnodes; ++i)
   {
     LWT_ISO_NODE *node = &(nodes[i]);
@@ -976,6 +995,7 @@ _lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
 
     if (!node->geom || !node->geom->point || !node->geom->point->npoints)
     {
+      if (motion_range) ptarray_free(motion_range);
       _lwt_release_nodes(nodes, numnodes);
       lwerror("Internal error: lwt_be_getNodeWithinBox2D returned node %"
               LWTFMT_ELEMID " with no vertices", node_id);
@@ -987,10 +1007,20 @@ _lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
     new_contains = ptarray_contains_point_partial(newedge->points, pt, isclosed, NULL) == LW_INSIDE;
     if (old_contains != new_contains)
     {
+      if (motion_range) ptarray_free(motion_range);
+      _lwt_release_nodes(nodes, numnodes);
+      return 1;
+    }
+
+    if (motion_range && node->containing_face != -1 &&
+        ptarray_contains_point(motion_range, pt) != LW_OUTSIDE)
+    {
+      ptarray_free(motion_range);
       _lwt_release_nodes(nodes, numnodes);
       return 1;
     }
   }
+  if (motion_range) ptarray_free(motion_range);
   if (nodes) _lwt_release_nodes(nodes, numnodes);
 
   return 0;
@@ -2044,6 +2074,7 @@ _lwt_FindAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID node, edgeend *data,
 static int
 _lwt_EdgeMoveWillChangeAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID edge_id,
                                       LWT_ELEMID start_node, LWT_ELEMID end_node,
+                                      LWT_ELEMID face_left, LWT_ELEMID face_right,
                                       LWLINE *oldedge, LWLINE *newedge )
 {
   POINT2D p1, p2;
@@ -2062,6 +2093,15 @@ _lwt_EdgeMoveWillChangeAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID edge_id,
   if ( _lwt_FindAdjacentEdges(topo, end_node, &epan_pre,
                               isclosed ? &span_pre : NULL, edge_id) < 0 )
     return -1;
+
+  if (isclosed && ptarray_isccw(oldedge->points) != ptarray_isccw(newedge->points))
+    return 1;
+
+  if (!isclosed &&
+      face_left != face_right &&
+      span_pre.nextCW == span_pre.nextCCW &&
+      epan_pre.nextCW == epan_pre.nextCCW)
+    return 1;
 
   if ( _lwt_InitEdgeEndByLine(&span_post, &epan_post, newedge, &p1, &p2) )
     return -1;
@@ -7629,6 +7669,8 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
   LWT_ELEMID *nearbyid = 0;
   LWT_ELEMID *nearby_start_node = 0;
   LWT_ELEMID *nearby_end_node = 0;
+  LWT_ELEMID *nearby_face_left = 0;
+  LWT_ELEMID *nearby_face_right = 0;
   LWLINE **snapped_edges = 0;
   int nearbyindex = 0;
   int nearbycount = 0;
@@ -7653,6 +7695,8 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     nearbyid = lwalloc(numedges * sizeof(LWT_ELEMID));
     nearby_start_node = lwalloc(numedges * sizeof(LWT_ELEMID));
     nearby_end_node = lwalloc(numedges * sizeof(LWT_ELEMID));
+    nearby_face_left = lwalloc(numedges * sizeof(LWT_ELEMID));
+    nearby_face_right = lwalloc(numedges * sizeof(LWT_ELEMID));
     for (i=0; i<numedges; ++i)
     {{
       LW_ON_INTERRUPT(return NULL);
@@ -7673,7 +7717,9 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
       nearby[nearbyindex] = g;
       nearbyid[nearbyindex] = e->edge_id;
       nearby_start_node[nearbyindex] = e->start_node;
-      nearby_end_node[nearbyindex++] = e->end_node;
+      nearby_end_node[nearbyindex] = e->end_node;
+      nearby_face_left[nearbyindex] = e->face_left;
+      nearby_face_right[nearbyindex++] = e->face_right;
     }}
     LWDEBUGF(1, "Found %d edges closer than tolerance (%g)", nearbyindex, tol);
     GEOSGeom_destroy(noded_g);
@@ -7879,6 +7925,8 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
                                                                   edge_id,
                                                                   nearby_start_node[i],
                                                                   nearby_end_node[i],
+                                                                  nearby_face_left[i],
+                                                                  nearby_face_right[i],
                                                                   edgeline,
                                                                   snappedline);
         if ( adjacency_collision )
@@ -8034,6 +8082,8 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
   if ( nearbyid ) lwfree(nearbyid);
   if ( nearby_start_node ) lwfree(nearby_start_node);
   if ( nearby_end_node ) lwfree(nearby_end_node);
+  if ( nearby_face_left ) lwfree(nearby_face_left);
+  if ( nearby_face_right ) lwfree(nearby_face_right);
   if ( nodes ) _lwt_release_nodes(nodes, numnodes);
   if ( edges ) _lwt_release_edges(edges, numedges);
 

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -39,6 +39,7 @@
 
 #include <inttypes.h>
 #include <math.h>
+#include <string.h>
 
 static bool
 _lwt_describe_point(const LWPOINT *pt, char *buf, size_t bufsize)
@@ -898,6 +899,204 @@ _lwt_CheckEdgeCrossing( LWT_TOPOLOGY* topo,
               /* would be NULL if num_edges was 0 */
 
   GEOSGeom_destroy(edgegg);
+
+  return 0;
+}
+
+static int
+_lwt_EdgeMoveWillHitNode( LWT_TOPOLOGY* topo,
+                          LWT_ELEMID start_node, LWT_ELEMID end_node,
+                          LWLINE *oldedge, LWLINE *newedge )
+{
+  GBOX mbox;
+  LWT_ISO_NODE *nodes;
+  const GBOX *edgebox;
+  uint64_t i, numnodes;
+  int isclosed = start_node == end_node;
+
+  lwgeom_add_bbox(lwline_as_lwgeom(newedge));
+  edgebox = lwgeom_get_bbox(lwline_as_lwgeom(newedge));
+
+  nodes = lwt_be_getNodeWithinBox2D(topo, edgebox, &numnodes,
+                                    LWT_COL_NODE_ALL, 0);
+  LWDEBUGF(1, "lwt_be_getNodeWithinBox2D returned %" PRIu64 " nodes", numnodes);
+  if (numnodes == UINT64_MAX)
+  {
+    PGTOPO_BE_ERROR();
+    return -1;
+  }
+  for (i=0; i<numnodes; ++i)
+  {
+    LWT_ISO_NODE *node = &(nodes[i]);
+    LWT_ELEMID node_id = node->node_id;
+    const POINT2D *pt;
+
+    if (node_id == start_node) continue;
+    if (node_id == end_node) continue;
+
+    if (!node->geom || !node->geom->point || !node->geom->point->npoints)
+    {
+      _lwt_release_nodes(nodes, numnodes);
+      lwerror("Internal error: lwt_be_getNodeWithinBox2D returned node %"
+              LWTFMT_ELEMID " with no vertices", node_id);
+      return -1;
+    }
+
+    pt = getPoint2d_cp(node->geom->point, 0);
+    if (ptarray_contains_point_partial(newedge->points, pt, LW_FALSE, NULL) == LW_BOUNDARY)
+    {
+      _lwt_release_nodes(nodes, numnodes);
+      return 1;
+    }
+  }
+  if (nodes) _lwt_release_nodes(nodes, numnodes);
+
+  lwgeom_add_bbox(lwline_as_lwgeom(oldedge));
+  lwgeom_add_bbox(lwline_as_lwgeom(newedge));
+  gbox_union(oldedge->bbox, newedge->bbox, &mbox);
+
+  nodes = lwt_be_getNodeWithinBox2D(topo, &mbox, &numnodes,
+                                    LWT_COL_NODE_ALL, 0);
+  LWDEBUGF(1, "lwt_be_getNodeWithinBox2D returned %" PRIu64 " nodes", numnodes);
+  if (numnodes == UINT64_MAX)
+  {
+    PGTOPO_BE_ERROR();
+    return -1;
+  }
+  for (i=0; i<numnodes; ++i)
+  {
+    LWT_ISO_NODE *node = &(nodes[i]);
+    LWT_ELEMID node_id = node->node_id;
+    const POINT2D *pt;
+    int old_contains;
+    int new_contains;
+
+    if (node_id == start_node) continue;
+    if (node_id == end_node) continue;
+
+    if (!node->geom || !node->geom->point || !node->geom->point->npoints)
+    {
+      _lwt_release_nodes(nodes, numnodes);
+      lwerror("Internal error: lwt_be_getNodeWithinBox2D returned node %"
+              LWTFMT_ELEMID " with no vertices", node_id);
+      return -1;
+    }
+
+    pt = getPoint2d_cp(node->geom->point, 0);
+    old_contains = ptarray_contains_point_partial(oldedge->points, pt, isclosed, NULL) == LW_INSIDE;
+    new_contains = ptarray_contains_point_partial(newedge->points, pt, isclosed, NULL) == LW_INSIDE;
+    if (old_contains != new_contains)
+    {
+      _lwt_release_nodes(nodes, numnodes);
+      return 1;
+    }
+  }
+  if (nodes) _lwt_release_nodes(nodes, numnodes);
+
+  return 0;
+}
+
+static int
+_lwt_EdgeGeomsCollide( LWLINE *edge1, LWLINE *edge2 )
+{
+  GEOSGeometry *edge1gg;
+  GEOSGeometry *edge2gg;
+  char *relate;
+  int match;
+  int collision = 0;
+
+  initGEOS(lwnotice, lwgeom_geos_error);
+
+  edge1gg = LWGEOM2GEOS(lwline_as_lwgeom(edge1), 0);
+  if (!edge1gg)
+  {
+    lwerror("Could not convert edge geometry to GEOS: %s", lwgeom_geos_errmsg);
+    return -1;
+  }
+
+  edge2gg = LWGEOM2GEOS(lwline_as_lwgeom(edge2), 0);
+  if (!edge2gg)
+  {
+    GEOSGeom_destroy(edge1gg);
+    lwerror("Could not convert edge geometry to GEOS: %s", lwgeom_geos_errmsg);
+    return -1;
+  }
+
+  relate = GEOSRelateBoundaryNodeRule(edge1gg, edge2gg, 2);
+  if (!relate)
+  {
+    GEOSGeom_destroy(edge2gg);
+    GEOSGeom_destroy(edge1gg);
+    lwerror("GEOSRelateBoundaryNodeRule error: %s", lwgeom_geos_errmsg);
+    return -1;
+  }
+
+  match = GEOSRelatePatternMatch(relate, "FF*F*****");
+  if (match == 2)
+  {
+    GEOSFree(relate);
+    GEOSGeom_destroy(edge2gg);
+    GEOSGeom_destroy(edge1gg);
+    lwerror("GEOSRelatePatternMatch error: %s", lwgeom_geos_errmsg);
+    return -1;
+  }
+  if (!match)
+    collision = 1;
+
+  GEOSFree(relate);
+  GEOSGeom_destroy(edge2gg);
+  GEOSGeom_destroy(edge1gg);
+
+  return collision;
+}
+
+static int
+_lwt_EdgeMoveWillCrossEdge( LWT_TOPOLOGY* topo,
+                            LWT_ELEMID edge_id, LWLINE *newedge )
+{
+  uint64_t i, num_edges;
+  LWT_ISO_EDGE *edges;
+  const GBOX *edgebox;
+
+  lwgeom_add_bbox(lwline_as_lwgeom(newedge));
+  edgebox = lwgeom_get_bbox(lwline_as_lwgeom(newedge));
+
+  edges = lwt_be_getEdgeWithinBox2D( topo, edgebox, &num_edges, LWT_COL_EDGE_ALL, 0 );
+  LWDEBUGF(1, "lwt_be_getEdgeWithinBox2D returned %" PRIu64 " edges", num_edges);
+  if (num_edges == UINT64_MAX)
+  {
+    PGTOPO_BE_ERROR();
+    return -1;
+  }
+
+  for (i=0; i<num_edges; ++i)
+  {
+    LWT_ISO_EDGE* edge = &(edges[i]);
+    int collision;
+
+    if ( edge->edge_id == edge_id ) continue;
+
+    if ( ! edge->geom )
+    {
+      _lwt_release_edges(edges, num_edges);
+      lwerror("Edge %" LWTFMT_ELEMID " has NULL geometry!", edge->edge_id);
+      return -1;
+    }
+
+    collision = _lwt_EdgeGeomsCollide(edge->geom, newedge);
+    if ( collision < 0 )
+    {
+      _lwt_release_edges(edges, num_edges);
+      return -1;
+    }
+
+    if ( collision )
+    {
+      _lwt_release_edges(edges, num_edges);
+      return 1;
+    }
+  }
+  if ( edges ) _lwt_release_edges(edges, num_edges);
 
   return 0;
 }
@@ -1840,6 +2039,46 @@ _lwt_FindAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID node, edgeend *data,
 
   /* Return number of incident edges found */
   return numedges;
+}
+
+static int
+_lwt_EdgeMoveWillChangeAdjacentEdges( LWT_TOPOLOGY* topo, LWT_ELEMID edge_id,
+                                      LWT_ELEMID start_node, LWT_ELEMID end_node,
+                                      LWLINE *oldedge, LWLINE *newedge )
+{
+  POINT2D p1, p2;
+  int isclosed = start_node == end_node;
+  edgeend span_pre, epan_pre;
+  edgeend span_post, epan_post;
+
+  getPoint2d_p(oldedge->points, 0, &p1);
+  getPoint2d_p(oldedge->points, oldedge->points->npoints-1, &p2);
+
+  if ( _lwt_InitEdgeEndByLine(&span_pre, &epan_pre, oldedge, &p1, &p2) )
+    return -1;
+  if ( _lwt_FindAdjacentEdges(topo, start_node, &span_pre,
+                              isclosed ? &epan_pre : NULL, edge_id) < 0 )
+    return -1;
+  if ( _lwt_FindAdjacentEdges(topo, end_node, &epan_pre,
+                              isclosed ? &span_pre : NULL, edge_id) < 0 )
+    return -1;
+
+  if ( _lwt_InitEdgeEndByLine(&span_post, &epan_post, newedge, &p1, &p2) )
+    return -1;
+  if ( _lwt_FindAdjacentEdges(topo, start_node, &span_post,
+                              isclosed ? &epan_post : NULL, edge_id) < 0 )
+    return -1;
+  if ( _lwt_FindAdjacentEdges(topo, end_node, &epan_post,
+                              isclosed ? &span_post : NULL, edge_id) < 0 )
+    return -1;
+
+  if ( span_pre.nextCW != span_post.nextCW ||
+       span_pre.nextCCW != span_post.nextCCW ||
+       epan_pre.nextCW != epan_post.nextCW ||
+       epan_pre.nextCCW != epan_post.nextCCW )
+    return 1;
+
+  return 0;
 }
 
 /*
@@ -7327,7 +7566,7 @@ _lwt_split_by_nodes(const LWGEOM *g, const LWGEOM *nodes)
 
 static LWT_ELEMID*
 _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
-            int handleFaceSplit, int maxNewEdges)
+            int handleFaceSplit, int maxNewEdges, int snapExistingEdges)
 {
   LWGEOM *geomsbuf[1];
   LWGEOM **geoms;
@@ -7387,6 +7626,10 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
               tol, qbox.xmin, qbox.ymin, qbox.xmax, qbox.ymax);
 
   LWGEOM **nearby = 0;
+  LWT_ELEMID *nearbyid = 0;
+  LWT_ELEMID *nearby_start_node = 0;
+  LWT_ELEMID *nearby_end_node = 0;
+  LWLINE **snapped_edges = 0;
   int nearbyindex = 0;
   int nearbycount = 0;
 
@@ -7407,6 +7650,9 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     /* collect those whose distance from us is < tol */
     nearbycount += numedges;
     nearby = lwalloc(numedges * sizeof(LWGEOM *));
+    nearbyid = lwalloc(numedges * sizeof(LWT_ELEMID));
+    nearby_start_node = lwalloc(numedges * sizeof(LWT_ELEMID));
+    nearby_end_node = lwalloc(numedges * sizeof(LWT_ELEMID));
     for (i=0; i<numedges; ++i)
     {{
       LW_ON_INTERRUPT(return NULL);
@@ -7424,7 +7670,10 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
       }
       GEOSGeom_destroy(edge_g);
       if ( dist && dist >= tol ) continue;
-      nearby[nearbyindex++] = g;
+      nearby[nearbyindex] = g;
+      nearbyid[nearbyindex] = e->edge_id;
+      nearby_start_node[nearbyindex] = e->start_node;
+      nearby_end_node[nearbyindex++] = e->end_node;
     }}
     LWDEBUGF(1, "Found %d edges closer than tolerance (%g)", nearbyindex, tol);
     GEOSGeom_destroy(noded_g);
@@ -7524,6 +7773,129 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     LWGEOM *diff, *xset;
 
     LWDEBUGF(1, "Line intersects %d edges", nearbyedgecount);
+
+    if ( snapExistingEdges )
+    {
+      LWDEBUG(1, "Snapping intersecting edges to incoming line vertices");
+      snapped_edges = lwalloc(nearbyedgecount * sizeof(LWLINE *));
+      memset(snapped_edges, 0, nearbyedgecount * sizeof(LWLINE *));
+      for (int i=0; i<nearbyedgecount; i++)
+      {
+        LWGEOM *edge = nearby[i];
+        LWLINE *edgeline = lwgeom_as_lwline(edge);
+        LWGEOM *snapped;
+        LWLINE *snappedline;
+        LWT_ELEMID edge_id = nearbyid[i];
+        POINT2D before, after;
+        int move_collision;
+        int edge_collision;
+        int adjacency_collision;
+
+        snapped = lwgeom_snap(edge, noded, tol);
+        snappedline = lwgeom_as_lwline(snapped);
+        if ( ! snappedline )
+        {
+          lwgeom_free(snapped);
+          lwgeom_free(noded);
+          lwerror("Snapping edge %" LWTFMT_ELEMID " produced a non-linestring", edge_id);
+          return NULL;
+        }
+
+        if ( lwgeom_same(snapped, edge) )
+        {
+          lwgeom_free(snapped);
+          continue;
+        }
+
+        getPoint2d_p(edgeline->points, 0, &before);
+        getPoint2d_p(snappedline->points, 0, &after);
+        if ( ! P2D_SAME_STRICT(&before, &after) )
+        {
+          lwgeom_free(snapped);
+          continue;
+        }
+
+        getPoint2d_p(edgeline->points, edgeline->points->npoints - 1, &before);
+        getPoint2d_p(snappedline->points, snappedline->points->npoints - 1, &after);
+        if ( ! P2D_SAME_STRICT(&before, &after) )
+        {
+          lwgeom_free(snapped);
+          continue;
+        }
+
+        if ( ! lwgeom_is_simple(lwline_as_lwgeom(snappedline)) )
+        {
+          lwgeom_free(snapped);
+          continue;
+        }
+
+        /* Avoid staging snaps that lwt_ChangeEdgeGeom would reject. */
+        move_collision = _lwt_EdgeMoveWillHitNode(topo,
+                                                 nearby_start_node[i],
+                                                 nearby_end_node[i],
+                                                 edgeline,
+                                                 snappedline);
+        if ( move_collision )
+        {
+          lwgeom_free(snapped);
+          if ( move_collision < 0 )
+          {
+            lwgeom_free(noded);
+            return NULL;
+          }
+          continue;
+        }
+
+        edge_collision = _lwt_EdgeMoveWillCrossEdge(topo, edge_id, snappedline);
+        if ( edge_collision )
+        {
+          lwgeom_free(snapped);
+          if ( edge_collision < 0 )
+          {
+            lwgeom_free(noded);
+            return NULL;
+          }
+          continue;
+        }
+
+        for (int j=0; j<i; j++)
+        {
+          if ( ! snapped_edges[j] ) continue;
+          edge_collision = _lwt_EdgeGeomsCollide(snapped_edges[j], snappedline);
+          if ( edge_collision ) break;
+        }
+        if ( edge_collision )
+        {
+          lwgeom_free(snapped);
+          if ( edge_collision < 0 )
+          {
+            lwgeom_free(noded);
+            return NULL;
+          }
+          continue;
+        }
+
+        adjacency_collision = _lwt_EdgeMoveWillChangeAdjacentEdges(topo,
+                                                                  edge_id,
+                                                                  nearby_start_node[i],
+                                                                  nearby_end_node[i],
+                                                                  edgeline,
+                                                                  snappedline);
+        if ( adjacency_collision )
+        {
+          lwgeom_free(snapped);
+          if ( adjacency_collision < 0 )
+          {
+            lwgeom_free(noded);
+            return NULL;
+          }
+          continue;
+        }
+
+        snapped_edges[i] = snappedline;
+        nearby[i] = lwline_as_lwgeom(snappedline);
+      }
+    }
 
     col = lwcollection_construct(COLLECTIONTYPE, topo->srid,
                                  NULL, nearbyedgecount, nearby);
@@ -7632,11 +8004,36 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     lwcollection_release(col);
   }
 
+  if ( snapped_edges )
+  {
+    LW_ON_INTERRUPT(return NULL);
+    for (int i=0; i<nearbyedgecount; i++)
+    {
+      if ( ! snapped_edges[i] ) continue;
+      if ( -1 == lwt_ChangeEdgeGeom( topo, nearbyid[i], snapped_edges[i] ) )
+      {
+        lwgeom_free(noded);
+        lwerror("lwt_ChangeEdgeGeom failed");
+        return NULL;
+      }
+    }
+  }
 
   LWDEBUG(1, "Freeing up nearby elements");
 
   /* TODO: free up endpoints of nearbyedges */
+  if ( snapped_edges )
+  {
+    for (int i=0; i<nearbyedgecount; i++)
+    {
+      if ( snapped_edges[i] ) lwline_free(snapped_edges[i]);
+    }
+    lwfree(snapped_edges);
+  }
   if ( nearby ) lwfree(nearby);
+  if ( nearbyid ) lwfree(nearbyid);
+  if ( nearby_start_node ) lwfree(nearby_start_node);
+  if ( nearby_end_node ) lwfree(nearby_end_node);
   if ( nodes ) _lwt_release_nodes(nodes, numnodes);
   if ( edges ) _lwt_release_edges(edges, numedges);
 
@@ -7730,15 +8127,15 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
 }
 
 LWT_ELEMID*
-lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges, int max_new_edges)
+lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges, int max_new_edges, int snap_existing_edges)
 {
-  return _lwt_AddLine(topo, line, tol, nedges, 1, max_new_edges);
+  return _lwt_AddLine(topo, line, tol, nedges, 1, max_new_edges, snap_existing_edges);
 }
 
 LWT_ELEMID*
 lwt_AddLineNoFace(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges)
 {
-  return _lwt_AddLine(topo, line, tol, nedges, 0, -1);
+  return _lwt_AddLine(topo, line, tol, nedges, 0, -1, 0);
 }
 
 static void
@@ -7754,7 +8151,7 @@ lwt_LoadLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int max_new_edges)
   int nedges;
 
   /* TODO: avoid allocating edge ids */
-  ids = lwt_AddLine(topo, line, tol, &nedges, max_new_edges);
+  ids = lwt_AddLine(topo, line, tol, &nedges, max_new_edges, 0);
   if ( nedges > 0 ) lwfree(ids);
 }
 

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -5171,6 +5171,7 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
   FACEEDGESSTATE *state;
   Datum result;
   LWT_ELEMID id;
+  bool snap_existing_edges = false;
 
   if (SRF_IS_FIRSTCALL())
   {
@@ -5187,6 +5188,11 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     if (PG_NARGS() > 3 && !PG_ARGISNULL(3))
     {
       max_new_edges = PG_GETARG_INT32(3);
+    }
+
+    if (PG_NARGS() > 4 && !PG_ARGISNULL(4))
+    {
+      snap_existing_edges = PG_GETARG_BOOL(4);
     }
 
     toponame_text = PG_GETARG_TEXT_P(0);
@@ -5249,7 +5255,7 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     }
 
     POSTGIS_DEBUG(1, "Calling lwt_AddLine");
-    elems = lwt_AddLine(topo, ln, tol, &nelems, max_new_edges);
+    elems = lwt_AddLine(topo, ln, tol, &nelems, max_new_edges, snap_existing_edges);
     POSTGIS_DEBUG(1, "lwt_AddLine returned");
     lwgeom_free(lwgeom);
     PG_FREE_IF_COPY(geom, 1);

--- a/topology/sql/populate.sql.in
+++ b/topology/sql/populate.sql.in
@@ -742,8 +742,10 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPoint(atopology varchar, apoint g
 --
 -- Changed: 3.6.0 uses bigint for IDs
 -- Changed: 3.7.0 have tolerance default to -1 (automatic)
+-- Changed: 3.7.0 add snap_edges parameter
 -- Replaces topogeo_addlinestring(varchar, geometry, float8) deprecated in 3.6.0
-CREATE OR REPLACE FUNCTION topology.TopoGeo_AddLinestring(atopology varchar, aline geometry, tolerance float8 DEFAULT -1, max_edges int DEFAULT -1)
+-- Replaces topogeo_addlinestring(varchar, geometry, float8, int) deprecated in 3.7.0
+CREATE OR REPLACE FUNCTION topology.TopoGeo_AddLinestring(atopology varchar, aline geometry, tolerance float8 DEFAULT -1, max_edges int DEFAULT -1, snap_edges boolean DEFAULT false)
 	RETURNS SETOF bigint AS
 	'MODULE_PATHNAME', 'TopoGeo_AddLinestring'
   LANGUAGE 'c' VOLATILE;

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -761,6 +761,19 @@ FROM topology.TopoGeo_AddLinestring(
 SELECT 't6034.snap.staged_swept_collision.invalid', * FROM topology.ValidateTopology('t6034_staged_swept_collision');
 SELECT NULL FROM topology.DropTopology('t6034_staged_swept_collision');
 
+SELECT NULL FROM topology.CreateTopology('t6034_staged_closed_swept_collision', 0, 0);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_closed_swept_collision', 'LINESTRING(2 3,2 7)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_closed_swept_collision', 'LINESTRING(0 0,10 0,10 10,0 10,0 0)'::geometry);
+SELECT 't6034.snap.staged_closed_swept_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  't6034_staged_closed_swept_collision',
+  'LINESTRING(1 0,0.5 3,0.5 7,1 10)'::geometry,
+  1.6,
+  snap_edges => true
+);
+SELECT 't6034.snap.staged_closed_swept_collision.invalid', * FROM topology.ValidateTopology('t6034_staged_closed_swept_collision');
+SELECT NULL FROM topology.DropTopology('t6034_staged_closed_swept_collision');
+
 \i :top_builddir/topology/test/load_topology.sql
 SELECT NULL FROM topology.ST_AddEdgeModFace(
   'city_data',

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -651,3 +651,103 @@ SELECT 't6064.2', count(*) > 0 FROM topology.TopoGeo_addLinestring('t6064',
 )');
 SELECT 't6064.check.final', * FROM topology.ValidateTopology('t6064');
 SELECT NULL FROM topology.DropTopology ('t6064');
+
+-- See https://trac.osgeo.org/postgis/ticket/6034
+SELECT NULL FROM topology.CreateTopology('t6034_default', 4258, 1e-6);
+WITH data AS (
+  SELECT
+    ST_GeomFromEWKB(decode('0102000020A21000001200000068327ABAA20F2E40065043A442D65040921E91F9370F2E40D919AF2C41D6504060224497020F2E4070FDC4B43FD65040D23D9393020F2E40CBFA843C3ED650402E8D07F1FA0E2E4062BC63223DD650407810A1AFEB0E2E40344261663CD650400A826F30CD0E2E4084E48E663CD65040D491F494880E2E40B8821B813DD65040149ACC0E6A0E2E40542DD1903AD650402F99B9F3C90D2E40B0A9B2913AD650400E6FB093940D2E400481E0D539D65040BC705590940D2E40C3DCA55D38D65040D87C88CCA30D2E40F4BE55E536D6504062934948C20D2E409527F06C35D65040EA83FD022D0E2E405BD339B034D65040B2B377793F0F2E40B939AFAE34D65040AE91F5FF5D0F2E4055D2EE9E37D650404C570E7933102E402FF6A19D37D65040', 'hex')) AS long_line,
+    ST_GeomFromEWKB(decode('0102000020A2100000030000004C570E7933102E402FF6A19D37D6504068327ABAA20F2E40E8A7839E37D6504068327ABAA20F2E40065043A442D65040', 'hex')) AS short_line
+)
+SELECT NULL FROM data, topology.TopoGeo_AddLinestring('t6034_default', long_line, 1e-6);
+WITH data AS (
+  SELECT ST_GeomFromEWKB(decode('0102000020A2100000030000004C570E7933102E402FF6A19D37D6504068327ABAA20F2E40E8A7839E37D6504068327ABAA20F2E40065043A442D65040', 'hex')) AS short_line
+)
+SELECT NULL FROM data, topology.TopoGeo_AddLinestring('t6034_default', short_line, 1e-6);
+SELECT 't6034.default.nearby', count(*) > 0 FROM topology.FindVertexSegmentPairsBelowDistance('t6034_default', 1e-6);
+SELECT NULL FROM topology.DropTopology('t6034_default');
+
+SELECT NULL FROM topology.CreateTopology('t6034_snap', 4258, 1e-6);
+WITH data AS (
+  SELECT
+    ST_GeomFromEWKB(decode('0102000020A21000001200000068327ABAA20F2E40065043A442D65040921E91F9370F2E40D919AF2C41D6504060224497020F2E4070FDC4B43FD65040D23D9393020F2E40CBFA843C3ED650402E8D07F1FA0E2E4062BC63223DD650407810A1AFEB0E2E40344261663CD650400A826F30CD0E2E4084E48E663CD65040D491F494880E2E40B8821B813DD65040149ACC0E6A0E2E40542DD1903AD650402F99B9F3C90D2E40B0A9B2913AD650400E6FB093940D2E400481E0D539D65040BC705590940D2E40C3DCA55D38D65040D87C88CCA30D2E40F4BE55E536D6504062934948C20D2E409527F06C35D65040EA83FD022D0E2E405BD339B034D65040B2B377793F0F2E40B939AFAE34D65040AE91F5FF5D0F2E4055D2EE9E37D650404C570E7933102E402FF6A19D37D65040', 'hex')) AS long_line,
+    ST_GeomFromEWKB(decode('0102000020A2100000030000004C570E7933102E402FF6A19D37D6504068327ABAA20F2E40E8A7839E37D6504068327ABAA20F2E40065043A442D65040', 'hex')) AS short_line
+)
+SELECT NULL FROM data, topology.TopoGeo_AddLinestring('t6034_snap', long_line, 1e-6);
+WITH data AS (
+  SELECT ST_GeomFromEWKB(decode('0102000020A2100000030000004C570E7933102E402FF6A19D37D6504068327ABAA20F2E40E8A7839E37D6504068327ABAA20F2E40065043A442D65040', 'hex')) AS short_line
+)
+SELECT 't6034.snap.edges', count(*) > 0
+FROM data, topology.TopoGeo_AddLinestring('t6034_snap', short_line, 1e-6, snap_edges => true);
+SELECT 't6034.snap.invalid', * FROM topology.ValidateTopology('t6034_snap');
+SELECT 't6034.snap.nearby', count(*) FROM topology.FindVertexSegmentPairsBelowDistance('t6034_snap', 1e-6);
+SELECT NULL FROM topology.DropTopology('t6034_snap');
+
+SELECT NULL FROM topology.CreateTopology('t6034_node_collision', 0, 0);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_node_collision', 'LINESTRING(0 0,10 0)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddPoint('t6034_node_collision', 'POINT(5 0.5)'::geometry);
+SELECT 't6034.snap.node_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  't6034_node_collision',
+  'LINESTRING(5 0.5,5 1)'::geometry,
+  1,
+  snap_edges => true
+);
+SELECT 't6034.snap.node_collision.invalid', * FROM topology.ValidateTopology('t6034_node_collision');
+SELECT NULL FROM topology.DropTopology('t6034_node_collision');
+
+SELECT NULL FROM topology.CreateTopology('t6034_motion_collision', 0, 0);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_motion_collision', 'LINESTRING(0 0,1 0,100 0)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddPoint('t6034_motion_collision', 'POINT(50 0.505050505050505)'::geometry);
+SELECT 't6034.snap.motion_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  't6034_motion_collision',
+  'LINESTRING(1 1,1 2)'::geometry,
+  2,
+  snap_edges => true
+);
+SELECT 't6034.snap.motion_collision.invalid', * FROM topology.ValidateTopology('t6034_motion_collision');
+SELECT NULL FROM topology.DropTopology('t6034_motion_collision');
+
+SELECT NULL FROM topology.CreateTopology('t6034_edge_collision', 0, 0);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_edge_collision', 'LINESTRING(0 0,5 0.4,10 0)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_edge_collision', 'LINESTRING(5 0.6,5 2)'::geometry);
+SELECT 't6034.snap.edge_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  't6034_edge_collision',
+  'LINESTRING(5 1,5 3)'::geometry,
+  1,
+  snap_edges => true
+);
+SELECT 't6034.snap.edge_collision.invalid', * FROM topology.ValidateTopology('t6034_edge_collision');
+SELECT NULL FROM topology.DropTopology('t6034_edge_collision');
+
+SELECT NULL FROM topology.CreateTopology('t6034_staged_collision', 0, 0);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_collision', 'LINESTRING(0 0,5 0.4,10 0)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_collision', 'LINESTRING(0 2,5 1.6,10 2)'::geometry);
+SELECT 't6034.snap.staged_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  't6034_staged_collision',
+  'LINESTRING(5 1,6 3)'::geometry,
+  1,
+  snap_edges => true
+);
+SELECT 't6034.snap.staged_collision.invalid', * FROM topology.ValidateTopology('t6034_staged_collision');
+SELECT NULL FROM topology.DropTopology('t6034_staged_collision');
+
+\i :top_builddir/topology/test/load_topology.sql
+SELECT NULL FROM topology.ST_AddEdgeModFace(
+  'city_data',
+  17,
+  18,
+  'LINESTRING(21 22,28 27,35 22)'
+);
+SELECT 't6034.snap.adjacency_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  'city_data',
+  'LINESTRING(28 18,28 17)'::geometry,
+  10,
+  snap_edges => true
+);
+SELECT 't6034.snap.adjacency_collision.invalid', * FROM topology.ValidateTopology('city_data');
+SELECT NULL FROM topology.DropTopology('city_data');

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -722,6 +722,19 @@ FROM topology.TopoGeo_AddLinestring(
 SELECT 't6034.snap.edge_collision.invalid', * FROM topology.ValidateTopology('t6034_edge_collision');
 SELECT NULL FROM topology.DropTopology('t6034_edge_collision');
 
+SELECT NULL FROM topology.CreateTopology('t6034_swept_edge_collision', 0, 0);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_swept_edge_collision', 'LINESTRING(0 0,10 0,10 10,0 10,0 0)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_swept_edge_collision', 'LINESTRING(4 0.4,6 0.4)'::geometry);
+SELECT 't6034.snap.swept_edge_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  't6034_swept_edge_collision',
+  'LINESTRING(5 1,5 2)'::geometry,
+  2,
+  snap_edges => true
+);
+SELECT 't6034.snap.swept_edge_collision.invalid', * FROM topology.ValidateTopology('t6034_swept_edge_collision');
+SELECT NULL FROM topology.DropTopology('t6034_swept_edge_collision');
+
 SELECT NULL FROM topology.CreateTopology('t6034_staged_collision', 0, 0);
 SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_collision', 'LINESTRING(0 0,5 0.4,10 0)'::geometry);
 SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_collision', 'LINESTRING(0 2,5 1.6,10 2)'::geometry);
@@ -734,6 +747,19 @@ FROM topology.TopoGeo_AddLinestring(
 );
 SELECT 't6034.snap.staged_collision.invalid', * FROM topology.ValidateTopology('t6034_staged_collision');
 SELECT NULL FROM topology.DropTopology('t6034_staged_collision');
+
+SELECT NULL FROM topology.CreateTopology('t6034_staged_swept_collision', 0, 0);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_swept_collision', 'LINESTRING(4 1.3,5 1.3,6 1.3)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t6034_staged_swept_collision', 'LINESTRING(0 0,5 0.4,10 0)'::geometry);
+SELECT 't6034.snap.staged_swept_collision', count(*) > 0
+FROM topology.TopoGeo_AddLinestring(
+  't6034_staged_swept_collision',
+  'LINESTRING(5 1.4,5 2)'::geometry,
+  2,
+  snap_edges => true
+);
+SELECT 't6034.snap.staged_swept_collision.invalid', * FROM topology.ValidateTopology('t6034_staged_swept_collision');
+SELECT NULL FROM topology.DropTopology('t6034_staged_swept_collision');
 
 \i :top_builddir/topology/test/load_topology.sql
 SELECT NULL FROM topology.ST_AddEdgeModFace(

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -242,5 +242,7 @@ t6034.snap.nearby|0
 t6034.snap.node_collision|t
 t6034.snap.motion_collision|t
 t6034.snap.edge_collision|t
+t6034.snap.swept_edge_collision|t
 t6034.snap.staged_collision|t
+t6034.snap.staged_swept_collision|t
 t6034.snap.adjacency_collision|t

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -245,4 +245,5 @@ t6034.snap.edge_collision|t
 t6034.snap.swept_edge_collision|t
 t6034.snap.staged_collision|t
 t6034.snap.staged_swept_collision|t
+t6034.snap.staged_closed_swept_collision|t
 t6034.snap.adjacency_collision|t

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -236,3 +236,11 @@ t6023.2|errors|
 t6062.edges|t
 t6064.1|t
 t6064.2|t
+t6034.default.nearby|t
+t6034.snap.edges|t
+t6034.snap.nearby|0
+t6034.snap.node_collision|t
+t6034.snap.motion_collision|t
+t6034.snap.edge_collision|t
+t6034.snap.staged_collision|t
+t6034.snap.adjacency_collision|t


### PR DESCRIPTION
## Summary
- add a `snap_edges` option to `TopoGeo_AddLinestring` for ticket #6034
- defer existing-edge geometry updates until after noding/splitting is computed
- compare snapped edge geometries with `lwgeom_same()` so coordinate-only snaps are preserved
- skip staged existing-edge snaps that would make `lwt_ChangeEdgeGeom` fail on node-motion, edge-crossing, staged-snap, swept-motion, or endpoint-adjacency disposition constraints
- add regression coverage showing default behavior still reports a nearby vertex/segment pair while `snap_edges => true` clears it, plus collision cases that are skipped safely
- document the new optional argument

Closes #6034

## Release / upgrade notes
- NEWS entry added for #6034.
- Topology SQL/C sources are updated; topology install/upgrade SQL is generated from `topology/sql/*.sql.in` during the normal extension build.

## Testing
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make install`
- `git diff --check`
- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C topology clean && make -C topology -j32`
- `sudo -n make -C postgis install`
- `sudo -n make -C topology install`
- `make -C extensions/postgis -j1 && sudo -n make -C extensions/postgis install`
- `make -C extensions/postgis_topology -j1 && sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring"` (covers snap-edge node-collision, edge-motion collision, edge-crossing collision, swept-edge collision, staged final-curve collision, staged swept-motion collision, and endpoint-adjacency collision skips plus normal/upgrade paths)
- `make -C doc check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/357
