### PR TITLE
build: keep compiler flags out of PGXS CPPFLAGS

### DIFF
--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -146,7 +146,8 @@ OBJS=$(PG_OBJS)
 # to an existing liblwgeom.so in the PostgreSQL $libdir supplied by an
 # older version of PostGIS, rather than with the static liblwgeom.a
 # supplied with newer versions of PostGIS
-PG_CPPFLAGS += -I@top_srcdir@/liblwgeom -I@top_builddir@/liblwgeom @CFLAGS@ @MODULE_CFLAGS@ -I@top_srcdir@/libpgcommon $(FLATGEOBUF_INCLUDE) $(WAYGU_INCLUDE) $(UTHASH_INCLUDE) @CPPFLAGS@ @PICFLAGS@
+PG_CPPFLAGS += -I@top_srcdir@/liblwgeom -I@top_builddir@/liblwgeom -I@top_srcdir@/libpgcommon $(FLATGEOBUF_INCLUDE) $(WAYGU_INCLUDE) $(UTHASH_INCLUDE) @CPPFLAGS@
+PG_CFLAGS += @CFLAGS@ @MODULE_CFLAGS@ @PICFLAGS@
 SHLIB_LINK_F = $(WAYGU_LIB) $(FLATGEOBUF_LIB) ../libpgcommon/libpgcommon.a ../liblwgeom/.libs/liblwgeom.a @SHLIB_LINK@
 
 # Extra files to remove during 'make clean'

--- a/raster/rt_pg/Makefile.in
+++ b/raster/rt_pg/Makefile.in
@@ -78,8 +78,6 @@ CC = @CC@
 PG_CPPFLAGS += \
 	$(LIBLWGEOM_CFLAGS) \
 	@CPPFLAGS@ \
-	@CFLAGS@ \
-	@MODULE_CFLAGS@ \
 	$(LIBGDAL_CFLAGS) \
 	$(LIBPGCOMMON_CFLAGS) \
 	$(LIBPROJ_CFLAGS) \
@@ -87,6 +85,7 @@ PG_CPPFLAGS += \
 	-I@builddir@ \
 	-I@builddir@/.. \
 	-I@top_builddir@
+PG_CFLAGS += @CFLAGS@ @MODULE_CFLAGS@
 SHLIB_LINK_F = @builddir@/../rt_core/librtcore.a $(LIBLWGEOM_LDFLAGS) $(LIBPGCOMMON_LDFLAGS) $(LIBGDAL_LDFLAGS) @SHLIB_LINK@
 
 # Extra files to remove during 'make clean'

--- a/sfcgal/Makefile.in
+++ b/sfcgal/Makefile.in
@@ -55,7 +55,8 @@ OBJS = lwgeom_sfcgal.o postgis_sfcgal_legacy.o
 # to an existing liblwgeom.so in the PostgreSQL $libdir supplied by an
 # older version of PostGIS, rather than with the static liblwgeom.a
 # supplied with newer versions of PostGIS
-PG_CPPFLAGS += -I@top_builddir@/liblwgeom -I@top_srcdir@/liblwgeom -I@top_srcdir@/libpgcommon @CFLAGS@ @MODULE_CFLAGS@ @CPPFLAGS@ @PICFLAGS@
+PG_CPPFLAGS += -I@top_builddir@/liblwgeom -I@top_srcdir@/liblwgeom -I@top_srcdir@/libpgcommon @CPPFLAGS@
+PG_CFLAGS += @CFLAGS@ @MODULE_CFLAGS@ @PICFLAGS@
 SHLIB_LINK_F = @top_builddir@/libpgcommon/libpgcommon.a @top_builddir@/liblwgeom/.libs/liblwgeom.a @SHLIB_LINK@
 
 # Add SFCGAL Flags if defined

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -52,7 +52,8 @@ OBJS = postgis_topology.o
 # to an existing liblwgeom.so in the PostgreSQL $libdir supplied by an
 # older version of PostGIS, rather than with the static liblwgeom.a
 # supplied with newer versions of PostGIS
-PG_CPPFLAGS += -I@top_builddir@/liblwgeom -I@top_srcdir@/liblwgeom -I@top_srcdir@/libpgcommon @CFLAGS@ @MODULE_CFLAGS@ @CPPFLAGS@ @PICFLAGS@
+PG_CPPFLAGS += -I@top_builddir@/liblwgeom -I@top_srcdir@/liblwgeom -I@top_srcdir@/libpgcommon @CPPFLAGS@
+PG_CFLAGS += @CFLAGS@ @MODULE_CFLAGS@ @PICFLAGS@
 SHLIB_LINK_F = @top_builddir@/libpgcommon/libpgcommon.a @top_builddir@/liblwgeom/.libs/liblwgeom.a @SHLIB_LINK@
 
 # Add SFCGAL Flags if defined


### PR DESCRIPTION
Summary:
- Move PostGIS module compiler flags from `PG_CPPFLAGS` to `PG_CFLAGS`.
- Keep include and preprocessor flags in `PG_CPPFLAGS` for PGXS and LLVM bitcode builds.
- Prevent PostgreSQL's `CLANG` bitcode rules from receiving flags meant for the configured C compiler.

Release / upgrade notes:
- No NEWS entry is added because this is build-system behavior only.
- No database extension upgrade step is needed; installed SQL/catalog objects are unchanged.

Current base/head:
- Base: `45c26068ef27de003a39e69c01532340063ecc13` (`upstream/master`)
- Head: `e1ac08804636c35be5b1779aa9ac530ec05fd93d`

Validation:
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
- `./autogen.sh`
- `CFLAGS="-O2 -fno-ipa-icf" ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `/usr/bin/perl ./utils/repo_revision.pl && make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C libpgcommon -j32`
- `make -n -C postgis lwgeom_inout.o lwgeom_inout.bc`
- `make -n -C raster/rt_pg rtpg_pixel.o rtpg_pixel.bc`
- `make -n -C topology postgis_topology.o postgis_topology.bc`
- `make -n -C sfcgal lwgeom_sfcgal.o lwgeom_sfcgal.bc`
- Dry-run assertion: for postgis, raster, topology, and sfcgal, the representative gcc `.o` command contains `-fno-ipa-icf` and the paired clang `.bc` command does not.
- `make -C postgis -j32`
- `make -C raster/rt_pg -j32`
- `make -C topology -j32`
- `make -C sfcgal -j32`

Closes #5733

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/354
