### PR TITLE
Add --without-comments configure option

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -20,6 +20,7 @@ endif
 
 HAVE_SFCGAL=@HAVE_SFCGAL@
 CAN_BUILD_COMMENTS=@CAN_BUILD_COMMENTS@
+INSTALL_COMMENTS=@INSTALL_COMMENTS@
 
 POSTGIS_MAJOR_VERSION=@POSTGIS_MAJOR_VERSION@
 POSTGIS_MINOR_VERSION=@POSTGIS_MINOR_VERSION@
@@ -66,7 +67,7 @@ endif
 all: postgis_revision.h
 
 ifeq (@SUPPORT_POSTGRESQL@,yes)
-ifeq ($(CAN_BUILD_COMMENTS),yes)
+ifeq ($(INSTALL_COMMENTS),yes)
 install: comments-install
 uninstall: comments-uninstall
 endif

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #5715, Add configure --without-comments to skip generated SQL comments
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,8 @@ These are only changes since 3.7.0beta1.
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
 
+ - #5715, Add configure --without-comments to skip generated SQL comments
+          (Darafei Praliaskouski)
 PostGIS 3.7.0beta1
 2026/07/20
 
@@ -189,8 +191,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and
           postgis.net documentation into doc/
-          (Darafei Praliaskouski)
- - #5715, Add configure --without-comments to skip generated SQL comments
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements

--- a/NEWS
+++ b/NEWS
@@ -190,6 +190,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           website, internals, style, release-process, Trac wiki, and
           postgis.net documentation into doc/
           (Darafei Praliaskouski)
