### PR TITLE
postgis: add 3D measure interpolation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,11 @@ These are only changes since 3.7.0beta1.
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
 
+* New Features *
+
+ - #3173, ST_3DAddMeasure measures linear referencing by 3D length
+          (Darafei Praliaskouski)
+
 PostGIS 3.7.0beta1
 2026/07/20
 
@@ -157,8 +162,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)
  - #5109, Document the meaning of topology.next_left_edge and topology.next_right_edge links (Darafei Praliaskouski)
  - #5889, [topology] Include representative locations in topology build errors (Darafei Praliaskouski)
- - #3173, ST_3DAddMeasure measures linear referencing by 3D length
-          (Darafei Praliaskouski)
  - #2614, Use GEOSPreparedDistance and caching to accelerate ST_DWithin (Paul Ramsey)
  - #6022, Document ST_AsMVTGeom tile-coordinate simplification (Darafei Praliaskouski)
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)

--- a/NEWS
+++ b/NEWS
@@ -212,6 +212,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)
  - #5889, [topology] Include representative locations in topology build errors (Darafei Praliaskouski)
+ - #3173, ST_3DAddMeasure measures linear referencing by 3D length
+          (Darafei Praliaskouski)
  - #2614, Use GEOSPreparedDistance and caching to accelerate ST_DWithin (Paul Ramsey)
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #3173, ST_3DAddMeasure measures linear referencing by 3D length
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/NEWS
+++ b/NEWS
@@ -157,6 +157,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)
  - #5109, Document the meaning of topology.next_left_edge and topology.next_right_edge links (Darafei Praliaskouski)
  - #5889, [topology] Include representative locations in topology build errors (Darafei Praliaskouski)
+ - #3173, ST_3DAddMeasure measures linear referencing by 3D length
+          (Darafei Praliaskouski)
  - #2614, Use GEOSPreparedDistance and caching to accelerate ST_DWithin (Paul Ramsey)
  - #6022, Document ST_AsMVTGeom tile-coordinate simplification (Darafei Praliaskouski)
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)

--- a/doc/reference_lrs.xml
+++ b/doc/reference_lrs.xml
@@ -930,17 +930,12 @@ ST_AddMeasure(
 		<title>Examples</title>
 
 		<programlisting>SELECT ST_AsText(ST_3DAddMeasure(
-ST_GeomFromEWKT('LINESTRING(0 0 0, 0 0 1, 0 0 4)'),10,20)) As ewelev;
-                  ewelev
-------------------------------------------
- LINESTRING ZM (0 0 0 10,0 0 1 12.5,0 0 4 20)
+ST_GeomFromEWKT('LINESTRING(0 0 0, 0 0 1, 0 0 4)'),10,20)) As ewelev;</programlisting>
+<screen>LINESTRING ZM (0 0 0 10,0 0 1 12.5,0 0 4 20)</screen>
 
-SELECT ST_AsText(ST_3DAddMeasure(
-ST_GeomFromEWKT('MULTILINESTRING((0 0 0, 0 0 1),(0 0 1, 0 0 4))'),10,20)) As ewelev;
-                                      ewelev
-----------------------------------------------------------------------------------
- MULTILINESTRING ZM ((0 0 0 10,0 0 1 12.5),(0 0 1 12.5,0 0 4 20))
-</programlisting>
+<programlisting>SELECT ST_AsText(ST_3DAddMeasure(
+ST_GeomFromEWKT('MULTILINESTRING((0 0 0, 0 0 1),(0 0 1, 0 0 4))'),10,20)) As ewelev;</programlisting>
+<screen>MULTILINESTRING ZM ((0 0 0 10,0 0 1 12.5),(0 0 1 12.5,0 0 4 20))</screen>
 	  </refsection>
 
 	  <refsection>

