### PR TITLE
doc: skip XML checks without xsltproc

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -264,6 +264,11 @@ VPATH = $(srcdir)
 
 CAN_CHECK_XML = yes
 
+ifeq ($(XSLTPROC),)
+check-xml: requirements_not_met_xsltproc
+CAN_CHECK_XML = no
+endif
+
 ifeq ($(XMLLINT),)
 postgis-nospecial.xml: requirements_not_met_xmllint
 postgis-out.xml: requirements_not_met_xmllint


### PR DESCRIPTION
Summary:
- skip doc XML validation from `make -C doc check` when configure did not find `xsltproc`
- keep direct `make -C doc check-xml` failing loudly with the existing dependency message

Validation:
- git diff --check
- make -C doc check XSLTPROC=
- make -C doc check-xml XSLTPROC=  # expected dependency failure
- make -C doc check

Closes #5655
