### PR TITLE
Add ST_GetFaceGeometry SRID overload (#6075)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Enhancements *
 
+ - #6075, [topology] Allow ST_GetFaceGeometry to assign an SRID to
+          the returned geometry (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -3159,17 +3159,24 @@ FROM topology.ST_GetFaceEdges('tt',1) As t(seq,edge)
 					<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
 					<paramdef><type>bigint </type> <parameter>aface</parameter></paramdef>
 					</funcprototype>
+					<funcprototype>
+					<funcdef>geometry <function>ST_GetFaceGeometry</function></funcdef>
+					<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
+					<paramdef><type>bigint </type> <parameter>aface</parameter></paramdef>
+					<paramdef><type>integer </type> <parameter>srid</parameter></paramdef>
+					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
 
 			<refsection>
                 <title>Description</title>
 
-                <para>Returns the polygon in the given topology with the specified face id. Builds the polygon from the edges making up the face.</para>
+                <para>Returns the polygon in the given topology with the specified face id. Builds the polygon from the edges making up the face. If <varname>srid</varname> is given, the returned geometry is assigned that SRID.</para>
 
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="1.1">Availability: 1.1 </para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 accept an SRID for the returned geometry.</para>
 	<para>&sqlmm_compliant; SQL-MM 3 Topo-Geo and Topo-Net 3: Routine Details: X.3.16</para>
 			</refsection>
 

--- a/topology/sql/sqlmm.sql.in
+++ b/topology/sql/sqlmm.sql.in
@@ -151,6 +151,16 @@ CREATE OR REPLACE FUNCTION topology.ST_GetFaceGeometry(toponame varchar, aface b
   RETURNS GEOMETRY AS
 	'MODULE_PATHNAME', 'ST_GetFaceGeometry'
   LANGUAGE 'c' STABLE;
+
+CREATE OR REPLACE FUNCTION topology.ST_GetFaceGeometry(toponame varchar, aface bigint, srid integer)
+  RETURNS GEOMETRY AS
+$$
+	SELECT CASE
+		WHEN $3 IS NULL THEN topology.ST_GetFaceGeometry($1, $2)
+		ELSE ST_SetSRID(topology.ST_GetFaceGeometry($1, $2), $3)
+	END;
+$$
+  LANGUAGE 'sql' STABLE;
 --} ST_GetFaceGeometry
 
 --{
@@ -603,4 +613,3 @@ LANGUAGE 'plpgsql' VOLATILE;
 --} ST_CreateTopoGeo
 
 --=}  SQL/MM block
-

--- a/topology/test/regress/st_getfacegeometry.sql
+++ b/topology/test/regress/st_getfacegeometry.sql
@@ -28,6 +28,7 @@ COPY tt.edge_data(
 -- See http://trac.osgeo.org/postgis/ticket/726
 SELECT 'f1 (with hole)', ST_asText(topology.st_getfacegeometry('tt', 1));
 SELECT 'f2 (fill hole)', ST_asText(topology.st_getfacegeometry('tt', 2));
+SELECT '#6075', ST_SRID(topology.st_getfacegeometry('tt', 1, 4326)), ST_asText(topology.st_getfacegeometry('tt', 1, 4326));
 
 -- Universal face has no geometry
 -- See http://trac.osgeo.org/postgis/ticket/973

--- a/topology/test/regress/st_getfacegeometry_expected
+++ b/topology/test/regress/st_getfacegeometry_expected
@@ -1,6 +1,7 @@
 t
 f1 (with hole)|POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,8 2,8 8,2 8,2 2))
 f2 (fill hole)|POLYGON((2 2,2 8,8 8,8 2,2 2))
+#6075|4326|POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,8 2,8 8,2 8,2 2))
 ERROR:  SQL/MM Spatial exception - universal face has no geometry
 ERROR:  SQL/MM Spatial exception - null argument
 ERROR:  SQL/MM Spatial exception - null argument


### PR DESCRIPTION
## Summary
- add a three-argument ST_GetFaceGeometry(toponame, face_id, srid) SQL overload
- keep the existing two-argument C function unchanged
- document the overload and add regression coverage for assigned SRID output

Closes #6075

## Release / upgrade notes
- NEWS entry added for #6075.
- No hand-written topology upgrade file is committed; `topology.sql` / `topology_upgrade.sql` are generated from `topology/sql/sqlmm.sql.in`.

## Testing
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j"$(nproc)"`
- `sudo make install`
- `make -C topology/test check RUNTESTFLAGS="--extension" TESTS="$(pwd)/topology/test/regress/st_getfacegeometry"`
- `make -C doc check-xml`
- `git diff --check`
