### PR TITLE
doc: document PostGIS function cost tiers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Enhancements *
 
+ - #2898, Document SQL function cost tiers for contributors
+          (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/postgis/sqldefines.h.in
+++ b/postgis/sqldefines.h.in
@@ -20,7 +20,15 @@
  * where the support functions have been used in
  * place of index SQL inlining.
  * See https://trac.osgeo.org/postgis/ticket/3675
- * for sideffects of costing inlined SQL.
+ * for side effects of costing inlined SQL.
+ *
+ * Cost tiers:
+ * - DEFAULT: cheap metadata, casts, accessors, operators, and index helpers.
+ * - LOW: simple serialization, measurement, or calculations over one geometry.
+ * - MEDIUM: constructors, parsers, exporters, transforms, or algorithms that
+ *   walk most or all coordinates.
+ * - HIGH: expensive GEOS, geography, raster, or multi-input operations where
+ *   planner support functions preserve index-assisted plans.
  */
 #define _COST_DEFAULT COST 1
 #define _COST_LOW COST 50
@@ -51,5 +59,3 @@
 #define SRID_USR_MAX @SRID_USR_MAX@
 
 #endif /* _LWPGIS_DEFINES */
-
-


### PR DESCRIPTION
## Summary

This documents the existing SQL function cost tiers next to the `_COST_*` definitions used by PostGIS SQL templates.

The comment now gives contributors a short rule of thumb for `_COST_DEFAULT`, `_COST_LOW`, `_COST_MEDIUM`, and `_COST_HIGH`, including the existing caution that high costs need planner support functions to preserve index-assisted plans.

Closes #2898

## Release / upgrade notes

- Added a `NEWS` entry under PostGIS 3.7.0 enhancements for #2898.
- No database extension upgrade is needed: this only changes source comments in `postgis/sqldefines.h.in` and the generated header.

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- inspected generated `postgis/sqldefines.h`
- `git diff --check`
