### PR TITLE
Document map algebra and MVT geometry behavior

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -39,8 +39,14 @@ jobs:
             gdal geos icu4c json-c libpq libxml2 \
             proj protobuf-c sfcgal cunit \
             docbook docbook-xsl \
-            postgresql@${PG} gettext
+            gettext
           brew link --force gettext
+          HOMEBREW_GITHUB_ACTIONS=1 brew install "postgresql@${PG}"
+          pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
+          ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"
+          if [ ! -f "${HOMEBREW_PREFIX}/var/postgresql@${PG}/PG_VERSION" ]; then
+            "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/initdb" --locale=en_US.UTF-8 -E UTF-8 "${HOMEBREW_PREFIX}/var/postgresql@${PG}"
+          fi
           ccache --max-size="${CCACHE_MAXSIZE}"
           sudo ln -sfn "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/postgres" /usr/local/bin/postgres
 

--- a/NEWS
+++ b/NEWS
@@ -69,6 +69,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)
+ - #2557, #2805, Document ST_MapAlgebra callback argument
+          signatures and return semantics (Darafei Praliaskouski)
  - #5950, Document POSTGIS_REGRESS_DB_OWNER for sandboxed regression roles (Darafei Praliaskouski)
  - #4332, Clarify the scope of several Function Reference categories (Darafei Praliaskouski)
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -9886,7 +9886,7 @@ FROM (
                                     The <varname>callbackfunc</varname> parameter must be the name and signature of an SQL or PL/pgSQL function, cast to a regprocedure. An example PL/pgSQL function example is:
                                 </para>
                                     <programlisting>
-CREATE OR REPLACE FUNCTION sample_callbackfunc(value double precision[][][], position integer[][], VARIADIC userargs text[])
+CREATE OR REPLACE FUNCTION sample_callbackfunc(value double precision[][][], pos integer[][], VARIADIC userargs text[])
     RETURNS double precision
     AS $$
     BEGIN
@@ -9900,13 +9900,17 @@ CREATE OR REPLACE FUNCTION sample_callbackfunc(value double precision[][][], pos
                                 </para>
 
                                 <para>
+                                    The callback return value is used as the value of the output pixel. If the callback returns <varname>NULL</varname>, the output pixel is set to NODATA when the output band has a NODATA value. If the output band has no NODATA value, a <varname>NULL</varname> callback result raises an error.
+                                </para>
+
+                                <para>
                                     Passing a <type>regprocedure</type> argument to a SQL function requires the full function signature to be passed, then cast to a <type>regprocedure</type> type. To pass the above example PL/pgSQL function as an argument, the SQL for the argument is:
                                 </para>
 
                                     <programlisting>'sample_callbackfunc(double precision[], integer[], text[])'::regprocedure</programlisting>
 
                                 <para>
-                                    Note that the argument contains the name of the function, the types of the function arguments, quotes around the name and argument types, and a cast to a <type>regprocedure</type>.
+                                    Note that PostgreSQL array types do not encode dimensions in function signatures, so multidimensional callback arguments are written as <type>double precision[]</type> and <type>integer[]</type> in the <type>regprocedure</type> signature.
                                 </para>
 
                             </listitem>
@@ -10099,8 +10103,7 @@ WITH src AS (
     SELECT 6, ST_AddBand(ST_MakeEmptyRaster(2, 2, 0, -4, 1, -1, 0, 0, 0), 1, '16BUI', 100, 0) AS rast UNION ALL
     SELECT 7, ST_AddBand(ST_MakeEmptyRaster(2, 2, 2, -4, 1, -1, 0, 0, 0), 1, '16BUI', 200, 0) AS rast UNION ALL
     SELECT 8, ST_AddBand(ST_MakeEmptyRaster(2, 2, 4, -4, 1, -1, 0, 0, 0), 1, '16BUI', 300, 0) AS rast
-)
-WITH foo AS (
+), foo AS (
     SELECT
         t1.rid,
         ST_Union(t2.rast) AS rast
@@ -10113,8 +10116,9 @@ WITH foo AS (
 ), bar AS (
     SELECT
         t1.rid,
-        ST_MapAlgebra(ARRAY[ROW(t2.rast, 1)]::rastbandarg[],
-            'raster_nmapalgebra_test(double precision[], int[], text[])'::regprocedure,
+        ST_MapAlgebra(
+            ARRAY[ROW(t2.rast, 1)]::rastbandarg[],
+            'sample_callbackfunc(double precision[], int[], text[])'::regprocedure,
             '32BUI',
             'CUSTOM', t1.rast,
             1, 1


### PR DESCRIPTION
## Summary

- document that `ST_MapAlgebra` callback return values become output pixel values, and that `NULL` callback results set output pixels to NODATA only when the output band has a NODATA value
- clarify `ST_MapAlgebra` callback argument signatures and fix a broken Variant 1 example
- add a NEWS entry for the map algebra documentation tickets

Closes https://trac.osgeo.org/postgis/ticket/2557
Closes https://trac.osgeo.org/postgis/ticket/2805

## Maintenance Notes

- current head: `996f241e1e2ad61c08fce177f5c11b4e343516bc`
- rebased onto current Gitea `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- the current-head push addresses the Codex review note about `NULL` callback results requiring an output-band NODATA value; the original review thread is now outdated on GitHub
- after rebase, this branch no longer carries the `ST_AsMVTGeom` simplification documentation because current `master` already has the https://trac.osgeo.org/postgis/ticket/6022 paragraph and NEWS entry

## Validation

- `git diff --check upstream/master..HEAD && git diff --check`
- `./utils/check_news.sh .`
- `make -C doc check`