--- a/doc/reference_lrs.xml
+++ b/doc/reference_lrs.xml
@@ -863,7 +863,7 @@ ST_AddMeasure(
 	  <refsection>
 		<title>Description</title>
 
-		   <para>Return a derived geometry with measure values linearly interpolated between the start and end points. If the geometry has no measure dimension, one is added. If the geometry has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported.</para>
+		   <para>Return a derived geometry with measure values linearly interpolated between the start and end points using 2D line length. If the geometry has no measure dimension, one is added. If the geometry has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported.</para>
 
 			<para role="availability" conformance="1.5.0">Availability: 1.5.0</para>
 
@@ -893,6 +893,60 @@ ST_AddMeasure(
 10,
 70) As ewelev;</programlisting>
 <screen role="visual-primary text-primary">MULTILINESTRING M ((1 0 10,2 0 20,4 0 40),(1 0 40,2 0 50,4 0 70))</screen>
+	  </refsection>
+
+	</refentry>
+
+	<refentry xml:id="ST_3DAddMeasure">
+	  <refnamediv>
+		<refname>ST_3DAddMeasure</refname>
+
+		<refpurpose>Interpolates measures along a linear geometry using 3D length.</refpurpose>
+	  </refnamediv>
+
+	  <refsynopsisdiv>
+		<funcsynopsis>
+		  <funcprototype>
+			<funcdef>geometry <function>ST_3DAddMeasure</function></funcdef>
+			<paramdef><type>geometry </type> <parameter>geom_mline</parameter></paramdef>
+			<paramdef><type>float8 </type> <parameter>measure_start</parameter></paramdef>
+			<paramdef><type>float8 </type> <parameter>measure_end</parameter></paramdef>
+		  </funcprototype>
+
+		</funcsynopsis>
+	  </refsynopsisdiv>
+
+	  <refsection>
+		<title>Description</title>
+
+		   <para>Return a derived geometry with measure values linearly interpolated between the start and end points using 3D line length. If the geometry has no measure dimension, one is added. If the geometry has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported. For inputs without a Z dimension, this behaves the same as <xref linkend="ST_AddMeasure"/>.</para>
+
+			<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+
+		<para>&Z_support;</para>
+	  </refsection>
+
+	  <refsection>
+		<title>Examples</title>
+
+		<programlisting>SELECT ST_AsText(ST_3DAddMeasure(
+ST_GeomFromEWKT('LINESTRING(0 0 0, 0 0 1, 0 0 4)'),10,20)) As ewelev;
+                  ewelev
+------------------------------------------
+ LINESTRING ZM (0 0 0 10,0 0 1 12.5,0 0 4 20)
+
+SELECT ST_AsText(ST_3DAddMeasure(
+ST_GeomFromEWKT('MULTILINESTRING((0 0 0, 0 0 1),(0 0 1, 0 0 4))'),10,20)) As ewelev;
+                                      ewelev
+----------------------------------------------------------------------------------
+ MULTILINESTRING ZM ((0 0 0 10,0 0 1 12.5),(0 0 1 12.5,0 0 4 20))
+</programlisting>
+	  </refsection>
+
+	  <refsection>
+		<title>See Also</title>
+
+		<para><xref linkend="ST_AddMeasure"/>, <xref linkend="ST_3DLineInterpolatePoint"/></para>
 	  </refsection>
 
 	</refentry>

--- a/doc/reference_lrs.xml
+++ b/doc/reference_lrs.xml
@@ -865,7 +865,7 @@ ST_AddMeasure(
 	  <refsection>
 		<title>Description</title>
 
-		   <para>Return a derived geometry with measure values linearly interpolated between the start and end points. If the geometry has no measure dimension, one is added. If the geometry has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported.</para>
+		   <para>Return a derived geometry with measure values linearly interpolated between the start and end points using 2D line length. If the geometry has no measure dimension, one is added. If the geometry has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported.</para>
 
 			<para role="availability" conformance="1.5.0">Availability: 1.5.0</para>
 
@@ -895,6 +895,60 @@ ST_AddMeasure(
 10,
 70) As ewelev;</programlisting>
 <screen role="visual-primary text-primary">MULTILINESTRING M ((1 0 10,2 0 20,4 0 40),(1 0 40,2 0 50,4 0 70))</screen>
+	  </refsection>
+
+	</refentry>
+
+	<refentry xml:id="ST_3DAddMeasure">
+	  <refnamediv>
+		<refname>ST_3DAddMeasure</refname>
+
+		<refpurpose>Interpolates measures along a linear geometry using 3D length.</refpurpose>
+	  </refnamediv>
+
+	  <refsynopsisdiv>
+		<funcsynopsis>
+		  <funcprototype>
+			<funcdef>geometry <function>ST_3DAddMeasure</function></funcdef>
+			<paramdef><type>geometry </type> <parameter>geom_mline</parameter></paramdef>
+			<paramdef><type>float8 </type> <parameter>measure_start</parameter></paramdef>
+			<paramdef><type>float8 </type> <parameter>measure_end</parameter></paramdef>
+		  </funcprototype>
+
+		</funcsynopsis>
+	  </refsynopsisdiv>
+
+	  <refsection>
+		<title>Description</title>
+
+		   <para>Return a derived geometry with measure values linearly interpolated between the start and end points using 3D line length. If the geometry has no measure dimension, one is added. If the geometry has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported. For inputs without a Z dimension, this behaves the same as <xref linkend="ST_AddMeasure"/>.</para>
+
+			<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+
+		<para>&Z_support;</para>
+	  </refsection>
+
+	  <refsection>
+		<title>Examples</title>
+
+		<programlisting>SELECT ST_AsText(ST_3DAddMeasure(
+ST_GeomFromEWKT('LINESTRING(0 0 0, 0 0 1, 0 0 4)'),10,20)) As ewelev;
+                  ewelev
+------------------------------------------
+ LINESTRING ZM (0 0 0 10,0 0 1 12.5,0 0 4 20)
+
+SELECT ST_AsText(ST_3DAddMeasure(
+ST_GeomFromEWKT('MULTILINESTRING((0 0 0, 0 0 1),(0 0 1, 0 0 4))'),10,20)) As ewelev;
+                                      ewelev
+----------------------------------------------------------------------------------
+ MULTILINESTRING ZM ((0 0 0 10,0 0 1 12.5),(0 0 1 12.5,0 0 4 20))
+</programlisting>
+	  </refsection>
+
+	  <refsection>
+		<title>See Also</title>
+
+		<para><xref linkend="ST_AddMeasure"/>, <xref linkend="ST_3DLineInterpolatePoint"/></para>
 	  </refsection>
 
 	</refentry>

--- a/doc/reference_lrs.xml
+++ b/doc/reference_lrs.xml
@@ -932,17 +932,12 @@ ST_AddMeasure(
 		<title>Examples</title>
 
 		<programlisting>SELECT ST_AsText(ST_3DAddMeasure(
-ST_GeomFromEWKT('LINESTRING(0 0 0, 0 0 1, 0 0 4)'),10,20)) As ewelev;
-                  ewelev
-------------------------------------------
- LINESTRING ZM (0 0 0 10,0 0 1 12.5,0 0 4 20)
+ST_GeomFromEWKT('LINESTRING(0 0 0, 0 0 1, 0 0 4)'),10,20)) As ewelev;</programlisting>
+<screen>LINESTRING ZM (0 0 0 10,0 0 1 12.5,0 0 4 20)</screen>
 
-SELECT ST_AsText(ST_3DAddMeasure(
-ST_GeomFromEWKT('MULTILINESTRING((0 0 0, 0 0 1),(0 0 1, 0 0 4))'),10,20)) As ewelev;
-                                      ewelev
-----------------------------------------------------------------------------------
- MULTILINESTRING ZM ((0 0 0 10,0 0 1 12.5),(0 0 1 12.5,0 0 4 20))
-</programlisting>
+<programlisting>SELECT ST_AsText(ST_3DAddMeasure(
+ST_GeomFromEWKT('MULTILINESTRING((0 0 0, 0 0 1),(0 0 1, 0 0 4))'),10,20)) As ewelev;</programlisting>
+<screen>MULTILINESTRING ZM ((0 0 0 10,0 0 1 12.5),(0 0 1 12.5,0 0 4 20))</screen>
 	  </refsection>
 
 	  <refsection>

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1625,6 +1625,8 @@ extern double ptarray_locate_point(const POINTARRAY *pa, const POINT4D *pt, doub
 */
 extern LWLINE *lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end);
 extern LWMLINE* lwmline_measured_from_lwmline(const LWMLINE *lwmline, double m_start, double m_end);
+extern LWLINE *lwline_measured_from_lwline_3d(const LWLINE *lwline, double m_start, double m_end);
+extern LWMLINE* lwmline_measured_from_lwmline_3d(const LWMLINE *lwmline, double m_start, double m_end);
 
 /**
 * Determine the location(s) along a measured line where m occurs and

--- a/liblwgeom/lwline.c
+++ b/liblwgeom/lwline.c
@@ -385,8 +385,8 @@ lwline_setPoint4d(LWLINE *line, uint32_t index, POINT4D *newpoint)
 * Re-write the measure coordinate (or add one, if it isn't already there) interpolating
 * the measure between the supplied start and end values.
 */
-LWLINE*
-lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end)
+static LWLINE *
+lwline_measured_from_lwline_internal(const LWLINE *lwline, double m_start, double m_end, int use_3d)
 {
 	int i = 0;
 	int hasm = 0, hasz = 0;
@@ -396,7 +396,7 @@ lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end)
 	double m_range = m_end - m_start;
 	double m;
 	POINTARRAY *pa = NULL;
