### PR TITLE
#1124 Add shp2pgsql unlogged table option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * New Features *
 
+ - #1124, shp2pgsql can create UNLOGGED tables for transient staging loads
+          (Darafei Praliaskouski)
  - [topology] FindVertexSegmentPairsBelowDistance function (Sandro Santilli)
  - ST_CoverageEdges, returns MultiLinestring of distinct shared edges in
           polygonal coverage (Paul Ramsey)

--- a/doc/man/shp2pgsql.1
+++ b/doc/man/shp2pgsql.1
@@ -108,6 +108,11 @@ If this option is used the output will be encoded in UTF-8.
 \fB\-I\fR
 Create a GiST index on the geometry column. 
 .TP 
+\fB\-u\fR
+Create the target table as UNLOGGED. This can speed up loading transient
+staging data, but PostgreSQL does not preserve unlogged table contents after
+a crash or unclean shutdown.
+.TP
 \fB\-N\fR <\fIpolicy\fR>
 Specify NULL geometries handling policy (insert,skip,abort).
 .TP 

--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -1996,6 +1996,17 @@ COMMIT;</programlisting>
     </varlistentry>
 
     <varlistentry>
+      <term><option>-u</option></term>
+      <listitem>
+        <para>
+          Create the target table as <literal>UNLOGGED</literal>. This can speed up loading
+          transient staging data, but PostgreSQL does not preserve unlogged table contents
+          after a crash or unclean shutdown.
+        </para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
       <term><option>-m</option></term>
       <listitem>
         <para>

--- a/loader/shp2pgsql-cli.c
+++ b/loader/shp2pgsql-cli.c
@@ -47,6 +47,7 @@ usage()
 	printf(_( "  -k  Keep postgresql identifiers case.\n" ));
 	printf(_( "  -i  Use int4 type for all integer dbf fields.\n" ));
 	printf(_( "  -I  Create a spatial index on the geocolumn.\n" ));
+	printf(_( "  -u  Create the table as UNLOGGED.\n" ));
 	printf(_("  -m <filename>  Specify a file containing a set of mappings of (long) column\n"
 	         "     names to 10 character DBF column names. The content of the file is one or\n"
 	         "     more lines of two names separated by white space and no trailing or\n"
@@ -105,7 +106,7 @@ main (int argc, char **argv)
 	set_loader_config_defaults(config);
 
 	/* Keep the flag list alphabetic so it's easy to see what's left. */
-	while ((c = pgis_getopt(argc, argv, "-?acdeg:ikm:nps:t:wDGIN:ST:W:X:Z")) != EOF)
+	while ((c = pgis_getopt(argc, argv, "-?acdeg:ikm:nps:t:uwDGIN:ST:W:X:Z")) != EOF)
 	{
 		// can not do this inside the switch case
 		if ('-' == c)
@@ -176,6 +177,10 @@ main (int argc, char **argv)
 
 		case 'I':
 			config->createindex = 1;
+			break;
+
+		case 'u':
+			config->unlogged = 1;
 			break;
 
 		case 'w':

--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -770,6 +770,7 @@ set_loader_config_defaults(SHPLOADERCONFIG *config)
 	config->quoteidentifiers = 0;
 	config->forceint4 = 0;
 	config->createindex = 0;
+	config->unlogged = 0;
 	config->analyze = 1;
 	config->readshape = 1;
 	config->force_output = FORCE_OUTPUT_DISABLE;
@@ -1350,12 +1351,14 @@ ShpLoaderGetSQLHeader(SHPLOADERSTATE *state, char **strheader)
 		*/
 		if (state->config->schema)
 		{
-			stringbuffer_aprintf(sb, "CREATE TABLE \"%s\".\"%s\" (gid serial",
+			stringbuffer_aprintf(sb, "CREATE %sTABLE \"%s\".\"%s\" (gid serial",
+			                     state->config->unlogged ? "UNLOGGED " : "",
 			                     state->config->schema, state->config->table);
 		}
 		else
 		{
-			stringbuffer_aprintf(sb, "CREATE TABLE \"%s\" (gid serial", state->config->table);
+			stringbuffer_aprintf(sb, "CREATE %sTABLE \"%s\" (gid serial",
+			                     state->config->unlogged ? "UNLOGGED " : "", state->config->table);
 		}
 
 		/* Generate the field types based upon the shapefile information */

--- a/loader/shp2pgsql-core.h
+++ b/loader/shp2pgsql-core.h
@@ -114,6 +114,9 @@ typedef struct shp_loader_config
 	/* 0 = no index, 1 = create index after load */
 	int createindex;
 
+	/* 0 = logged table, 1 = create as UNLOGGED table */
+	int unlogged;
+
     /* 0 = don't analyze tables , 1 = analyze tables */
 	int analyze;
 

--- a/loader/shp2pgsql-gui.c
+++ b/loader/shp2pgsql-gui.c
@@ -113,6 +113,7 @@ static GtkWidget *checkbutton_loader_options_forceint = NULL;
 static GtkWidget *checkbutton_loader_options_autoindex = NULL;
 static GtkWidget *checkbutton_loader_options_dbfonly = NULL;
 static GtkWidget *checkbutton_loader_options_dumpformat = NULL;
+static GtkWidget *checkbutton_loader_options_unlogged = NULL;
 static GtkWidget *checkbutton_loader_options_geography = NULL;
 static GtkWidget *checkbutton_loader_options_simplegeoms = NULL;
 
@@ -540,6 +541,7 @@ update_loader_config_globals_from_options_ui(SHPLOADERCONFIG *config)
 	gboolean createindex = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_autoindex));
 	gboolean dbfonly = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_dbfonly));
 	gboolean dumpformat = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_dumpformat));
