### PR TITLE
#5423, Use expanded DocBook input for EPUB

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -39,8 +39,14 @@ jobs:
             gdal geos icu4c json-c libpq libxml2 \
             proj protobuf-c sfcgal cunit \
             docbook docbook-xsl \
-            postgresql@${PG} gettext
+            gettext
           brew link --force gettext
+          HOMEBREW_GITHUB_ACTIONS=1 brew install "postgresql@${PG}"
+          pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
+          ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"
+          if [ ! -f "${HOMEBREW_PREFIX}/var/postgresql@${PG}/PG_VERSION" ]; then
+            "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/initdb" --locale=en_US.UTF-8 -E UTF-8 "${HOMEBREW_PREFIX}/var/postgresql@${PG}"
+          fi
           ccache --max-size="${CCACHE_MAXSIZE}"
           sudo ln -sfn "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/postgres" /usr/local/bin/postgres
 

--- a/NEWS
+++ b/NEWS
@@ -173,6 +173,11 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - GH-885, [topology] Avoid GMP overflow in ring orientation for very large
           finite coordinates (Darafei Praliaskouski)
+ - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,
+          including guards for malformed TWKB reads and counts (Darafei Praliaskouski)
+ - #5423, Use a DTD-free expanded DocBook input for EPUB builds so
+          out-of-tree builds do not need dbtoepub entity path support
+          (Darafei Praliaskouski)
  - #6073, #6074, Stabilize geography LRS endpoint interpolation and pole
           centroid regressions on 32-bit systems (Darafei Praliaskouski)
  - #6082, Fix Japanese PDF build by avoiding non-ASCII arrows in SQL

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -405,6 +405,9 @@ postgis-out.xml: postgis.xml Makefile $(XML_INPUTS) Makefile
 	$(PERL) -lpe "s'@@LAST_RELEASE_VERSION@@'${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}'g;s'@@POSTGIS_DOWNLOAD_URL@@'${POSTGIS_DOWNLOAD_URL}'g;" $< > $@.in
 	$(XMLLINT) $(XSLTPROC_PATH_OPT) --noent -o $@ $@.in
 
+postgis-out-epub.xml: postgis-out.xml Makefile
+	$(XMLLINT) $(XSLTPROC_PATH_OPT) --dropdtd -o $@ $<
+
 chunked-html: ## Generate multi-file html in html/postgis-en/
 
 chunked-html: $(html_builddir)/postgis$(DOCSUFFIX)/index.html
@@ -465,7 +468,7 @@ pdf-install: postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS
 pdf-uninstall:
 	rm -f $(DESTDIR)$(docdir)/postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).pdf
 
-postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).epub: postgis-out.xml images
+postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).epub: postgis-out-epub.xml images
 ifeq ($(DBTOEPUB),)
 	@echo
 	@echo "configure was unable to find the 'dbtoepub' utility program."
@@ -526,6 +529,7 @@ cheatsheet-clean:
 
 clean: images-clean html-clean pdf-clean epub-clean cheatsheet-clean clean-pot ## Remove generated files except comments
 	rm -f images # work around https://trac.osgeo.org/postgis/ticket/5422
+	rm -f postgis-out-epub.xml
 	rm -f $(XML_GENERATED_SOURCES)
 	rm -f postgis-nospecial.xml postgis-nospecial.xml.in
 	rm -f postgis-out.xml postgis-out.xml.in


### PR DESCRIPTION
## Summary

- generate a DTD-free expanded DocBook input specifically for EPUB builds
- feed that input to `dbtoepub` so out-of-tree builds do not need dbtoepub entity path support
- add a NEWS entry for Trac ticket 5423

Closes https://trac.osgeo.org/postgis/ticket/5423

## Current status

Rebased over current `upstream/master` (`4e470f153`) at head `8038d1851`.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check`
- `make -C doc postgis-out-epub.xml`
- `xmllint --noout doc/postgis-out-epub.xml`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`

`dbtoepub` is not installed in this local environment, so the final EPUB packaging command was not run here.
