### PR TITLE
doc: document topology transaction maintenance

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,6 +67,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
+ - #5681, Document transaction and vacuum management during topology loading
+          (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1404,12 +1404,30 @@ change in a topology would be overkill, so it is the caller's duty
 to take care of that.
 </para>
 
+<para>
+When loading or heavily editing a large topology, prefer working in
+shorter transactions or batches rather than one long transaction. After
+each batch commits, run <command>VACUUM ANALYZE</command> on the edited
+topology tables, or at least on the <varname>node</varname>,
+<varname>edge_data</varname>, <varname>face</varname>, and
+<varname>relation</varname> tables of the topology schema. This lets
+PostgreSQL remove dead tuples, clean up indexes, refresh planner
+statistics, and make those statistics visible to the next batch of
+topology operations.
+</para>
+
 <note>
 <para>
-That the statistics updated by autovacuum
-will NOT be visible to transactions which started before autovacuum
-process completed, so long-running transactions will need to run
-ANALYZE themselves, to use updated statistics.
+If a loader must keep a transaction open, do not run
+<command>VACUUM</command> inside that transaction block; PostgreSQL
+will reject it. You can still run <command>ANALYZE</command> on the
+edited topology tables to refresh planner statistics for later
+statements in the same transaction. Statistics refreshed by another
+session become visible to later statements under PostgreSQL's default
+<literal>READ COMMITTED</literal> isolation level after that maintenance
+transaction commits; transactions using a longer-lived snapshot, such as
+<literal>REPEATABLE READ</literal> or <literal>SERIALIZABLE</literal>,
+will not see those concurrent changes until they restart.
 </para>
 </note>
 


### PR DESCRIPTION
## Summary
- document shorter transactions and batches for large topology load/edit operations
- recommend vacuum/analyze maintenance after committed batches so dead tuples and planner stats do not accumulate unseen
- clarify that `VACUUM` belongs after committed batches, while `ANALYZE` can refresh planner statistics for later statements inside a long-running loader transaction
- rebase the docs-only branch onto current `upstream/master` (`45c26068e`)

## Validation
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check-xml`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `git clang-format --diff upstream/master -- doc/extras_topology.xml NEWS` (reported no modified files to format)

Closes #5681

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/353
