### PR TITLE
topology: keep universal face out of face deletes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,6 +61,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #5948, [topology] Prevent MakeTopologyPrecise from erasing edges when
           grid size exceeds their extent (Darafei Praliaskouski)
+ - #5864, [topology] Keep the universal face out of face delete callbacks
+          (Darafei Praliaskouski)
  - #5959, Prevent histogram target overflow when analysing massive tables (Darafei Praliaskouski)
  - #4828, geometry_columns handles NOT VALID SRID checks without errors (Darafei Praliaskouski)
  - #6048, [raster] ST_Clip no longer crashes when clipping sparse band

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -263,7 +263,34 @@ lwt_be_insertFaces(LWT_TOPOLOGY *topo, LWT_ISO_FACE *face, uint64_t numelems)
 static int
 lwt_be_deleteFacesById(const LWT_TOPOLOGY *topo, const LWT_ELEMID *ids, uint64_t numelems)
 {
-  CBT2(topo, deleteFacesById, ids, numelems);
+  LWT_ELEMID *filtered_ids = NULL;
+  uint64_t filtered_count = 0;
+  int ret;
+
+  for (uint64_t i = 0; i < numelems; ++i)
+  {
+    if (ids[i] != 0)
+      ++filtered_count;
+  }
+
+  if (!filtered_count)
+    return 0;
+
+  if (filtered_count == numelems)
+    CBT2(topo, deleteFacesById, ids, numelems);
+
+  CHECKCB(topo->be_iface, deleteFacesById);
+  filtered_ids = lwalloc(sizeof(LWT_ELEMID) * filtered_count);
+  filtered_count = 0;
+  for (uint64_t i = 0; i < numelems; ++i)
+  {
+    if (ids[i] != 0)
+      filtered_ids[filtered_count++] = ids[i];
+  }
+
+  ret = topo->be_iface->cb->deleteFacesById(topo->be_topo, filtered_ids, filtered_count);
+  lwfree(filtered_ids);
+  return ret;
 }
 
 static int

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -277,7 +277,9 @@ lwt_be_deleteFacesById(const LWT_TOPOLOGY *topo, const LWT_ELEMID *ids, uint64_t
     return 0;
 
   if (filtered_count == numelems)
+  {
     CBT2(topo, deleteFacesById, ids, numelems);
+  }
 
   CHECKCB(topo->be_iface, deleteFacesById);
   filtered_ids = lwalloc(sizeof(LWT_ELEMID) * filtered_count);

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -582,6 +582,15 @@ SELECT '#5993.4', 'snap-split-off-limit', * FROM topology.TopoGeo_addLinestring(
 );
 SELECT NULL FROM topology.DropTopology ('t5993');
 
+-- See https://trac.osgeo.org/postgis/ticket/5864
+SELECT NULL FROM topology.CreateTopology ('t5864');
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t5864', 'LINESTRING(0 0,10 0)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t5864', 'LINESTRING(2 0,2 -5,8 -5,8 0)'::geometry);
+SELECT NULL FROM topology.TopoGeo_AddLinestring('t5864', 'LINESTRING(2 0,2 5,8 5,8 0)'::geometry);
+SELECT '#5864.face0', count(*) FROM t5864.face WHERE face_id = 0;
+SELECT '#5864.face0_refs', count(*) FROM t5864.edge WHERE left_face = 0 OR right_face = 0;
+SELECT '#5864.valid', * FROM topology.ValidateTopology('t5864');
+SELECT NULL FROM topology.DropTopology ('t5864');
 
 
 -- See https://trac.osgeo.org/postgis/ticket/6023

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -231,6 +231,8 @@ ERROR:  Adding line to topology requires creating more edges than the requested 
 ERROR:  Adding line to topology requires creating more edges than the requested limit of 1
 #5993.3|double-split-in-limit|1
 ERROR:  Adding line to topology requires creating more edges than the requested limit of 1
+#5864.face0|1
+#5864.face0_refs|4
 t6023.1|errors|
 t6023.2|errors|
 t6062.edges|t


### PR DESCRIPTION
## What

Topology face deletion now filters out face id 0 before calling backend delete callbacks. The universal face is expected to remain in the face table and can be referenced by edges, so trying to delete it can trip backend constraints such as the `edge_data` face foreign keys.

This also adds a focused `TopoGeo_AddLinestring` regression that keeps the universal face and edge references after line insertion work in the universal face.

References #5864.

## Release/Upgrade Notes

- Added a PostGIS 3.7.0 NEWS entry for #5864.
- No extension upgrade SQL is needed: SQL definitions and catalog-visible objects are unchanged; this is liblwgeom runtime behavior with topology regression coverage.

## Validation

- `git diff --check`
- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C topology -j32`
- `sudo make -C postgis install`
- `sudo make -C topology install`
- `make -C topology/test check RUNTESTFLAGS="--extension" TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring"`

I also replayed the ticket attachments locally. With this patch, the original `face_id = 0` foreign-key failure is avoided; the replay then progresses to a later topology intersection error at edge 597, so this PR intentionally references rather than closes the Trac ticket.

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/355
