### PR TITLE
utils: make postgis_restore skip-list schema-aware

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,9 @@ These are only changes since 3.7.0beta1.
 
  - #4323, GT-584, [sfcgal] Document that straight-skeleton and approximate-medial-axis
           functions ignore input Z and return 2D geometries (Darafei Praliaskouski)
+ - #6063, Keep postgis_restore from skipping application tables that share
+          names with PostGIS-owned tables in other schemas
+          (Darafei Praliaskouski)
  - GT-545, Fix FlatGeobuf geometry, property, and spatial-index byte order on
           big-endian platforms (Darafei Praliaskouski)
  - [raster] Fix invalid reads in raster band initialization and
@@ -279,9 +282,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           dropping the tail (Darafei Praliaskouski)
  - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for
           MinGW builds (Darafei Praliaskouski)
- - #6063, Keep postgis_restore from skipping application tables that share
-          names with PostGIS-owned tables in other schemas
-          (Darafei Praliaskouski)
  - GH-886, ST_ClusterRelateWin validates NULL relate matrices before
           detoasting them (Darafei Praliaskouski)
  - GH-889, ST_Relate pattern inversion avoids out-of-bounds access on

--- a/NEWS
+++ b/NEWS
@@ -279,6 +279,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           dropping the tail (Darafei Praliaskouski)
  - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for
           MinGW builds (Darafei Praliaskouski)
+ - #6063, Keep postgis_restore from skipping application tables that share
+          names with PostGIS-owned tables in other schemas
+          (Darafei Praliaskouski)
  - GH-886, ST_ClusterRelateWin validates NULL relate matrices before
           detoasting them (Darafei Praliaskouski)
  - GH-889, ST_Relate pattern inversion avoids out-of-bounds access on

--- a/utils/Makefile.in
+++ b/utils/Makefile.in
@@ -126,7 +126,10 @@ check: check-unit
 create_upgrade_replaced_function_errors_check:
 	srcdir=$(srcdir) PERL=$(PERL) $(SHELL) $(srcdir)/check_create_upgrade_replaced_function_errors.sh
 
-check-unit: postgis_restore-check create_upgrade_replaced_function_errors_check
+postgis_restore-schema-check: postgis_restore.pl
+	$(PERL) $(srcdir)/test_postgis_restore_schema.pl ./postgis_restore.pl
+
+check-unit: postgis_restore-check create_upgrade_replaced_function_errors_check postgis_restore-schema-check
 
 installdir:
 	@mkdir -p $(DESTDIR)$(bindir)

--- a/utils/postgis_restore.pl.in
+++ b/utils/postgis_restore.pl.in
@@ -56,6 +56,7 @@ Usage:	$me [-v] [-L TOC] [-s schema] <dumpfile>
 my $DEBUG = 0;
 my $POSTGIS_SCHEMA;
 my $POSTGIS_TOC;
+my $TOC_IDENTIFIER = qr/"(?:""|[^"])*"|\S+/;
 
 # NOTE: the SRID limits here are being discussed:
 # http://lists.osgeo.org/pipermail/postgis-devel/2012-February/018440.html
@@ -127,8 +128,18 @@ if(!defined($POSTGIS_TOC)) {
 } else {
   open( DUMP, '<' . $POSTGIS_TOC) || die "$me:\tCannot open TOC file '$POSTGIS_TOC'\n";
 }
+my @dump_lines = <DUMP>;
+close(DUMP) || die "$me: pg_restore returned an error\n";
+
+if ( not defined($POSTGIS_SCHEMA) )
+{
+  $POSTGIS_SCHEMA = discover_postgis_schema(@dump_lines);
+  print STDERR "  Setting postgis schema to $POSTGIS_SCHEMA, as found in the dump\n"
+    if $DEBUG && defined($POSTGIS_SCHEMA);
+}
+
 open( MANIFEST, ">$manifest" ) || die "$me:\tCannot open manifest file '$manifest'\n";
