### PR TITLE
Fix geometry_columns stale relation lookup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -64,6 +64,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
  - #3103, Add regression coverage for exact-schema find_srid and
           geometry_columns lookups (Darafei Praliaskouski)
+ - #6038, Avoid stale relation lookups in geometry_columns after topology
+          objects are dropped (Darafei Praliaskouski)
  - #5655, [doc] Skip XML validation during `make check` when xsltproc is
           unavailable (Darafei Praliaskouski)
  - #5487, Improve error detail for repeated upgrades after an incomplete

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -6521,7 +6521,40 @@ SELECT current_database()::character varying(256) AS f_table_catalog,
      ) sr ON sr.connamespace = n.oid AND sr.conrelid = c.oid AND (a.attnum = ANY (sr.conkey))
   WHERE (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'm'::"char", 'f'::"char", 'p'::"char"]))
   AND NOT c.relname = 'raster_columns'::name AND t.typname = 'geometry'::name
-  AND NOT pg_is_other_temp_schema(c.relnamespace) AND has_table_privilege(c.oid, 'SELECT'::text);
+  AND NOT pg_is_other_temp_schema(c.relnamespace)
+  -- A stale MVCC snapshot can still see a dropped pg_class row (#6038).
+  -- Re-resolve the qualified relation name only when the schema is visible,
+  -- because to_regclass reports permission errors for inaccessible schemas.
+  -- Without schema visibility, keep the old OID-based privilege semantics.
+  -- Keep the visible-schema SELECT check in the same CASE branch as the
+  -- re-resolution guard so PostgreSQL cannot evaluate it for a stale OID.
+  AND CASE WHEN has_schema_privilege(c.relnamespace, 'USAGE'::text)
+           THEN CASE WHEN pg_catalog.to_regclass(pg_catalog.format('%I.%I', n.nspname, c.relname)) = c.oid
+                     THEN pg_catalog.has_table_privilege(c.oid, 'SELECT')
+                     ELSE false
+                END
+           ELSE pg_catalog.has_table_privilege(c.oid, 'SELECT') IS NOT NULL
+      END
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM pg_roles
+      WHERE rolname = current_user
+        AND rolsuper
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM pg_roles
+      WHERE rolname = 'pg_read_all_data'
+        AND pg_has_role(current_user, oid, 'USAGE')
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) AS acl
+      WHERE acl.privilege_type = 'SELECT'
+        AND (acl.grantee = 0 OR pg_has_role(acl.grantee, 'USAGE'))
+    )
+  );
 
 -- TODO: support RETURNING and raise a WARNING
 CREATE OR REPLACE RULE geometry_columns_insert AS

--- a/regress/core/regress_management.sql
+++ b/regress/core/regress_management.sql
@@ -4,5 +4,65 @@ SET client_min_messages TO warning;
 CREATE TABLE test_pt(gid SERIAL PRIMARY KEY, geom geometry);
 INSERT INTO test_pt(geom) VALUES(ST_GeomFromEWKT('SRID=4326;POINT M(1 2 3)'));
 SELECT populate_geometry_columns('test_pt'::regclass);
+SELECT '#6038.before', srid FROM geometry_columns WHERE f_table_schema = 'public' AND f_table_name = 'test_pt' AND f_geometry_column = 'geom';
 SELECT 'The result: ' || DropGeometryTable('test_pt');