-	POINT3DZ p1, p2;
+	POINT4D p1, p2;
 
 	if ( lwline->type != LINETYPE )
 	{
@@ -411,8 +411,9 @@ lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end)
 	if ( lwline->points )
 	{
 		npoints = lwline->points->npoints;
-		length = ptarray_length_2d(lwline->points);
-		getPoint3dz_p(lwline->points, 0, &p1);
+		length = use_3d ? ptarray_length(lwline->points) : ptarray_length_2d(lwline->points);
+		if (npoints > 0)
+			getPoint4d_p(lwline->points, 0, &p1);
 	}
 
 	pa = ptarray_construct(hasz, hasm, npoints);
@@ -420,13 +421,19 @@ lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end)
 	for ( i = 0; i < npoints; i++ )
 	{
 		POINT4D q;
-		POINT2D a, b;
-		getPoint3dz_p(lwline->points, i, &p2);
-		a.x = p1.x;
-		a.y = p1.y;
-		b.x = p2.x;
-		b.y = p2.y;
-		length_so_far += distance2d_pt_pt(&a, &b);
+		getPoint4d_p(lwline->points, i, &p2);
+		if (use_3d && hasz)
+		{
+			POINT3D a = {p1.x, p1.y, p1.z};
+			POINT3D b = {p2.x, p2.y, p2.z};
+			length_so_far += distance3d_pt_pt(&a, &b);
+		}
+		else
+		{
+			POINT2D a = {p1.x, p1.y};
+			POINT2D b = {p2.x, p2.y};
+			length_so_far += distance2d_pt_pt(&a, &b);
+		}
 		if ( length > 0.0 )
 			m = m_start + m_range * length_so_far / length;
 		/* #3172, support (valid) zero-length inputs */
@@ -443,6 +450,18 @@ lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end)
 	}
 
 	return lwline_construct(lwline->srid, NULL, pa);
