### PR TITLE
doc: fix Japanese PDF listing arrows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,
           including guards for malformed TWKB reads and counts (Darafei Praliaskouski)
+ - #6082, Fix Japanese PDF build by avoiding non-ASCII arrows in SQL
+          program listings (Darafei Praliaskouski)
  - Build PostgreSQL extension modules with `-fno-semantic-interposition` when
           available so LTO can optimize same-DSO calls to exported PostGIS
           entry points directly instead of routing through the module PLT; in

--- a/doc/reference_sfcgal.xml
+++ b/doc/reference_sfcgal.xml
@@ -2083,14 +2083,14 @@ SELECT CG_ApproximateMedialAxis('POLYGON((0 0,2 0,2 1,0 1,0 0))', true);
                     <tbody>
                         <row>
                             <entry>
-                                <programlisting>-- height 2.0 → 6 patches
+                                <programlisting>-- height 2.0 -> 6 patches
 SELECT ST_NumPatches(
   CG_GenerateSkillionRoof(
     'POLYGON((0 0,5 0,5 4,0 4,0 0))',
     2.0));
 -- 6
 
--- height 4.0 → 5 patches (one face filtered)
+-- height 4.0 -> 5 patches (one face filtered)
 SELECT ST_NumPatches(
   CG_GenerateSkillionRoof(
     'POLYGON((0 0,5 0,5 4,0 4,0 0))',


### PR DESCRIPTION
## Summary
- replace Unicode arrows in the CG_GenerateSkillionRoof SQL program listing with ASCII arrows
- avoid XeTeX/listings treating those arrows as undefined control sequences in the Japanese PDF build
- add a NEWS entry for Trac #6082

## Testing
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- reproduced failure before the patch with `make -C doc/po/ja local-pdf V=1`: `postgis-out.tex:30066: Undefined control sequence`
- `make -C doc/po/ja local-pdf V=1`
- `git diff --check`

Closes #6082
