### PR TITLE
topology: keep closest-edge KNN lookup index-orderable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -105,6 +105,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,
           including guards for malformed TWKB reads and counts (Darafei Praliaskouski)
+ - #5903, [topology] Keep closest-edge KNN lookups index-orderable
+          on PostgreSQL/GiST versions that reject secondary sorts
+          (Darafei Praliaskouski)
  - #6073, #6074, Stabilize geography LRS endpoint interpolation and pole
           centroid regressions on 32-bit systems (Darafei Praliaskouski)
  - #6082, Fix Japanese PDF build by avoiding non-ASCII arrows in SQL

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -3116,7 +3116,7 @@ cb_getClosestEdge( const LWT_BE_TOPOLOGY* topo, const LWPOINT* pt, uint64_t *num
   addEdgeFields(sql, fields, 0);
   appendStringInfo(sql,
 		   " FROM \"%s\".edge_data"
-		   " ORDER BY geom <-> $1 ASC, edge_id ASC"
+		   " ORDER BY geom <-> $1 ASC"
 		   " LIMIT 1",
 		   topo->name);
 


### PR DESCRIPTION
Summary:
- Remove the secondary `edge_id` sort from the topology closest-edge KNN query so PostgreSQL can keep using GiST distance ordering.
- Add a NEWS entry for the topology regression reported in https://trac.osgeo.org/postgis/ticket/5903.

Release / upgrade notes:
- NEWS records the bug fix for https://trac.osgeo.org/postgis/ticket/5903.
- No SQL upgrade step is needed; this changes topology C query behavior only.

Current base/head:
- Base: `45c26068ef27de003a39e69c01532340063ecc13` (`upstream/master`)
- Head: `b05871b604ecfe5f3ad11ea9355bdfd27d409c35`

Validation:
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
- `git clang-format --diff upstream/master -- topology/postgis_topology.c`
- `./utils/check_news.sh .`
- `/usr/bin/perl ./utils/repo_revision.pl && make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C libpgcommon -j32`
- `make -C postgis -j32`
- `make -C topology -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `make -C extensions/postgis_topology -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring $(pwd)/topology/test/regress/getfacecontainingpoint"`
- Extra neighboring coverage: `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topogeo_addpoint"`

Closes #5903

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/356