+}
+
+LWLINE *
+lwline_measured_from_lwline(const LWLINE *lwline, double m_start, double m_end)
+{
+	return lwline_measured_from_lwline_internal(lwline, m_start, m_end, LW_FALSE);
+}
+
+LWLINE *
+lwline_measured_from_lwline_3d(const LWLINE *lwline, double m_start, double m_end)
+{
+	return lwline_measured_from_lwline_internal(lwline, m_start, m_end, LW_TRUE);
 }
 
 LWGEOM*

--- a/liblwgeom/lwmline.c
+++ b/liblwgeom/lwmline.c
@@ -52,13 +52,15 @@ LWMLINE* lwmline_add_lwline(LWMLINE *mobj, const LWLINE *obj)
 * Re-write the measure ordinate (or add one, if it isn't already there) interpolating
 * the measure between the supplied start and end values.
 */
-LWMLINE*
-lwmline_measured_from_lwmline(const LWMLINE *lwmline, double m_start, double m_end)
+static LWMLINE *
+lwmline_measured_from_lwmline_internal(const LWMLINE *lwmline, double m_start, double m_end, int use_3d)
 {
 	uint32_t i = 0;
 	int hasm = 0, hasz = 0;
 	double length = 0.0, length_so_far = 0.0;
 	double m_range = m_end - m_start;
+	uint32_t non_empty_count = 0;
+	uint32_t non_empty_index = 0;
 	LWGEOM **geoms = NULL;
 
 	if ( lwmline->type != MULTILINETYPE )
@@ -76,8 +78,10 @@ lwmline_measured_from_lwmline(const LWMLINE *lwmline, double m_start, double m_e
 		LWLINE *lwline = (LWLINE*)lwmline->geoms[i];
 		if ( lwline->points && lwline->points->npoints > 1 )
 		{
-			length += ptarray_length_2d(lwline->points);
+			length += use_3d ? ptarray_length(lwline->points) : ptarray_length_2d(lwline->points);
 		}
+		if (lwline->points && lwline->points->npoints > 0)
+			non_empty_count++;
 	}
 
 	if ( lwgeom_is_empty((LWGEOM*)lwmline) )
@@ -95,18 +99,48 @@ lwmline_measured_from_lwmline(const LWMLINE *lwmline, double m_start, double m_e
 
 		if ( lwline->points && lwline->points->npoints > 1 )
 		{
-			sub_length = ptarray_length_2d(lwline->points);
+			sub_length = use_3d ? ptarray_length(lwline->points) : ptarray_length_2d(lwline->points);
 		}
 
-		sub_m_start = (m_start + m_range * length_so_far / length);
-		sub_m_end = (m_start + m_range * (length_so_far + sub_length) / length);
+		if (length > 0.0)
+		{
+			sub_m_start = (m_start + m_range * length_so_far / length);
+			sub_m_end = (m_start + m_range * (length_so_far + sub_length) / length);
+		}
+		else
+		{
+			if (lwline->points && lwline->points->npoints > 0)
+			{
+				sub_m_start = m_start + m_range * (double)non_empty_index / (double)non_empty_count;
+				sub_m_end = m_start + m_range * (double)(non_empty_index + 1) / (double)non_empty_count;
+				non_empty_index++;
+			}
+			else
+			{
+				sub_m_start = m_start + m_range * (double)non_empty_index / (double)non_empty_count;
+				sub_m_end = sub_m_start;
+			}
+		}
 
-		geoms[i] = (LWGEOM*)lwline_measured_from_lwline(lwline, sub_m_start, sub_m_end);
+		geoms[i] = use_3d ? (LWGEOM *)lwline_measured_from_lwline_3d(lwline, sub_m_start, sub_m_end)
+				  : (LWGEOM *)lwline_measured_from_lwline(lwline, sub_m_start, sub_m_end);
 
 		length_so_far += sub_length;
 	}
 
 	return (LWMLINE*)lwcollection_construct(lwmline->type, lwmline->srid, NULL, lwmline->ngeoms, geoms);
+}
+
+LWMLINE *
+lwmline_measured_from_lwmline(const LWMLINE *lwmline, double m_start, double m_end)
+{
+	return lwmline_measured_from_lwmline_internal(lwmline, m_start, m_end, LW_FALSE);
+}
+
+LWMLINE *
+lwmline_measured_from_lwmline_3d(const LWMLINE *lwmline, double m_start, double m_end)
+{
+	return lwmline_measured_from_lwmline_internal(lwmline, m_start, m_end, LW_TRUE);
 }
 
 void lwmline_free(LWMLINE *mline)

--- a/postgis/lwgeom_functions_lrs.c
+++ b/postgis/lwgeom_functions_lrs.c
@@ -72,6 +72,46 @@ Datum ST_AddMeasure(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(gout);
 }
 
+/*
+ * Add a measure dimension to a line, interpolating linearly by 3D length
+ * from the start value to the end value.
+ * ST_3DAddMeasure(Geometry, StartMeasure, EndMeasure) returns Geometry
+ */
+Datum ST_3DAddMeasure(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(ST_3DAddMeasure);
+Datum
+ST_3DAddMeasure(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *gin = PG_GETARG_GSERIALIZED_P(0);
+	GSERIALIZED *gout;
+	double start_measure = PG_GETARG_FLOAT8(1);
+	double end_measure = PG_GETARG_FLOAT8(2);
+	LWGEOM *lwin, *lwout;
+	int type = gserialized_get_type(gin);
+
+	/* Raise an error if input is not a linestring or multilinestring */
+	if (type != LINETYPE && type != MULTILINETYPE)
+	{
+		lwpgerror("Only LINESTRING and MULTILINESTRING are supported");
+		PG_RETURN_NULL();
+	}
+
+	lwin = lwgeom_from_gserialized(gin);
+	if (type == LINETYPE)
+		lwout = (LWGEOM *)lwline_measured_from_lwline_3d((LWLINE *)lwin, start_measure, end_measure);
+	else
+		lwout = (LWGEOM *)lwmline_measured_from_lwmline_3d((LWMLINE *)lwin, start_measure, end_measure);
+
+	lwgeom_free(lwin);
+
+	if (lwout == NULL)
+		PG_RETURN_NULL();
+
+	gout = geometry_serialize(lwout);
+	lwgeom_free(lwout);
+
+	PG_RETURN_POINTER(gout);
+}
 
 /*
 * Locate a point along a feature based on a measure value.

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -3853,6 +3853,13 @@ CREATE OR REPLACE FUNCTION ST_AddMeasure(geometry, float8, float8)
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_MEDIUM;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_3DAddMeasure(geometry, float8, float8)
+	RETURNS geometry
+	AS 'MODULE_PATHNAME', 'ST_3DAddMeasure'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_MEDIUM;
+
 ---------------------------------------------------------------
 -- TEMPORAL
 ---------------------------------------------------------------

--- a/regress/core/regress_lrs.sql
+++ b/regress/core/regress_lrs.sql
@@ -92,6 +92,14 @@ select 'line_interpolate_points', ST_AsText(ST_LineInterpolatePoints('LINESTRING
 
 select 'addMeasure1', ST_AsText(ST_AddMeasure('LINESTRING(0 0, 2 0, 4 0)', 10, 20));
 select 'addMeasure2', ST_AsText(ST_AddMeasure('LINESTRING(0 0, 9 0, 10 0)', 10, 20));
+select 'addMeasure3d1', ST_AsText(ST_3DAddMeasure('LINESTRING(0 0 0, 0 0 1, 0 0 4)', 10, 20));
+select 'addMeasure3d2', ST_AsText(ST_3DAddMeasure('MULTILINESTRING((0 0 0, 0 0 1),(0 0 1, 0 0 4))', 10, 20));
+select 'addMeasure3d2d', ST_AsText(ST_3DAddMeasure('LINESTRING(0 0, 9 0, 10 0)', 10, 20));
+select 'addMeasure3dempty', ST_AsText(ST_3DAddMeasure('LINESTRING EMPTY', 10, 20));
+select 'addMeasure3dzeromline', ST_AsText(ST_3DAddMeasure('MULTILINESTRING((0 0 0, 0 0 0),(1 1 1, 1 1 1))', 10, 20));
+select 'addMeasure3dzeromlineempty1', ST_AsText(ST_3DAddMeasure('MULTILINESTRING Z (EMPTY,(0 0 0, 0 0 0))', 10, 20));
+select 'addMeasure3dzeromlineempty2', ST_AsText(ST_3DAddMeasure('MULTILINESTRING Z ((0 0 0, 0 0 0),EMPTY)', 10, 20));
+select 'addMeasurezeromlineempty', ST_AsText(ST_AddMeasure('MULTILINESTRING(EMPTY,(0 0, 0 0))', 10, 20));
 
 --
 -- ST_InterpolatePoint

--- a/regress/core/regress_lrs_expected
+++ b/regress/core/regress_lrs_expected
@@ -45,6 +45,14 @@ line_interpolate_points|POINT(0.7 0.7)
 line_interpolate_points|MULTIPOINT((0.3 0.3),(0.6 0.6),(0.9 0.9))
 addMeasure1|LINESTRING M (0 0 10,2 0 15,4 0 20)
 addMeasure2|LINESTRING M (0 0 10,9 0 19,10 0 20)
+addMeasure3d1|LINESTRING ZM (0 0 0 10,0 0 1 12.5,0 0 4 20)
+addMeasure3d2|MULTILINESTRING ZM ((0 0 0 10,0 0 1 12.5),(0 0 1 12.5,0 0 4 20))
+addMeasure3d2d|LINESTRING M (0 0 10,9 0 19,10 0 20)
+addMeasure3dempty|LINESTRING M EMPTY
+addMeasure3dzeromline|MULTILINESTRING ZM ((0 0 0 10,0 0 0 15),(1 1 1 15,1 1 1 20))
+addMeasure3dzeromlineempty1|MULTILINESTRING ZM (EMPTY,(0 0 0 10,0 0 0 20))
+addMeasure3dzeromlineempty2|MULTILINESTRING ZM ((0 0 0 10,0 0 0 20),EMPTY)
+addMeasurezeromlineempty|MULTILINESTRING M (EMPTY,(0 0 10,0 0 20))
 interpolatePoint1|2
 interpolatePoint2|3
 3DinterpolatePoint1|10


### PR DESCRIPTION
## Summary

- add `ST_3DAddMeasure` for measure interpolation by 3D line length
- keep `ST_AddMeasure` behavior unchanged and document that it uses 2D line length
- preserve empty-line behavior and avoid NaN/Inf measures for fully degenerate multilines
- skip `EMPTY` multiline members when assigning zero-length measure subranges
- add LRS regression coverage for 3D lines, 3D multilines, 2D fallback, empty lines, zero-length multilines, and zero-length multilines with `EMPTY` members

Closes https://trac.osgeo.org/postgis/ticket/3173

## Current status

Rebased over current `master` (`4e470f153`) at head `514945654`.

## Release / upgrade notes

- NEWS entry added for https://trac.osgeo.org/postgis/ticket/3173.
- SQL declarations are updated in `postgis/postgis.sql.in`; extension upgrade SQL is generated from the SQL sources during the normal extension build.

## Testing

- read PR body/diff/commits/checks/reviewThreads before public action; previous CI and CodeRabbit were green and reviewThreads were resolved/outdated
- `git diff --check upstream/master..HEAD`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- liblwgeom/liblwgeom.h.in liblwgeom/lwline.c liblwgeom/lwmline.c postgis/lwgeom_functions_lrs.c postgis/postgis.sql.in regress/core/regress_lrs.sql regress/core/regress_lrs_expected doc/reference_lrs.xml NEWS`
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C postgis postgis_upgrade.sql`
- `make -C doc check-xml`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/regress/core/regress_lrs"`
- `make -C regress check RUNTESTFLAGS='--upgrade --extension --verbose' TESTS="$(pwd)/regress/core/regress_lrs"`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`

Notes: `configure` reported `dbtoepub` missing, so EPUB documentation was not built. The focused XML documentation check and LRS fresh/automatic-upgrade/explicit-upgrade regression passes all completed successfully on the rebased head.
