### PR TITLE
postgis: fix UpdateGeometrySRID catalog parameter name

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -58,6 +58,8 @@ jobs:
             postgresql@${PG} gettext
           brew link --force gettext
           ccache --max-size="${CCACHE_MAXSIZE}"
+          pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
+          ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"
           sudo ln -sfn "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/postgres" /usr/local/bin/postgres
 
       - name: Build and test

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -55,8 +55,14 @@ jobs:
             gdal geos icu4c json-c libpq libxml2 \
             proj protobuf-c sfcgal cunit \
             docbook docbook-xsl \
-            postgresql@${PG} gettext
+            gettext
           brew link --force gettext
+          HOMEBREW_GITHUB_ACTIONS=1 brew install "postgresql@${PG}"
+          pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
+          ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"
+          if [ ! -f "${HOMEBREW_PREFIX}/var/postgresql@${PG}/PG_VERSION" ]; then
+            "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/initdb" --locale=en_US.UTF-8 -E UTF-8 "${HOMEBREW_PREFIX}/var/postgresql@${PG}"
+          fi
           ccache --max-size="${CCACHE_MAXSIZE}"
           pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
           ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"

--- a/NEWS
+++ b/NEWS
@@ -38,11 +38,19 @@ These are only changes since 3.7.0beta1.
  - GT-564, Avoid ST_MakePolygon failures with NULL hole array entries
           (Darafei Praliaskouski)
  - #6110, regression in speed with geometry_columns
+ - #2630, Fix typo in five-argument UpdateGeometrySRID catalog_name parameter
+          (Darafei Praliaskouski)
 
 * Enhancements *
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+
+* Breaking Changes *
+
+ - #2630, Recreate five-argument UpdateGeometrySRID during extension upgrade
+          to correct the first argument name from catalogn_name to catalog_name
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta1
 2026/07/20

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,14 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 These are only changes since 3.7.0beta1.
 
+* Breaking Changes *
+
+ - #2630, Recreate five-argument UpdateGeometrySRID during extension upgrade
+          to correct the first argument name from catalogn_name to catalog_name
+          (Darafei Praliaskouski)
+ - #2630, Fix typo in five-argument UpdateGeometrySRID catalog_name parameter
+          (Darafei Praliaskouski)
+
 * Bug Fixes *
 
  - Stop the extension upgrade script running ANALYZE inside its transaction,
@@ -38,8 +46,6 @@ These are only changes since 3.7.0beta1.
  - GT-564, Avoid ST_MakePolygon failures with NULL hole array entries
           (Darafei Praliaskouski)
  - #6110, regression in speed with geometry_columns
- - #2630, Fix typo in five-argument UpdateGeometrySRID catalog_name parameter
-          (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -2883,7 +2883,7 @@ LANGUAGE 'sql' VOLATILE STRICT;
 --
 -----------------------------------------------------------------------
 -- Changed: 2.1.4 check against real_schema
-CREATE OR REPLACE FUNCTION UpdateGeometrySRID(catalogn_name varchar,schema_name varchar,table_name varchar,column_name varchar,new_srid_in integer)
+CREATE OR REPLACE FUNCTION UpdateGeometrySRID(catalog_name varchar,schema_name varchar,table_name varchar,column_name varchar,new_srid_in integer)
 	RETURNS text
 	AS
 $$

--- a/postgis/postgis_before_upgrade.sql
+++ b/postgis/postgis_before_upgrade.sql
@@ -53,7 +53,8 @@ SELECT _postgis_drop_function_by_identity
 SELECT _postgis_drop_function_by_identity
 	(
 	'UpdateGeometrySRID',
-	'catalogn_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer'
+	'catalogn_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer',
+	'370'
 	);
 
 

--- a/postgis/postgis_before_upgrade.sql
+++ b/postgis/postgis_before_upgrade.sql
@@ -46,6 +46,16 @@ SELECT _postgis_drop_function_by_identity
 	'catalogn_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid integer'
 	);
 
