### PR TITLE
#2207, Document postgis_transform_geometry

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
+ - #2207, Document postgis_transform_geometry (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/doc/reference_srs.xml
+++ b/doc/reference_srs.xml
@@ -189,6 +189,78 @@ SRID=3785;POINT(-13732990.8753491 6178458.96425423)
     </refsection>
   </refentry>
 
+  <refentry xml:id="postgis_transform_geometry">
+    <refnamediv>
+    <refname>postgis_transform_geometry</refname>
+
+    <refpurpose>Return a new geometry with coordinates transformed using
+      explicit source and destination PROJ.4 strings.</refpurpose>
+    </refnamediv>
+
+    <refsynopsisdiv>
+      <funcsynopsis>
+        <funcprototype>
+          <funcdef>geometry <function>postgis_transform_geometry</function></funcdef>
+          <paramdef><type>geometry </type> <parameter>geom</parameter></paramdef>
+          <paramdef><type>text </type> <parameter>from_proj</parameter></paramdef>
+          <paramdef><type>text </type> <parameter>to_proj</parameter></paramdef>
+          <paramdef><type>integer </type> <parameter>to_srid</parameter></paramdef>
+        </funcprototype>
+      </funcsynopsis>
+    </refsynopsisdiv>
+
+    <refsection>
+    <title>Description</title>
+
+      <para>Transforms the coordinates of a geometry from the coordinate
+        reference system defined by <varname>from_proj</varname> to the
+        coordinate reference system defined by <varname>to_proj</varname>.
+        The geometry SRID is set to <varname>to_srid</varname> after the
+        transformation. Pass zero for <varname>to_srid</varname> when the
+        destination coordinate reference system is not known to
+        <varname>spatial_ref_sys</varname>.</para>
+
+      <para>This is a low-level transformation function. For most use cases,
+        use <xref linkend="ST_Transform"/> instead, which chooses the input
+        and output coordinate reference systems from SRIDs and can
+        automatically select a suitable conversion pipeline.</para>
+
+      <note>
+        <para>Requires PostGIS be compiled with PROJ support. Use
+          <xref linkend="PostGIS_Full_Version"/> to confirm you have PROJ
+          support compiled in.</para>
+      </note>
+
+      <para role="availability" conformance="2.0.0">Availability: 2.0.0</para>
+      <para>&curve_support;</para>
+      <para>&P_support;</para>
+
+    </refsection>
+
+    <refsection>
+    <title>Examples</title>
+
+      <programlisting>SELECT ST_AsEWKT(
+  postgis_transform_geometry(
+    ST_SetSRID(ST_Point(-71.104, 42.315), 4326),
+    '+proj=longlat +datum=WGS84 +no_defs',
+    '+proj=utm +zone=19 +datum=WGS84 +units=m +no_defs',
+    32619));
+
+                st_asewkt
+-----------------------------------------
+ SRID=32619;POINT(326610.0202377897 4686894.997199282)
+      </programlisting>
+
+    </refsection>
+
+    <refsection>
+    <title>See Also</title>
+
+      <para><xref linkend="spatial_ref_sys"/>, <xref linkend="ST_SetSRID"/>, <xref linkend="ST_SRID"/>, <xref linkend="ST_Transform"/>, <xref linkend="ST_TransformPipeline"/></para>
+    </refsection>
+  </refentry>
+
   <refentry xml:id="ST_Transform">
     <refnamediv>
     <refname>ST_Transform</refname>
@@ -351,7 +423,7 @@ CREATE INDEX idx_geom_26986_parcels
     <refsection>
     <title>See Also</title>
 
-    <para><xref linkend="spatial_ref_sys"/>, <xref linkend="ST_SetSRID"/>, <xref linkend="ST_SRID"/>, <xref linkend="UpdateGeometrySRID"/>, <xref linkend="ST_TransformPipeline"/></para>
+    <para><xref linkend="spatial_ref_sys"/>, <xref linkend="ST_SetSRID"/>, <xref linkend="ST_SRID"/>, <xref linkend="postgis_transform_geometry"/>, <xref linkend="UpdateGeometrySRID"/>, <xref linkend="ST_TransformPipeline"/></para>
     </refsection>
   </refentry>
 


### PR DESCRIPTION
## Summary

- document the low-level `postgis_transform_geometry` helper in the SRS reference
- add it to the `ST_Transform` see-also list
- add a NEWS entry for Trac ticket 2207

Closes https://trac.osgeo.org/postgis/ticket/2207

## Current status

Rebased over current `upstream/master` (`4e470f153`) at head `ccc050776`.

## Validation

- read PR body/diff/commits/checks/reviewThreads before public action; old CI/CodeRabbit were green and reviewThreads were empty
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check-xml`
- `make -C doc check`
- `make -C doc comments`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
