### PR TITLE
Fix tiger shell loader schema creation (#6072)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ PostGIS 3.6.5
 
 * Fixes *
 
+- #6072, Create tiger_data schema from shell tiger loader scripts
+         (Darafei Praliaskouski)
 - #5989, CurvePolygon distance corner case (Paul Ramsey)
 - #5357, ST_LineFromEncodedPolyline dropping close points (Paul Ramsey)
 
@@ -3131,5 +3133,4 @@ PostGIS 0.1
 - truely_inside()
 - rtree index support functions
 - gist index support functions
-
 

--- a/extensions/postgis_tiger_geocoder/Makefile.in
+++ b/extensions/postgis_tiger_geocoder/Makefile.in
@@ -78,7 +78,10 @@ sql/test-normalize_address.sql: sql_bits/test_tuples_only_unaligned.sql.in ../..
 	cat $^ > $@
 
 sql/test-upgrade.sql: | sql
-	echo 'ALTER EXTENSION ${EXTENSION} UPDATE TO "ANY"; ALTER EXTENSION ${EXTENSION} UPDATE TO "$(EXTVERSION)"' > $@
+	echo '\\pset tuples_only on' > $@
+	echo '\\pset format unaligned' >> $@
+	echo 'ALTER EXTENSION ${EXTENSION} UPDATE TO "ANY"; ALTER EXTENSION ${EXTENSION} UPDATE TO "$(EXTVERSION)";' >> $@
+	echo "SELECT '#6072', position('CREATE SCHEMA IF NOT EXISTS tiger_data' in loader_generate_script(ARRAY['RI'], 'sh')) > 0;" >> $@
 
 ## no_relocate clause is only available in PostgreSQL 16 and above, so strip it for lower
 ifeq ($(EXTSCHEMA_SUPPORTED),yes)
@@ -92,6 +95,7 @@ endif
 
 expected/test-upgrade.out: sql/test-upgrade.sql | expected
 	cp $< $@
+	echo "#6072|t" >> $@
 
 sql/test-pagc_normalize_address.sql: sql_bits/test_tuples_only_unaligned.sql.in ../../extras/tiger_geocoder/regress/pagc_normalize_address_regress.sql | sql
 	cat $^ > $@

--- a/extras/tiger_geocoder/tiger_loader_2025.sql
+++ b/extras/tiger_geocoder/tiger_loader_2025.sql
@@ -288,6 +288,7 @@ cd ${staging_fold}
 ', E'rm -f ${TMPDIR}/*.*
 ${PSQL} -c "DROP SCHEMA IF EXISTS ${staging_schema} CASCADE;"
 ${PSQL} -c "CREATE SCHEMA ${staging_schema};"
+${PSQL} -c "CREATE SCHEMA IF NOT EXISTS ${data_schema};"
 for z in *.zip; do $UNZIPTOOL -o -d $TMPDIR $z; done
 cd $TMPDIR;\n', '${PSQL}', '/', '${SHP2PGSQL}', 'export ',
 'for z in *${table_name}*.dbf; do


### PR DESCRIPTION
## Summary
- create the tiger_data schema from generated Unix shell tiger loader scripts
- use `CREATE SCHEMA IF NOT EXISTS` directly so shell loaders do not expand PL/pgSQL dollar quotes
- add a tiger geocoder upgrade regression that checks the sh loader script contains the schema creation command
- keep the upgrade regression portable across supported PostgreSQL versions by using `position(...)` instead of PostgreSQL 15+ `regexp_count`
- add a 3.6.5 NEWS entry

## Tests
- `git diff --check`
- `make -j32`
- `sudo -n make install`
- `make -C extensions/postgis_tiger_geocoder -j1`
- `make -C extensions/postgis_tiger_geocoder installcheck`

Closes #6072 for PostGIS 3.6