+	gboolean unlogged = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_unlogged));
 	gboolean geography = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_geography));
 	gboolean simplegeoms = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_simplegeoms));
 
@@ -606,6 +608,12 @@ update_loader_config_globals_from_options_ui(SHPLOADERCONFIG *config)
 	else
 		config->dump_format = 0;
 
+	/* Create an unlogged table */
+	if (unlogged)
+		config->unlogged = 1;
+	else
+		config->unlogged = 0;
+
 	/* Simple geometries only */
 	if (simplegeoms)
 		config->simple_geometries = 1;
@@ -625,6 +633,7 @@ update_options_ui_from_loader_config_globals(void)
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_autoindex), global_loader_config->createindex ? TRUE : FALSE);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_dbfonly), global_loader_config->readshape ? FALSE : TRUE);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_dumpformat), global_loader_config->dump_format ? TRUE : FALSE);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_unlogged), global_loader_config->unlogged ? TRUE : FALSE);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_geography), global_loader_config->geography ? TRUE : FALSE);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton_loader_options_simplegeoms), global_loader_config->simple_geometries ? TRUE : FALSE);
 
@@ -2712,7 +2721,7 @@ pgui_create_loader_options_dialog()
 	gtk_window_set_keep_above (GTK_WINDOW(dialog_loader_options), TRUE);
 	gtk_window_set_default_size (GTK_WINDOW(dialog_loader_options), 180, -1);
 
-	table_options = gtk_table_new(7, 3, TRUE);
+	table_options = gtk_table_new(9, 3, TRUE);
 	gtk_container_set_border_width (GTK_CONTAINER (table_options), 12);
 	gtk_table_set_row_spacings(GTK_TABLE(table_options), 5);
 	gtk_table_set_col_spacings(GTK_TABLE(table_options), 10);
@@ -2752,16 +2761,22 @@ pgui_create_loader_options_dialog()
 	gtk_table_attach_defaults(GTK_TABLE(table_options), align_options_center, 0, 1, 5, 6 );
 	gtk_container_add (GTK_CONTAINER (align_options_center), checkbutton_loader_options_dumpformat);
 
-	pgui_create_options_dialog_add_label(table_options, _("Load into GEOGRAPHY column"), 0.0, 6);
-	checkbutton_loader_options_geography = gtk_check_button_new();
+	pgui_create_options_dialog_add_label(table_options, _("Create as UNLOGGED table"), 0.0, 6);
+	checkbutton_loader_options_unlogged = gtk_check_button_new();
 	align_options_center = gtk_alignment_new( 0.5, 0.5, 0.0, 1.0 );
 	gtk_table_attach_defaults(GTK_TABLE(table_options), align_options_center, 0, 1, 6, 7 );
-	gtk_container_add (GTK_CONTAINER (align_options_center), checkbutton_loader_options_geography);
+	gtk_container_add (GTK_CONTAINER (align_options_center), checkbutton_loader_options_unlogged);
 
-	pgui_create_options_dialog_add_label(table_options, _("Generate simple geometries instead of MULTI geometries"), 0.0, 7);
-	checkbutton_loader_options_simplegeoms = gtk_check_button_new();
+	pgui_create_options_dialog_add_label(table_options, _("Load into GEOGRAPHY column"), 0.0, 7);
+	checkbutton_loader_options_geography = gtk_check_button_new();
 	align_options_center = gtk_alignment_new( 0.5, 0.5, 0.0, 1.0 );
 	gtk_table_attach_defaults(GTK_TABLE(table_options), align_options_center, 0, 1, 7, 8 );
+	gtk_container_add (GTK_CONTAINER (align_options_center), checkbutton_loader_options_geography);
+
+	pgui_create_options_dialog_add_label(table_options, _("Generate simple geometries instead of MULTI geometries"), 0.0, 8);
+	checkbutton_loader_options_simplegeoms = gtk_check_button_new();
+	align_options_center = gtk_alignment_new( 0.5, 0.5, 0.0, 1.0 );
+	gtk_table_attach_defaults(GTK_TABLE(table_options), align_options_center, 0, 1, 8, 9 );
 	gtk_container_add (GTK_CONTAINER (align_options_center), checkbutton_loader_options_simplegeoms);
 
 	/* Catch the response from the dialog */


### PR DESCRIPTION
Closes #1124

This adds a `-u` option to `shp2pgsql` so create/drop/prepare/dump modes emit `CREATE UNLOGGED TABLE` for transient staging loads. The shared loader config also exposes the option through `shp2pgsql-gui`, and the loader docs, manpage, and NEWS entry are updated.

Release / upgrade notes:
- NEWS entry added for #1124.
- No database extension upgrade step is needed; this changes loader binaries/UI/docs only.

Validation:
- `make -C loader -j$(nproc)`
- `make -C doc check-xml`
- `git diff --check`
- smoke checks for `-u` create/drop/prepare/dump output and append mode staying insert-only
