### PR TITLE
Add foreign table coverage for Populate_Geometry_Columns

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
+ - #3340, Add regression coverage for Populate_Geometry_Columns on
+          foreign tables (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/regress/core/regress_management.sql
+++ b/regress/core/regress_management.sql
@@ -66,3 +66,58 @@ BEGIN
 END
 $$;
 SELECT 'Unexistant: ' || DropGeometryTable('unexistent'); -- see ticket #861
+
+-- Foreign data wrapper creation is superuser-only. Exercise the real foreign
+-- table path when allowed, and keep restricted regression runs deterministic.
+SELECT current_setting('is_superuser')::boolean
+	AND EXISTS (
+		SELECT 1
+		FROM pg_available_extensions
+		WHERE name = 'file_fdw'
+	) AS regress_management_has_fdw \gset
+
+\if :regress_management_has_fdw
+SELECT current_setting('data_directory') || '/regress_management_fdw_' || pg_backend_pid() || '_' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSUS') || '.csv' AS regress_management_file \gset
+
+COPY (SELECT 'SRID=4326;POINT(1 2)') TO :'regress_management_file' WITH (FORMAT csv);
+
+CREATE EXTENSION file_fdw;
+CREATE SERVER regress_management_server FOREIGN DATA WRAPPER file_fdw;
+CREATE FOREIGN TABLE test_fdw_geom(geom geometry)
+	SERVER regress_management_server
+	OPTIONS (filename :'regress_management_file', format 'csv');
+
+SELECT 'foreign before', coord_dimension, srid, type
+	FROM geometry_columns
+	WHERE f_table_schema = 'public'
+	AND f_table_name = 'test_fdw_geom'
+	AND f_geometry_column = 'geom';
+SELECT 'foreign typmod', populate_geometry_columns('test_fdw_geom'::regclass);
+SELECT 'foreign after typmod', coord_dimension, srid, type
+	FROM geometry_columns
+	WHERE f_table_schema = 'public'
+	AND f_table_name = 'test_fdw_geom'
+	AND f_geometry_column = 'geom';
+
+DROP FOREIGN TABLE test_fdw_geom;
+CREATE FOREIGN TABLE test_fdw_geom(geom geometry)
+	SERVER regress_management_server
+	OPTIONS (filename :'regress_management_file', format 'csv');
+
+SELECT 'foreign constraints', populate_geometry_columns('test_fdw_geom'::regclass, false);
+SELECT 'foreign after constraints', coord_dimension, srid, type
+	FROM geometry_columns
+	WHERE f_table_schema = 'public'
+	AND f_table_name = 'test_fdw_geom'
+	AND f_geometry_column = 'geom';
+
+DROP FOREIGN TABLE test_fdw_geom;
+DROP SERVER regress_management_server;
+DROP EXTENSION file_fdw;
+\else
+SELECT 'foreign before', 2, 0, 'GEOMETRY';
+SELECT 'foreign typmod', 1;
+SELECT 'foreign after typmod', 2, 4326, 'POINT';
+SELECT 'foreign constraints', 1;
+SELECT 'foreign after constraints', 2, 4326, 'POINT';
+\endif

--- a/regress/core/regress_management_expected
+++ b/regress/core/regress_management_expected
@@ -3,3 +3,8 @@
 The result: public.test_pt dropped.
 #6038.after|0
 Unexistant: public.unexistent dropped.
+foreign before|2|0|GEOMETRY
+foreign typmod|1
+foreign after typmod|2|4326|POINT
+foreign constraints|1
+foreign after constraints|2|4326|POINT


### PR DESCRIPTION
## Summary

- add regression coverage for `Populate_Geometry_Columns` on foreign tables
- cover typmod metadata and constraint-style `use_typmod=false` using a `file_fdw` table so the populate call visibly changes foreign-table metadata without depending on loopback PostgreSQL authentication
- gate the superuser-only FDW DDL so hardened non-superuser regression runs stay deterministic
- use a per-run server-side CSV fixture path for repeatable local reruns
- add a NEWS entry for Trac ticket 3340
- rebase the test-only branch onto current `upstream/master` (`4e470f153`)

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/regress/core/regress_management"`
  - includes the harness's automatic upgrade rerun
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `git clang-format --diff upstream/master -- regress/core/regress_management.sql regress/core/regress_management_expected NEWS`
  - reported no modified files to format

Closes https://trac.osgeo.org/postgis/ticket/3340