-while( my $l = <DUMP> ) {
+foreach my $l ( @dump_lines ) {
 
   next if $l =~ /^\;/;
   my $sigHR = linesignature($l);
@@ -143,17 +154,12 @@ while( my $l = <DUMP> ) {
   $sig =~ s/\s//g;
   $hasTopology = 1 if $sig eq 'SCHEMAtopology';
 
-	if ( not defined ($POSTGIS_SCHEMA) )
-	{
-		if ( $l =~ / TABLE DATA ([^ ]*) spatial_ref_sys / )
-		{
-			$POSTGIS_SCHEMA = $1;
-			print STDERR "  Setting postgis schema to $POSTGIS_SCHEMA, as found in the dump\n"
-			  if $DEBUG;
-		}
-	}
-
   if ( $skip{$sig} ) {
+    if ( ! line_is_from_postgis_schema($l, $sig) ) {
+      print STDERR "KEEP: $sigHR (schema is not PostGIS-owned)\n" if $DEBUG;
+      print MANIFEST $l;
+      next
+    }
     print STDERR "SKIP: $sigHR\n" if $DEBUG;
     next
   }
@@ -162,7 +168,6 @@ while( my $l = <DUMP> ) {
 
 }
 close(MANIFEST);
-close(DUMP) || die "$me: pg_restore returned an error\n";
 
 ######################################################################
 # Convert the dump file into an ASCII file, stripping out the
@@ -198,6 +203,7 @@ print STDOUT "CREATE TEMP TABLE _pgis_restore_spatial_ref_sys AS "
 print STDOUT "DELETE FROM spatial_ref_sys;\n";
 
 my $inCopy;
+my $current_search_path_schema = $POSTGIS_SCHEMA;
 while( my $l = <INPUT> ) {
   if ( $l =~ /^COPY .+ FROM stdin;$/ ) {
     $inCopy = 1;
@@ -208,7 +214,8 @@ while( my $l = <INPUT> ) {
 
   next if !$inCopy && $l =~ /^ *--/;
 
-  if ( $l =~ /^SET search_path/ ) {
+  if ( $l =~ /^SET search_path = (.*);/ ) {
+    $current_search_path_schema = first_search_path_schema($1);
     $l =~ s/; *$/, public;/;
   }
 
@@ -329,7 +336,7 @@ while( my $l = <INPUT> ) {
   }
 
   # Clamp SRIDS in spatial_ref_sys
-  elsif ( $l =~ /COPY spatial_ref_sys /)
+  elsif ( copy_is_postgis_spatial_ref_sys($l, $current_search_path_schema) )
   {
     print STDOUT $l;
     while( my $subline = <INPUT>)
@@ -409,7 +416,7 @@ sub linesignature {
   $line =~ s/PROCEDURAL LANGUAGE/PROCEDURALLANGUAGE/;
   $line =~ s/SEQUENCE SET/SEQUENCE_SET/;
 
-  if( $line =~ /^(\d+)\; (\d+) (\d+) FK (\w+) (\w+) (.*) (\w*)/ ) {
+  if( $line =~ /^(\d+)\; (\d+) (\d+) FK (\w+) ($TOC_IDENTIFIER) (.*) (\w*)/ ) {
     $sig = "FK " . $4 . " " . $6;
   }
   # We strip argument names from function comments
@@ -427,20 +434,20 @@ sub linesignature {
 
     $sig = "COMMENT FUNCTION $name(" . join(', ', @unnamed_args) . ")";
   }
-  elsif( $line =~ /^(\d+)\; (\d+) (\d+) (\w+) - (\w+) (.*) (\w*)/ ) {
+  elsif( $line =~ /^(\d+)\; (\d+) (\d+) (\w+) - ($TOC_IDENTIFIER) (.*) (\w*)/ ) {
     $sig = $4 . " " . $5 . " " . $6;
   }
-  elsif( $line =~ /^(\d+)\; (\d+) (\d+) (\w+) (\w+) (.*) (\w*)/ ) {
+  elsif( $line =~ /^(\d+)\; (\d+) (\d+) (\w+) ($TOC_IDENTIFIER) (.*) (\w*)/ ) {
     $sig = $4 . " " . $6;
   }
   elsif( $line =~ /PROCEDURALLANGUAGE.*plpgsql/ ) {
     $sig = "PROCEDURAL LANGUAGE plpgsql";
   }
-  elsif ( $line =~ /SCHEMA - (\w+)/ ) {
-    $sig = "SCHEMA $1";
+  elsif ( $line =~ /SCHEMA - ($TOC_IDENTIFIER)/ ) {
+    $sig = "SCHEMA " . toc_unquote_identifier($1);
   }
-  elsif ( $line =~ /SEQUENCE - (\w+)/ ) {
-    $sig = "SEQUENCE $1";
+  elsif ( $line =~ /SEQUENCE - ($TOC_IDENTIFIER)/ ) {
+    $sig = "SEQUENCE " . toc_unquote_identifier($1);
   }
   else {
     # TODO: something smarter here...
@@ -453,6 +460,193 @@ sub linesignature {
 
   return $sig;
 
+}
+
+# Returns true when a TOC line belongs to the PostGIS install schema or to
+# topology. Unqualified skip signatures must not hide user objects with the same
+# name in application schemas, for example a user table named "layer" (#6063).
+sub line_is_from_postgis_schema {
+  my $line = shift;
+  my $sig = shift;
+  my $schema = toc_line_schema($line);
+
+  return 0 if ! defined $schema && is_schema_sensitive_relation_signature($sig);
+  return 1 if ! defined $schema;
+  return 1 if $schema eq 'topology';
+
+  if ( ! defined($POSTGIS_SCHEMA) )
+  {
+    return 0 if is_schema_sensitive_relation_signature($sig);
+    return 1;
+  }
+
+  my $postgis_schema = $POSTGIS_SCHEMA;
+  return 0 if $schema ne $postgis_schema;
+  return is_postgis_catalog_relation_signature($sig)
+    if is_schema_sensitive_relation_signature($sig);
+  return 1;
+}
+
+sub is_schema_sensitive_relation_signature {
+  my $sig = shift;
+
+  return $sig =~ /^(?:TABLE|TABLEDATA|ACLTABLE|ACLTABLEDATA|CONSTRAINT|FKCONSTRAINT|INDEX|TRIGGER|RULE|SEQUENCE|DEFAULT)/;
+}
+
+sub is_postgis_catalog_relation_signature {
+  my $sig = shift;
+
+  return $sig =~ /^(?:TABLE|TABLEDATA|ACLTABLE|ACLTABLEDATA)spatial_ref_sys$/ ||
+         $sig =~ /^CONSTRAINTspatial_ref_sys/ ||
+         $sig =~ /^(?:VIEW|ACLTABLE|RULE)geometry_columns/ ||
+         $sig =~ /^(?:VIEW|ACLTABLE)geography_columns/ ||
+         $sig =~ /^(?:VIEW|ACLTABLE)raster_columns/ ||
+         $sig =~ /^(?:VIEW|ACLTABLE)raster_overviews/;
+}
+
+sub toc_line_schema {
+  my $line = shift;
+
+  $line =~ s/\n$//;
+  $line =~ s/\r$//;
+  $line =~ s/OPERATOR CLASS/OPERATORCLASS/;
+  $line =~ s/TABLE DATA/TABLEDATA/;
+  $line =~ s/SHELL TYPE/SHELLTYPE/;
+  $line =~ s/PROCEDURAL LANGUAGE/PROCEDURALLANGUAGE/;
+  $line =~ s/SEQUENCE SET/SEQUENCE_SET/;
+
+  return toc_unquote_identifier($2)
+    if $line =~ /^\d+\; \d+ \d+ ACL ($TOC_IDENTIFIER) SCHEMA ($TOC_IDENTIFIER) /;
+  return toc_unquote_identifier($1) if $line =~ /^\d+\; \d+ \d+ ACL ($TOC_IDENTIFIER) /;
+  return toc_unquote_identifier($1) if $line =~ /^\d+\; \d+ \d+ FK CONSTRAINT ($TOC_IDENTIFIER) /;
+  return toc_unquote_identifier($1) if $line =~ /^\d+\; \d+ \d+ COMMENT ($TOC_IDENTIFIER) /;
+  return toc_unquote_identifier($1) if $line =~ /^\d+\; \d+ \d+ DEFAULT ($TOC_IDENTIFIER) /;
+
+  return toc_unquote_identifier($1) if $line =~ /^\d+\; \d+ \d+ (?:TABLEDATA|TABLE|VIEW|MATERIALIZED VIEW|SEQUENCE|INDEX|CONSTRAINT|TRIGGER|RULE|FUNCTION|SHELLTYPE|TYPE|DOMAIN|OPERATOR|OPERATORCLASS|OPERATOR FAMILY|AGGREGATE) ($TOC_IDENTIFIER) /;
+
+  return undef;
+}
+
+sub toc_unquote_identifier {
+  my $identifier = shift;
+
+  if ( $identifier =~ /^"((?:""|[^"])*)"$/ ) {
+    $identifier = $1;
+    $identifier =~ s/""/"/g;
+  }
+
+  return $identifier;
+}
+
+sub discover_postgis_schema {
+  my @toc_lines = @_;
+  my %spatial_ref_sys_schema = ();
+  my %spatial_ref_sys_table_schema = ();
+  my %spatial_ref_sys_tabledata_schema = ();
+  my %postgis_object_schema = ();
+
+  foreach my $line ( @toc_lines ) {
+    next if $line =~ /^\;/;
+    my $sigHR = linesignature($line);
+    next unless length($sigHR);
+    my $sig = $sigHR;
+    $sig =~ s/^COMMENT//g;
+    $sig =~ s/^SHELLTYPE/TYPE/g;
+    $sig =~ s/\s//g;
+    my $schema = toc_line_schema($line);
+    next unless defined($schema);
+    next if $schema eq 'topology';
+
+    my $quoted_schema = toc_quote_identifier($schema);
+    $spatial_ref_sys_schema{$schema} = 1
+      if $line =~ / TABLE(?: DATA)? (?:\Q$schema\E|\Q$quoted_schema\E) spatial_ref_sys / ||
+         $line =~ / ACL (?:\Q$schema\E|\Q$quoted_schema\E) TABLE spatial_ref_sys /;
+    $spatial_ref_sys_table_schema{$schema} = 1
+      if $sig eq 'TABLEspatial_ref_sys';
+    $spatial_ref_sys_tabledata_schema{$schema} = 1
+      if $sig eq 'TABLEDATAspatial_ref_sys';
+
+    if ( $skip{$sig} && ! is_schema_sensitive_relation_signature($sig) ) {
+      $postgis_object_schema{$schema}++;
+    }
+  }
+
+  my @extension_config_schemas = grep {
+    $spatial_ref_sys_tabledata_schema{$_} && !$spatial_ref_sys_table_schema{$_}
+  } keys %spatial_ref_sys_schema;
+  return $extension_config_schemas[0] if @extension_config_schemas == 1;
+
+  my @candidates = grep { $postgis_object_schema{$_} } keys %spatial_ref_sys_schema;
+  @candidates = sort { $postgis_object_schema{$b} <=> $postgis_object_schema{$a} } @candidates;
+  return $candidates[0] if @candidates;
+
+  my @spatial_ref_sys_schemas = keys %spatial_ref_sys_schema;
+  return $spatial_ref_sys_schemas[0] if @spatial_ref_sys_schemas == 1;
+
+  return undef;
+}
+
+sub toc_quote_identifier {
+  my $identifier = shift;
+
+  $identifier =~ s/"/""/g;
+  return '"' . $identifier . '"';
+}
+
+sub copy_is_postgis_spatial_ref_sys {
+  my $line = shift;
+  my $current_schema = shift;
+  my $schema;
+
+  if ( $line =~ /^COPY (?:"((?:""|[^"])*)"|([^\s."]+))\."spatial_ref_sys"\s/ ||
+       $line =~ /^COPY (?:"((?:""|[^"])*)"|([^\s."]+))\.spatial_ref_sys\s/ )
+  {
+    $schema = defined($1) ? $1 : $2;
+    $schema =~ s/""/"/g if defined($schema);
+  }
+  elsif ( $line =~ /^COPY "?spatial_ref_sys"?\s/ )
+  {
+    $schema = $current_schema;
+  }
+  else
+  {
+    return 0;
+  }
+
+  return schema_is_postgis_schema($schema);
+}
+
+sub schema_is_postgis_schema {
+  my $schema = shift;
+
+  return 0 unless defined $schema;
+  return $schema eq $POSTGIS_SCHEMA if defined $POSTGIS_SCHEMA;
+  return $schema eq 'public';
+}
+
+sub first_search_path_schema {
+  my $search_path = shift;
+
+  foreach my $schema (split(/,/, $search_path)) {
+    $schema =~ s/^\s+//;
+    $schema =~ s/\s+$//;
+    $schema = unquote_identifier($schema);
+    next if $schema eq '$user';
+    return $schema;
+  }
+
+  return undef;
+}
+
+sub unquote_identifier {
+  my $identifier = shift;
+
+  if ( $identifier =~ /^"(.*)"$/ ) {
+    $identifier = $1;
+    $identifier =~ s/""/"/g;
+  }
+
+  return $identifier;
 }
 
 #

--- a/utils/test_postgis_restore_schema.pl
+++ b/utils/test_postgis_restore_schema.pl
@@ -1,0 +1,180 @@
+#!/usr/bin/env perl
+
+#
+# PostGIS - Spatial Types for PostgreSQL
+# http://postgis.net
+#
+# Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+#
+# This is free software; you can redistribute and/or modify it under
+# the terms of the GNU General Public Licence. See the COPYING file.
+#
+
+use warnings;
+use strict;
+
+use File::Temp qw(tempdir);
+
+my $restore_script = shift @ARGV
+  or die "Usage: $0 <postgis_restore.pl>\n";
+
+sub write_file {
+  my ($path, $contents) = @_;
+  open(my $fh, '>', $path) || die "Could not write $path: $!\n";
+  print {$fh} $contents;
+  close($fh) || die "Could not close $path: $!\n";
+}
+
+sub install_fake_programs {
+  my ($bindir) = @_;
+
+  write_file("$bindir/pg_dump", <<'SH');
+#!/bin/sh
+echo "pg_dump (fake)"
+SH
+  chmod 0755, "$bindir/pg_dump";
+
+  write_file("$bindir/pg_restore", <<'SH');
+#!/bin/sh
+for arg in "$@"; do
+  if test "$arg" = "--version"; then
+    echo "pg_restore (fake)"
+    exit 0
+  fi
+  if test "$arg" = "-l"; then
+    cat "$POSTGIS_RESTORE_TEST_TOC"
+    exit 0
+  fi
+done
+cat "$POSTGIS_RESTORE_TEST_SQL"
+SH
+  chmod 0755, "$bindir/pg_restore";
+}
+
+sub run_restore {
+  my ($toc, $sql) = @_;
+  my $dir = tempdir(CLEANUP => 1);
+  my $bindir = "$dir/bin";
+  mkdir $bindir || die "Could not create $bindir: $!\n";
+  install_fake_programs($bindir);
+
+  my $dump = "$dir/test.dump";
+  my $toc_file = "$dir/toc.txt";
+  my $sql_file = "$dir/restore.sql";
+  write_file($dump, "fake dump\n");
+  write_file($toc_file, $toc);
+  write_file($sql_file, $sql);
+
+  local $ENV{PATH} = "$bindir:$ENV{PATH}";
+  local $ENV{POSTGIS_RESTORE_TEST_TOC} = $toc_file;
+  local $ENV{POSTGIS_RESTORE_TEST_SQL} = $sql_file;
+
+  open(my $out, '-|', $^X, $restore_script, $dump)
+    || die "Could not run $restore_script: $!\n";
+  my $stdout = do { local $/; <$out> };
+  close($out) || die "$restore_script failed\n";
+
+  open(my $manifest, '<', "$dump.lst")
+    || die "Could not read generated manifest: $!\n";
+  my $manifest_text = do { local $/; <$manifest> };
+  close($manifest) || die "Could not close generated manifest: $!\n";
+
+  return ($stdout, $manifest_text);
+}
+
+sub assert_contains {
+  my ($text, $needle, $label) = @_;
+  die "not ok - $label\nMissing: $needle\nIn:\n$text\n"
+    if index($text, $needle) < 0;
+}
+
+sub assert_not_contains {
+  my ($text, $needle, $label) = @_;
+  die "not ok - $label\nUnexpected: $needle\nIn:\n$text\n"
+    if index($text, $needle) >= 0;
+}
+
+my ($stdout, $manifest) = run_restore(<<'TOC', <<'SQL');
+1; 0 0 TABLE public topology postgres
+2; 0 0 SEQUENCE public topology_id_seq postgres
+3; 0 0 DEFAULT public topology id postgres
+4; 0 0 COMMENT public TABLE topology postgres
+5; 0 0 TABLE DATA public topology postgres
+6; 0 0 TABLE DATA public spatial_ref_sys postgres
+7; 0 0 TABLE topology layer postgres
+8; 0 0 ACL topology TABLE layer postgres
+9; 0 0 ACL - SCHEMA topology postgres
+TOC
+SET search_path = public, pg_catalog;
+SQL
+
+assert_contains($manifest, 'TABLE public topology', 'keep public table named topology');
+assert_contains($manifest, 'SEQUENCE public topology_id_seq', 'keep serial sequence for public topology');
+assert_contains($manifest, 'DEFAULT public topology id', 'keep serial default for public topology');
+assert_contains($manifest, 'COMMENT public TABLE topology', 'keep comments for public topology');
+assert_not_contains($manifest, 'TABLE topology layer', 'skip real topology layer table');
+assert_not_contains($manifest, 'ACL topology TABLE layer', 'skip real topology layer ACL');
+assert_not_contains($manifest, 'ACL - SCHEMA topology', 'skip real topology schema ACL');
+
+($stdout, $manifest) = run_restore(<<'TOC', <<'SQL');
+1; 0 0 TABLE app spatial_ref_sys postgres
+2; 0 0 TABLE DATA app spatial_ref_sys postgres
+3; 0 0 TABLE DATA postgis spatial_ref_sys postgres
+4; 0 0 FUNCTION postgis st_concavehull(geometry, double precision, boolean) postgres
+TOC
+SET search_path = app, pg_catalog;
+COPY spatial_ref_sys (srid, auth_name) FROM stdin;
+1000000	app
+\.
+SET search_path = postgis, pg_catalog;
+COPY spatial_ref_sys (srid, auth_name) FROM stdin;
+1000000	postgis
+\.
+SQL
+
+assert_contains($manifest, 'TABLE app spatial_ref_sys', 'keep application spatial_ref_sys table');
+assert_contains($manifest, 'TABLE DATA app spatial_ref_sys', 'keep application spatial_ref_sys data');
+assert_not_contains($manifest, 'TABLE DATA postgis spatial_ref_sys', 'skip PostGIS spatial_ref_sys data');
+assert_not_contains($manifest, 'FUNCTION postgis st_concavehull', 'skip PostGIS function before restore');
+assert_contains($stdout, "1000000\tapp", 'do not clamp application spatial_ref_sys COPY');
+assert_not_contains($stdout, "1000000\tpostgis", 'clamp PostGIS spatial_ref_sys COPY');
+
+($stdout, $manifest) = run_restore(<<'TOC', <<'SQL');
+1; 0 0 TABLE app spatial_ref_sys postgres
+2; 0 0 TABLE DATA app spatial_ref_sys postgres
+3; 0 0 FUNCTION app st_concavehull(geometry, double precision, boolean) postgres
+4; 0 0 TABLE DATA postgis spatial_ref_sys postgres
+TOC
+SET search_path = app, pg_catalog;
+COPY spatial_ref_sys (srid, auth_name) FROM stdin;
+1000000	app
+\.
+SET search_path = postgis, pg_catalog;
+COPY spatial_ref_sys (srid, auth_name) FROM stdin;
+1000000	postgis
+\.
+SQL
+
+assert_contains($manifest, 'TABLE app spatial_ref_sys', 'keep application spatial_ref_sys table when app objects match skip list');
+assert_contains($manifest, 'TABLE DATA app spatial_ref_sys', 'keep application spatial_ref_sys data when app objects match skip list');
+assert_contains($manifest, 'FUNCTION app st_concavehull', 'keep application function named like PostGIS function');
+assert_not_contains($manifest, 'TABLE DATA postgis spatial_ref_sys', 'skip extension-owned PostGIS spatial_ref_sys data');
+assert_contains($stdout, "1000000\tapp", 'do not clamp application spatial_ref_sys COPY selected by app object');
+assert_not_contains($stdout, "1000000\tpostgis", 'clamp extension-owned PostGIS spatial_ref_sys COPY');
+
+($stdout, $manifest) = run_restore(<<'TOC', <<'SQL');
+1; 0 0 TABLE DATA postgis spatial_ref_sys postgres
+2; 0 0 SHELL TYPE app geometry postgres
+3; 0 0 TYPE app geometry postgres
+4; 0 0 SHELL TYPE postgis geometry postgres
+5; 0 0 TYPE postgis geometry postgres
+TOC
+SET search_path = app, pg_catalog;
+SQL
+
+assert_contains($manifest, 'SHELL TYPE app geometry', 'keep application shell type named geometry');
+assert_contains($manifest, 'TYPE app geometry', 'keep application type named geometry');
+assert_not_contains($manifest, 'SHELL TYPE postgis geometry', 'skip PostGIS shell type');
+assert_not_contains($manifest, 'TYPE postgis geometry', 'skip PostGIS type');
+
+print "ok - postgis_restore schema-aware skip tests\n";


### PR DESCRIPTION
## Summary

- Keep `postgis_restore` skip-list matches schema-aware for schema-bearing TOC entries.
- Detect the PostGIS install schema from PostGIS-owned TOC entries plus `spatial_ref_sys`, avoiding application tables that merely share that name.
- Preserve application tables, ACLs, comments, shell types, and dependent entries such as constraints, sequences, and defaults while still skipping PostGIS-owned `topology.layer` and topology schema ACLs.
- Keep PostGIS function/type skip-list entries skippable before the PostGIS schema is discovered.
- Avoid applying `spatial_ref_sys` COPY SRID rewrites to application tables with the same name.

Closes https://trac.osgeo.org/postgis/ticket/6063

## Current State

- Rebased onto current Gitea `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`.
- Current head is `982950a158eeaa8d77bb4971976161a46d2a5fbc`.
- GitHub review threads: 13 total, all resolved and outdated on the current head.
- GitHub checks are queued on the current head.

## Validation

- `git diff --check upstream/master..HEAD && git diff --check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- NEWS utils/Makefile.in utils/postgis_restore.pl.in utils/test_postgis_restore_schema.pl`
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C postgis postgis_upgrade.sql`
- `make -C raster/rt_pg rtpostgis_upgrade.sql uninstall_rtpostgis.sql`
- `make -C topology topology_upgrade.sql uninstall_topology.sql`
- `make -C sfcgal uninstall_sfcgal.sql`
- `make -C utils postgis_restore.pl`
- `perl -c utils/postgis_restore.pl`
- `perl -c utils/test_postgis_restore_schema.pl`
- `make -C utils postgis_restore-schema-check`
- `rm -f utils/postgis_restore_data.needlessly-hardcoded && make -C utils check-unit`
