### PR TITLE
#1408, Flatten transparent images for PDF docs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -70,6 +70,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5593, Docs: render manual images with GraphicsMagick without temporary files,
           enabling parallel builds, keeping ImageMagick fallbacks working, and
           documenting the generator workflow for contributors (Darafei Praliaskouski)
+ - #1408, Docs: flatten transparent manual images onto white backgrounds for
+          PDF builds while keeping HTML images transparent (Darafei Praliaskouski)
  - [fuzzers] Centralize OSS-Fuzz build/dependency logic in PostGIS scripts,
           prefer requested CXX over pg_config --cc for internal C++ checks, and
           make fuzzer linking/runtime dependency packaging portable

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -49,6 +49,7 @@ DOCSUFFIX=-en
 # TODO: change this ?
 html_builddir=$(abs_builddir)/html
 images_builddir=$(html_builddir)/images
+pdf_images_builddir=$(abs_builddir)/pdf/images
 
 ifneq (,$(findstring dev,$(POSTGIS_MICRO_VERSION)))
   POSTGIS_DOWNLOAD_URL=https://postgis.net/stuff
@@ -417,7 +418,7 @@ $(html_builddir)/postgis$(DOCSUFFIX).html: postgis-out.xml Makefile
 		$<
 
 
-postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).pdf: postgis-out.xml $(abs_srcdir)/texstyle-common.sty $(abs_srcdir)/texstyle.sty | images
+postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).pdf: postgis-out.xml $(abs_srcdir)/texstyle-common.sty $(abs_srcdir)/texstyle.sty | images pdf-images
 ifeq ($(DBLATEX),)
 	@echo
 	@echo "configure was unable to find the 'dblatex' utility program."
@@ -427,7 +428,7 @@ ifeq ($(DBLATEX),)
 else
 	$(DBLATEX) -T native -t pdf \
 		 -x "--path $(XSLT_PATH)" \
-		 -I "$(abs_builddir)/html" \
+		 -I "$(abs_builddir)/pdf" \
 		 -P doc.collab.show=0 \
 		 -P figure.note="images/note" \
 		 -P figure.tip="images/tip" \
@@ -482,12 +483,16 @@ doxygen: doxygen.cfg
 images images-install images-uninstall images-clean:
 	$(MAKE) -C $(images_builddir) $@
 
+pdf-images: images
+	$(MAKE) -C $(images_builddir) $@ PDF_IMAGES_BUILD_DIR="$(pdf_images_builddir)"
+
 html-clean:
 	rm -f $(html_builddir)/postgis$(DOCSUFFIX).html
 	rm -rf $(html_builddir)/postgis$(DOCSUFFIX)/
 
 pdf-clean:
 	rm -f postgis*$(DOCSUFFIX).pdf
+	rm -rf $(abs_builddir)/pdf
 
 epub-clean:
 	rm -f postgis*$(DOCSUFFIX).epub

--- a/doc/html/images/Makefile.in
+++ b/doc/html/images/Makefile.in
@@ -262,6 +262,9 @@ ALL_IMAGES = \
 	$(GENERATED_IMAGES_RESIZED) \
 	$(STATIC_IMAGES)
 
+PDF_IMAGES_BUILD_DIR ?= pdf-images
+PDF_IMAGES = $(ALL_IMAGES:%=$(PDF_IMAGES_BUILD_DIR)/%)
+
 OBJS=styles.o generator.o
 
 # Build the generator
@@ -269,6 +272,8 @@ all: generator
 
 # generate the images
 images: $(ALL_IMAGES)
+
+pdf-images: $(PDF_IMAGES)
 
 images-install: $(ALL_IMAGES)
 	mkdir -p $(DESTDIR)$(htmldir)/images
@@ -284,6 +289,23 @@ $(OBJS): %.o: %.c
 # Command to symlink each of the static images
 $(STATIC_IMAGES):
 	ln -fs $(srcdir)/static/$@ $@
+
+$(PDF_IMAGES_BUILD_DIR)/%: %
+	@mkdir -p $(dir $@)
+	@converter=$${POSTGIS_DOC_CONVERTER:-}; \
+	if test -z "$$converter"; then \
+		if command -v gm >/dev/null 2>&1; then \
+			converter="gm convert"; \
+		elif command -v magick >/dev/null 2>&1; then \
+			converter="magick convert"; \
+		elif command -v convert >/dev/null 2>&1; then \
+			converter="convert"; \
+		else \
+			echo "Could not find GraphicsMagick or ImageMagick executables (gm, magick, convert)." >&2; \
+			exit 1; \
+		fi; \
+	fi; \
+	$$converter "$<" -background white -flatten "$@"
 
 # Command to build each of the .wkt files
 $(GENERATED_IMAGES): %.png: wkt/%.wkt generator wkt/styles.conf
@@ -312,3 +334,4 @@ distclean: clean
 
 images-clean:
 	rm -f $(ALL_IMAGES)
+	rm -rf $(PDF_IMAGES_BUILD_DIR)


### PR DESCRIPTION
## Summary
- add a PDF-only manual image tree that flattens transparent PNG/GIF assets onto white backgrounds
- keep the existing transparent `html/images` outputs for HTML builds
- point dblatex at the flattened `pdf/images` tree and clean it with `pdf-clean`
- add a NEWS entry for Trac #1408

## Testing
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc pdf-images -j32` passed after rerunning around an existing `postgis_revision.h` generator race in the first parallel build
- verified a transparent source image (`doc/html/images/ccbysa.png`) changed from non-opaque `srgba` to opaque `srgb` in `doc/pdf/images/ccbysa.png`
- `make -C doc pdf -j32`
- `make -C doc clean`
- `git diff --check`

Closes #1408
