### PR TITLE
Document ST_FindExtent

### DIFF
--- a/doc/reference_bbox.xml
+++ b/doc/reference_bbox.xml
@@ -198,6 +198,66 @@
       </refsection>
     </refentry>
 
+    <refentry xml:id="ST_FindExtent">
+      <refnamediv>
+        <refname>ST_FindExtent</refname>
+
+        <refpurpose>Returns the exact extent of a geometry column.</refpurpose>
+      </refnamediv>
+
+      <refsynopsisdiv>
+        <funcsynopsis>
+          <funcprototype>
+            <funcdef>box2d <function>ST_FindExtent</function></funcdef>
+            <paramdef><type>text </type> <parameter>schema_name</parameter></paramdef>
+            <paramdef><type>text </type> <parameter>table_name</parameter></paramdef>
+            <paramdef><type>text </type> <parameter>geocolumn_name</parameter></paramdef>
+          </funcprototype>
+
+          <funcprototype>
+            <funcdef>box2d <function>ST_FindExtent</function></funcdef>
+            <paramdef><type>text </type> <parameter>table_name</parameter></paramdef>
+            <paramdef><type>text </type> <parameter>geocolumn_name</parameter></paramdef>
+          </funcprototype>
+        </funcsynopsis>
+      </refsynopsisdiv>
+
+      <refsection>
+        <title>Description</title>
+
+        <para>Returns the exact extent of a geometry column as a <xref linkend="box2d_type"/>.
+        The current schema is used if not specified.</para>
+
+        <para>This function computes the exact table extent by scanning the table.
+        For a faster estimate based on table statistics, use
+        <xref linkend="ST_EstimatedExtent"/>.</para>
+
+        <para role="availability" conformance="2.2.0">Availability: 2.2.0</para>
+        <para role="changed" conformance="2.2.0">Changed: 2.2.0. In prior versions this was called ST_Find_Extent.</para>
+
+        <para>&curve_support;</para>
+      </refsection>
+
+      <refsection>
+        <title>Examples</title>
+
+        <programlisting>SELECT ST_FindExtent('ny', 'edges', 'geom');
+--result--
+BOX(-8877653 4912316,-8010225.5 5589284)
+
+SELECT ST_FindExtent('feature_poly', 'geom');
+--result--
+BOX(-124.659652709961 24.6830825805664,-67.7798080444336 49.0012092590332)
+        </programlisting>
+      </refsection>
+
+      <refsection>
+        <title>See Also</title>
+
+        <para><xref linkend="ST_EstimatedExtent"/>, <xref linkend="ST_Extent"/>, <xref linkend="ST_3DExtent"/></para>
+      </refsection>
+    </refentry>
+
     <refentry xml:id="ST_Expand">
       <refnamediv>
         <refname>ST_Expand</refname>

--- a/regress/core/estimatedextent.sql
+++ b/regress/core/estimatedextent.sql
@@ -5,6 +5,8 @@ analyze t;
 select '#877.2', ST_EstimatedExtent('public', 't','g');
 SET client_min_messages TO NOTICE;
 insert into t(g) values ('LINESTRING(-10 -50, 20 30)');
+select '#1689.1', ST_FindExtent('t','g');
+select '#1689.2', ST_FindExtent('public','t','g');
 
 -- #877.3
 select '#877.3', round(st_xmin(e.e)::numeric, 5), round(st_xmax(e.e)::numeric, 5),

--- a/regress/core/estimatedextent_expected
+++ b/regress/core/estimatedextent_expected
@@ -2,6 +2,8 @@ WARNING:  stats for "t.g" do not exist
 #877.1|
 WARNING:  stats for "t.g" do not exist
 #877.2|
+#1689.1|BOX(-10 -50,20 30)
+#1689.2|BOX(-10 -50,20 30)
 WARNING:  stats for "t.g" do not exist
 #877.3||||
 #877.4|-10.15000|20.15000|-50.40000|30.40000


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/1689

## Summary
- Add the missing `ST_FindExtent` manual entry.
- Document both table/column and schema/table/column signatures.
- Note the prior `ST_Find_Extent` name and cross-link exact/estimated extent alternatives.
- Add regression coverage for both `ST_FindExtent` signatures.

## Current branch
- Base: `postgis/postgis` `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- Head: `103c6f6ba9c814420182ebe9a462f1ed4aa2d49a`

## Validation
- `make -C doc check`
- `make -C regress/core check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/regress/core/estimatedextent"`; the harness also ran the upgrade pass because `--upgrade` was not explicitly supplied
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- doc/reference_bbox.xml regress/core/estimatedextent.sql regress/core/estimatedextent_expected`

The focused regression exercises this docs/test-only PR against the PostGIS build currently installed in the local PostgreSQL cluster; the patch does not modify extension SQL or compiled code. GitHub CI has been queued for this refreshed head.
