### PR TITLE
postgis: expose GEOS exact equality predicate

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
+
+ - #3197, Add ST_EqualsExact as a GEOS exact-equality wrapper with
+          coordinate tolerance semantics (Darafei Praliaskouski)
 
 
 PostGIS 3.7.0beta2

--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,8 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #3197, Add ST_EqualsExact as a GEOS exact-equality wrapper with
+          coordinate tolerance semantics (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta1
 2026/07/20

--- a/doc/reference_relationship.xml
+++ b/doc/reference_relationship.xml
@@ -845,7 +845,68 @@ WHERE ST_Crosses(roads.geom, highways.geom);</programlisting>
     <refsection>
     <title>See Also</title>
 
-    <para><xref linkend="ST_IsValid"/>, <xref linkend="ST_OrderingEquals"/>, <xref linkend="ST_Reverse"/>, <xref linkend="ST_Within"/></para>
+    <para><xref linkend="ST_EqualsExact"/>, <xref linkend="ST_IsValid"/>, <xref linkend="ST_OrderingEquals"/>, <xref linkend="ST_Reverse"/>, <xref linkend="ST_Within"/></para>
+    </refsection>
+
+  </refentry>
+
+  <refentry xml:id="ST_EqualsExact">
+    <refnamediv>
+    <refname>ST_EqualsExact</refname>
+
+    <refpurpose>Tests if two geometries have the same structure and XY coordinate values</refpurpose>
+    </refnamediv>
+
+    <refsynopsisdiv>
+    <funcsynopsis>
+      <funcprototype>
+      <funcdef>boolean <function>ST_EqualsExact</function></funcdef>
+      <paramdef><type>geometry </type> <parameter>A</parameter></paramdef>
+      <paramdef><type>geometry </type> <parameter>B</parameter></paramdef>
+      <paramdef choice="opt"><type>integer </type> <parameter>decimal = 6</parameter></paramdef>
+      </funcprototype>
+    </funcsynopsis>
+    </refsynopsisdiv>
+
+    <refsection>
+    <title>Description</title>
+
+    <para>Returns <varname>true</varname> if the given geometries are structurally equal in the
+      GEOS exact-equality sense. Unlike <xref linkend="ST_Equals"/>, this comparison is sensitive
+      to geometry type, component structure, and coordinate order.</para>
+
+    <para>The optional <varname>decimal</varname> argument uses decimal-place semantics.
+      It is converted to a GEOS tolerance using
+      <code>0.5 * 10^-decimal</code>, so the default value <code>6</code> accepts XY coordinate
+      differences up to <code>5e-7</code>.</para>
+
+    <para>This function follows the GEOS 2D comparison model. Differences only in Z or M ordinates
+      do not affect the result.</para>
+
+    <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+    <para>Performed by the GEOS module</para>
+    </refsection>
+
+    <refsection>
+    <title>Examples</title>
+
+    <programlisting>SELECT ST_EqualsExact('POINT(0 0)', 'POINT(0.0000004 0)');
+</programlisting>
+<screen>t</screen>
+    <programlisting>SELECT ST_EqualsExact(
+         'LINESTRING(0 0, 1 1)',
+         'MULTILINESTRING((0 0, 1 1))');
+</programlisting>
+<screen>f</screen>
+    <programlisting>SELECT ST_EqualsExact('POINT Z (0 0 1)', 'POINT Z (0 0 2)');
+</programlisting>
+<screen>t</screen>
+    </refsection>
+
+    <refsection>
+    <title>See Also</title>
+
+    <para><xref linkend="ST_Equals"/>, <xref linkend="ST_OrderingEquals"/></para>
     </refsection>
 
   </refentry>

--- a/postgis/lwgeom_geos_predicates.c
+++ b/postgis/lwgeom_geos_predicates.c
@@ -28,6 +28,8 @@
 
 #include "../postgis_config.h"
 
+#include <math.h>
+
 /* PostgreSQL */
 #include "postgres.h"
 #include "funcapi.h"
@@ -61,7 +63,7 @@ Datum covers(PG_FUNCTION_ARGS);
 Datum overlaps(PG_FUNCTION_ARGS);
 Datum coveredby(PG_FUNCTION_ARGS);
 Datum ST_Equals(PG_FUNCTION_ARGS);
-
+Datum ST_EqualsExact(PG_FUNCTION_ARGS);
 
 /*
  * Utility to quickly check for polygonal geometries
@@ -302,7 +304,48 @@ Datum ST_Equals(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(result);
 }
 
+PG_FUNCTION_INFO_V1(ST_EqualsExact);
+Datum
+ST_EqualsExact(PG_FUNCTION_ARGS)
+{
+	SHARED_GSERIALIZED *shared_geom1 = ToastCacheGetGeometry(fcinfo, 0);
+	SHARED_GSERIALIZED *shared_geom2 = ToastCacheGetGeometry(fcinfo, 1);
+	const GSERIALIZED *geom1 = shared_gserialized_get(shared_geom1);
+	const GSERIALIZED *geom2 = shared_gserialized_get(shared_geom2);
+	int32 decimal = PG_GETARG_INT32(2);
+	double tolerance = 0.5 * pow(10.0, -(double)decimal);
+	GEOSGeometry *g1, *g2;
+	int8_t result;
 
+	if (!isfinite(tolerance))
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("ST_EqualsExact: decimal argument %d produces a non-finite tolerance", decimal)));
+	}
+
+	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
+
+	initGEOS(lwpgnotice, lwgeom_geos_error);
+
+	g1 = POSTGIS2GEOS(geom1);
+	if (!g1)
+		HANDLE_GEOS_ERROR("First argument geometry could not be converted to GEOS");
+	g2 = POSTGIS2GEOS(geom2);
+	if (!g2)
+	{
+		GEOSGeom_destroy(g1);
+		HANDLE_GEOS_ERROR("Second argument geometry could not be converted to GEOS");
+	}
+	result = GEOSEqualsExact(g1, g2, tolerance);
+	GEOSGeom_destroy(g1);
+	GEOSGeom_destroy(g2);
+
+	if (result == 2)
+		HANDLE_GEOS_ERROR("GEOSEqualsExact");
+
+	PG_RETURN_BOOL(result);
+}
 
 PG_FUNCTION_INFO_V1(touches);
 Datum touches(PG_FUNCTION_ARGS)

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -4984,6 +4984,13 @@ CREATE OR REPLACE FUNCTION ST_Equals(geom1 geometry, geom2 geometry)
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_HIGH;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_EqualsExact(geom1 geometry, geom2 geometry, "decimal" integer DEFAULT 6)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME','ST_EqualsExact'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_HIGH;
+
 -----------------------------------------------------------------------------
 
 -- PostGIS equivalent function: IsValid(geometry)

--- a/regress/core/regress.sql
+++ b/regress/core/regress.sql
@@ -402,3 +402,11 @@ AND proleakproof;
 SELECT 'UNEXPECTED', postgis_full_version()
 	WHERE postgis_full_version() LIKE '%UNPACKAGED%'
 	   OR postgis_full_version() LIKE '%need upgrade%';
+
+SELECT 317, ST_EqualsExact('POINT(0 0)', 'POINT(0.0000004 0)');
+SELECT 318, ST_EqualsExact('POINT(0 0)', 'POINT(0.0000006 0)');
+SELECT 319, ST_EqualsExact('POINT(0 0)', 'POINT(0.000004 0)', 5);
+SELECT 320, ST_EqualsExact('POINT(0 0)', 'POINT(0.000006 0)', 5);
+SELECT 321, ST_EqualsExact('LINESTRING(0 0, 1 1)', 'MULTILINESTRING((0 0, 1 1))');
+SELECT 322, ST_EqualsExact('LINESTRING(0 0, 1 1)', 'LINESTRING(1 1, 0 0)');
+SELECT 323, ST_EqualsExact('POINT Z (0 0 1)', 'POINT Z (0 0 2)');

--- a/regress/core/regress_expected
+++ b/regress/core/regress_expected
@@ -232,3 +232,10 @@ ERROR:  ST_TileEnvelope: Margin must not be less than -50%, margin=-0.510000
 315|0
 316|t|LINESTRING(40 8.660254037844387,35 8.660254037844387)
 leakproof_compare_support|14
+317|t
+318|f
+319|t
+320|f
+321|f
+322|f
+323|t


### PR DESCRIPTION
Summary:

- Add `ST_EqualsExact(geometry, geometry, decimal integer DEFAULT 6)` as a SQL wrapper around GEOS `GEOSEqualsExact`.
- Keep the GEOS exact-equality contract visible: the comparison is structural, type-sensitive, order-sensitive, and uses GEOS 2D coordinate semantics.
- Convert the decimal-place argument to the GEOS tolerance as `0.5 * 10^-decimal`, matching the Trac request.
- Add reference documentation, regression coverage, and a release note.

Dependency notes:

- PostGIS still requires GEOS 3.10+ for this branch.
- `GEOSEqualsExact` is present in the GEOS 3.10 C API, so no newer GEOS guard is needed for this wrapper.

Validation:

- `git diff --check`
- `git clang-format --diff origin/master -- postgis/lwgeom_geos_predicates.c regress/core/regress.sql regress/core/regress_expected`
- `./utils/check_news.sh .`
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make -j32`
- `sudo -n make install`
- `make -C doc check-xml`
- `make -C regress check RUNTESTFLAGS='--extension --verbose' TESTS='regress/core/regress'`

Closes https://trac.osgeo.org/postgis/ticket/3197
References https://github.com/postgis/postgis/pull/934
