### PR TITLE
Fix RemoveUnusedPrimitives stale heal node check (#5937)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -134,6 +134,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           dropping the tail (Darafei Praliaskouski)
  - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for
           MinGW builds (Darafei Praliaskouski)
+ - #5937, [topology] RemoveUnusedPrimitives tolerates stale candidate nodes
+          after healing removes another valid node (Darafei Praliaskouski)
  - Build PostgreSQL extension modules with `-fno-semantic-interposition` when
           available so LTO can optimize same-DSO calls to exported PostGIS
           entry points directly instead of routing through the module PLT; in

--- a/topology/sql/cleanup/RemoveUnusedPrimitives.sql.in
+++ b/topology/sql/cleanup/RemoveUnusedPrimitives.sql.in
@@ -34,6 +34,7 @@ DECLARE
   edgeMap JSONB := '{}';
   edge1 BIGINT;
   edge2 BIGINT;
+  sharedNodes BIGINT[];
   removedNode BIGINT;
   ok BOOLEAN;
   fixedLinks INT := 0;
@@ -671,16 +672,55 @@ BEGIN
     ok := false;
 
     BEGIN
+      IF bbox IS NOT NULL THEN
+        sql := format(
+          $$
+            SELECT array_agg(node_id)
+            FROM (
+              SELECT e1.start_node node_id
+              FROM %1$I.edge_data e1, %1$I.edge_data e2
+              WHERE e1.edge_id = $1
+                AND e2.edge_id = $2
+                AND e1.start_node IN (e2.start_node, e2.end_node)
+
+              UNION
+
+              SELECT e1.end_node node_id
+              FROM %1$I.edge_data e1, %1$I.edge_data e2
+              WHERE e1.edge_id = $1
+                AND e2.edge_id = $2
+                AND e1.end_node IN (e2.start_node, e2.end_node)
+            ) shared
+          $$,
+          topo.name
+        );
+        EXECUTE sql USING edge1, edge2 INTO sharedNodes;
+        IF sharedNodes IS NULL OR NOT (sharedNodes && rec.connecting_nodes::bigint[]) THEN
+          RAISE DEBUG 'Skipping stale bbox-limited heal of edges % and % currently joined by nodes % instead of candidate nodes %',
+            edge1, edge2, sharedNodes, rec.connecting_nodes;
+          CONTINUE;
+        END IF;
+      END IF;
+
       -- TODO: replace ST_ModEdgeHeal loop with a faster direct deletion and healing
       removedNode := topology.ST_ModEdgeHeal(topo.name, edge1, edge2);
-      IF NOT removedNode = ANY ( rec.connecting_nodes ) THEN
-        RAISE EXCEPTION 'Healing of edges % and % was reported '
-                        'to remove node % while we expected any of % instead',
-                        edge1, edge2, removedNode, rec.connecting_nodes;
+      IF bbox IS NOT NULL AND NOT removedNode = ANY ( rec.connecting_nodes ) THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'PT943',
+          MESSAGE = format(
+            'Skipping stale bbox-limited heal of edges %s and %s because it removed node %s instead of candidate nodes %s',
+            edge1, edge2, removedNode, rec.connecting_nodes
+          );
+      ELSIF NOT removedNode = ANY ( rec.connecting_nodes ) THEN
+        RAISE DEBUG 'Healing of edges % and % removed node % instead of one of stale candidate nodes %',
+          edge1, edge2, removedNode, rec.connecting_nodes;
       END IF;
       RAISE DEBUG 'Edge % merged into %, dropping node %', edge2, edge1, removedNode;
       ok := 1;
-    EXCEPTION WHEN OTHERS
+    EXCEPTION WHEN SQLSTATE 'PT943'
+    THEN
+      RAISE DEBUG '%', SQLERRM;
+    WHEN OTHERS
     THEN
       RAISE WARNING 'Edges % and % joined by node % could not be healed: %', edge1, edge2, rec.connecting_nodes, SQLERRM;
     END;
@@ -698,4 +738,3 @@ BEGIN
   RETURN deletedEdges + deletedNodes + deletedNodesDeg2;
 END;
 $BODY$ LANGUAGE 'plpgsql' VOLATILE;
-

--- a/topology/test/regress/removeunusedprimitives.sql
+++ b/topology/test/regress/removeunusedprimitives.sql
@@ -239,6 +239,43 @@ SELECT '#5303', 'clean', topology.RemoveUnusedPrimitives('city_data');
 SELECT '#5303', 'changed', * FROM features.check_changed_features();
 SELECT '#5303', 'invalidity', * FROM topology.ValidateTopology('city_data');
 
+--
+-- See https://trac.osgeo.org/postgis/ticket/5937
+--
+
+SELECT NULL FROM topology.CreateTopology('t5937');
+CREATE TABLE features.t5937_f(id serial primary key);
+SELECT NULL FROM topology.AddTopoGeometryColumn('t5937', 'features', 't5937_f', 'g', 'line');
+SELECT NULL FROM topology.toTopoGeom(ST_ExteriorRing(ST_MakeEnvelope(0,0,10,10)), 't5937', 1);
+SELECT NULL FROM topology.TopoGeo_AddPoint('t5937', ST_Point(10,0));
+SELECT NULL FROM topology.TopoGeo_AddPoint('t5937', ST_Point(0,10));
+SELECT NULL FROM topology.TopoGeo_AddPoint('t5937', ST_Point(10,10));
+SELECT '#5937', 'clean', topology.RemoveUnusedPrimitives('t5937');
+SELECT '#5937', 'invalidity', * FROM topology.ValidateTopology('t5937');
+SELECT NULL FROM topology.DropTopology('t5937');
+DROP TABLE features.t5937_f;
+
+--
+-- Bbox-limited cleanup should not accept a stale heal that removes
+-- a node outside the bbox-filtered candidate set.
+--
+
+SELECT NULL FROM topology.CreateTopology('t5937_bbox');
+CREATE TABLE features.t5937_bbox_f(id serial primary key);
+SELECT NULL FROM topology.AddTopoGeometryColumn('t5937_bbox', 'features', 't5937_bbox_f', 'g', 'line');
+SELECT NULL FROM topology.toTopoGeom(ST_ExteriorRing(ST_MakeEnvelope(0,0,10,10)), 't5937_bbox', 1);
+SELECT NULL FROM topology.TopoGeo_AddPoint('t5937_bbox', ST_Point(10,0));
+SELECT NULL FROM topology.TopoGeo_AddPoint('t5937_bbox', ST_Point(0,10));
+SELECT NULL FROM topology.TopoGeo_AddPoint('t5937_bbox', ST_Point(10,10));
+SELECT '#5937-bbox', 'clean', topology.RemoveUnusedPrimitives(
+  't5937_bbox',
+  ST_GeomFromText('POLYGON((-1 -1, 11 -1, -1 11, -1 -1))')
+);
+SELECT '#5937-bbox', 'nodes', array_agg(node_id ORDER BY node_id) FROM t5937_bbox.node;
+SELECT '#5937-bbox', 'invalidity', * FROM topology.ValidateTopology('t5937_bbox');
+SELECT NULL FROM topology.DropTopology('t5937_bbox');
+DROP TABLE features.t5937_bbox_f;
+
 
 --
 -- Cleanup

--- a/topology/test/regress/removeunusedprimitives_expected
+++ b/topology/test/regress/removeunusedprimitives_expected
@@ -9,3 +9,6 @@ t5|clean|2
 t6|clean|3
 #5289|clean|1
 #5303|clean|0
+#5937|clean|3
+#5937-bbox|clean|2
+#5937-bbox|nodes|{2,4}


### PR DESCRIPTION
## Summary
- avoid aborting unbounded RemoveUnusedPrimitives when a successful ST_ModEdgeHeal removes a node outside a stale precomputed candidate set
- keep that unbounded mismatch visible as DEBUG output
- preserve bbox-limited cleanup by skipping/rolling back stale heals that would remove a node outside the bbox-filtered candidate set
- add regressions for the ticket #5937 repro and a bbox-limited stale-heal case

## Release / upgrade notes
- added a 3.7.0 `NEWS` entry for #5937
- no checked-in upgrade SQL file is needed: topology install/upgrade SQL is generated from `topology/sql/cleanup/RemoveUnusedPrimitives.sql.in`, and `make -C topology topology.sql topology_upgrade.sql` regenerates the updated function body into both generated scripts

## Maintenance
- rebased on current `upstream/master` (`902880616da9cf054786b24bd243a7e454c3c34a`)
- refreshed head: `5118737a587af1a24ee4e3e8a2a1cc1ff042a2ed`
- prior resolved bbox-limited cleanup review thread remains outdated after the rebase

## Validation
- `make -C topology topology.sql topology_upgrade.sql`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `dropdb --if-exists postgis_reg && make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/removeunusedprimitives"` (fresh and automatic-upgrade; run twice)
- `make -C topology -j16`
- `./utils/check_news.sh .`
- `git diff --check`
- `git diff upstream/master..HEAD --check`
- `git clang-format --diff upstream/master -- topology/sql/cleanup/RemoveUnusedPrimitives.sql.in topology/test/regress/removeunusedprimitives.sql topology/test/regress/removeunusedprimitives_expected NEWS`

Closes #5937

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/351
