### PR TITLE
doc: document ST_Translate M preservation

### DIFF
--- a/doc/reference_transformation.xml
+++ b/doc/reference_transformation.xml
@@ -520,13 +520,15 @@ SELECT ST_AsText(ST_Scale('LINESTRING(1 1, 2 2)', 'POINT(2 2)', 'POINT(1 1)'::ge
 		<title>Description</title>
 
 		<para>Returns a new geometry whose coordinates are translated delta x,delta y,delta z units. Units are
-		based on the units defined in spatial reference (SRID) for this geometry.</para>
+		based on the units defined in spatial reference (SRID) for this geometry.
+		M coordinates are preserved.</para>
 
 		<note><para>Prior to 1.3.4, this function crashes if used with geometries that contain CURVES.  This is fixed in 1.3.4+</para></note>
 
 		<para role="availability" conformance="1.2.2">Availability: 1.2.2</para>
 		<para>&Z_support;</para>
 		<para>&curve_support;</para>
+		<para>&M_support;</para>
 	  </refsection>
 
 	  <refsection>
@@ -550,6 +552,17 @@ SELECT ST_AsText(ST_Scale('LINESTRING(1 1, 2 2)', 'POINT(2 2)', 'POINT(1 1)'::ge
 	st_asewkt
 	---------
 	POINT(5 12 3)
+		</programlisting>
+		<para>Move points with a measure coordinate</para>
+		<programlisting>SELECT ST_AsEWKT(ST_Translate(ST_GeomFromEWKT('POINTM(0 0 11)'), 5, 12));
+	st_asewkt
+	---------
+	POINTM(5 12 11)
+
+SELECT ST_AsEWKT(ST_Translate(ST_GeomFromEWKT('POINT(0 0 7 11)'), 5, 12, 3));
+	st_asewkt
+	---------
+	POINT(5 12 10 11)
 		</programlisting>
 		<para>Move a curve and a point</para>
 <programlisting>SELECT ST_AsText(ST_Translate(ST_Collect('CURVEPOLYGON(CIRCULARSTRING(4 3,3.12 0.878,1 0,-1.121 5.1213,6 7, 8 9,4 3))','POINT(1 3)'),1,2));

--- a/regress/core/affine.sql
+++ b/regress/core/affine.sql
@@ -3,6 +3,8 @@
 -- ST_Translate
 select 'ST_Translate', ST_asewkt(ST_Translate('POINT(0 0)'::geometry, 5, 12));
 select 'ST_Translate', ST_asewkt(ST_Translate('POINT(0 0 0)'::geometry, -3, -7, 3));
+select 'ST_TranslateM', ST_asewkt(ST_Translate(ST_GeomFromEWKT('POINTM(0 0 11)'), 5, 12));
+select 'ST_TranslateZM', ST_asewkt(ST_Translate(ST_GeomFromEWKT('POINT(0 0 7 11)'), 5, 12, 3));
 
 -- ST_Scale
 select 'ST_Scale', ST_asewkt(ST_Scale('POINT(1 1)'::geometry, 5, 5));

--- a/regress/core/affine_expected
+++ b/regress/core/affine_expected
@@ -1,5 +1,7 @@
 ST_Translate|POINT(5 12)
 ST_Translate|POINT(-3 -7 3)
+ST_TranslateM|POINTM(5 12 11)
+ST_TranslateZM|POINT(5 12 10 11)
 ST_Scale|POINT(5 5)
 ST_Scale|POINT(3 2)
 ST_Scale|POINT(40 40 40)


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/3063

## Summary
- Document that `ST_Translate` preserves M coordinates.
- Add POINTM and ZM examples.
- Add affine regression coverage for M/ZM translation preservation.

## Current branch
- Base: `postgis/postgis` `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- Head: `a2a5bb897a499aaac56f30af583bb8f9febe2865`

## Validation
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check-xml`
- `make -C regress check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/regress/core/affine"`; the harness also ran the affine upgrade pass because `--upgrade` was not explicitly supplied
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- doc/reference_transformation.xml regress/core/affine.sql regress/core/affine_expected`

GitHub CI and CodeRabbit have been queued for this refreshed head.