+-- FUNCTION UpdateGeometrySRID changed the name of the args (http://trac.osgeo.org/postgis/ticket/2630) for 3.7
+-- It changed the parameter `catalogn_name` to `catalog_name`
+-- (catalogn_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer)
+-- Dropping it conditionally since the same signature still exists.
+SELECT _postgis_drop_function_by_identity
+	(
+	'UpdateGeometrySRID',
+	'catalogn_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer'
+	);
+
 
 --deprecated and removed in 2.1
 -- Hack to fix 2.0 naming

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -631,6 +631,14 @@ SELECT '#1596.7', srid FROM geometry_columns
   WHERE f_table_name = 'road_pg' AND f_geometry_column = 'roads_geom';
 DROP TABLE road_pg;
 
+-- #2630 --
+SELECT '#2630', p.proargnames::text
+FROM pg_catalog.pg_proc p
+JOIN pg_catalog.pg_extension e ON e.extname = 'postgis'
+  AND e.extnamespace = p.pronamespace
+WHERE p.proname = 'updategeometrysrid'
+  AND p.proargtypes = '1043 1043 1043 1043 23'::oidvector;
+
 -- #1596
 WITH inp AS ( SELECT
  'POLYGON((-176 -22,-176 -21,-175 -21,-175 -22,-176 -22))'::geography as a,

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -634,9 +634,10 @@ DROP TABLE road_pg;
 -- #2630 --
 SELECT '#2630', p.proargnames::text
 FROM pg_catalog.pg_proc p
-JOIN pg_catalog.pg_extension e ON e.extname = 'postgis'
-  AND e.extnamespace = p.pronamespace
 WHERE p.proname = 'updategeometrysrid'
+  AND p.pronamespace = COALESCE(
+    (SELECT extnamespace FROM pg_catalog.pg_extension WHERE extname = 'postgis'),
+    pg_catalog.current_schema()::pg_catalog.regnamespace)
   AND p.proargtypes = '1043 1043 1043 1043 23'::oidvector;
 
 -- #1596

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -637,7 +637,7 @@ FROM pg_catalog.pg_proc p
 WHERE p.proname = 'updategeometrysrid'
   AND p.pronamespace = COALESCE(
     (SELECT extnamespace FROM pg_catalog.pg_extension WHERE extname = 'postgis'),
-    pg_catalog.current_schema()::pg_catalog.regnamespace)
+    pg_catalog.rtrim(:'schema', '.')::pg_catalog.regnamespace)
   AND p.proargtypes = '1043 1043 1043 1043 23'::oidvector;
 
 -- #1596

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -210,6 +210,7 @@ ERROR:  invalid SRID: 999000 not found in spatial_ref_sys
 NOTICE:  SRID value -1 converted to the officially unknown SRID value 0
 #1596.6|public.road_pg.roads_geom SRID changed to 0
 #1596.7|0
+#2630|{catalog_name,schema_name,table_name,column_name,new_srid_in}
 #1596|Point[GS]
 #1695|MULTIPOLYGON EMPTY
 #1697.1|0


### PR DESCRIPTION
Summary:

- Rename the five-argument `UpdateGeometrySRID` parameter from `catalogn_name` to `catalog_name`.
- Drop the old same-signature function during extension upgrade so PostgreSQL records the corrected argument name in `pg_proc`.
- Use a 3.7-specific deprecated-function suffix so the rename cannot collide with older `UpdateGeometrySRID` cleanup paths.
- Keep the regression assertion valid for extension installs, direct SQL loads, non-default schemas, and upgrade runs.
- Keep macOS CI PostgreSQL setup deterministic for the branch's validation path.
- Add the release note under both Breaking Changes and Bug Fixes because this is a catalog-visible argument-name correction.

Validation:

- `git diff --check`
- `git clang-format --diff origin/master -- postgis/postgis.sql.in postgis/postgis_before_upgrade.sql regress/core/tickets.sql .github/workflows/ci-macos.yml`
- `./utils/check_news.sh .`
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make -j32`
- `sudo -n make install`
- `make -C regress staged-install`
- `./regress/run_test.pl --build-dir "$(pwd)" --extension --verbose regress/core/tickets`
- `./regress/run_test.pl --build-dir "$(pwd)" --schema=postgis --verbose regress/core/tickets`
- `./regress/run_test.pl --build-dir "$(pwd)" --extension --schema=postgis --verbose regress/core/tickets`
- `./regress/run_test.pl --build-dir "$(pwd)" --extension --upgrade --verbose regress/core/tickets`
- `./regress/run_test.pl --build-dir "$(pwd)" --schema=postgis --upgrade --verbose regress/core/tickets`
- `./regress/run_test.pl --build-dir "$(pwd)" --extension --schema=postgis --upgrade --verbose regress/core/tickets`

Closes https://trac.osgeo.org/postgis/ticket/2630
References https://github.com/postgis/postgis/pull/921