+SELECT '#6038.after', count(*) FROM geometry_columns WHERE f_table_schema = 'public' AND f_table_name = 'test_pt' AND f_geometry_column = 'geom';
+DO $$
+DECLARE
+	can_switch_role boolean;
+BEGIN
+	SELECT rolsuper INTO can_switch_role
+	FROM pg_roles
+	WHERE rolname = current_user;
+
+	IF can_switch_role THEN
+		DROP SCHEMA IF EXISTS test6038_private CASCADE;
+		DROP TABLE IF EXISTS public.test6038_visible_geom;
+		DROP ROLE IF EXISTS test6038_invisible;
+		DROP ROLE IF EXISTS test6038_visible;
+		CREATE ROLE test6038_invisible;
+		CREATE ROLE test6038_visible;
+		GRANT test6038_invisible TO CURRENT_USER;
+		GRANT test6038_visible TO CURRENT_USER;
+		CREATE TABLE public.test6038_visible_geom(geom geometry(Point, 4326));
+		GRANT SELECT ON public.test6038_visible_geom TO test6038_visible;
+		CREATE SCHEMA test6038_private;
+		CREATE TABLE test6038_private.hidden_geom(geom geometry(Point, 4326));
+		REVOKE ALL ON SCHEMA test6038_private FROM PUBLIC;
+		GRANT SELECT ON test6038_private.hidden_geom TO test6038_invisible;
+
+		EXECUTE 'SET LOCAL ROLE test6038_visible';
+		IF 1 != (SELECT count(*) FROM geometry_columns WHERE f_table_schema = 'public' AND f_table_name = 'test6038_visible_geom') THEN
+			RAISE EXCEPTION 'geometry_columns did not expose currently selectable table in visible schema';
+		END IF;
+		EXECUTE 'RESET ROLE';
+
+		REVOKE SELECT ON public.test6038_visible_geom FROM test6038_visible;
+		EXECUTE 'SET LOCAL ROLE test6038_visible';
+		IF 0 != (SELECT count(*) FROM geometry_columns WHERE f_table_schema = 'public' AND f_table_name = 'test6038_visible_geom') THEN
+			RAISE EXCEPTION 'geometry_columns exposed metadata after SELECT was revoked in visible schema';
+		END IF;
+		EXECUTE 'RESET ROLE';
+
+		-- The view must not resolve names inside schemas hidden from the caller.
+		EXECUTE 'SET LOCAL ROLE test6038_invisible';
+		IF 1 != (SELECT count(*) FROM geometry_columns WHERE f_table_schema = 'test6038_private') THEN
+			RAISE EXCEPTION 'geometry_columns did not preserve OID-based SELECT visibility in hidden schema';
+		END IF;
+		EXECUTE 'RESET ROLE';
+
+		REVOKE SELECT ON test6038_private.hidden_geom FROM test6038_invisible;
+		EXECUTE 'SET LOCAL ROLE test6038_invisible';
+		IF 0 != (SELECT count(*) FROM geometry_columns WHERE f_table_schema = 'test6038_private') THEN
+			RAISE EXCEPTION 'geometry_columns exposed hidden-schema metadata after SELECT was revoked';
+		END IF;
+		EXECUTE 'RESET ROLE';
+
+		DROP SCHEMA test6038_private CASCADE;
+		DROP TABLE public.test6038_visible_geom;
+		DROP ROLE test6038_invisible;
+		DROP ROLE test6038_visible;
+	END IF;
+END
+$$;
 SELECT 'Unexistant: ' || DropGeometryTable('unexistent'); -- see ticket #861

--- a/regress/core/regress_management_expected
+++ b/regress/core/regress_management_expected
@@ -1,3 +1,5 @@
 1
+#6038.before|4326
 The result: public.test_pt dropped.
+#6038.after|0
 Unexistant: public.unexistent dropped.


### PR DESCRIPTION
## Summary
- Filter stale `pg_class` rows from `geometry_columns` by re-resolving the qualified relation name before exposing geometry metadata when the schema name is visible.
- Preserve the hidden-schema path by keeping an OID-only existence check while requiring visible schemas to pass PostgreSQL's current `has_table_privilege(c.oid, 'SELECT')` check.
- Replace the `geometry_columns` SELECT visibility check with catalog ACL logic so dropped relations are not opened again by OID.
- Preserve superuser, predefined reader role, inherited-role, and PUBLIC SELECT visibility semantics without overriding explicit owner ACL revokes.
- Add regression coverage for `geometry_columns` before and after `DropGeometryTable`, visible-schema SELECT revokes, and hidden-schema SELECT grant/revoke behavior when the runner can switch roles without requiring that privilege in sandboxed runs.

Closes https://trac.osgeo.org/postgis/ticket/6038

## Release / upgrade notes
- NEWS entry added for https://trac.osgeo.org/postgis/ticket/6038.
- SQL view definition is updated in `postgis/postgis.sql.in`; extension upgrade SQL is generated from the SQL sources during the normal extension build.

## Maintenance notes
- current head: `457b045f8d842dbdc4ee7f9a0568918341e9e2c2`
- the current patch uses the current privilege check for visible schemas while keeping hidden-schema name resolution out of the stale-OID guard

## Tests
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git diff --check gitea/master..HEAD`
- `git diff --check`
- `git clang-format --diff upstream/master -- postgis/postgis.sql.in regress/core/regress_management.sql regress/core/regress_management_expected NEWS`
- `make -C postgis -j32`
- `sudo -n make -C postgis install`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C extensions/postgis install`
- `rm -rf regress/00-regress-install && make -C regress staged-install-core`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/regress_management"` (fresh and automatic upgrade paths)
- manual two-session stale-snapshot smokes on PostgreSQL 18: after another session dropped the table, stale-transaction `geometry_columns` returned zero rows and `find_srid` raised the normal not-registered exception; after another session revoked SELECT, the stale transaction stopped seeing the `geometry_columns` row
- manual SQL ACL smoke for no grant, inherited role grant, PUBLIC grant, explicit owner SELECT revoke, predefined reader role, and superuser visibility