+ - #5715, Add configure --without-comments to skip generated SQL comments
+          (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/configure.ac
+++ b/configure.ac
@@ -249,8 +249,7 @@ fi
 AC_PATH_PROG([XMLLINT], [xmllint], [])
 if test "x$XMLLINT" = "x"; then
 	dnl AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
-	AC_MSG_WARN([xmllint is not installed so documentation cannot be built])
-	CAN_BUILD_DOCS=no
+	AC_MSG_WARN([xmllint is not installed so generated SQL comments cannot be built])
 	CAN_BUILD_COMMENTS=no
 fi
 AC_SUBST([XMLLINT])

--- a/configure.ac
+++ b/configure.ac
@@ -220,25 +220,42 @@ dnl
 dnl Search for xsltproc which is required for building documentation
 dnl
 
-CAN_BUILD_COMMENTS=yes
+AC_ARG_WITH([comments],
+	[AS_HELP_STRING([--without-comments],
+		[disable building and installing generated SQL comments])],
+	[],
+	[with_comments=yes])
 
-AC_PATH_PROG([XSLTPROC], [xsltproc], [])
-if test "x$XSLTPROC" = "x"; then
-	AC_MSG_WARN([xsltproc is not installed so documentation cannot be built])
-  CAN_BUILD_COMMENTS=no
+CAN_BUILD_COMMENTS=yes
+if test "x$with_comments" = "xno"; then
+	AC_MSG_NOTICE([SQL comments generation disabled by --without-comments])
+	XSLTPROC=
+	CAN_BUILD_COMMENTS=no
+else
+	AC_PATH_PROG([XSLTPROC], [xsltproc], [])
+	if test "x$XSLTPROC" = "x"; then
+		AC_MSG_WARN([xsltproc is not installed so documentation cannot be built])
+	  CAN_BUILD_COMMENTS=no
+	fi
 fi
+AC_SUBST([XSLTPROC])
 
 AC_PATH_PROG([XMLCATALOG], [xmlcatalog], [])
 if test "x$XMLCATALOG" = "x"; then
 	AC_MSG_WARN([xmlcatalog is not installed so documentation cannot be checked])
 fi
 
-AC_PATH_PROG([XMLLINT], [xmllint], [])
-if test "x$XMLLINT" = "x"; then
-	dnl AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
-	AC_MSG_WARN([xmlcatalog is not installed so documentation cannot be built])
-	CAN_BUILD_COMMENTS=no
+if test "x$with_comments" = "xno"; then
+	XMLLINT=
+else
+	AC_PATH_PROG([XMLLINT], [xmllint], [])
+	if test "x$XMLLINT" = "x"; then
+		dnl AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
+		AC_MSG_WARN([xmllint is not installed so documentation cannot be built])
+		CAN_BUILD_COMMENTS=no
+	fi
 fi
+AC_SUBST([XMLLINT])
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -252,7 +252,8 @@ fi
 AC_PATH_PROG([XMLLINT], [xmllint], [])
 if test "x$XMLLINT" = "x"; then
 	dnl AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
-	AC_MSG_WARN([xmllint is not installed so generated SQL comments cannot be built])
+	AC_MSG_WARN([xmllint is not installed so documentation cannot be built])
+	CAN_BUILD_DOCS=no
 	CAN_BUILD_COMMENTS=no
 fi
 AC_SUBST([XMLLINT])

--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,7 @@ AC_ARG_WITH([comments],
 
 CAN_BUILD_DOCS=yes
 CAN_BUILD_COMMENTS=yes
+INSTALL_COMMENTS=yes
 AC_PATH_PROG([XSLTPROC], [xsltproc], [])
 if test "x$XSLTPROC" = "x"; then
 	AC_MSG_WARN([xsltproc is not installed so documentation cannot be built])
@@ -239,7 +240,9 @@ AC_SUBST([XSLTPROC])
 if test "x$with_comments" = "xno"; then
 	AC_MSG_NOTICE([SQL comments generation disabled by --without-comments])
 	CAN_BUILD_COMMENTS=no
+	INSTALL_COMMENTS=no
 fi
+AC_SUBST([INSTALL_COMMENTS])
 
 AC_PATH_PROG([XMLCATALOG], [xmlcatalog], [])
 if test "x$XMLCATALOG" = "x"; then

--- a/configure.ac
+++ b/configure.ac
@@ -226,34 +226,32 @@ AC_ARG_WITH([comments],
 	[],
 	[with_comments=yes])
 
+CAN_BUILD_DOCS=yes
 CAN_BUILD_COMMENTS=yes
-if test "x$with_comments" = "xno"; then
-	AC_MSG_NOTICE([SQL comments generation disabled by --without-comments])
-	XSLTPROC=
+AC_PATH_PROG([XSLTPROC], [xsltproc], [])
+if test "x$XSLTPROC" = "x"; then
+	AC_MSG_WARN([xsltproc is not installed so documentation cannot be built])
+	CAN_BUILD_DOCS=no
 	CAN_BUILD_COMMENTS=no
-else
-	AC_PATH_PROG([XSLTPROC], [xsltproc], [])
-	if test "x$XSLTPROC" = "x"; then
-		AC_MSG_WARN([xsltproc is not installed so documentation cannot be built])
-	  CAN_BUILD_COMMENTS=no
-	fi
 fi
 AC_SUBST([XSLTPROC])
+
+if test "x$with_comments" = "xno"; then
+	AC_MSG_NOTICE([SQL comments generation disabled by --without-comments])
+	CAN_BUILD_COMMENTS=no
+fi
 
 AC_PATH_PROG([XMLCATALOG], [xmlcatalog], [])
 if test "x$XMLCATALOG" = "x"; then
 	AC_MSG_WARN([xmlcatalog is not installed so documentation cannot be checked])
 fi
 
-if test "x$with_comments" = "xno"; then
-	XMLLINT=
-else
-	AC_PATH_PROG([XMLLINT], [xmllint], [])
-	if test "x$XMLLINT" = "x"; then
-		dnl AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
-		AC_MSG_WARN([xmllint is not installed so documentation cannot be built])
-		CAN_BUILD_COMMENTS=no
-	fi
+AC_PATH_PROG([XMLLINT], [xmllint], [])
+if test "x$XMLLINT" = "x"; then
+	dnl AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
+	AC_MSG_WARN([xmllint is not installed so documentation cannot be built])
+	CAN_BUILD_DOCS=no
+	CAN_BUILD_COMMENTS=no
 fi
 AC_SUBST([XMLLINT])
 
@@ -289,7 +287,7 @@ if test "x$MSGINIT" = "x"; then
 	AC_MSG_WARN([msginit is not installed so new translations cannot be initialized])
 fi
 
-CAN_BUILD_PDF=${CAN_BUILD_COMMENTS}
+CAN_BUILD_PDF=${CAN_BUILD_DOCS}
 
 AC_PATH_PROG([CONVERT], [convert], [])
 if test "x$CONVERT" = "x"; then
@@ -306,7 +304,7 @@ fi
 AC_SUBST(CAN_BUILD_COMMENTS)
 AC_SUBST(CAN_BUILD_PDF)
 
-CAN_BUILD_EPUB=${CAN_BUILD_COMMENTS}
+CAN_BUILD_EPUB=${CAN_BUILD_DOCS}
 AC_PATH_PROG([DBTOEPUB], [dbtoepub], [])
 if test "x$DBTOEPUB" = "x"; then
   AC_MSG_WARN([dbtoepub is not installed so EPUB documentation cannot be built])

--- a/configure.ac
+++ b/configure.ac
@@ -252,8 +252,7 @@ fi
 AC_PATH_PROG([XMLLINT], [xmllint], [])
 if test "x$XMLLINT" = "x"; then
 	dnl AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
-	AC_MSG_WARN([xmllint is not installed so documentation cannot be built])
-	CAN_BUILD_DOCS=no
+	AC_MSG_WARN([xmllint is not installed so documentation cannot be checked])
 	CAN_BUILD_COMMENTS=no
 fi
 AC_SUBST([XMLLINT])

--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -563,10 +563,14 @@ PostGIS was built successfully. Ready to install.</screen>
           <para>
                 All the functions have comments generated from the
                 documentation. If you wish to install these comments into your spatial
-                databases later, run the command which requires docbook.  The postgis_comments.sql and other
-                package comment files are
-                        also packaged in the tar.gz distribution in the doc folder so no need to make comments
-                        if installing from the tar ball.  Comments are also included as part of the CREATE EXTENSION install.
+                databases later, run the command which requires docbook. If your
+                documentation toolchain is unavailable or broken, pass
+                <option>--without-comments</option> to <command>configure</command>
+                to skip building and installing generated SQL comments. The
+                postgis_comments.sql and other package comment files are also
+                packaged in the tar.gz distribution in the doc folder so no need to
+                make comments if installing from the tar ball. Comments are also
+                included as part of the CREATE EXTENSION install.
           </para>
 
     <programlisting language="bash">make comments</programlisting>
@@ -590,7 +594,7 @@ PostGIS was built successfully. Ready to install.</screen>
     <para>If you are building from source repository, you need to build the function descriptions first. These get built if you have docbook installed. You can also manually build with the statement:
     </para>
     <programlisting language="bash">make comments</programlisting>
-    <para>Building the comments is not necessary if you are building from a release tar ball since these are packaged pre-built with the tar ball already.</para>
+    <para>Building the comments is not necessary if you are building from a release tar ball since these are packaged pre-built with the tar ball already. To skip building and installing generated SQL comments from a source checkout, run <command>configure</command> with <option>--without-comments</option>.</para>
     <para>The extensions should automatically build as part of the make install process.  You can if needed build from the extensions
     folders or copy files if you need them on a different server. </para>
 	    <para>Set <varname>PGUSER</varname> if you need to override the psql connection user, then test before installing. After installation, run the extension regression tests.</para>

--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -569,8 +569,10 @@ PostGIS was built successfully. Ready to install.</screen>
                 to skip building and installing generated SQL comments. The
                 postgis_comments.sql and other package comment files are also
                 packaged in the tar.gz distribution in the doc folder so no need to
-                make comments if installing from the tar ball. Comments are also
-                included as part of the CREATE EXTENSION install.
+                make comments if installing from the tar ball. Source checkout
+                installs that need database comments should run
+                <command>make comments-install</command> after the comments are
+                available.
           </para>
 
     <programlisting language="bash">make comments</programlisting>


### PR DESCRIPTION
## Summary

- add `./configure --without-comments` to disable generated SQL comment builds and installs
- keep default comment generation and fallback comment installation unchanged when comments are not explicitly disabled
- keep PDF/EPUB documentation format gates tied to documentation tool availability rather than the SQL comments toggle
- leave missing-`xmllint` documentation gating intact, because the DocBook build rules still require `xmllint`
- document the option in the installation guide and add a NEWS entry

Closes https://trac.osgeo.org/postgis/ticket/5715

## Release / upgrade notes

- NEWS entry added for https://trac.osgeo.org/postgis/ticket/5715.
- No database extension upgrade step is needed; this is a build/configure/install option and does not change SQL/catalog objects.

## Validation

- Rebased onto current Gitea `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`.
- `./autogen.sh`
- `./configure --without-comments`
- `rg -n "^CAN_BUILD_COMMENTS|^INSTALL_COMMENTS|CAN_BUILD_PDF|CAN_BUILD_EPUB" GNUmakefile doc/Makefile config.log`
- with generated `doc/*_comments.sql` files present, `make -C doc comments-install DESTDIR=/tmp/postgis-5715-no-comments-install-current && test ! -e /tmp/postgis-5715-no-comments-install-current` passes under `--without-comments`
- `make -n -k install 2>&1 | rg "comments-install|Makefile.comments|Entering directory '.*/doc'"` produces no output under `--without-comments`
- `./configure`
- `make -C doc comments`
- `make -C doc comments-install DESTDIR=/tmp/postgis-5715-comments-install-current`
- `./configure --help | rg -n "comments|with-comments"`
- `ac_cv_path_XMLLINT= ./configure` confirms missing `xmllint` disables documentation/comment generation together, matching the DocBook rules
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD && git diff --check`
- `git clang-format upstream/master --diff`
