### PR TITLE
topology: rewrite topoelement domain columns during upgrade (#6016)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -102,6 +102,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #6083, Pass configured dependency include paths to fuzzer smoke builds
           (Darafei Praliaskouski)
+ - #6016, [topology] Rewrite existing topoelement domain columns while
+          upgrading them from integer arrays to bigint arrays
+          (Darafei Praliaskouski)
  - #3103, Add regression coverage for exact-schema find_srid and
           geometry_columns lookups (Darafei Praliaskouski)
  - #1705, Infer constraint metadata for direct view and materialized view

--- a/postgis/common_after_upgrade.sql
+++ b/postgis/common_after_upgrade.sql
@@ -18,6 +18,74 @@
 --
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+-- Array-of-domain columns are temporarily moved to text arrays before
+-- generated domain constraints are restored, then converted back here.
+DO LANGUAGE 'plpgsql'
+$POSTGIS_DOMAIN_ARRAY_COLUMN_RESTORE$
+DECLARE
+	rec RECORD;
+	sql TEXT;
+BEGIN
+	FOR rec IN
+		SELECT *
+		FROM pg_temp._postgis_topology_domain_array_columns
+	LOOP
+		sql := pg_catalog.format(
+			'ALTER TABLE %s ALTER COLUMN %I TYPE %s USING (%I::%s)',
+			rec.attrelid::regclass,
+			rec.attname,
+			rec.target_domain_type,
+			rec.attname,
+			rec.target_domain_type
+		);
+		EXECUTE sql;
+
+		IF rec.default_expr IS NOT NULL THEN
+			sql := pg_catalog.format(
+				'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::pg_catalog.text[]::%s)',
+				rec.attrelid::regclass,
+				rec.attname,
+				rec.default_expr,
+				rec.target_domain_type
+			);
+			EXECUTE sql;
+		END IF;
+	END LOOP;
+
+	DROP TABLE IF EXISTS pg_temp._postgis_topology_domain_array_columns;
+EXCEPTION
+WHEN undefined_table THEN
+	NULL;
+END
+$POSTGIS_DOMAIN_ARRAY_COLUMN_RESTORE$;
+
+DO LANGUAGE 'plpgsql'
+$POSTGIS_DOMAIN_DEFAULT_RESTORE$
+DECLARE
+	rec RECORD;
+	sql TEXT;
+BEGIN
+	FOR rec IN
+		SELECT *
+		FROM pg_temp._postgis_topology_domain_defaults
+	LOOP
+		sql := pg_catalog.format(
+			'ALTER DOMAIN %I.%I SET DEFAULT ((%s)::text::%s)',
+			rec.domain_schema,
+			rec.domain_name,
+			rec.default_expr,
+			rec.new_domain_type
+		);
+		EXECUTE sql;
+	END LOOP;
+
+		DROP TABLE IF EXISTS pg_temp._postgis_topology_domain_defaults;
+EXCEPTION
+WHEN undefined_table THEN
+	NULL;
+END
+$POSTGIS_DOMAIN_DEFAULT_RESTORE$;
+
 -- DROP auxiliary function (created by common_before_upgrade.sql)
 DROP FUNCTION _postgis_drop_function_by_identity(text, text, text);
 DROP FUNCTION _postgis_drop_function_by_signature(text, text);

--- a/postgis/common_after_upgrade.sql
+++ b/postgis/common_after_upgrade.sql
@@ -18,8 +18,9 @@
 --
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
--- Array-of-domain columns are temporarily moved to text arrays before
--- generated domain constraints are restored, then converted back here.
+-- Array-of-domain columns are normally restored before generated domain
+-- constraints are re-added. Keep this final cleanup as a defensive fallback for
+-- interrupted helper runs that left saved text[] columns behind.
 DO LANGUAGE 'plpgsql'
 $POSTGIS_DOMAIN_ARRAY_COLUMN_RESTORE$
 DECLARE

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -582,7 +582,7 @@ BEGIN
 					WHERE dep.classid = 'pg_catalog.pg_class'::regclass
 					AND dep.refobjid = a.attrelid
 					AND dep.refobjsubid IN (0, a.attnum)
-					AND ic.relkind = 'i'
+					AND ic.relkind IN ('i', 'I')
 					AND a.atttypid = domain_array_oid
 					LIMIT 1
 				) AS dependent_index ON true
@@ -875,13 +875,25 @@ BEGIN
 								FROM pg_catalog.pg_depend AS dep
 								JOIN pg_catalog.pg_class AS ic
 									ON ic.oid = dep.objid
-									AND ic.relkind = 'i'
+									AND ic.relkind IN ('i', 'I')
 								JOIN pg_catalog.pg_index AS ix
 									ON ix.indexrelid = ic.oid
 								WHERE dep.classid = 'pg_catalog.pg_class'::regclass
 								AND dep.refobjid = a.attrelid
 								AND dep.refobjsubid IN (0, a.attnum)
 							)
+						)
+						OR EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_type AS rt
+							JOIN pg_catalog.pg_attribute AS ra
+								ON ra.atttypid = rt.oid
+								AND ra.attnum > 0
+								AND NOT ra.attisdropped
+							JOIN pg_catalog.pg_class AS rc
+								ON rc.oid = ra.attrelid
+								AND rc.relkind IN ('r', 'p', 'm')
+							WHERE rt.typrelid = a.attrelid
 						)
 						OR EXISTS (
 							SELECT 1
@@ -1111,7 +1123,7 @@ BEGIN
 									AND dep.refobjsubid IN (0, ca.attnum)
 								JOIN pg_catalog.pg_class AS ic
 									ON ic.oid = dep.objid
-									AND ic.relkind = 'i'
+									AND ic.relkind IN ('i', 'I')
 								JOIN pg_catalog.pg_index AS ix
 									ON ix.indexrelid = ic.oid
 							)
@@ -1224,7 +1236,7 @@ BEGIN
 							FROM pg_catalog.pg_depend AS dep
 							JOIN pg_catalog.pg_class AS ic
 								ON ic.oid = dep.objid
-								AND ic.relkind = 'i'
+								AND ic.relkind IN ('i', 'I')
 							JOIN pg_catalog.pg_index AS ix
 								ON ix.indexrelid = ic.oid
 							WHERE dep.classid = 'pg_catalog.pg_class'::regclass
@@ -1413,7 +1425,7 @@ BEGIN
 								AND dep.refobjsubid IN (0, ca.attnum)
 							JOIN pg_catalog.pg_class AS ic
 								ON ic.oid = dep.objid
-								AND ic.relkind = 'i'
+								AND ic.relkind IN ('i', 'I')
 							JOIN pg_catalog.pg_index AS ix
 								ON ix.indexrelid = ic.oid
 						)
@@ -1476,6 +1488,35 @@ BEGIN
 						ON rc.oid = ra.attrelid
 						AND rc.relkind IN ('r', 'p', 'm')
 					WHERE rt.typrelid = a.attrelid
+				)
+				AND NOT EXISTS (
+					WITH RECURSIVE inherited_relid(attrelid) AS (
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						WHERE i.inhparent = a.attrelid
+						UNION ALL
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						JOIN inherited_relid AS ir
+							ON ir.attrelid = i.inhparent
+					)
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_type AS rt
+						ON rt.typrelid = ca.attrelid
+					JOIN pg_catalog.pg_attribute AS ra
+						ON ra.atttypid = rt.oid
+						AND ra.attnum > 0
+						AND NOT ra.attisdropped
+					JOIN pg_catalog.pg_class AS rc
+						ON rc.oid = ra.attrelid
+						AND rc.relkind IN ('r', 'p', 'm')
 				)
 				AND NOT EXISTS (
 					SELECT 1

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -178,25 +178,165 @@ CREATE OR REPLACE FUNCTION _postgis_topology_upgrade_domain_type(
 ) RETURNS void AS $$
 DECLARE
 	detail TEXT;
+	domain_oid OID;
+	domain_schema TEXT := 'topology';
+	domain_constraint RECORD;
+	domain_column RECORD;
+	domain_default RECORD;
+	sql TEXT;
 	-- We need the base types of the old and new types - if multidimensional (int[][]), we need just one dimension at most
 	old_base_type TEXT := pg_catalog.regexp_replace(old_domain_type, E'(\\[\\])+$', '[]');
 	new_base_type TEXT := pg_catalog.regexp_replace(new_domain_type, E'(\\[\\])+$', '[]');
 	array_dims INT := (SELECT count(*) FROM pg_catalog.regexp_matches (old_domain_type, E'\\[\\]', 'g'));
 BEGIN
-	IF EXISTS (SELECT 1 FROM pg_catalog.pg_type AS t
-		WHERE  typnamespace::regnamespace::text = 'topology'
-		AND typname::text ILIKE domain_name
-		AND typbasetype::regtype::text ILIKE old_base_type
-    AND typndims = array_dims)
+	SELECT t.oid
+	FROM pg_catalog.pg_type AS t
+	WHERE typnamespace::regnamespace::text = domain_schema
+	AND typname::text ILIKE domain_name
+	-- Databases upgraded by the broken 3.6 path can already have
+	-- the new catalog base type while old-width row values remain.
+	AND typbasetype IN (old_base_type::regtype::oid, new_base_type::regtype::oid)
+	AND typndims = array_dims
+	INTO domain_oid;
+
+	IF domain_oid IS NOT NULL
   	THEN
 		BEGIN
-			-- HACK: We need to swap out the base type and number of dimensions
+			FOR domain_constraint IN
+				SELECT conname
+				FROM pg_catalog.pg_constraint
+				WHERE contypid = domain_oid
+			LOOP
+				sql := pg_catalog.format(
+					'ALTER DOMAIN %I.%I DROP CONSTRAINT IF EXISTS %I',
+					domain_schema,
+					domain_name,
+					domain_constraint.conname
+				);
+				EXECUTE sql;
+			END LOOP;
+
 			UPDATE pg_catalog.pg_type
 			SET typbasetype = new_base_type::regtype::oid, typndims = array_dims
-			WHERE typnamespace::regnamespace::text = 'topology'
-			AND typname::text ILIKE domain_name
-			AND typbasetype::regtype::text ILIKE old_base_type
-			AND typndims = array_dims;
+			WHERE oid = domain_oid;
+
+			-- Child tables are skipped by the row rewrite below because
+			-- ALTER TABLE on the root recurses to them, but child defaults
+			-- are independent pg_attrdef entries and must be rebuilt too.
+			FOR domain_default IN
+				SELECT
+					a.attrelid,
+					a.attname,
+					pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr
+				FROM pg_catalog.pg_attribute AS a
+				JOIN pg_catalog.pg_class AS c
+					ON c.oid = a.attrelid
+				JOIN pg_catalog.pg_attrdef AS d
+					ON d.adrelid = a.attrelid
+					AND d.adnum = a.attnum
+				WHERE a.atttypid = domain_oid
+				AND a.attnum > 0
+				AND NOT a.attisdropped
+				AND a.attgenerated = ''
+				AND c.relkind IN ('r', 'p')
+				AND EXISTS (
+					SELECT 1
+					FROM pg_catalog.pg_inherits AS i
+					JOIN pg_catalog.pg_attribute AS pa
+						ON pa.attrelid = i.inhparent
+						AND pa.attname = a.attname
+						AND pa.atttypid = a.atttypid
+						AND pa.attnum > 0
+						AND NOT pa.attisdropped
+					WHERE i.inhrelid = a.attrelid
+				)
+			LOOP
+				sql := pg_catalog.format(
+					'ALTER TABLE %s ALTER COLUMN %I DROP DEFAULT',
+					domain_default.attrelid::regclass,
+					domain_default.attname
+				);
+				EXECUTE sql;
+
+				sql := pg_catalog.format(
+					'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::text::%s::%I.%I)',
+					domain_default.attrelid::regclass,
+					domain_default.attname,
+					domain_default.default_expr,
+					new_domain_type,
+					domain_schema,
+					domain_name
+				);
+				EXECUTE sql;
+			END LOOP;
+
+			-- Existing table rows are still physically stored with the old
+			-- array element width. Whole-array output can mask that fact, so
+			-- force every dependent table column through text into the new
+			-- array representation before the domain constraints are restored.
+			FOR domain_column IN
+				SELECT
+					a.attrelid,
+					a.attname,
+					pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr
+				FROM pg_catalog.pg_attribute AS a
+				JOIN pg_catalog.pg_class AS c
+					ON c.oid = a.attrelid
+				LEFT JOIN pg_catalog.pg_attrdef AS d
+					ON d.adrelid = a.attrelid
+					AND d.adnum = a.attnum
+				WHERE a.atttypid = domain_oid
+				AND a.attnum > 0
+				AND NOT a.attisdropped
+				AND a.attgenerated = ''
+				AND c.relkind IN ('r', 'p')
+				AND NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.pg_inherits AS i
+					JOIN pg_catalog.pg_attribute AS pa
+						ON pa.attrelid = i.inhparent
+						AND pa.attname = a.attname
+						AND pa.atttypid = a.atttypid
+						AND pa.attnum > 0
+						AND NOT pa.attisdropped
+					WHERE i.inhrelid = a.attrelid
+				)
+			LOOP
+				IF domain_column.default_expr IS NOT NULL THEN
+					sql := pg_catalog.format(
+						'ALTER TABLE %s ALTER COLUMN %I DROP DEFAULT',
+						domain_column.attrelid::regclass,
+						domain_column.attname
+					);
+					EXECUTE sql;
+				END IF;
+
+				sql := pg_catalog.format(
+					'ALTER TABLE %s ALTER COLUMN %I TYPE %I.%I USING (%I::text::%s::%I.%I)',
+					domain_column.attrelid::regclass,
+					domain_column.attname,
+					domain_schema,
+					domain_name,
+					domain_column.attname,
+					new_domain_type,
+					domain_schema,
+					domain_name
+				);
+				EXECUTE sql;
+
+				IF domain_column.default_expr IS NOT NULL THEN
+					sql := pg_catalog.format(
+						'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::text::%s::%I.%I)',
+						domain_column.attrelid::regclass,
+						domain_column.attname,
+						domain_column.default_expr,
+						new_domain_type,
+						domain_schema,
+						domain_name
+					);
+					EXECUTE sql;
+				END IF;
+			END LOOP;
 
 			RAISE INFO 'Upgraded % from % to %', domain_name, old_domain_type, new_domain_type;
 		EXCEPTION

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -564,6 +564,56 @@ BEGIN
 				END IF;
 			END LOOP;
 
+			-- User domains and composite types can hide topology domains behind
+			-- another column type OID, so the exact-OID rewrite below cannot
+			-- prove that all old-width storage was repaired.
+			FOR domain_skipped_column IN
+				WITH RECURSIVE nested_type(type_oid) AS (
+					SELECT pg_catalog.unnest(domain_att_type_oids)
+					UNION
+					SELECT nested_candidate.type_oid
+					FROM nested_type
+					JOIN LATERAL (
+						SELECT t.oid AS type_oid
+						FROM pg_catalog.pg_type AS t
+						WHERE t.typbasetype = nested_type.type_oid
+						OR t.typelem = nested_type.type_oid
+						UNION
+						SELECT ct.oid AS type_oid
+						FROM pg_catalog.pg_attribute AS ta
+						JOIN pg_catalog.pg_class AS tc
+							ON tc.oid = ta.attrelid
+							AND tc.relkind = 'c'
+						JOIN pg_catalog.pg_type AS ct
+							ON ct.typrelid = tc.oid
+						WHERE ta.atttypid = nested_type.type_oid
+						AND ta.attnum > 0
+						AND NOT ta.attisdropped
+					) AS nested_candidate ON true
+					WHERE nested_candidate.type_oid <> ALL(domain_att_type_oids)
+				)
+				SELECT DISTINCT
+					a.attrelid,
+					a.attname,
+					a.atttypid::regtype AS nested_type_name
+				FROM pg_catalog.pg_attribute AS a
+				JOIN pg_catalog.pg_class AS c
+					ON c.oid = a.attrelid
+				JOIN nested_type AS nt
+					ON nt.type_oid = a.atttypid
+				WHERE a.atttypid <> ALL(domain_att_type_oids)
+				AND a.attnum > 0
+				AND NOT a.attisdropped
+				AND c.relkind IN ('r', 'p', 'm')
+			LOOP
+				skipped_repair := true;
+				RAISE WARNING 'Could not rewrite %.% for topology.% because its type % contains that domain; move the value through text into a freshly created type after upgrade',
+					domain_skipped_column.attrelid::regclass,
+					domain_skipped_column.attname,
+					domain_name,
+					domain_skipped_column.nested_type_name;
+			END LOOP;
+
 			FOR domain_generated_source_column IN
 				SELECT
 					a.attrelid,

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -194,6 +194,7 @@ DECLARE
 	domain_skipped_column RECORD;
 	sql TEXT;
 	skipped_repair BOOLEAN := false;
+	restored_domain_array_columns BOOLEAN := false;
 	-- We need the base types of the old and new types - if multidimensional (int[][]), we need just one dimension at most
 	old_base_type TEXT := pg_catalog.regexp_replace(old_domain_type, E'(\\[\\])+$', '[]');
 	new_base_type TEXT := pg_catalog.regexp_replace(new_domain_type, E'(\\[\\])+$', '[]');
@@ -293,8 +294,9 @@ BEGIN
 			-- Older upgrade sources may not have constraints introduced after
 			-- the original domain was created.  Treat those canonical topology
 			-- constraints like captured constraints so incomplete repairs keep
-			-- them NOT VALID, while complete repairs install the fresh-domain
-			-- constraint set as validated.
+				-- them NOT VALID. Complete repairs install the fresh-domain
+				-- constraint set as validated unless rewritten domain-array
+				-- columns still depend on the domain and force NOT VALID restore.
 			IF pg_catalog.lower(domain_name) = 'topoelement' THEN
 				IF NOT EXISTS (
 					SELECT 1
@@ -1760,6 +1762,7 @@ BEGIN
 					FROM pg_temp._postgis_topology_domain_array_columns
 					WHERE target_domain_type = pg_catalog.format('%I.%I[]', domain_schema, domain_name)
 				LOOP
+					restored_domain_array_columns := true;
 					sql := pg_catalog.format(
 						'ALTER TABLE %s ALTER COLUMN %I TYPE %s USING (%I::%s)',
 						domain_column.attrelid::regclass,
@@ -1785,9 +1788,9 @@ BEGIN
 				DELETE FROM pg_temp._postgis_topology_domain_array_columns
 				WHERE target_domain_type = pg_catalog.format('%I.%I[]', domain_schema, domain_name);
 
-					FOR domain_constraint IN
-						SELECT
-							value->>'name' AS conname,
+				FOR domain_constraint IN
+					SELECT
+						value->>'name' AS conname,
 						CASE
 						WHEN skipped_repair THEN value->>'definition'
 						WHEN COALESCE((value->>'not_valid_by_repair')::boolean, false) THEN pg_catalog.regexp_replace(
@@ -1808,9 +1811,12 @@ BEGIN
 				LOOP
 					-- If some old-width rows were intentionally skipped, restoring
 					-- constraints as validated would scan those rows and can abort
-					-- the whole repair. Mark only constraints demoted by this repair,
-					-- so a later complete retry can revalidate them without changing
-					-- user-created NOT VALID constraints.
+					-- the whole repair. PostgreSQL also rejects validated domain
+					-- constraints while array/container columns still depend on the
+					-- domain, even after those columns have been rewritten. Mark only
+					-- constraints demoted by skipped storage as retry candidates; the
+					-- array-dependency case is structural, not evidence of old-width
+					-- storage left behind.
 					sql := pg_catalog.format(
 						'ALTER DOMAIN %I.%I ADD CONSTRAINT %I %s%s',
 						domain_schema,
@@ -1818,7 +1824,7 @@ BEGIN
 						domain_constraint.conname,
 						domain_constraint.constraint_def,
 						CASE
-						WHEN skipped_repair
+						WHEN (skipped_repair OR restored_domain_array_columns)
 							AND domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
 						THEN ' NOT VALID'
 						ELSE ''

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -391,7 +391,11 @@ BEGIN
 					dependent_publication.publication_relid,
 					dependent_publication.publication_name,
 					dependent_generated_column.attrelid AS generated_attrelid,
-					dependent_generated_column.attname AS generated_attname
+					dependent_generated_column.attname AS generated_attname,
+					dependent_constraint.constraint_oid,
+					dependent_constraint.constraint_name,
+					dependent_index.index_oid,
+					dependent_index.index_name
 				FROM pg_catalog.pg_attribute AS a
 				JOIN pg_catalog.pg_class AS c
 					ON c.oid = a.attrelid
@@ -430,7 +434,7 @@ BEGIN
 						ON t.oid = dep.objid
 					WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
 					AND dep.refobjid = a.attrelid
-					AND dep.refobjsubid = a.attnum
+					AND dep.refobjsubid IN (0, a.attnum)
 					LIMIT 1
 				) AS dependent_trigger ON true
 				LEFT JOIN LATERAL (
@@ -492,6 +496,35 @@ BEGIN
 					) AS generated_dependency
 					LIMIT 1
 				) AS dependent_generated_column ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						con.oid AS constraint_oid,
+						con.conname AS constraint_name
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_constraint AS con
+						ON con.oid = dep.objid
+					WHERE dep.classid = 'pg_catalog.pg_constraint'::regclass
+					AND dep.refobjid = a.attrelid
+					AND dep.refobjsubid IN (0, a.attnum)
+					AND a.atttypid = domain_array_oid
+					LIMIT 1
+				) AS dependent_constraint ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						ic.oid AS index_oid,
+						ic.relname AS index_name
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_class AS ic
+						ON ic.oid = dep.objid
+					JOIN pg_catalog.pg_index AS ix
+						ON ix.indexrelid = ic.oid
+					WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+					AND dep.refobjid = a.attrelid
+					AND dep.refobjsubid IN (0, a.attnum)
+					AND ic.relkind = 'i'
+					AND a.atttypid = domain_array_oid
+					LIMIT 1
+				) AS dependent_index ON true
 				WHERE a.atttypid = ANY(domain_att_type_oids)
 				AND a.attnum > 0
 				AND NOT a.attisdropped
@@ -503,6 +536,8 @@ BEGIN
 					OR dependent_function.function_oid IS NOT NULL
 					OR dependent_publication.publication_relid IS NOT NULL
 					OR dependent_generated_column.attrelid IS NOT NULL
+					OR dependent_constraint.constraint_oid IS NOT NULL
+					OR dependent_index.index_oid IS NOT NULL
 				)
 			LOOP
 				skipped_repair := true;
@@ -555,6 +590,18 @@ BEGIN
 						domain_name,
 						domain_skipped_column.generated_attrelid::regclass,
 						domain_skipped_column.generated_attname;
+				ELSIF domain_skipped_column.constraint_oid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because constraint % depends on its domain array type; drop and recreate the constraint, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.constraint_name;
+				ELSIF domain_skipped_column.index_oid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because index % depends on its domain array type; drop and recreate the index, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.index_name;
 				ELSE
 					RAISE WARNING 'Could not rewrite %.% for topology.% because materialized view % depends on it; refresh or recreate the materialized view and repair the column after upgrade',
 						domain_skipped_column.attrelid::regclass,
@@ -729,7 +776,32 @@ BEGIN
 							FROM pg_catalog.pg_depend AS dep
 							WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
 							AND dep.refobjid = a.attrelid
-							AND dep.refobjsubid = a.attnum
+							AND dep.refobjsubid IN (0, a.attnum)
+						)
+						OR (
+							a.atttypid = domain_array_oid
+							AND EXISTS (
+								SELECT 1
+								FROM pg_catalog.pg_depend AS dep
+								WHERE dep.classid = 'pg_catalog.pg_constraint'::regclass
+								AND dep.refobjid = a.attrelid
+								AND dep.refobjsubid IN (0, a.attnum)
+							)
+						)
+						OR (
+							a.atttypid = domain_array_oid
+							AND EXISTS (
+								SELECT 1
+								FROM pg_catalog.pg_depend AS dep
+								JOIN pg_catalog.pg_class AS ic
+									ON ic.oid = dep.objid
+									AND ic.relkind = 'i'
+								JOIN pg_catalog.pg_index AS ix
+									ON ix.indexrelid = ic.oid
+								WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+								AND dep.refobjid = a.attrelid
+								AND dep.refobjsubid IN (0, a.attnum)
+							)
 						)
 						OR EXISTS (
 							SELECT 1
@@ -819,10 +891,13 @@ BEGIN
 							AND (
 								(
 									dep.classid IN (
-										'pg_catalog.pg_trigger'::regclass,
 										'pg_catalog.pg_publication_rel'::regclass
 									)
 									AND dep.refobjsubid = ca.attnum
+								)
+								OR (
+									dep.classid = 'pg_catalog.pg_trigger'::regclass
+									AND dep.refobjsubid IN (0, ca.attnum)
 								)
 								OR (
 									dep.classid = 'pg_catalog.pg_proc'::regclass
@@ -991,7 +1066,32 @@ BEGIN
 						FROM pg_catalog.pg_depend AS dep
 						WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
 						AND dep.refobjid = a.attrelid
-						AND dep.refobjsubid = a.attnum
+						AND dep.refobjsubid IN (0, a.attnum)
+					)
+					AND NOT (
+						a.atttypid = domain_array_oid
+						AND EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							WHERE dep.classid = 'pg_catalog.pg_constraint'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid IN (0, a.attnum)
+						)
+					)
+					AND NOT (
+						a.atttypid = domain_array_oid
+						AND EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							JOIN pg_catalog.pg_class AS ic
+								ON ic.oid = dep.objid
+								AND ic.relkind = 'i'
+							JOIN pg_catalog.pg_index AS ix
+								ON ix.indexrelid = ic.oid
+							WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid IN (0, a.attnum)
+						)
 					)
 					AND NOT EXISTS (
 						SELECT 1
@@ -1081,10 +1181,13 @@ BEGIN
 							AND (
 								(
 									dep.classid IN (
-										'pg_catalog.pg_trigger'::regclass,
 										'pg_catalog.pg_publication_rel'::regclass
 									)
 									AND dep.refobjsubid = ca.attnum
+								)
+								OR (
+									dep.classid = 'pg_catalog.pg_trigger'::regclass
+									AND dep.refobjsubid IN (0, ca.attnum)
 								)
 								OR (
 									dep.classid = 'pg_catalog.pg_proc'::regclass
@@ -1277,7 +1380,7 @@ BEGIN
 						FROM pg_catalog.pg_depend AS dep
 						WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
 						AND dep.refobjid = a.attrelid
-						AND dep.refobjsubid = a.attnum
+						AND dep.refobjsubid IN (0, a.attnum)
 					)
 					AND NOT EXISTS (
 						SELECT 1
@@ -1399,10 +1502,13 @@ BEGIN
 							AND (
 								(
 									dep.classid IN (
-										'pg_catalog.pg_trigger'::regclass,
 										'pg_catalog.pg_publication_rel'::regclass
 									)
 									AND dep.refobjsubid = ca.attnum
+								)
+								OR (
+									dep.classid = 'pg_catalog.pg_trigger'::regclass
+									AND dep.refobjsubid IN (0, ca.attnum)
 								)
 								OR (
 									dep.classid = 'pg_catalog.pg_proc'::regclass

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -1608,11 +1608,52 @@ BEGIN
 						domain_name,
 						pg_catalog.current_setting('server_version');
 				END IF;
-			END LOOP;
+				END LOOP;
 
-				FOR domain_constraint IN
-					SELECT
-						value->>'name' AS conname,
+				-- Restore array-of-domain columns before re-adding domain
+				-- constraints. Recasting text[] after NOT VALID constraints are
+				-- back would validate each element as a new domain value, which
+				-- defeats the incomplete-repair path for grandfathered rows.
+				CREATE TEMP TABLE IF NOT EXISTS pg_temp._postgis_topology_domain_array_columns (
+					attrelid OID,
+					attname NAME,
+					target_domain_type TEXT,
+					default_expr TEXT
+				) ON COMMIT DROP;
+
+				FOR domain_column IN
+					SELECT *
+					FROM pg_temp._postgis_topology_domain_array_columns
+					WHERE target_domain_type = pg_catalog.format('%I.%I[]', domain_schema, domain_name)
+				LOOP
+					sql := pg_catalog.format(
+						'ALTER TABLE %s ALTER COLUMN %I TYPE %s USING (%I::%s)',
+						domain_column.attrelid::regclass,
+						domain_column.attname,
+						domain_column.target_domain_type,
+						domain_column.attname,
+						domain_column.target_domain_type
+					);
+					EXECUTE sql;
+
+					IF domain_column.default_expr IS NOT NULL THEN
+						sql := pg_catalog.format(
+							'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::pg_catalog.text[]::%s)',
+							domain_column.attrelid::regclass,
+							domain_column.attname,
+							domain_column.default_expr,
+							domain_column.target_domain_type
+						);
+						EXECUTE sql;
+					END IF;
+				END LOOP;
+
+				DELETE FROM pg_temp._postgis_topology_domain_array_columns
+				WHERE target_domain_type = pg_catalog.format('%I.%I[]', domain_schema, domain_name);
+
+					FOR domain_constraint IN
+						SELECT
+							value->>'name' AS conname,
 						CASE
 						WHEN skipped_repair THEN value->>'definition'
 						WHEN COALESCE((value->>'not_valid_by_repair')::boolean, false) THEN pg_catalog.regexp_replace(

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -182,7 +182,7 @@ DECLARE
 	domain_oid OID;
 	domain_array_oid OID;
 	domain_att_type_oids OID[];
-	topology_domain_oids OID[];
+	nested_topology_type_oids OID[];
 	domain_schema TEXT := 'topology';
 	domain_constraint RECORD;
 	domain_constraint_defs JSONB := '[]'::JSONB;
@@ -235,20 +235,36 @@ BEGIN
 		BEGIN
 			domain_att_type_oids := pg_catalog.array_remove(ARRAY[domain_oid, domain_array_oid], 0::oid);
 
+			-- Generated expressions and user-visible container types can hide
+			-- topology domains behind a different atttypid. Use one recursive
+			-- closure so every dependency check reasons about the same set of
+			-- exact and nested domain-storage carriers.
+			WITH RECURSIVE nested_type(type_oid) AS (
+				SELECT pg_catalog.unnest(domain_att_type_oids)
+				UNION
+				SELECT nested_candidate.type_oid
+				FROM nested_type
+				JOIN LATERAL (
+					SELECT t.oid AS type_oid
+					FROM pg_catalog.pg_type AS t
+					WHERE t.typbasetype = nested_type.type_oid
+					OR t.typelem = nested_type.type_oid
+					UNION
+					SELECT ct.oid AS type_oid
+					FROM pg_catalog.pg_attribute AS ta
+					JOIN pg_catalog.pg_class AS tc
+						ON tc.oid = ta.attrelid
+						AND tc.relkind = 'c'
+					JOIN pg_catalog.pg_type AS ct
+						ON ct.typrelid = tc.oid
+					WHERE ta.atttypid = nested_type.type_oid
+					AND ta.attnum > 0
+					AND NOT ta.attisdropped
+				) AS nested_candidate ON true
+			)
 			SELECT pg_catalog.array_agg(type_oid)
-			FROM (
-				SELECT t.oid AS type_oid
-				FROM pg_catalog.pg_type AS t
-				WHERE t.typnamespace = domain_schema::regnamespace
-				AND t.typname IN ('topoelement', 'topoelementarray')
-				UNION ALL
-				SELECT t.typarray
-				FROM pg_catalog.pg_type AS t
-				WHERE t.typnamespace = domain_schema::regnamespace
-				AND t.typname IN ('topoelement', 'topoelementarray')
-				AND t.typarray <> 0
-			) AS topology_types
-				INTO topology_domain_oids;
+			FROM nested_type
+				INTO nested_topology_type_oids;
 
 				FOR domain_constraint IN
 					SELECT
@@ -615,30 +631,6 @@ BEGIN
 			-- another column type OID, so the exact-OID rewrite below cannot
 			-- prove that all old-width storage was repaired.
 			FOR domain_skipped_column IN
-				WITH RECURSIVE nested_type(type_oid) AS (
-					SELECT pg_catalog.unnest(domain_att_type_oids)
-					UNION
-					SELECT nested_candidate.type_oid
-					FROM nested_type
-					JOIN LATERAL (
-						SELECT t.oid AS type_oid
-						FROM pg_catalog.pg_type AS t
-						WHERE t.typbasetype = nested_type.type_oid
-						OR t.typelem = nested_type.type_oid
-						UNION
-						SELECT ct.oid AS type_oid
-						FROM pg_catalog.pg_attribute AS ta
-						JOIN pg_catalog.pg_class AS tc
-							ON tc.oid = ta.attrelid
-							AND tc.relkind = 'c'
-						JOIN pg_catalog.pg_type AS ct
-							ON ct.typrelid = tc.oid
-						WHERE ta.atttypid = nested_type.type_oid
-						AND ta.attnum > 0
-						AND NOT ta.attisdropped
-					) AS nested_candidate ON true
-					WHERE nested_candidate.type_oid <> ALL(domain_att_type_oids)
-				)
 				SELECT DISTINCT
 					a.attrelid,
 					a.attname,
@@ -646,7 +638,7 @@ BEGIN
 				FROM pg_catalog.pg_attribute AS a
 				JOIN pg_catalog.pg_class AS c
 					ON c.oid = a.attrelid
-				JOIN nested_type AS nt
+				JOIN pg_catalog.unnest(nested_topology_type_oids) AS nt(type_oid)
 					ON nt.type_oid = a.atttypid
 				WHERE a.atttypid <> ALL(domain_att_type_oids)
 				AND a.attnum > 0
@@ -687,7 +679,7 @@ BEGIN
 							AND sa.attnum = dep.refobjsubid
 						WHERE gd.adrelid = a.attrelid
 						AND gd.adnum = a.attnum
-						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.atttypid = ANY(nested_topology_type_oids)
 						AND sa.attnum > 0
 						AND NOT sa.attisdropped
 						AND sa.attnum <> a.attnum
@@ -702,7 +694,7 @@ BEGIN
 						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
 						AND dep.objid = a.attrelid
 						AND dep.objsubid = a.attnum
-						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.atttypid = ANY(nested_topology_type_oids)
 						AND sa.attnum > 0
 						AND NOT sa.attisdropped
 						AND sa.attnum <> a.attnum
@@ -1435,7 +1427,7 @@ BEGIN
 							AND sa.attnum = dep.refobjsubid
 						WHERE gd.adrelid = a.attrelid
 						AND gd.adnum = a.attnum
-						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.atttypid = ANY(nested_topology_type_oids)
 						AND sa.attnum > 0
 						AND NOT sa.attisdropped
 						AND sa.attnum <> a.attnum
@@ -1448,7 +1440,7 @@ BEGIN
 						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
 						AND dep.objid = a.attrelid
 						AND dep.objsubid = a.attnum
-						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.atttypid = ANY(nested_topology_type_oids)
 						AND sa.attnum > 0
 						AND NOT sa.attisdropped
 						AND sa.attnum <> a.attnum

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -255,7 +255,7 @@ BEGIN
 					FROM pg_catalog.pg_attribute AS ta
 					JOIN pg_catalog.pg_class AS tc
 						ON tc.oid = ta.attrelid
-						AND tc.relkind = 'c'
+						AND tc.relkind IN ('c', 'r', 'p')
 					JOIN pg_catalog.pg_type AS ct
 						ON ct.typrelid = tc.oid
 					WHERE ta.atttypid = nested_type.type_oid
@@ -267,11 +267,52 @@ BEGIN
 			FROM nested_type
 				INTO nested_topology_type_oids;
 
-				FOR domain_constraint IN
-					SELECT
-						conname,
-						pg_catalog.pg_get_constraintdef(oid) AS constraint_def,
-						pg_catalog.obj_description(oid, 'pg_constraint') LIKE '%' || constraint_not_valid_marker || '%' AS not_valid_by_repair
+			FOR domain_default IN
+				SELECT
+					n.nspname AS domain_schema,
+					t.typname AS domain_name,
+					pg_catalog.pg_get_expr(t.typdefaultbin, 0) AS default_expr,
+					t.oid::regtype::text AS new_domain_type
+				FROM pg_catalog.pg_type AS t
+				JOIN pg_catalog.pg_namespace AS n
+					ON n.oid = t.typnamespace
+				WHERE t.typtype = 'd'
+				AND t.oid <> domain_oid
+				AND t.oid = ANY(nested_topology_type_oids)
+				AND t.typdefaultbin IS NOT NULL
+			LOOP
+				-- A user domain over the topology domain can have its own
+				-- default expression compiled against the old array storage.
+				-- Save it before the base domain catalog rewrite and restore it
+				-- through text after the new topology storage is in force.
+				CREATE TEMP TABLE IF NOT EXISTS pg_temp._postgis_topology_domain_defaults (
+					domain_schema TEXT,
+					domain_name TEXT,
+					default_expr TEXT,
+					new_domain_type TEXT
+				) ON COMMIT DROP;
+
+				sql := pg_catalog.format(
+					'ALTER DOMAIN %I.%I DROP DEFAULT',
+					domain_default.domain_schema,
+					domain_default.domain_name
+				);
+				EXECUTE sql;
+
+				INSERT INTO pg_temp._postgis_topology_domain_defaults
+					VALUES (
+						domain_default.domain_schema,
+						domain_default.domain_name,
+						domain_default.default_expr,
+						domain_default.new_domain_type
+					);
+			END LOOP;
+
+			FOR domain_constraint IN
+				SELECT
+					conname,
+					pg_catalog.pg_get_constraintdef(oid) AS constraint_def,
+					pg_catalog.obj_description(oid, 'pg_constraint') LIKE '%' || constraint_not_valid_marker || '%' AS not_valid_by_repair
 					FROM pg_catalog.pg_constraint
 					WHERE contypid = domain_oid
 				LOOP
@@ -413,7 +454,9 @@ BEGIN
 					dependent_constraint.constraint_oid,
 					dependent_constraint.constraint_name,
 					dependent_index.index_oid,
-					dependent_index.index_name
+					dependent_index.index_name,
+					dependent_row_type_column.attrelid AS row_type_attrelid,
+					dependent_row_type_column.attname AS row_type_attname
 				FROM pg_catalog.pg_attribute AS a
 				JOIN pg_catalog.pg_class AS c
 					ON c.oid = a.attrelid
@@ -543,6 +586,21 @@ BEGIN
 					AND a.atttypid = domain_array_oid
 					LIMIT 1
 				) AS dependent_index ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						ra.attrelid,
+						ra.attname
+					FROM pg_catalog.pg_type AS rt
+					JOIN pg_catalog.pg_attribute AS ra
+						ON ra.atttypid = rt.oid
+						AND ra.attnum > 0
+						AND NOT ra.attisdropped
+					JOIN pg_catalog.pg_class AS rc
+						ON rc.oid = ra.attrelid
+						AND rc.relkind IN ('r', 'p', 'm')
+					WHERE rt.typrelid = a.attrelid
+					LIMIT 1
+				) AS dependent_row_type_column ON true
 				WHERE a.atttypid = ANY(domain_att_type_oids)
 				AND a.attnum > 0
 				AND NOT a.attisdropped
@@ -556,6 +614,7 @@ BEGIN
 					OR dependent_generated_column.attrelid IS NOT NULL
 					OR dependent_constraint.constraint_oid IS NOT NULL
 					OR dependent_index.index_oid IS NOT NULL
+					OR dependent_row_type_column.attrelid IS NOT NULL
 				)
 			LOOP
 				skipped_repair := true;
@@ -620,6 +679,13 @@ BEGIN
 						domain_skipped_column.attname,
 						domain_name,
 						domain_skipped_column.index_name;
+				ELSIF domain_skipped_column.row_type_attrelid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because column %.% uses its table row type; move the dependent value through text into a freshly created type after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.row_type_attrelid::regclass,
+						domain_skipped_column.row_type_attname;
 				ELSE
 					RAISE WARNING 'Could not rewrite %.% for topology.% because materialized view % depends on it; refresh or recreate the materialized view and repair the column after upgrade',
 						domain_skipped_column.attrelid::regclass,
@@ -747,6 +813,8 @@ BEGIN
 				FROM pg_catalog.pg_attribute AS a
 				JOIN pg_catalog.pg_class AS c
 					ON c.oid = a.attrelid
+				JOIN pg_catalog.pg_type AS at
+					ON at.oid = a.atttypid
 				JOIN pg_catalog.pg_attrdef AS d
 					ON d.adrelid = a.attrelid
 					AND d.adnum = a.attnum
@@ -755,6 +823,7 @@ BEGIN
 					OR (
 						a.atttypid = ANY(nested_topology_type_oids)
 						AND a.atttypid <> ALL(domain_att_type_oids)
+						AND at.typtype = 'd'
 					)
 				)
 				AND a.attnum > 0
@@ -765,6 +834,7 @@ BEGIN
 					(
 						a.atttypid = ANY(nested_topology_type_oids)
 						AND a.atttypid <> ALL(domain_att_type_oids)
+						AND at.typtype = 'd'
 					)
 					OR EXISTS (
 						SELECT 1
@@ -1394,6 +1464,18 @@ BEGIN
 						AND ga.attnum = dep.objsubid
 					WHERE dep.classid = 'pg_catalog.pg_class'::regclass
 					AND ga.attgenerated <> ''
+					)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.pg_type AS rt
+					JOIN pg_catalog.pg_attribute AS ra
+						ON ra.atttypid = rt.oid
+						AND ra.attnum > 0
+						AND NOT ra.attisdropped
+					JOIN pg_catalog.pg_class AS rc
+						ON rc.oid = ra.attrelid
+						AND rc.relkind IN ('r', 'p', 'm')
+					WHERE rt.typrelid = a.attrelid
 				)
 				AND NOT EXISTS (
 					SELECT 1

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -194,6 +194,7 @@ DECLARE
 	domain_skipped_column RECORD;
 	sql TEXT;
 	skipped_repair BOOLEAN := false;
+	skipped_domain_type_oids OID[] := ARRAY[]::OID[];
 	restored_domain_array_columns BOOLEAN := false;
 	-- We need the base types of the old and new types - if multidimensional (int[][]), we need just one dimension at most
 	old_base_type TEXT := pg_catalog.regexp_replace(old_domain_type, E'(\\[\\])+$', '[]');
@@ -310,44 +311,63 @@ BEGIN
 
 			FOR domain_constraint IN
 				SELECT
-					conname,
-					pg_catalog.pg_get_constraintdef(oid) AS constraint_def,
-					pg_catalog.obj_description(oid, 'pg_constraint') LIKE '%' || constraint_not_valid_marker || '%' AS not_valid_by_repair
-					FROM pg_catalog.pg_constraint
-					WHERE contypid = domain_oid
-				LOOP
-					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
-						pg_catalog.jsonb_build_object(
-							'name', domain_constraint.conname,
-							'definition', domain_constraint.constraint_def,
-							'not_valid_by_repair', domain_constraint.not_valid_by_repair
-						)
-					);
-					sql := pg_catalog.format(
-						'ALTER DOMAIN %I.%I DROP CONSTRAINT IF EXISTS %I',
-					domain_schema,
-					domain_name,
+					t.oid AS domain_oid,
+					n.nspname AS domain_schema,
+					t.typname AS domain_name,
+					con.conname,
+					pg_catalog.pg_get_constraintdef(con.oid) AS constraint_def,
+					con.convalidated,
+					pg_catalog.obj_description(con.oid, 'pg_constraint') LIKE '%' || constraint_not_valid_marker || '%' AS not_valid_by_repair
+				FROM pg_catalog.pg_constraint AS con
+				JOIN pg_catalog.pg_type AS t
+					ON t.oid = con.contypid
+					AND t.typtype = 'd'
+				JOIN pg_catalog.pg_namespace AS n
+					ON n.oid = t.typnamespace
+				WHERE con.contypid = ANY(nested_topology_type_oids)
+			LOOP
+				domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
+					pg_catalog.jsonb_build_object(
+						'domain_oid', domain_constraint.domain_oid,
+						'domain_schema', domain_constraint.domain_schema,
+						'domain_name', domain_constraint.domain_name,
+						'name', domain_constraint.conname,
+						'definition', domain_constraint.constraint_def,
+						'convalidated', domain_constraint.convalidated,
+						'not_valid_by_repair', domain_constraint.not_valid_by_repair
+					)
+				);
+				sql := pg_catalog.format(
+					'ALTER DOMAIN %I.%I DROP CONSTRAINT IF EXISTS %I',
+					domain_constraint.domain_schema,
+					domain_constraint.domain_name,
 					domain_constraint.conname
 				);
-					EXECUTE sql;
-				END LOOP;
+				EXECUTE sql;
+			END LOOP;
 
 			-- Older upgrade sources may not have constraints introduced after
 			-- the original domain was created.  Treat those canonical topology
 			-- constraints like captured constraints so incomplete repairs keep
-				-- them NOT VALID. Complete repairs install the fresh-domain
-				-- constraint set as validated unless rewritten domain-array
-				-- columns still depend on the domain and force NOT VALID restore.
+			-- them NOT VALID. Complete repairs install the fresh-domain
+			-- constraint set as validated unless rewritten domain-array
+			-- columns still depend on the domain and force NOT VALID restore.
 			IF pg_catalog.lower(domain_name) = 'topoelement' THEN
 				IF NOT EXISTS (
 					SELECT 1
 					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
-					WHERE value->>'name' = 'dimensions'
+					WHERE value->>'domain_schema' = domain_schema
+					AND value->>'domain_name' = domain_name
+					AND value->>'name' = 'dimensions'
 				) THEN
 					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
 						pg_catalog.jsonb_build_object(
+							'domain_schema', domain_schema,
+							'domain_name', domain_name,
+							'domain_oid', domain_oid,
 							'name', 'dimensions',
 							'definition', 'CHECK (array_upper(VALUE, 2) IS NULL AND array_upper(VALUE, 1) = 2)',
+							'convalidated', true,
 							'not_valid_by_repair', true
 						)
 					);
@@ -356,12 +376,18 @@ BEGIN
 				IF NOT EXISTS (
 					SELECT 1
 					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
-					WHERE value->>'name' = 'type_range'
+					WHERE value->>'domain_schema' = domain_schema
+					AND value->>'domain_name' = domain_name
+					AND value->>'name' = 'type_range'
 				) THEN
 					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
 						pg_catalog.jsonb_build_object(
+							'domain_schema', domain_schema,
+							'domain_name', domain_name,
+							'domain_oid', domain_oid,
 							'name', 'type_range',
 							'definition', 'CHECK (VALUE[2] > 0)',
+							'convalidated', true,
 							'not_valid_by_repair', true
 						)
 					);
@@ -370,12 +396,18 @@ BEGIN
 				IF NOT EXISTS (
 					SELECT 1
 					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
-					WHERE value->>'name' = 'lower_dimension'
+					WHERE value->>'domain_schema' = domain_schema
+					AND value->>'domain_name' = domain_name
+					AND value->>'name' = 'lower_dimension'
 				) THEN
 					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
 						pg_catalog.jsonb_build_object(
+							'domain_schema', domain_schema,
+							'domain_name', domain_name,
+							'domain_oid', domain_oid,
 							'name', 'lower_dimension',
 							'definition', 'CHECK (array_lower(VALUE, 1) = 1)',
+							'convalidated', true,
 							'not_valid_by_repair', true
 						)
 					);
@@ -384,12 +416,18 @@ BEGIN
 				IF NOT EXISTS (
 					SELECT 1
 					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
-					WHERE value->>'name' = 'type_range'
+					WHERE value->>'domain_schema' = domain_schema
+					AND value->>'domain_name' = domain_name
+					AND value->>'name' = 'type_range'
 				) THEN
 					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
 						pg_catalog.jsonb_build_object(
+							'domain_schema', domain_schema,
+							'domain_name', domain_name,
+							'domain_oid', domain_oid,
 							'name', 'type_range',
 							'definition', 'CHECK (array_upper(VALUE, 2) = 2 AND array_upper(VALUE, 3) IS NULL)',
+							'convalidated', true,
 							'not_valid_by_repair', true
 						)
 					);
@@ -618,6 +656,7 @@ BEGIN
 				)
 			LOOP
 				skipped_repair := true;
+				skipped_domain_type_oids := pg_catalog.array_append(skipped_domain_type_oids, domain_oid);
 				IF domain_skipped_column.relkind = 'm' THEN
 					RAISE WARNING 'Could not rewrite materialized view column %.% for topology.%; refresh or recreate the materialized view after upgrade',
 						domain_skipped_column.attrelid::regclass,
@@ -700,6 +739,7 @@ BEGIN
 			-- prove that all old-width storage was repaired.
 			FOR domain_skipped_column IN
 				SELECT DISTINCT
+					a.atttypid AS nested_type_oid,
 					a.attrelid,
 					a.attname,
 					a.atttypid::regtype AS nested_type_name
@@ -714,6 +754,10 @@ BEGIN
 				AND c.relkind IN ('r', 'p', 'm')
 			LOOP
 				skipped_repair := true;
+				skipped_domain_type_oids := pg_catalog.array_append(
+					skipped_domain_type_oids,
+					domain_skipped_column.nested_type_oid
+				);
 				RAISE WARNING 'Could not rewrite %.% for topology.% because its type % contains that domain; move the value through text into a freshly created type after upgrade',
 					domain_skipped_column.attrelid::regclass,
 					domain_skipped_column.attname,
@@ -776,6 +820,7 @@ BEGIN
 				AND c.relkind IN ('r', 'p')
 			LOOP
 				skipped_repair := true;
+				skipped_domain_type_oids := pg_catalog.array_append(skipped_domain_type_oids, domain_oid);
 				RAISE WARNING 'Could not rewrite generated column %.% for topology.% because it reads unrepaired column %.%; drop and recreate the generated column after repairing its source column',
 					domain_generated_source_column.attrelid::regclass,
 					domain_generated_source_column.attname,
@@ -1861,6 +1906,7 @@ BEGIN
 					EXECUTE sql;
 				ELSE
 					skipped_repair := true;
+					skipped_domain_type_oids := pg_catalog.array_append(skipped_domain_type_oids, domain_oid);
 					RAISE WARNING 'Could not rewrite stored generated column %.% for topology.% on PostgreSQL %, generated expression reset requires PostgreSQL 17 or later',
 						domain_generated_column.attrelid::regclass,
 						domain_generated_column.attname,
@@ -1913,21 +1959,28 @@ BEGIN
 
 				FOR domain_constraint IN
 					SELECT
+						(value->>'domain_oid')::oid AS domain_oid,
+						value->>'domain_schema' AS domain_schema,
+						value->>'domain_name' AS domain_name,
 						value->>'name' AS conname,
 						CASE
-						WHEN skipped_repair THEN value->>'definition'
-						WHEN COALESCE((value->>'not_valid_by_repair')::boolean, false) THEN pg_catalog.regexp_replace(
-							value->>'definition',
-							'[[:space:]]+NOT[[:space:]]+VALID[[:space:]]*$',
-							'',
-							'i'
-						)
-						ELSE pg_catalog.regexp_replace(
-							value->>'definition',
-							'[[:space:]]*$',
-							'',
-							'i'
-						)
+							WHEN COALESCE((value->>'convalidated')::boolean, false)
+								OR (
+									COALESCE((value->>'not_valid_by_repair')::boolean, false)
+									AND (value->>'domain_oid')::oid <> ALL(skipped_domain_type_oids)
+								)
+							THEN pg_catalog.regexp_replace(
+								value->>'definition',
+								'[[:space:]]+NOT[[:space:]]+VALID[[:space:]]*$',
+								'',
+								'i'
+							)
+							ELSE pg_catalog.regexp_replace(
+								value->>'definition',
+								'[[:space:]]*$',
+								'',
+								'i'
+							)
 						END AS constraint_def,
 						COALESCE((value->>'not_valid_by_repair')::boolean, false) AS not_valid_by_repair
 					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
@@ -1942,19 +1995,35 @@ BEGIN
 					-- storage left behind.
 					sql := pg_catalog.format(
 						'ALTER DOMAIN %I.%I ADD CONSTRAINT %I %s%s',
-						domain_schema,
-						domain_name,
+						domain_constraint.domain_schema,
+						domain_constraint.domain_name,
 						domain_constraint.conname,
 						domain_constraint.constraint_def,
 						CASE
-						WHEN (skipped_repair OR restored_domain_array_columns)
-							AND domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
-						THEN ' NOT VALID'
-						ELSE ''
+							-- Array-of-domain columns force NOT VALID only for
+							-- the domain they directly depend on. Nested user
+							-- domains are restored from the same saved set, but
+							-- keeping their validated constraints validated avoids
+							-- silently weakening unrelated user checks.
+							WHEN (
+								(
+									skipped_repair
+									AND domain_constraint.domain_oid = ANY(skipped_domain_type_oids)
+								)
+								OR (
+									restored_domain_array_columns
+									AND domain_constraint.domain_schema = domain_schema
+									AND domain_constraint.domain_name = domain_name
+								)
+							)
+								AND domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
+							THEN ' NOT VALID'
+							ELSE ''
 						END
 					);
 					EXECUTE sql;
 					IF skipped_repair
+						AND domain_constraint.domain_oid = ANY(skipped_domain_type_oids)
 						AND (
 							domain_constraint.not_valid_by_repair
 							OR domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
@@ -1963,8 +2032,8 @@ BEGIN
 						sql := pg_catalog.format(
 							'COMMENT ON CONSTRAINT %I ON DOMAIN %I.%I IS %L',
 							domain_constraint.conname,
-							domain_schema,
-							domain_name,
+							domain_constraint.domain_schema,
+							domain_constraint.domain_name,
 							constraint_not_valid_marker
 						);
 						EXECUTE sql;

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -207,6 +207,7 @@ DECLARE
 		ELSE deprecated_in_version
 	END;
 	repair_marker TEXT := 'postgis-topology-domain-storage-repaired-' || marker_version;
+	constraint_not_valid_marker TEXT := 'postgis-topology-domain-constraint-not-valid-by-repair-' || marker_version;
 BEGIN
 	SELECT
 		t.oid,
@@ -247,29 +248,94 @@ BEGIN
 				AND t.typname IN ('topoelement', 'topoelementarray')
 				AND t.typarray <> 0
 			) AS topology_types
-			INTO topology_domain_oids;
+				INTO topology_domain_oids;
 
-			FOR domain_constraint IN
-				SELECT
-					conname,
-					pg_catalog.pg_get_constraintdef(oid) AS constraint_def
-				FROM pg_catalog.pg_constraint
-				WHERE contypid = domain_oid
-			LOOP
-				domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
-					pg_catalog.jsonb_build_object(
-						'name', domain_constraint.conname,
-						'definition', domain_constraint.constraint_def
-					)
-				);
-				sql := pg_catalog.format(
-					'ALTER DOMAIN %I.%I DROP CONSTRAINT IF EXISTS %I',
+				FOR domain_constraint IN
+					SELECT
+						conname,
+						pg_catalog.pg_get_constraintdef(oid) AS constraint_def,
+						pg_catalog.obj_description(oid, 'pg_constraint') LIKE '%' || constraint_not_valid_marker || '%' AS not_valid_by_repair
+					FROM pg_catalog.pg_constraint
+					WHERE contypid = domain_oid
+				LOOP
+					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
+						pg_catalog.jsonb_build_object(
+							'name', domain_constraint.conname,
+							'definition', domain_constraint.constraint_def,
+							'not_valid_by_repair', domain_constraint.not_valid_by_repair
+						)
+					);
+					sql := pg_catalog.format(
+						'ALTER DOMAIN %I.%I DROP CONSTRAINT IF EXISTS %I',
 					domain_schema,
 					domain_name,
 					domain_constraint.conname
 				);
-				EXECUTE sql;
-			END LOOP;
+					EXECUTE sql;
+				END LOOP;
+
+			-- Older upgrade sources may not have constraints introduced after
+			-- the original domain was created.  Treat those canonical topology
+			-- constraints like captured constraints so incomplete repairs keep
+			-- them NOT VALID, while complete repairs install the fresh-domain
+			-- constraint set as validated.
+			IF pg_catalog.lower(domain_name) = 'topoelement' THEN
+				IF NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
+					WHERE value->>'name' = 'dimensions'
+				) THEN
+					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
+						pg_catalog.jsonb_build_object(
+							'name', 'dimensions',
+							'definition', 'CHECK (array_upper(VALUE, 2) IS NULL AND array_upper(VALUE, 1) = 2)',
+							'not_valid_by_repair', true
+						)
+					);
+				END IF;
+
+				IF NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
+					WHERE value->>'name' = 'type_range'
+				) THEN
+					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
+						pg_catalog.jsonb_build_object(
+							'name', 'type_range',
+							'definition', 'CHECK (VALUE[2] > 0)',
+							'not_valid_by_repair', true
+						)
+					);
+				END IF;
+
+				IF NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
+					WHERE value->>'name' = 'lower_dimension'
+				) THEN
+					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
+						pg_catalog.jsonb_build_object(
+							'name', 'lower_dimension',
+							'definition', 'CHECK (array_lower(VALUE, 1) = 1)',
+							'not_valid_by_repair', true
+						)
+					);
+				END IF;
+			ELSIF pg_catalog.lower(domain_name) = 'topoelementarray' THEN
+				IF NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
+					WHERE value->>'name' = 'type_range'
+				) THEN
+					domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
+						pg_catalog.jsonb_build_object(
+							'name', 'type_range',
+							'definition', 'CHECK (array_upper(VALUE, 2) = 2 AND array_upper(VALUE, 3) IS NULL)',
+							'not_valid_by_repair', true
+						)
+					);
+				END IF;
+			END IF;
 
 			UPDATE pg_catalog.pg_type
 			SET typbasetype = new_base_type::regtype::oid, typndims = array_dims
@@ -352,7 +418,7 @@ BEGIN
 						ON p.oid = dep.objid
 					WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
 					AND dep.refobjid = a.attrelid
-					AND dep.refobjsubid = a.attnum
+					AND dep.refobjsubid IN (0, a.attnum)
 					LIMIT 1
 				) AS dependent_policy ON true
 				LEFT JOIN LATERAL (
@@ -606,7 +672,7 @@ BEGIN
 							FROM pg_catalog.pg_depend AS dep
 							WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
 							AND dep.refobjid = a.attrelid
-							AND dep.refobjsubid = a.attnum
+							AND dep.refobjsubid IN (0, a.attnum)
 						)
 						OR EXISTS (
 							SELECT 1
@@ -668,15 +734,15 @@ BEGIN
 						)
 						SELECT 1
 						FROM inherited_relid AS i
-						JOIN pg_catalog.pg_attribute AS ca
-							ON ca.attrelid = i.attrelid
-							AND ca.attname = a.attname
-							AND ca.atttypid = a.atttypid
-							AND ca.attnum > 0
-							AND NOT ca.attisdropped
-						JOIN pg_catalog.pg_depend AS dep
-							ON dep.refobjid = ca.attrelid
-							AND dep.refobjsubid = ca.attnum
+							JOIN pg_catalog.pg_attribute AS ca
+								ON ca.attrelid = i.attrelid
+								AND ca.attname = a.attname
+								AND ca.atttypid = a.atttypid
+								AND ca.attnum > 0
+								AND NOT ca.attisdropped
+							JOIN pg_catalog.pg_depend AS dep
+								ON dep.refobjid = ca.attrelid
+								AND dep.refobjsubid IN (0, ca.attnum)
 							WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
 						)
 						OR EXISTS (
@@ -868,7 +934,7 @@ BEGIN
 						FROM pg_catalog.pg_depend AS dep
 						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
 						AND dep.refobjid = a.attrelid
-						AND dep.refobjsubid = a.attnum
+						AND dep.refobjsubid IN (0, a.attnum)
 					)
 					AND NOT EXISTS (
 						SELECT 1
@@ -930,15 +996,15 @@ BEGIN
 					)
 					SELECT 1
 					FROM inherited_relid AS i
-					JOIN pg_catalog.pg_attribute AS ca
-						ON ca.attrelid = i.attrelid
-						AND ca.attname = a.attname
-						AND ca.atttypid = a.atttypid
-						AND ca.attnum > 0
-						AND NOT ca.attisdropped
-					JOIN pg_catalog.pg_depend AS dep
-						ON dep.refobjid = ca.attrelid
-						AND dep.refobjsubid = ca.attnum
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND dep.refobjsubid IN (0, ca.attnum)
 						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
 					)
 					AND NOT EXISTS (
@@ -1154,7 +1220,7 @@ BEGIN
 						FROM pg_catalog.pg_depend AS dep
 						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
 						AND dep.refobjid = a.attrelid
-						AND dep.refobjsubid = a.attnum
+						AND dep.refobjsubid IN (0, a.attnum)
 					)
 					AND NOT EXISTS (
 						SELECT 1
@@ -1256,9 +1322,9 @@ BEGIN
 						AND NOT ca.attisdropped
 					JOIN pg_catalog.pg_depend AS dep
 						ON dep.refobjid = ca.attrelid
-						AND dep.refobjsubid = ca.attnum
-						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
-					)
+						AND dep.refobjsubid IN (0, ca.attnum)
+					WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+				)
 					AND NOT EXISTS (
 						WITH RECURSIVE inherited_relid(attrelid) AS (
 							SELECT i.inhrelid
@@ -1396,39 +1462,62 @@ BEGIN
 				END IF;
 			END LOOP;
 
-			FOR domain_constraint IN
-				SELECT
-					value->>'name' AS conname,
-					CASE
-					WHEN skipped_repair THEN value->>'definition'
-					ELSE pg_catalog.regexp_replace(
-						value->>'definition',
-						'[[:space:]]+NOT[[:space:]]+VALID[[:space:]]*$',
-						'',
-						'i'
-					)
-					END AS constraint_def
-				FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
-			LOOP
-				-- If some old-width rows were intentionally skipped, restoring
-				-- constraints as validated would scan those rows and can abort
-				-- the whole repair.  A later complete retry must strip any
-				-- previous NOT VALID state so the repaired domain is canonical.
-				sql := pg_catalog.format(
-					'ALTER DOMAIN %I.%I ADD CONSTRAINT %I %s%s',
-					domain_schema,
-					domain_name,
-					domain_constraint.conname,
-					domain_constraint.constraint_def,
-					CASE
-					WHEN skipped_repair
-						AND domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
-					THEN ' NOT VALID'
-					ELSE ''
-					END
-				);
-				EXECUTE sql;
-			END LOOP;
+				FOR domain_constraint IN
+					SELECT
+						value->>'name' AS conname,
+						CASE
+						WHEN skipped_repair THEN value->>'definition'
+						WHEN COALESCE((value->>'not_valid_by_repair')::boolean, false) THEN pg_catalog.regexp_replace(
+							value->>'definition',
+							'[[:space:]]+NOT[[:space:]]+VALID[[:space:]]*$',
+							'',
+							'i'
+						)
+						ELSE pg_catalog.regexp_replace(
+							value->>'definition',
+							'[[:space:]]*$',
+							'',
+							'i'
+						)
+						END AS constraint_def,
+						COALESCE((value->>'not_valid_by_repair')::boolean, false) AS not_valid_by_repair
+					FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
+				LOOP
+					-- If some old-width rows were intentionally skipped, restoring
+					-- constraints as validated would scan those rows and can abort
+					-- the whole repair. Mark only constraints demoted by this repair,
+					-- so a later complete retry can revalidate them without changing
+					-- user-created NOT VALID constraints.
+					sql := pg_catalog.format(
+						'ALTER DOMAIN %I.%I ADD CONSTRAINT %I %s%s',
+						domain_schema,
+						domain_name,
+						domain_constraint.conname,
+						domain_constraint.constraint_def,
+						CASE
+						WHEN skipped_repair
+							AND domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
+						THEN ' NOT VALID'
+						ELSE ''
+						END
+					);
+					EXECUTE sql;
+					IF skipped_repair
+						AND (
+							domain_constraint.not_valid_by_repair
+							OR domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
+						)
+					THEN
+						sql := pg_catalog.format(
+							'COMMENT ON CONSTRAINT %I ON DOMAIN %I.%I IS %L',
+							domain_constraint.conname,
+							domain_schema,
+							domain_name,
+							constraint_not_valid_marker
+						);
+						EXECUTE sql;
+					END IF;
+				END LOOP;
 
 			IF skipped_repair THEN
 				RAISE WARNING 'Topology.% domain storage repair was incomplete; repair marker was not written',

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -177,36 +177,91 @@ CREATE OR REPLACE FUNCTION _postgis_topology_upgrade_domain_type(
 	deprecated_in_version text DEFAULT 'xxx'
 ) RETURNS void AS $$
 DECLARE
+	context TEXT;
 	detail TEXT;
 	domain_oid OID;
+	domain_array_oid OID;
+	domain_att_type_oids OID[];
+	topology_domain_oids OID[];
 	domain_schema TEXT := 'topology';
 	domain_constraint RECORD;
+	domain_constraint_defs JSONB := '[]'::JSONB;
 	domain_column RECORD;
+	domain_default_expr TEXT;
 	domain_default RECORD;
+	domain_generated_column RECORD;
+	domain_generated_source_column RECORD;
+	domain_skipped_column RECORD;
 	sql TEXT;
+	skipped_repair BOOLEAN := false;
 	-- We need the base types of the old and new types - if multidimensional (int[][]), we need just one dimension at most
 	old_base_type TEXT := pg_catalog.regexp_replace(old_domain_type, E'(\\[\\])+$', '[]');
 	new_base_type TEXT := pg_catalog.regexp_replace(new_domain_type, E'(\\[\\])+$', '[]');
 	array_dims INT := (SELECT count(*) FROM pg_catalog.regexp_matches (old_domain_type, E'\\[\\]', 'g'));
+	marker_version TEXT := CASE
+		WHEN deprecated_in_version ~ '^[0-9]+[.][0-9]+'
+		THEN pg_catalog.concat(
+			pg_catalog.split_part(deprecated_in_version, '.', 1),
+			pg_catalog.lpad(pg_catalog.split_part(deprecated_in_version, '.', 2), 2, '0')
+		)
+		ELSE deprecated_in_version
+	END;
+	repair_marker TEXT := 'postgis-topology-domain-storage-repaired-' || marker_version;
 BEGIN
-	SELECT t.oid
+	SELECT
+		t.oid,
+		t.typarray,
+		CASE
+			WHEN t.typdefaultbin IS NOT NULL THEN pg_catalog.pg_get_expr(t.typdefaultbin, 0)
+			ELSE NULL
+		END
 	FROM pg_catalog.pg_type AS t
 	WHERE typnamespace::regnamespace::text = domain_schema
 	AND typname::text ILIKE domain_name
 	-- Databases upgraded by the broken 3.6 path can already have
 	-- the new catalog base type while old-width row values remain.
-	AND typbasetype IN (old_base_type::regtype::oid, new_base_type::regtype::oid)
+	AND (
+		typbasetype = old_base_type::regtype::oid
+		OR (
+			typbasetype = new_base_type::regtype::oid
+			AND COALESCE(pg_catalog.obj_description(t.oid, 'pg_type'), '') NOT LIKE '%' || repair_marker || '%'
+		)
+	)
 	AND typndims = array_dims
-	INTO domain_oid;
+	INTO domain_oid, domain_array_oid, domain_default_expr;
 
-	IF domain_oid IS NOT NULL
-  	THEN
+	IF domain_oid IS NOT NULL THEN
 		BEGIN
+			domain_att_type_oids := pg_catalog.array_remove(ARRAY[domain_oid, domain_array_oid], 0::oid);
+
+			SELECT pg_catalog.array_agg(type_oid)
+			FROM (
+				SELECT t.oid AS type_oid
+				FROM pg_catalog.pg_type AS t
+				WHERE t.typnamespace = domain_schema::regnamespace
+				AND t.typname IN ('topoelement', 'topoelementarray')
+				UNION ALL
+				SELECT t.typarray
+				FROM pg_catalog.pg_type AS t
+				WHERE t.typnamespace = domain_schema::regnamespace
+				AND t.typname IN ('topoelement', 'topoelementarray')
+				AND t.typarray <> 0
+			) AS topology_types
+			INTO topology_domain_oids;
+
 			FOR domain_constraint IN
-				SELECT conname
+				SELECT
+					conname,
+					pg_catalog.pg_get_constraintdef(oid) AS constraint_def
 				FROM pg_catalog.pg_constraint
 				WHERE contypid = domain_oid
 			LOOP
+				domain_constraint_defs := domain_constraint_defs || pg_catalog.jsonb_build_array(
+					pg_catalog.jsonb_build_object(
+						'name', domain_constraint.conname,
+						'definition', domain_constraint.constraint_def
+					)
+				);
 				sql := pg_catalog.format(
 					'ALTER DOMAIN %I.%I DROP CONSTRAINT IF EXISTS %I',
 					domain_schema,
@@ -220,35 +275,528 @@ BEGIN
 			SET typbasetype = new_base_type::regtype::oid, typndims = array_dims
 			WHERE oid = domain_oid;
 
-			-- Child tables are skipped by the row rewrite below because
-			-- ALTER TABLE on the root recurses to them, but child defaults
-			-- are independent pg_attrdef entries and must be rebuilt too.
+			IF domain_default_expr IS NOT NULL THEN
+				sql := pg_catalog.format(
+					'ALTER DOMAIN %I.%I DROP DEFAULT',
+					domain_schema,
+					domain_name
+				);
+				EXECUTE sql;
+
+				CREATE TEMP TABLE IF NOT EXISTS pg_temp._postgis_topology_domain_defaults (
+					domain_schema TEXT,
+					domain_name TEXT,
+					default_expr TEXT,
+					new_domain_type TEXT
+				) ON COMMIT DROP;
+
+				INSERT INTO pg_temp._postgis_topology_domain_defaults
+					VALUES (
+						domain_schema,
+						domain_name,
+						domain_default_expr,
+						new_domain_type
+					);
+			END IF;
+
+			-- Rewrite-rule, row-level security policy, trigger,
+			-- SQL-function/procedure, publication-column, and
+			-- generated-expression dependencies make ALTER COLUMN TYPE fail.
+			-- Skip those columns and withhold the repair marker so a later
+			-- manual cleanup can retry instead of rolling back unrelated
+			-- domain repairs.
+			-- PostgreSQL 14 records generated-expression dependencies as
+			-- pg_class attribute dependencies; later releases also expose
+			-- pg_attrdef dependencies.
+			FOR domain_skipped_column IN
+				SELECT
+					a.attrelid,
+					a.attname,
+					c.relkind,
+					dependent_view.view_relid,
+					dependent_view.view_relkind,
+					dependent_view.rulename,
+					dependent_policy.policy_oid,
+					dependent_policy.policy_name,
+					dependent_trigger.trigger_oid,
+					dependent_trigger.trigger_name,
+					dependent_function.function_oid,
+					dependent_function.function_name,
+					dependent_publication.publication_relid,
+					dependent_publication.publication_name,
+					dependent_generated_column.attrelid AS generated_attrelid,
+					dependent_generated_column.attname AS generated_attname
+				FROM pg_catalog.pg_attribute AS a
+				JOIN pg_catalog.pg_class AS c
+					ON c.oid = a.attrelid
+				LEFT JOIN LATERAL (
+					SELECT
+						vc.oid AS view_relid,
+						vc.relkind AS view_relkind,
+						rw.rulename
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_rewrite AS rw
+						ON rw.oid = dep.objid
+					JOIN pg_catalog.pg_class AS vc
+						ON vc.oid = rw.ev_class
+					WHERE dep.refobjid = a.attrelid
+					AND dep.refobjsubid IN (0, a.attnum)
+					LIMIT 1
+				) AS dependent_view ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						p.oid AS policy_oid,
+						p.polname AS policy_name
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_policy AS p
+						ON p.oid = dep.objid
+					WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+					AND dep.refobjid = a.attrelid
+					AND dep.refobjsubid = a.attnum
+					LIMIT 1
+				) AS dependent_policy ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						t.oid AS trigger_oid,
+						t.tgname AS trigger_name
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_trigger AS t
+						ON t.oid = dep.objid
+					WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
+					AND dep.refobjid = a.attrelid
+					AND dep.refobjsubid = a.attnum
+					LIMIT 1
+				) AS dependent_trigger ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						p.oid AS function_oid,
+						p.oid::regprocedure::text AS function_name
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_proc AS p
+						ON p.oid = dep.objid
+					WHERE dep.classid = 'pg_catalog.pg_proc'::regclass
+					AND dep.refobjid = a.attrelid
+					AND dep.refobjsubid IN (0, a.attnum)
+					LIMIT 1
+				) AS dependent_function ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						pr.oid AS publication_relid,
+						pub.pubname AS publication_name
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_publication_rel AS pr
+						ON pr.oid = dep.objid
+					JOIN pg_catalog.pg_publication AS pub
+						ON pub.oid = pr.prpubid
+					WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
+					AND dep.refobjid = a.attrelid
+					AND dep.refobjsubid = a.attnum
+					LIMIT 1
+				) AS dependent_publication ON true
+				LEFT JOIN LATERAL (
+					SELECT
+						generated_dependency.attrelid,
+						generated_dependency.attname
+					FROM (
+						SELECT
+							ga.attrelid,
+							ga.attname
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attrdef AS gd
+							ON gd.oid = dep.objid
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = gd.adrelid
+							AND ga.attnum = gd.adnum
+						WHERE dep.classid = 'pg_catalog.pg_attrdef'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+						AND ga.attgenerated <> ''
+						UNION ALL
+						SELECT
+							ga.attrelid,
+							ga.attname
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = dep.objid
+							AND ga.attnum = dep.objsubid
+						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+						AND ga.attgenerated <> ''
+					) AS generated_dependency
+					LIMIT 1
+				) AS dependent_generated_column ON true
+				WHERE a.atttypid = ANY(domain_att_type_oids)
+				AND a.attnum > 0
+				AND NOT a.attisdropped
+				AND (
+					c.relkind = 'm'
+					OR dependent_view.view_relid IS NOT NULL
+					OR dependent_policy.policy_oid IS NOT NULL
+					OR dependent_trigger.trigger_oid IS NOT NULL
+					OR dependent_function.function_oid IS NOT NULL
+					OR dependent_publication.publication_relid IS NOT NULL
+					OR dependent_generated_column.attrelid IS NOT NULL
+				)
+			LOOP
+				skipped_repair := true;
+				IF domain_skipped_column.relkind = 'm' THEN
+					RAISE WARNING 'Could not rewrite materialized view column %.% for topology.%; refresh or recreate the materialized view after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name;
+				ELSIF domain_skipped_column.view_relkind = 'v' THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because view % depends on it; drop and recreate the view, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.view_relid::regclass;
+				ELSIF domain_skipped_column.view_relkind IN ('r', 'p') THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because rule % on % depends on it; drop and recreate the rule, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.rulename,
+						domain_skipped_column.view_relid::regclass;
+				ELSIF domain_skipped_column.policy_oid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because row-level security policy % depends on it; drop and recreate the policy, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.policy_name;
+				ELSIF domain_skipped_column.trigger_oid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because trigger % depends on it; drop and recreate the trigger, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.trigger_name;
+				ELSIF domain_skipped_column.function_oid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because function or procedure % depends on it; drop and recreate the routine, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.function_name;
+				ELSIF domain_skipped_column.publication_relid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because publication % depends on it; drop and recreate the publication relation entry, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.publication_name;
+				ELSIF domain_skipped_column.generated_attrelid IS NOT NULL THEN
+					RAISE WARNING 'Could not rewrite %.% for topology.% because generated column %.% depends on it; drop and recreate the generated column, then repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.generated_attrelid::regclass,
+						domain_skipped_column.generated_attname;
+				ELSE
+					RAISE WARNING 'Could not rewrite %.% for topology.% because materialized view % depends on it; refresh or recreate the materialized view and repair the column after upgrade',
+						domain_skipped_column.attrelid::regclass,
+						domain_skipped_column.attname,
+						domain_name,
+						domain_skipped_column.view_relid::regclass;
+				END IF;
+			END LOOP;
+
+			FOR domain_generated_source_column IN
+				SELECT
+					a.attrelid,
+					a.attname,
+					generated_source.attrelid AS source_attrelid,
+					generated_source.attname AS source_attname
+				FROM pg_catalog.pg_attribute AS a
+				JOIN pg_catalog.pg_class AS c
+					ON c.oid = a.attrelid
+				JOIN LATERAL (
+					SELECT
+						source_dependency.attrelid,
+						source_dependency.attname
+					FROM (
+						SELECT
+							sa.attrelid,
+							sa.attname
+						FROM pg_catalog.pg_attrdef AS gd
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.classid = 'pg_catalog.pg_attrdef'::regclass
+							AND dep.objid = gd.oid
+						JOIN pg_catalog.pg_attribute AS sa
+							ON sa.attrelid = dep.refobjid
+							AND sa.attnum = dep.refobjsubid
+						WHERE gd.adrelid = a.attrelid
+						AND gd.adnum = a.attnum
+						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.attnum > 0
+						AND NOT sa.attisdropped
+						AND sa.attnum <> a.attnum
+						UNION ALL
+						SELECT
+							sa.attrelid,
+							sa.attname
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attribute AS sa
+							ON sa.attrelid = dep.refobjid
+							AND sa.attnum = dep.refobjsubid
+						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+						AND dep.objid = a.attrelid
+						AND dep.objsubid = a.attnum
+						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.attnum > 0
+						AND NOT sa.attisdropped
+						AND sa.attnum <> a.attnum
+					) AS source_dependency
+					LIMIT 1
+				) AS generated_source ON true
+				WHERE a.atttypid = ANY(domain_att_type_oids)
+				AND a.attnum > 0
+				AND NOT a.attisdropped
+				AND a.attgenerated = 's'
+				AND c.relkind IN ('r', 'p')
+			LOOP
+				skipped_repair := true;
+				RAISE WARNING 'Could not rewrite generated column %.% for topology.% because it reads unrepaired column %.%; drop and recreate the generated column after repairing its source column',
+					domain_generated_source_column.attrelid::regclass,
+					domain_generated_source_column.attname,
+					domain_name,
+					domain_generated_source_column.source_attrelid::regclass,
+					domain_generated_source_column.source_attname;
+			END LOOP;
+
+			-- Some table columns cannot enter the row rewrite below, but their
+			-- defaults are independent pg_attrdef entries and can still be
+			-- rebuilt through the new array storage.
 			FOR domain_default IN
 				SELECT
 					a.attrelid,
 					a.attname,
-					pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr
+					pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr,
+					CASE
+						WHEN a.atttypid = domain_array_oid THEN
+							pg_catalog.format('%I.%I[]', domain_schema, domain_name)
+						ELSE
+							pg_catalog.format('%I.%I', domain_schema, domain_name)
+					END AS target_domain_type,
+					CASE
+						WHEN a.atttypid = domain_array_oid THEN
+							'pg_catalog.text[]'
+						ELSE
+							new_domain_type
+					END AS storage_cast_type
 				FROM pg_catalog.pg_attribute AS a
 				JOIN pg_catalog.pg_class AS c
 					ON c.oid = a.attrelid
 				JOIN pg_catalog.pg_attrdef AS d
 					ON d.adrelid = a.attrelid
 					AND d.adnum = a.attnum
-				WHERE a.atttypid = domain_oid
+				WHERE a.atttypid = ANY(domain_att_type_oids)
 				AND a.attnum > 0
 				AND NOT a.attisdropped
 				AND a.attgenerated = ''
 				AND c.relkind IN ('r', 'p')
-				AND EXISTS (
-					SELECT 1
-					FROM pg_catalog.pg_inherits AS i
-					JOIN pg_catalog.pg_attribute AS pa
-						ON pa.attrelid = i.inhparent
-						AND pa.attname = a.attname
-						AND pa.atttypid = a.atttypid
-						AND pa.attnum > 0
-						AND NOT pa.attisdropped
-					WHERE i.inhrelid = a.attrelid
+				AND (
+					EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_rewrite AS rw
+							ON rw.oid = dep.objid
+						WHERE dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+					)
+						OR EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid = a.attnum
+						)
+						OR EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid = a.attnum
+						)
+						OR EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							WHERE dep.classid = 'pg_catalog.pg_proc'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid IN (0, a.attnum)
+						)
+						OR EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid = a.attnum
+						)
+						OR EXISTS (
+							SELECT 1
+							FROM (
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							JOIN pg_catalog.pg_attrdef AS gd
+								ON gd.oid = dep.objid
+							JOIN pg_catalog.pg_attribute AS ga
+								ON ga.attrelid = gd.adrelid
+								AND ga.attnum = gd.adnum
+							WHERE dep.classid = 'pg_catalog.pg_attrdef'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid IN (0, a.attnum)
+							AND ga.attgenerated <> ''
+							UNION ALL
+							SELECT 1
+							FROM pg_catalog.pg_depend AS dep
+							JOIN pg_catalog.pg_attribute AS ga
+								ON ga.attrelid = dep.objid
+								AND ga.attnum = dep.objsubid
+							WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+							AND dep.refobjid = a.attrelid
+							AND dep.refobjsubid IN (0, a.attnum)
+							AND ga.attgenerated <> ''
+						) AS generated_dependency
+					)
+						OR EXISTS (
+							WITH RECURSIVE inherited_relid(attrelid) AS (
+								SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							WHERE i.inhparent = a.attrelid
+							UNION ALL
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							JOIN inherited_relid AS ir
+								ON ir.attrelid = i.inhparent
+						)
+						SELECT 1
+						FROM inherited_relid AS i
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND dep.refobjsubid = ca.attnum
+							WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+						)
+						OR EXISTS (
+							WITH RECURSIVE inherited_relid(attrelid) AS (
+								SELECT i.inhrelid
+								FROM pg_catalog.pg_inherits AS i
+								WHERE i.inhparent = a.attrelid
+								UNION ALL
+								SELECT i.inhrelid
+								FROM pg_catalog.pg_inherits AS i
+								JOIN inherited_relid AS ir
+									ON ir.attrelid = i.inhparent
+						)
+						SELECT 1
+						FROM inherited_relid AS i
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND (
+								(
+									dep.classid IN (
+										'pg_catalog.pg_trigger'::regclass,
+										'pg_catalog.pg_publication_rel'::regclass
+									)
+									AND dep.refobjsubid = ca.attnum
+								)
+								OR (
+									dep.classid = 'pg_catalog.pg_proc'::regclass
+									AND dep.refobjsubid IN (0, ca.attnum)
+								)
+							)
+					)
+						OR EXISTS (
+							WITH RECURSIVE inherited_relid(attrelid) AS (
+								SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							WHERE i.inhparent = a.attrelid
+							UNION ALL
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							JOIN inherited_relid AS ir
+								ON ir.attrelid = i.inhparent
+						)
+						SELECT 1
+						FROM inherited_relid AS i
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND dep.refobjsubid IN (0, ca.attnum)
+						JOIN pg_catalog.pg_rewrite AS rw
+							ON rw.oid = dep.objid
+					)
+					OR EXISTS (
+						WITH RECURSIVE inherited_relid(attrelid) AS (
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							WHERE i.inhparent = a.attrelid
+							UNION ALL
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							JOIN inherited_relid AS ir
+								ON ir.attrelid = i.inhparent
+						)
+						SELECT 1
+						FROM inherited_relid AS i
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND dep.refobjsubid IN (0, ca.attnum)
+						JOIN pg_catalog.pg_attrdef AS gd
+							ON gd.oid = dep.objid
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = gd.adrelid
+							AND ga.attnum = gd.adnum
+						WHERE dep.classid = 'pg_catalog.pg_attrdef'::regclass
+						AND ga.attgenerated <> ''
+						UNION ALL
+						SELECT 1
+						FROM inherited_relid AS i
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND dep.refobjsubid IN (0, ca.attnum)
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = dep.objid
+							AND ga.attnum = dep.objsubid
+						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+						AND ga.attgenerated <> ''
+					)
+					OR EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_inherits AS i
+						JOIN pg_catalog.pg_attribute AS pa
+							ON pa.attrelid = i.inhparent
+							AND pa.attname = a.attname
+							AND pa.atttypid = a.atttypid
+							AND pa.attnum > 0
+							AND NOT pa.attisdropped
+						WHERE i.inhrelid = a.attrelid
+					)
 				)
 			LOOP
 				sql := pg_catalog.format(
@@ -259,13 +807,12 @@ BEGIN
 				EXECUTE sql;
 
 				sql := pg_catalog.format(
-					'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::text::%s::%I.%I)',
+					'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::text::%s::%s)',
 					domain_default.attrelid::regclass,
 					domain_default.attname,
 					domain_default.default_expr,
-					new_domain_type,
-					domain_schema,
-					domain_name
+					domain_default.storage_cast_type,
+					domain_default.target_domain_type
 				);
 				EXECUTE sql;
 			END LOOP;
@@ -274,22 +821,233 @@ BEGIN
 			-- array element width. Whole-array output can mask that fact, so
 			-- force every dependent table column through text into the new
 			-- array representation before the domain constraints are restored.
+			-- Roots with blocked children are skipped as a unit because
+			-- ALTER TABLE would recurse into those children and abort the
+			-- entire domain repair.
 			FOR domain_column IN
 				SELECT
 					a.attrelid,
 					a.attname,
-					pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr
+					pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr,
+					CASE
+						WHEN a.atttypid = domain_array_oid THEN
+							pg_catalog.format('%I.%I[]', domain_schema, domain_name)
+						ELSE
+							pg_catalog.format('%I.%I', domain_schema, domain_name)
+					END AS target_domain_type,
+					CASE
+						WHEN a.atttypid = domain_array_oid THEN
+							'pg_catalog.text[]'
+						ELSE
+							new_domain_type
+					END AS storage_cast_type,
+					a.atttypid = domain_array_oid AS is_domain_array
 				FROM pg_catalog.pg_attribute AS a
 				JOIN pg_catalog.pg_class AS c
 					ON c.oid = a.attrelid
 				LEFT JOIN pg_catalog.pg_attrdef AS d
 					ON d.adrelid = a.attrelid
 					AND d.adnum = a.attnum
-				WHERE a.atttypid = domain_oid
+				WHERE a.atttypid = ANY(domain_att_type_oids)
 				AND a.attnum > 0
 				AND NOT a.attisdropped
 				AND a.attgenerated = ''
 				AND c.relkind IN ('r', 'p')
+				AND NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_rewrite AS rw
+						ON rw.oid = dep.objid
+					JOIN pg_catalog.pg_class AS mc
+						ON mc.oid = rw.ev_class
+					WHERE dep.refobjid = a.attrelid
+					AND dep.refobjsubid IN (0, a.attnum)
+				)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid = a.attnum
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid = a.attnum
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_proc'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid = a.attnum
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attrdef AS gd
+							ON gd.oid = dep.objid
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = gd.adrelid
+							AND ga.attnum = gd.adnum
+						WHERE dep.classid = 'pg_catalog.pg_attrdef'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+						AND ga.attgenerated <> ''
+						UNION ALL
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = dep.objid
+							AND ga.attnum = dep.objsubid
+						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+						AND ga.attgenerated <> ''
+					) AS generated_dependency
+				)
+					AND NOT EXISTS (
+						WITH RECURSIVE inherited_relid(attrelid) AS (
+							SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						WHERE i.inhparent = a.attrelid
+						UNION ALL
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						JOIN inherited_relid AS ir
+							ON ir.attrelid = i.inhparent
+					)
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid = ca.attnum
+						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+					)
+					AND NOT EXISTS (
+						WITH RECURSIVE inherited_relid(attrelid) AS (
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							WHERE i.inhparent = a.attrelid
+							UNION ALL
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							JOIN inherited_relid AS ir
+								ON ir.attrelid = i.inhparent
+						)
+						SELECT 1
+						FROM inherited_relid AS i
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND (
+								(
+									dep.classid IN (
+										'pg_catalog.pg_trigger'::regclass,
+										'pg_catalog.pg_publication_rel'::regclass
+									)
+									AND dep.refobjsubid = ca.attnum
+								)
+								OR (
+									dep.classid = 'pg_catalog.pg_proc'::regclass
+									AND dep.refobjsubid IN (0, ca.attnum)
+								)
+							)
+					)
+					AND NOT EXISTS (
+						WITH RECURSIVE inherited_relid(attrelid) AS (
+							SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						WHERE i.inhparent = a.attrelid
+						UNION ALL
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						JOIN inherited_relid AS ir
+							ON ir.attrelid = i.inhparent
+					)
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid IN (0, ca.attnum)
+					JOIN pg_catalog.pg_rewrite AS rw
+						ON rw.oid = dep.objid
+				)
+					AND NOT EXISTS (
+						WITH RECURSIVE inherited_relid(attrelid) AS (
+							SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						WHERE i.inhparent = a.attrelid
+						UNION ALL
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						JOIN inherited_relid AS ir
+							ON ir.attrelid = i.inhparent
+					)
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid IN (0, ca.attnum)
+					JOIN pg_catalog.pg_attrdef AS gd
+						ON gd.oid = dep.objid
+					JOIN pg_catalog.pg_attribute AS ga
+						ON ga.attrelid = gd.adrelid
+						AND ga.attnum = gd.adnum
+					WHERE dep.classid = 'pg_catalog.pg_attrdef'::regclass
+					AND ga.attgenerated <> ''
+					UNION ALL
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid IN (0, ca.attnum)
+					JOIN pg_catalog.pg_attribute AS ga
+						ON ga.attrelid = dep.objid
+						AND ga.attnum = dep.objsubid
+					WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+					AND ga.attgenerated <> ''
+				)
 				AND NOT EXISTS (
 					SELECT 1
 					FROM pg_catalog.pg_inherits AS i
@@ -311,39 +1069,392 @@ BEGIN
 					EXECUTE sql;
 				END IF;
 
-				sql := pg_catalog.format(
-					'ALTER TABLE %s ALTER COLUMN %I TYPE %I.%I USING (%I::text::%s::%I.%I)',
-					domain_column.attrelid::regclass,
-					domain_column.attname,
-					domain_schema,
-					domain_name,
-					domain_column.attname,
-					new_domain_type,
-					domain_schema,
-					domain_name
-				);
+				IF domain_column.is_domain_array THEN
+					CREATE TEMP TABLE IF NOT EXISTS pg_temp._postgis_topology_domain_array_columns (
+						attrelid OID,
+						attname NAME,
+						target_domain_type TEXT,
+						default_expr TEXT
+					) ON COMMIT DROP;
+
+					INSERT INTO pg_temp._postgis_topology_domain_array_columns
+						VALUES (
+							domain_column.attrelid,
+							domain_column.attname,
+							domain_column.target_domain_type,
+							domain_column.default_expr
+						);
+				END IF;
+
+				IF domain_column.is_domain_array THEN
+					-- text[] keeps NULL domain-array elements representable while
+					-- the column is detached from the topology domain.
+					sql := pg_catalog.format(
+						'ALTER TABLE %s ALTER COLUMN %I TYPE pg_catalog.text[] USING (%I::pg_catalog.text[])',
+						domain_column.attrelid::regclass,
+						domain_column.attname,
+						domain_column.attname
+					);
+				ELSE
+					sql := pg_catalog.format(
+						'ALTER TABLE %s ALTER COLUMN %I TYPE %s USING (%I::text::%s)',
+						domain_column.attrelid::regclass,
+						domain_column.attname,
+						domain_column.target_domain_type,
+						domain_column.attname,
+						domain_column.storage_cast_type
+					);
+				END IF;
 				EXECUTE sql;
 
-				IF domain_column.default_expr IS NOT NULL THEN
+				IF domain_column.default_expr IS NOT NULL AND NOT domain_column.is_domain_array THEN
 					sql := pg_catalog.format(
-						'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::text::%s::%I.%I)',
+						'ALTER TABLE %s ALTER COLUMN %I SET DEFAULT ((%s)::text::%s::%s)',
 						domain_column.attrelid::regclass,
 						domain_column.attname,
 						domain_column.default_expr,
-						new_domain_type,
-						domain_schema,
-						domain_name
+						domain_column.storage_cast_type,
+						domain_column.target_domain_type
 					);
 					EXECUTE sql;
 				END IF;
 			END LOOP;
 
+			-- PostgreSQL 17 can recompute stored generated columns without
+			-- dropping them. Older supported releases do not expose a safe
+			-- equivalent that preserves dependent objects and column metadata.
+			FOR domain_generated_column IN
+				SELECT
+					a.attrelid,
+					a.attname,
+					pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS generation_expr
+				FROM pg_catalog.pg_attribute AS a
+				JOIN pg_catalog.pg_class AS c
+					ON c.oid = a.attrelid
+				JOIN pg_catalog.pg_attrdef AS d
+					ON d.adrelid = a.attrelid
+					AND d.adnum = a.attnum
+				WHERE a.atttypid = ANY(domain_att_type_oids)
+				AND a.attnum > 0
+				AND NOT a.attisdropped
+				AND a.attgenerated = 's'
+				AND c.relkind IN ('r', 'p')
+				AND NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.pg_depend AS dep
+					JOIN pg_catalog.pg_rewrite AS rw
+						ON rw.oid = dep.objid
+					JOIN pg_catalog.pg_class AS mc
+						ON mc.oid = rw.ev_class
+					WHERE dep.refobjid = a.attrelid
+					AND dep.refobjsubid IN (0, a.attnum)
+				)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid = a.attnum
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_trigger'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid = a.attnum
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_proc'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid = a.attnum
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM (
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attrdef AS gd
+							ON gd.oid = dep.objid
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = gd.adrelid
+							AND ga.attnum = gd.adnum
+						WHERE dep.classid = 'pg_catalog.pg_attrdef'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+						AND ga.attgenerated <> ''
+						UNION ALL
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attribute AS ga
+							ON ga.attrelid = dep.objid
+							AND ga.attnum = dep.objsubid
+						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+						AND dep.refobjid = a.attrelid
+						AND dep.refobjsubid IN (0, a.attnum)
+						AND ga.attgenerated <> ''
+					) AS generated_dependency
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM (
+						SELECT 1
+						FROM pg_catalog.pg_attrdef AS gd
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.classid = 'pg_catalog.pg_attrdef'::regclass
+							AND dep.objid = gd.oid
+						JOIN pg_catalog.pg_attribute AS sa
+							ON sa.attrelid = dep.refobjid
+							AND sa.attnum = dep.refobjsubid
+						WHERE gd.adrelid = a.attrelid
+						AND gd.adnum = a.attnum
+						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.attnum > 0
+						AND NOT sa.attisdropped
+						AND sa.attnum <> a.attnum
+						UNION ALL
+						SELECT 1
+						FROM pg_catalog.pg_depend AS dep
+						JOIN pg_catalog.pg_attribute AS sa
+							ON sa.attrelid = dep.refobjid
+							AND sa.attnum = dep.refobjsubid
+						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+						AND dep.objid = a.attrelid
+						AND dep.objsubid = a.attnum
+						AND sa.atttypid = ANY(topology_domain_oids)
+						AND sa.attnum > 0
+						AND NOT sa.attisdropped
+						AND sa.attnum <> a.attnum
+					) AS generated_source_dependency
+				)
+				AND NOT EXISTS (
+					WITH RECURSIVE inherited_relid(attrelid) AS (
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						WHERE i.inhparent = a.attrelid
+						UNION ALL
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						JOIN inherited_relid AS ir
+							ON ir.attrelid = i.inhparent
+					)
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid = ca.attnum
+						WHERE dep.classid = 'pg_catalog.pg_policy'::regclass
+					)
+					AND NOT EXISTS (
+						WITH RECURSIVE inherited_relid(attrelid) AS (
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							WHERE i.inhparent = a.attrelid
+							UNION ALL
+							SELECT i.inhrelid
+							FROM pg_catalog.pg_inherits AS i
+							JOIN inherited_relid AS ir
+								ON ir.attrelid = i.inhparent
+						)
+						SELECT 1
+						FROM inherited_relid AS i
+						JOIN pg_catalog.pg_attribute AS ca
+							ON ca.attrelid = i.attrelid
+							AND ca.attname = a.attname
+							AND ca.atttypid = a.atttypid
+							AND ca.attnum > 0
+							AND NOT ca.attisdropped
+						JOIN pg_catalog.pg_depend AS dep
+							ON dep.refobjid = ca.attrelid
+							AND (
+								(
+									dep.classid IN (
+										'pg_catalog.pg_trigger'::regclass,
+										'pg_catalog.pg_publication_rel'::regclass
+									)
+									AND dep.refobjsubid = ca.attnum
+								)
+								OR (
+									dep.classid = 'pg_catalog.pg_proc'::regclass
+									AND dep.refobjsubid IN (0, ca.attnum)
+								)
+							)
+					)
+					AND NOT EXISTS (
+						WITH RECURSIVE inherited_relid(attrelid) AS (
+							SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						WHERE i.inhparent = a.attrelid
+						UNION ALL
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						JOIN inherited_relid AS ir
+							ON ir.attrelid = i.inhparent
+					)
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid IN (0, ca.attnum)
+					JOIN pg_catalog.pg_rewrite AS rw
+						ON rw.oid = dep.objid
+				)
+				AND NOT EXISTS (
+					WITH RECURSIVE inherited_relid(attrelid) AS (
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						WHERE i.inhparent = a.attrelid
+						UNION ALL
+						SELECT i.inhrelid
+						FROM pg_catalog.pg_inherits AS i
+						JOIN inherited_relid AS ir
+							ON ir.attrelid = i.inhparent
+					)
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid IN (0, ca.attnum)
+					JOIN pg_catalog.pg_attrdef AS gd
+						ON gd.oid = dep.objid
+					JOIN pg_catalog.pg_attribute AS ga
+						ON ga.attrelid = gd.adrelid
+						AND ga.attnum = gd.adnum
+					WHERE dep.classid = 'pg_catalog.pg_attrdef'::regclass
+					AND ga.attgenerated <> ''
+					UNION ALL
+					SELECT 1
+					FROM inherited_relid AS i
+					JOIN pg_catalog.pg_attribute AS ca
+						ON ca.attrelid = i.attrelid
+						AND ca.attname = a.attname
+						AND ca.atttypid = a.atttypid
+						AND ca.attnum > 0
+						AND NOT ca.attisdropped
+					JOIN pg_catalog.pg_depend AS dep
+						ON dep.refobjid = ca.attrelid
+						AND dep.refobjsubid IN (0, ca.attnum)
+					JOIN pg_catalog.pg_attribute AS ga
+						ON ga.attrelid = dep.objid
+						AND ga.attnum = dep.objsubid
+					WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+					AND ga.attgenerated <> ''
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM pg_catalog.pg_inherits AS i
+					JOIN pg_catalog.pg_attribute AS pa
+						ON pa.attrelid = i.inhparent
+						AND pa.attname = a.attname
+						AND pa.atttypid = a.atttypid
+						AND pa.attnum > 0
+						AND NOT pa.attisdropped
+					WHERE i.inhrelid = a.attrelid
+				)
+			LOOP
+				IF pg_catalog.current_setting('server_version_num')::int >= 170000 THEN
+					sql := pg_catalog.format(
+						'ALTER TABLE %s ALTER COLUMN %I SET EXPRESSION AS (%s)',
+						domain_generated_column.attrelid::regclass,
+						domain_generated_column.attname,
+						domain_generated_column.generation_expr
+					);
+					EXECUTE sql;
+				ELSE
+					skipped_repair := true;
+					RAISE WARNING 'Could not rewrite stored generated column %.% for topology.% on PostgreSQL %, generated expression reset requires PostgreSQL 17 or later',
+						domain_generated_column.attrelid::regclass,
+						domain_generated_column.attname,
+						domain_name,
+						pg_catalog.current_setting('server_version');
+				END IF;
+			END LOOP;
+
+			FOR domain_constraint IN
+				SELECT
+					value->>'name' AS conname,
+					CASE
+					WHEN skipped_repair THEN value->>'definition'
+					ELSE pg_catalog.regexp_replace(
+						value->>'definition',
+						'[[:space:]]+NOT[[:space:]]+VALID[[:space:]]*$',
+						'',
+						'i'
+					)
+					END AS constraint_def
+				FROM pg_catalog.jsonb_array_elements(domain_constraint_defs) AS value
+			LOOP
+				-- If some old-width rows were intentionally skipped, restoring
+				-- constraints as validated would scan those rows and can abort
+				-- the whole repair.  A later complete retry must strip any
+				-- previous NOT VALID state so the repaired domain is canonical.
+				sql := pg_catalog.format(
+					'ALTER DOMAIN %I.%I ADD CONSTRAINT %I %s%s',
+					domain_schema,
+					domain_name,
+					domain_constraint.conname,
+					domain_constraint.constraint_def,
+					CASE
+					WHEN skipped_repair
+						AND domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'
+					THEN ' NOT VALID'
+					ELSE ''
+					END
+				);
+				EXECUTE sql;
+			END LOOP;
+
+			IF skipped_repair THEN
+				RAISE WARNING 'Topology.% domain storage repair was incomplete; repair marker was not written',
+					domain_name;
+			ELSE
+				sql := pg_catalog.format(
+					'COMMENT ON DOMAIN %I.%I IS %L',
+					domain_schema,
+					domain_name,
+					pg_catalog.concat_ws(
+						E'\n',
+						NULLIF(pg_catalog.obj_description(domain_oid, 'pg_type'), ''),
+						repair_marker
+					)
+				);
+				EXECUTE sql;
+			END IF;
+
 			RAISE INFO 'Upgraded % from % to %', domain_name, old_domain_type, new_domain_type;
 		EXCEPTION
 		WHEN others THEN
-			GET STACKED DIAGNOSTICS detail := PG_EXCEPTION_DETAIL;
+			GET STACKED DIAGNOSTICS
+				context := PG_EXCEPTION_CONTEXT,
+				detail := PG_EXCEPTION_DETAIL;
 			RAISE WARNING 'Could not modify % from % to %, got % (%)',
-				domain_name, old_domain_type, new_domain_type, SQLERRM, SQLSTATE USING DETAIL = detail;
+				domain_name, old_domain_type, new_domain_type, SQLERRM, SQLSTATE USING DETAIL = detail, HINT = context;
 			RETURN;
 		END;
 	ELSE

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -195,6 +195,7 @@ DECLARE
 	sql TEXT;
 	skipped_repair BOOLEAN := false;
 	skipped_domain_type_oids OID[] := ARRAY[]::OID[];
+	skipped_domain_constraint_oids OID[] := ARRAY[]::OID[];
 	restored_domain_array_columns BOOLEAN := false;
 	-- We need the base types of the old and new types - if multidimensional (int[][]), we need just one dimension at most
 	old_base_type TEXT := pg_catalog.regexp_replace(old_domain_type, E'(\\[\\])+$', '[]');
@@ -559,7 +560,7 @@ BEGIN
 						ON pub.oid = pr.prpubid
 					WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
 					AND dep.refobjid = a.attrelid
-					AND dep.refobjsubid = a.attnum
+					AND dep.refobjsubid IN (0, a.attnum)
 					LIMIT 1
 				) AS dependent_publication ON true
 				LEFT JOIN LATERAL (
@@ -850,6 +851,10 @@ BEGIN
 					CASE
 						WHEN a.atttypid = domain_array_oid THEN
 							'pg_catalog.text[]'
+						WHEN ate.typtype = 'd'
+							AND at.typelem = ANY(nested_topology_type_oids)
+						THEN
+							'pg_catalog.text[]'
 						WHEN a.atttypid <> ALL(domain_att_type_oids) THEN
 							a.atttypid::regtype::text
 						ELSE
@@ -860,6 +865,8 @@ BEGIN
 					ON c.oid = a.attrelid
 				JOIN pg_catalog.pg_type AS at
 					ON at.oid = a.atttypid
+				LEFT JOIN pg_catalog.pg_type AS ate
+					ON ate.oid = at.typelem
 				JOIN pg_catalog.pg_attrdef AS d
 					ON d.adrelid = a.attrelid
 					AND d.adnum = a.attnum
@@ -869,6 +876,11 @@ BEGIN
 						a.atttypid = ANY(nested_topology_type_oids)
 						AND a.atttypid <> ALL(domain_att_type_oids)
 						AND at.typtype = 'd'
+					)
+					OR (
+						ate.typtype = 'd'
+						AND at.typelem = ANY(nested_topology_type_oids)
+						AND at.typelem <> ALL(domain_att_type_oids)
 					)
 				)
 				AND a.attnum > 0
@@ -880,6 +892,11 @@ BEGIN
 						a.atttypid = ANY(nested_topology_type_oids)
 						AND a.atttypid <> ALL(domain_att_type_oids)
 						AND at.typtype = 'd'
+					)
+					OR (
+						ate.typtype = 'd'
+						AND at.typelem = ANY(nested_topology_type_oids)
+						AND at.typelem <> ALL(domain_att_type_oids)
 					)
 					OR EXISTS (
 						SELECT 1
@@ -952,7 +969,7 @@ BEGIN
 							FROM pg_catalog.pg_depend AS dep
 							WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
 							AND dep.refobjid = a.attrelid
-							AND dep.refobjsubid = a.attnum
+							AND dep.refobjsubid IN (0, a.attnum)
 						)
 						OR EXISTS (
 							SELECT 1
@@ -1030,7 +1047,7 @@ BEGIN
 									dep.classid IN (
 										'pg_catalog.pg_publication_rel'::regclass
 									)
-									AND dep.refobjsubid = ca.attnum
+									AND dep.refobjsubid IN (0, ca.attnum)
 								)
 								OR (
 									dep.classid = 'pg_catalog.pg_trigger'::regclass
@@ -1301,7 +1318,7 @@ BEGIN
 						FROM pg_catalog.pg_depend AS dep
 						WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
 						AND dep.refobjid = a.attrelid
-						AND dep.refobjsubid = a.attnum
+						AND dep.refobjsubid IN (0, a.attnum)
 					)
 					AND NOT EXISTS (
 						SELECT 1
@@ -1379,7 +1396,7 @@ BEGIN
 									dep.classid IN (
 										'pg_catalog.pg_publication_rel'::regclass
 									)
-									AND dep.refobjsubid = ca.attnum
+									AND dep.refobjsubid IN (0, ca.attnum)
 								)
 								OR (
 									dep.classid = 'pg_catalog.pg_trigger'::regclass
@@ -1690,7 +1707,7 @@ BEGIN
 						FROM pg_catalog.pg_depend AS dep
 						WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
 						AND dep.refobjid = a.attrelid
-						AND dep.refobjsubid = a.attnum
+						AND dep.refobjsubid IN (0, a.attnum)
 					)
 					AND NOT EXISTS (
 						SELECT 1
@@ -1800,7 +1817,7 @@ BEGIN
 									dep.classid IN (
 										'pg_catalog.pg_publication_rel'::regclass
 									)
-									AND dep.refobjsubid = ca.attnum
+									AND dep.refobjsubid IN (0, ca.attnum)
 								)
 								OR (
 									dep.classid = 'pg_catalog.pg_trigger'::regclass
@@ -1957,6 +1974,40 @@ BEGIN
 				DELETE FROM pg_temp._postgis_topology_domain_array_columns
 				WHERE target_domain_type = pg_catalog.format('%I.%I[]', domain_schema, domain_name);
 
+				-- Skipped carrier types may wrap topology domains through arrays,
+				-- user domains, composites, or table row types. Expose every
+				-- contained type OID before choosing validated restoration for the
+				-- saved domain constraints.
+				WITH RECURSIVE skipped_constraint_type(type_oid) AS (
+					SELECT skipped_type_oid
+					FROM pg_catalog.unnest(skipped_domain_type_oids) AS skipped_type(skipped_type_oid)
+					UNION
+					SELECT contained_type.type_oid
+					FROM skipped_constraint_type AS skipped_type
+					JOIN pg_catalog.pg_type AS t
+						ON t.oid = skipped_type.type_oid
+					JOIN LATERAL (
+						SELECT t.typelem AS type_oid
+						WHERE t.typelem <> 0::oid
+						UNION
+						SELECT t.typbasetype AS type_oid
+						WHERE t.typbasetype <> 0::oid
+						UNION
+						SELECT a.atttypid AS type_oid
+						FROM pg_catalog.pg_attribute AS a
+						WHERE a.attrelid = t.typrelid
+						AND a.attnum > 0
+						AND NOT a.attisdropped
+					) AS contained_type ON true
+				)
+				SELECT pg_catalog.array_agg(DISTINCT type_oid)
+				FROM skipped_constraint_type
+				INTO skipped_domain_constraint_oids;
+				skipped_domain_constraint_oids := COALESCE(
+					skipped_domain_constraint_oids,
+					ARRAY[]::OID[]
+				);
+
 				FOR domain_constraint IN
 					SELECT
 						(value->>'domain_oid')::oid AS domain_oid,
@@ -1967,7 +2018,7 @@ BEGIN
 							WHEN COALESCE((value->>'convalidated')::boolean, false)
 								OR (
 									COALESCE((value->>'not_valid_by_repair')::boolean, false)
-									AND (value->>'domain_oid')::oid <> ALL(skipped_domain_type_oids)
+									AND (value->>'domain_oid')::oid <> ALL(skipped_domain_constraint_oids)
 								)
 							THEN pg_catalog.regexp_replace(
 								value->>'definition',
@@ -2008,7 +2059,7 @@ BEGIN
 							WHEN (
 								(
 									skipped_repair
-									AND domain_constraint.domain_oid = ANY(skipped_domain_type_oids)
+									AND domain_constraint.domain_oid = ANY(skipped_domain_constraint_oids)
 								)
 								OR (
 									restored_domain_array_columns
@@ -2023,7 +2074,7 @@ BEGIN
 					);
 					EXECUTE sql;
 					IF skipped_repair
-						AND domain_constraint.domain_oid = ANY(skipped_domain_type_oids)
+						AND domain_constraint.domain_oid = ANY(skipped_domain_constraint_oids)
 						AND (
 							domain_constraint.not_valid_by_repair
 							OR domain_constraint.constraint_def !~* '[[:space:]]NOT[[:space:]]+VALID[[:space:]]*$'

--- a/postgis/common_before_upgrade.sql
+++ b/postgis/common_before_upgrade.sql
@@ -718,7 +718,9 @@ BEGIN
 
 			-- Some table columns cannot enter the row rewrite below, but their
 			-- defaults are independent pg_attrdef entries and can still be
-			-- rebuilt through the new array storage.
+			-- rebuilt through the new array storage. Nested carrier defaults
+			-- need the same treatment so they do not keep creating old-width
+			-- topology domain values after their storage rewrite is skipped.
 			FOR domain_default IN
 				SELECT
 					a.attrelid,
@@ -727,12 +729,16 @@ BEGIN
 					CASE
 						WHEN a.atttypid = domain_array_oid THEN
 							pg_catalog.format('%I.%I[]', domain_schema, domain_name)
+						WHEN a.atttypid <> ALL(domain_att_type_oids) THEN
+							a.atttypid::regtype::text
 						ELSE
 							pg_catalog.format('%I.%I', domain_schema, domain_name)
 					END AS target_domain_type,
 					CASE
 						WHEN a.atttypid = domain_array_oid THEN
 							'pg_catalog.text[]'
+						WHEN a.atttypid <> ALL(domain_att_type_oids) THEN
+							a.atttypid::regtype::text
 						ELSE
 							new_domain_type
 					END AS storage_cast_type
@@ -742,13 +748,23 @@ BEGIN
 				JOIN pg_catalog.pg_attrdef AS d
 					ON d.adrelid = a.attrelid
 					AND d.adnum = a.attnum
-				WHERE a.atttypid = ANY(domain_att_type_oids)
+				WHERE (
+					a.atttypid = ANY(domain_att_type_oids)
+					OR (
+						a.atttypid = ANY(nested_topology_type_oids)
+						AND a.atttypid <> ALL(domain_att_type_oids)
+					)
+				)
 				AND a.attnum > 0
 				AND NOT a.attisdropped
 				AND a.attgenerated = ''
 				AND c.relkind IN ('r', 'p')
 				AND (
-					EXISTS (
+					(
+						a.atttypid = ANY(nested_topology_type_oids)
+						AND a.atttypid <> ALL(domain_att_type_oids)
+					)
+					OR EXISTS (
 						SELECT 1
 						FROM pg_catalog.pg_depend AS dep
 						JOIN pg_catalog.pg_rewrite AS rw
@@ -959,27 +975,86 @@ BEGIN
 							AND ca.attname = a.attname
 							AND ca.atttypid = a.atttypid
 							AND ca.attnum > 0
-							AND NOT ca.attisdropped
-						JOIN pg_catalog.pg_depend AS dep
-							ON dep.refobjid = ca.attrelid
-							AND dep.refobjsubid IN (0, ca.attnum)
-						JOIN pg_catalog.pg_attribute AS ga
-							ON ga.attrelid = dep.objid
-							AND ga.attnum = dep.objsubid
-						WHERE dep.classid = 'pg_catalog.pg_class'::regclass
-						AND ga.attgenerated <> ''
-					)
-					OR EXISTS (
-						SELECT 1
-						FROM pg_catalog.pg_inherits AS i
-						JOIN pg_catalog.pg_attribute AS pa
-							ON pa.attrelid = i.inhparent
-							AND pa.attname = a.attname
-							AND pa.atttypid = a.atttypid
-							AND pa.attnum > 0
-							AND NOT pa.attisdropped
-						WHERE i.inhrelid = a.attrelid
-					)
+								AND NOT ca.attisdropped
+							JOIN pg_catalog.pg_depend AS dep
+								ON dep.refobjid = ca.attrelid
+								AND dep.refobjsubid IN (0, ca.attnum)
+							JOIN pg_catalog.pg_attribute AS ga
+								ON ga.attrelid = dep.objid
+								AND ga.attnum = dep.objsubid
+							WHERE dep.classid = 'pg_catalog.pg_class'::regclass
+							AND ga.attgenerated <> ''
+						)
+						OR (
+							a.atttypid = domain_array_oid
+							AND EXISTS (
+								WITH RECURSIVE inherited_relid(attrelid) AS (
+									SELECT i.inhrelid
+									FROM pg_catalog.pg_inherits AS i
+									WHERE i.inhparent = a.attrelid
+									UNION ALL
+									SELECT i.inhrelid
+									FROM pg_catalog.pg_inherits AS i
+									JOIN inherited_relid AS ir
+										ON ir.attrelid = i.inhparent
+								)
+								SELECT 1
+								FROM inherited_relid AS i
+								JOIN pg_catalog.pg_attribute AS ca
+									ON ca.attrelid = i.attrelid
+									AND ca.attname = a.attname
+									AND ca.atttypid = a.atttypid
+									AND ca.attnum > 0
+									AND NOT ca.attisdropped
+								JOIN pg_catalog.pg_depend AS dep
+									ON dep.classid = 'pg_catalog.pg_constraint'::regclass
+									AND dep.refobjid = ca.attrelid
+									AND dep.refobjsubid IN (0, ca.attnum)
+							)
+						)
+						OR (
+							a.atttypid = domain_array_oid
+							AND EXISTS (
+								WITH RECURSIVE inherited_relid(attrelid) AS (
+									SELECT i.inhrelid
+									FROM pg_catalog.pg_inherits AS i
+									WHERE i.inhparent = a.attrelid
+									UNION ALL
+									SELECT i.inhrelid
+									FROM pg_catalog.pg_inherits AS i
+									JOIN inherited_relid AS ir
+										ON ir.attrelid = i.inhparent
+								)
+								SELECT 1
+								FROM inherited_relid AS i
+								JOIN pg_catalog.pg_attribute AS ca
+									ON ca.attrelid = i.attrelid
+									AND ca.attname = a.attname
+									AND ca.atttypid = a.atttypid
+									AND ca.attnum > 0
+									AND NOT ca.attisdropped
+								JOIN pg_catalog.pg_depend AS dep
+									ON dep.classid = 'pg_catalog.pg_class'::regclass
+									AND dep.refobjid = ca.attrelid
+									AND dep.refobjsubid IN (0, ca.attnum)
+								JOIN pg_catalog.pg_class AS ic
+									ON ic.oid = dep.objid
+									AND ic.relkind = 'i'
+								JOIN pg_catalog.pg_index AS ix
+									ON ix.indexrelid = ic.oid
+							)
+						)
+						OR EXISTS (
+							SELECT 1
+							FROM pg_catalog.pg_inherits AS i
+							JOIN pg_catalog.pg_attribute AS pa
+								ON pa.attrelid = i.inhparent
+								AND pa.attname = a.attname
+								AND pa.atttypid = a.atttypid
+								AND pa.attnum > 0
+								AND NOT pa.attisdropped
+							WHERE i.inhrelid = a.attrelid
+						)
 				)
 			LOOP
 				sql := pg_catalog.format(
@@ -1212,6 +1287,65 @@ BEGIN
 					JOIN pg_catalog.pg_rewrite AS rw
 						ON rw.oid = dep.objid
 				)
+					AND NOT (
+						a.atttypid = domain_array_oid
+						AND EXISTS (
+							WITH RECURSIVE inherited_relid(attrelid) AS (
+								SELECT i.inhrelid
+								FROM pg_catalog.pg_inherits AS i
+								WHERE i.inhparent = a.attrelid
+								UNION ALL
+								SELECT i.inhrelid
+								FROM pg_catalog.pg_inherits AS i
+								JOIN inherited_relid AS ir
+									ON ir.attrelid = i.inhparent
+							)
+							SELECT 1
+							FROM inherited_relid AS i
+							JOIN pg_catalog.pg_attribute AS ca
+								ON ca.attrelid = i.attrelid
+								AND ca.attname = a.attname
+								AND ca.atttypid = a.atttypid
+								AND ca.attnum > 0
+								AND NOT ca.attisdropped
+							JOIN pg_catalog.pg_depend AS dep
+								ON dep.classid = 'pg_catalog.pg_constraint'::regclass
+								AND dep.refobjid = ca.attrelid
+								AND dep.refobjsubid IN (0, ca.attnum)
+						)
+					)
+					AND NOT (
+						a.atttypid = domain_array_oid
+						AND EXISTS (
+							WITH RECURSIVE inherited_relid(attrelid) AS (
+								SELECT i.inhrelid
+								FROM pg_catalog.pg_inherits AS i
+								WHERE i.inhparent = a.attrelid
+								UNION ALL
+								SELECT i.inhrelid
+								FROM pg_catalog.pg_inherits AS i
+								JOIN inherited_relid AS ir
+									ON ir.attrelid = i.inhparent
+							)
+							SELECT 1
+							FROM inherited_relid AS i
+							JOIN pg_catalog.pg_attribute AS ca
+								ON ca.attrelid = i.attrelid
+								AND ca.attname = a.attname
+								AND ca.atttypid = a.atttypid
+								AND ca.attnum > 0
+								AND NOT ca.attisdropped
+							JOIN pg_catalog.pg_depend AS dep
+								ON dep.classid = 'pg_catalog.pg_class'::regclass
+								AND dep.refobjid = ca.attrelid
+								AND dep.refobjsubid IN (0, ca.attnum)
+							JOIN pg_catalog.pg_class AS ic
+								ON ic.oid = dep.objid
+								AND ic.relkind = 'i'
+							JOIN pg_catalog.pg_index AS ix
+								ON ix.indexrelid = ic.oid
+						)
+					)
 					AND NOT EXISTS (
 						WITH RECURSIVE inherited_relid(attrelid) AS (
 							SELECT i.inhrelid

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -317,6 +317,14 @@ BEGIN
   IF (SELECT count(*) FROM upgrade_test.domain_blocked_inherit_grandchild_view) != 1 THEN
     RAISE EXCEPTION 'dependent topology domain inherited grandchild view was not preserved during upgrade';
   END IF;
+
+  IF (SELECT count(*) FROM upgrade_test.domain_row_type_blocked_child) != 1 THEN
+    RAISE EXCEPTION 'dependent topology domain inherited child row type was not preserved during upgrade';
+  END IF;
+
+  IF (SELECT count(*) FROM upgrade_test.domain_row_type_blocked_carrier) != 1 THEN
+    RAISE EXCEPTION 'dependent topology domain inherited child row-type carrier was not preserved during upgrade';
+  END IF;
 END
 $$;
 
@@ -386,6 +394,29 @@ BEGIN
     RAISE EXCEPTION 'rewritten table row-type topology carrier default did not preserve value: %',
       row_carrier_value;
   END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_row_carrier_source'::regclass
+    AND a.attname = 'a';
+
+  IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+    RAISE EXCEPTION 'row-type-blocked topology domain column default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_row_carrier_source DEFAULT VALUES;
+  SELECT a INTO STRICT row_carrier_value
+    FROM upgrade_test.domain_row_carrier_source;
+
+  IF row_carrier_value[1] != 107 OR row_carrier_value[2] != 108 THEN
+    RAISE EXCEPTION 'rewritten row-type-blocked topology domain default did not preserve value: %',
+      row_carrier_value;
+  END IF;
 END
 $$;
 
@@ -442,6 +473,26 @@ BEGIN
 
   IF default_element[1] != 101 OR default_element[2] != 102 THEN
     RAISE EXCEPTION 'rewritten inherited topology domain array default did not preserve value: %',
+      default_value;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_class
+    WHERE oid = 'upgrade_test.domain_array_partition_index_expr_idx'::regclass
+  ) THEN
+    RAISE EXCEPTION 'partitioned topology domain array expression index was not preserved during upgrade';
+  END IF;
+
+  INSERT INTO upgrade_test.domain_array_partition_index_parent(id) VALUES (2);
+
+  SELECT a INTO STRICT default_value
+    FROM upgrade_test.domain_array_partition_index_parent
+    WHERE id = 2;
+  default_element := default_value[1]::topology.topoelement;
+
+  IF default_element[1] != 111 OR default_element[2] != 112 THEN
+    RAISE EXCEPTION 'rewritten partitioned topology domain array default did not preserve value: %',
       default_value;
   END IF;
 END

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -236,17 +236,18 @@ BEGIN
     RAISE EXCEPTION 'dependent topology domain SQL function was not preserved during upgrade';
   END IF;
 
-  IF current_setting('server_version_num')::integer >= 150000
-    AND NOT EXISTS (
-      SELECT 1
-      FROM pg_catalog.pg_publication AS p
-      JOIN pg_catalog.pg_publication_rel AS pr
-        ON pr.prpubid = p.oid
-      WHERE p.pubname = 'upgrade_test_domain_publication'
-      AND pr.prrelid = 'upgrade_test.domain_publication_source'::regclass
-    )
-  THEN
-    RAISE EXCEPTION 'dependent topology domain publication relation was not preserved during upgrade';
+  IF current_setting('server_version_num')::integer >= 150000 THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_publication AS p
+        JOIN pg_catalog.pg_publication_rel AS pr
+          ON pr.prpubid = p.oid
+        WHERE p.pubname = 'upgrade_test_domain_publication'
+        AND pr.prrelid = 'upgrade_test.domain_publication_source'::regclass
+      )
+    THEN
+      RAISE EXCEPTION 'dependent topology domain publication relation was not preserved during upgrade';
+    END IF;
   END IF;
 
   IF (SELECT count(*) FROM upgrade_test.domain_blocked_partition_child_view) != 1 THEN
@@ -301,17 +302,18 @@ BEGIN
     RAISE EXCEPTION 'dependent topology domain partition-child SQL function was not preserved during upgrade';
   END IF;
 
-  IF current_setting('server_version_num')::integer >= 150000
-    AND NOT EXISTS (
-      SELECT 1
-      FROM pg_catalog.pg_publication AS p
-      JOIN pg_catalog.pg_publication_rel AS pr
-        ON pr.prpubid = p.oid
-      WHERE p.pubname = 'upgrade_test_domain_child_publication'
-      AND pr.prrelid = 'upgrade_test.domain_publication_child_child'::regclass
-    )
-  THEN
-    RAISE EXCEPTION 'dependent topology domain partition-child publication relation was not preserved during upgrade';
+  IF current_setting('server_version_num')::integer >= 150000 THEN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_publication AS p
+        JOIN pg_catalog.pg_publication_rel AS pr
+          ON pr.prpubid = p.oid
+        WHERE p.pubname = 'upgrade_test_domain_child_publication'
+        AND pr.prrelid = 'upgrade_test.domain_publication_child_child'::regclass
+      )
+    THEN
+      RAISE EXCEPTION 'dependent topology domain partition-child publication relation was not preserved during upgrade';
+    END IF;
   END IF;
 
   IF (SELECT count(*) FROM upgrade_test.domain_blocked_inherit_grandchild_view) != 1 THEN
@@ -331,6 +333,7 @@ $$;
 DO $$
 DECLARE
   nested_value topology.topoelement;
+  nested_array_value topology.topoelementarray;
   default_expr text;
   row_carrier_value topology.topoelement;
 BEGIN
@@ -370,6 +373,90 @@ BEGIN
     RAISE EXCEPTION 'rewritten nested topology domain-level default did not preserve value: %',
       nested_value;
   END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'upgrade_test.unused_nested_topoelement'::regtype
+    AND conname = 'unused_nested_topoelement_validated'
+    AND convalidated
+  ) THEN
+    RAISE EXCEPTION 'unrelated validated nested topology domain constraint was restored unvalidated';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'upgrade_test.nested_topoelement'::regtype
+    AND conname = 'nested_topoelement_positive'
+  ) THEN
+    RAISE EXCEPTION 'nested topology domain constraint was not restored during upgrade';
+  END IF;
+
+  BEGIN
+    CREATE TEMP TABLE domain_nested_constraint_probe (
+      a upgrade_test.nested_topoelement
+    ) ON COMMIT DROP;
+    INSERT INTO domain_nested_constraint_probe VALUES (
+      '{0,1}'::topology.topoelement::upgrade_test.nested_topoelement
+    );
+    RAISE EXCEPTION 'nested topology domain constraint did not reject invalid value';
+  EXCEPTION WHEN check_violation THEN
+    NULL;
+  END;
+
+  SELECT pg_catalog.pg_get_expr(t.typdefaultbin, 0)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_type AS t
+    WHERE t.oid = 'upgrade_test.nested_topoelementarray'::regtype;
+
+  IF default_expr IS NULL OR default_expr NOT LIKE '%::text)::upgrade_test.nested_topoelementarray%' THEN
+    RAISE EXCEPTION 'nested topology domain array default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  CREATE TEMP TABLE domain_nested_array_default_probe (
+    a upgrade_test.nested_topoelementarray
+  ) ON COMMIT DROP;
+  INSERT INTO domain_nested_array_default_probe DEFAULT VALUES;
+  SELECT a::topology.topoelementarray INTO STRICT nested_array_value
+    FROM domain_nested_array_default_probe;
+
+  IF nested_array_value[1][1] != 93 OR nested_array_value[1][2] != 94 THEN
+    RAISE EXCEPTION 'rewritten nested topology domain array default did not preserve value: %',
+      nested_array_value;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'upgrade_test.unused_nested_topoelementarray'::regtype
+    AND conname = 'unused_nested_topoelementarray_validated'
+    AND convalidated
+  ) THEN
+    RAISE EXCEPTION 'unrelated validated nested topology domain array constraint was restored unvalidated';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'upgrade_test.nested_topoelementarray'::regtype
+    AND conname = 'nested_topoelementarray_positive'
+  ) THEN
+    RAISE EXCEPTION 'nested topology domain array constraint was not restored during upgrade';
+  END IF;
+
+  BEGIN
+    CREATE TEMP TABLE domain_nested_array_constraint_probe (
+      a upgrade_test.nested_topoelementarray
+    ) ON COMMIT DROP;
+    INSERT INTO domain_nested_array_constraint_probe VALUES (
+      '{{0,1}}'::topology.topoelementarray::upgrade_test.nested_topoelementarray
+    );
+    RAISE EXCEPTION 'nested topology domain array constraint did not reject invalid value';
+  EXCEPTION WHEN check_violation THEN
+    NULL;
+  END;
 
   SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
     INTO STRICT default_expr

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -139,7 +139,7 @@ BEGIN
       ''
     ) LIKE '%postgis-topology-domain-storage-repaired-306%'
   THEN
-    RAISE EXCEPTION 'topoelement repair marker was set despite skipped materialized view storage';
+    RAISE EXCEPTION 'topoelement repair marker was set despite skipped storage';
   END IF;
 
   IF COALESCE(
@@ -151,7 +151,7 @@ BEGIN
       ''
     ) LIKE '%postgis-topology-domain-storage-repaired-306%'
   THEN
-    RAISE EXCEPTION 'topoelementarray repair marker was set despite skipped materialized view storage';
+    RAISE EXCEPTION 'topoelementarray repair marker was set despite skipped storage';
   END IF;
 END
 $$;
@@ -252,6 +252,14 @@ BEGIN
 
   IF (SELECT count(*) FROM upgrade_test.domain_blocked_inherit_grandchild_view) != 1 THEN
     RAISE EXCEPTION 'dependent topology domain inherited grandchild view was not preserved during upgrade';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM upgrade_test.domain_nested_type_test) != 1 THEN
+    RAISE EXCEPTION 'nested topology domain storage fixture was not preserved during upgrade';
   END IF;
 END
 $$;

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -20,6 +20,56 @@ DO $$
 DECLARE
   row RECORD;
 BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelement'::regtype
+    AND conname = 'upgrade_test_topoelement_restored'
+    AND NOT convalidated
+  ) THEN
+    RAISE EXCEPTION 'topoelement domain constraint was not restored unvalidated during incomplete upgrade repair';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelement'::regtype
+    AND conname = 'upgrade_test_topoelement_already_not_valid'
+    AND NOT convalidated
+  ) THEN
+    RAISE EXCEPTION 'pre-existing unvalidated topoelement domain constraint was not restored during incomplete upgrade repair';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelementarray'::regtype
+    AND conname = 'upgrade_test_topoelementarray_restored'
+    AND NOT convalidated
+  ) THEN
+    RAISE EXCEPTION 'topoelementarray domain constraint was not restored unvalidated during incomplete upgrade repair';
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelement'::regtype
+    AND conname IN ('dimensions', 'type_range', 'lower_dimension')
+    AND NOT convalidated
+  ) != 3 THEN
+    RAISE EXCEPTION 'canonical topoelement domain constraints were not preserved unvalidated during incomplete upgrade repair';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelementarray'::regtype
+    AND conname = 'type_range'
+    AND NOT convalidated
+  ) THEN
+    RAISE EXCEPTION 'canonical topoelementarray domain constraint was not preserved unvalidated during incomplete upgrade repair';
+  END IF;
+
   SELECT a, b INTO STRICT row
     FROM upgrade_test.domain_test
     ORDER BY ctid ASC
@@ -45,6 +95,345 @@ INSERT INTO upgrade_test.domain_partition_test_1 (id) VALUES (3);
 SELECT tableoid::regclass, id, a[1], a[2]
   FROM upgrade_test.domain_partition_test
   ORDER BY id;
+
+INSERT INTO upgrade_test.domain_level_default_test DEFAULT VALUES;
+SELECT id, a[1], a[2]
+  FROM upgrade_test.domain_level_default_test
+  ORDER BY id;
+
+INSERT INTO upgrade_test.domain_array_test DEFAULT VALUES;
+SELECT id, a[1] IS NULL, a[2][1], a[2][2], b[1] IS NULL, b[2][1][1], b[2][1][2]
+  FROM upgrade_test.domain_array_test
+  ORDER BY id;
+
+DO $$
+BEGIN
+  IF COALESCE(
+    pg_catalog.obj_description('topology.topoelement'::regtype::oid, 'pg_type'),
+    ''
+  ) LIKE '%postgis-topology-domain-storage-repaired-3.6.0%'
+    OR COALESCE(
+      pg_catalog.obj_description('topology.topoelement'::regtype::oid, 'pg_type'),
+      ''
+    ) LIKE '%postgis-topology-domain-storage-repaired-306%'
+  THEN
+    RAISE EXCEPTION 'topoelement repair marker was set despite skipped materialized view storage';
+  END IF;
+
+  IF COALESCE(
+    pg_catalog.obj_description('topology.topoelementarray'::regtype::oid, 'pg_type'),
+    ''
+  ) LIKE '%postgis-topology-domain-storage-repaired-3.6.0%'
+    OR COALESCE(
+      pg_catalog.obj_description('topology.topoelementarray'::regtype::oid, 'pg_type'),
+      ''
+    ) LIKE '%postgis-topology-domain-storage-repaired-306%'
+  THEN
+    RAISE EXCEPTION 'topoelementarray repair marker was set despite skipped materialized view storage';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM upgrade_test.domain_view_test) != 1 THEN
+    RAISE EXCEPTION 'dependent topology domain view was not preserved during upgrade';
+  END IF;
+
+  IF (SELECT count(*) FROM upgrade_test.domain_whole_row_view_test) != 1 THEN
+    RAISE EXCEPTION 'dependent topology domain whole-row view was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_policy
+    WHERE polrelid = 'upgrade_test.domain_policy_source'::regclass
+    AND polname = 'domain_policy_source_a_policy'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain row-level security policy was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_trigger
+    WHERE tgrelid = 'upgrade_test.domain_trigger_source'::regclass
+    AND tgname = 'domain_trigger_source_a_trigger'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain trigger was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_proc
+    WHERE pronamespace = 'upgrade_test'::regnamespace
+    AND proname = 'domain_function_source_read'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain SQL function was not preserved during upgrade';
+  END IF;
+
+  IF current_setting('server_version_num')::integer >= 150000
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_publication AS p
+      JOIN pg_catalog.pg_publication_rel AS pr
+        ON pr.prpubid = p.oid
+      WHERE p.pubname = 'upgrade_test_domain_publication'
+      AND pr.prrelid = 'upgrade_test.domain_publication_source'::regclass
+    )
+  THEN
+    RAISE EXCEPTION 'dependent topology domain publication relation was not preserved during upgrade';
+  END IF;
+
+  IF (SELECT count(*) FROM upgrade_test.domain_blocked_partition_child_view) != 1 THEN
+    RAISE EXCEPTION 'dependent topology domain partition-child view was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_trigger
+    WHERE tgrelid = 'upgrade_test.domain_trigger_child_child'::regclass
+    AND tgname = 'domain_trigger_child_a_trigger'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain partition-child trigger was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_proc
+    WHERE pronamespace = 'upgrade_test'::regnamespace
+    AND proname = 'domain_function_child_read'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain partition-child SQL function was not preserved during upgrade';
+  END IF;
+
+  IF current_setting('server_version_num')::integer >= 150000
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_publication AS p
+      JOIN pg_catalog.pg_publication_rel AS pr
+        ON pr.prpubid = p.oid
+      WHERE p.pubname = 'upgrade_test_domain_child_publication'
+      AND pr.prrelid = 'upgrade_test.domain_publication_child_child'::regclass
+    )
+  THEN
+    RAISE EXCEPTION 'dependent topology domain partition-child publication relation was not preserved during upgrade';
+  END IF;
+
+  IF (SELECT count(*) FROM upgrade_test.domain_blocked_inherit_grandchild_view) != 1 THEN
+    RAISE EXCEPTION 'dependent topology domain inherited grandchild view was not preserved during upgrade';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_rewrite
+    WHERE ev_class = 'upgrade_test.domain_rule_source'::regclass
+    AND rulename = 'domain_rule_source_insert'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain rule was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_rewrite
+    WHERE ev_class = 'upgrade_test.domain_external_rule_target'::regclass
+    AND rulename = 'domain_external_rule_target_insert'
+  ) THEN
+    RAISE EXCEPTION 'external dependent topology domain rule was not preserved during upgrade';
+  END IF;
+END
+$$;
+
+DO $$
+DECLARE
+  row RECORD;
+  expected RECORD;
+  dependent_generated_value topology.topoelement;
+  cross_dependent_generated_value topology.topoelementarray;
+BEGIN
+  IF current_setting('server_version_num')::integer >= 170000 THEN
+    CREATE TEMP TABLE domain_generated_storage_probe (
+      a topology.topoelement,
+      b topology.topoelementarray
+    ) ON COMMIT DROP;
+    INSERT INTO domain_generated_storage_probe VALUES (
+      ARRAY[15::bigint, 16::bigint]::topology.topoelement,
+      ARRAY[ARRAY[17::bigint, 18::bigint]]::topology.topoelementarray
+    );
+
+    SELECT a, b INTO STRICT row
+      FROM upgrade_test.domain_generated_test;
+
+    SELECT pg_column_size(a) AS a_size, pg_column_size(b) AS b_size
+      INTO STRICT expected
+      FROM domain_generated_storage_probe;
+
+    IF row.a[1] != 15 OR row.a[2] != 16 THEN
+      RAISE EXCEPTION 'generated topoelement storage was not rewritten during upgrade: %', row.a;
+    END IF;
+
+    IF pg_column_size(row.a) != expected.a_size THEN
+      RAISE EXCEPTION 'generated topoelement storage size was not rewritten during upgrade: %', row.a;
+    END IF;
+
+    IF row.b[1][1] != 17 OR row.b[1][2] != 18 THEN
+      RAISE EXCEPTION 'generated topoelementarray storage was not rewritten during upgrade: %', row.b;
+    END IF;
+
+    IF pg_column_size(row.b) != expected.b_size THEN
+      RAISE EXCEPTION 'generated topoelementarray storage size was not rewritten during upgrade: %', row.b;
+    END IF;
+
+    SELECT g INTO STRICT dependent_generated_value
+      FROM upgrade_test.domain_generated_source_dependency_test;
+
+    IF dependent_generated_value[1] != 39 OR dependent_generated_value[2] != 40 THEN
+      RAISE EXCEPTION 'generated topology domain source dependency was not preserved during upgrade: %',
+        dependent_generated_value;
+    END IF;
+
+    SELECT g INTO STRICT cross_dependent_generated_value
+      FROM upgrade_test.domain_generated_cross_dependency_test;
+
+    IF cross_dependent_generated_value[1][1] != 43
+      OR cross_dependent_generated_value[1][2] != 44
+    THEN
+      RAISE EXCEPTION 'generated topology domain cross dependency was not preserved during upgrade: %',
+        cross_dependent_generated_value;
+    END IF;
+  END IF;
+END
+$$;
+
+DO $$
+DECLARE
+  default_expr text;
+BEGIN
+  IF (SELECT generated_id FROM upgrade_test.domain_generated_dependency_test) != 37 THEN
+    RAISE EXCEPTION 'generated topology domain dependency was not preserved during upgrade';
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_generated_dependency_test'::regclass
+    AND a.attname = 'a';
+
+  IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+    RAISE EXCEPTION 'skipped topology domain column default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_generated_dependency_test(id) VALUES (2);
+  IF (
+    SELECT generated_id
+    FROM upgrade_test.domain_generated_dependency_test
+    WHERE id = 2
+  ) != 41 THEN
+    RAISE EXCEPTION 'rewritten skipped topology domain default did not preserve generated dependency value';
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_policy_source'::regclass
+    AND a.attname = 'a';
+
+  IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+    RAISE EXCEPTION 'RLS-skipped topology domain column default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_policy_source(id) VALUES (2);
+  IF (
+    SELECT a[1]
+    FROM upgrade_test.domain_policy_source
+    WHERE id = 2
+  ) != 45 THEN
+    RAISE EXCEPTION 'rewritten RLS-skipped topology domain default did not preserve value';
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_trigger_source'::regclass
+    AND a.attname = 'a';
+
+  IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+    RAISE EXCEPTION 'trigger-skipped topology domain column default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_trigger_source(id) VALUES (2);
+  IF (
+    SELECT a[1]
+    FROM upgrade_test.domain_trigger_source
+    WHERE id = 2
+  ) != 49 THEN
+    RAISE EXCEPTION 'rewritten trigger-skipped topology domain default did not preserve value';
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_function_source'::regclass
+    AND a.attname = 'a';
+
+  IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+    RAISE EXCEPTION 'function-skipped topology domain column default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_function_source(id) VALUES (2);
+  IF (
+    SELECT a[1]
+    FROM upgrade_test.domain_function_source
+    WHERE id = 2
+  ) != 61 THEN
+    RAISE EXCEPTION 'rewritten function-skipped topology domain default did not preserve value';
+  END IF;
+
+  IF current_setting('server_version_num')::integer >= 150000 THEN
+    SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+      INTO STRICT default_expr
+      FROM pg_catalog.pg_attribute AS a
+      JOIN pg_catalog.pg_attrdef AS d
+        ON d.adrelid = a.attrelid
+        AND d.adnum = a.attnum
+      WHERE a.attrelid = 'upgrade_test.domain_publication_source'::regclass
+      AND a.attname = 'a';
+
+    IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+      RAISE EXCEPTION 'publication-skipped topology domain column default was not rewritten during upgrade: %',
+        default_expr;
+    END IF;
+
+    INSERT INTO upgrade_test.domain_publication_source(id) VALUES (2);
+    IF (
+      SELECT a[1]
+      FROM upgrade_test.domain_publication_source
+      WHERE id = 2
+    ) != 53 THEN
+      RAISE EXCEPTION 'rewritten publication-skipped topology domain default did not preserve value';
+    END IF;
+  END IF;
+END
+$$;
 
 INSERT INTO upgrade_test.domain_test values (
   '{1,2}'::topology.topoelement,

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -15,6 +15,37 @@ INSERT INTO upgrade_test.domain_test values (
 
 SELECT * FROM topology.layer;
 
+-- https://trac.osgeo.org/postgis/ticket/6016
+DO $$
+DECLARE
+  row RECORD;
+BEGIN
+  SELECT a, b INTO STRICT row
+    FROM upgrade_test.domain_test
+    ORDER BY ctid ASC
+    LIMIT 1;
+
+  IF row.a[1] != 1 OR row.a[2] != 2 THEN
+    RAISE EXCEPTION 'topoelement storage was not rewritten during upgrade: %', row.a;
+  END IF;
+
+  IF row.b[1][1] != 2 OR row.b[1][2] != 3 THEN
+    RAISE EXCEPTION 'topoelementarray storage was not rewritten during upgrade: %', row.b;
+  END IF;
+END
+$$;
+
+INSERT INTO upgrade_test.domain_default_test DEFAULT VALUES;
+SELECT id, a[1], a[2], b[1][1], b[1][2]
+  FROM upgrade_test.domain_default_test
+  ORDER BY id;
+
+INSERT INTO upgrade_test.domain_partition_test (id) VALUES (2);
+INSERT INTO upgrade_test.domain_partition_test_1 (id) VALUES (3);
+SELECT tableoid::regclass, id, a[1], a[2]
+  FROM upgrade_test.domain_partition_test
+  ORDER BY id;
+
 INSERT INTO upgrade_test.domain_test values (
   '{1,2}'::topology.topoelement,
   '{{2,3}}'::topology.topoelementarray
@@ -22,4 +53,3 @@ INSERT INTO upgrade_test.domain_test values (
 
 SELECT topology.DropTopology('upgrade_test');
 SELECT topology.DropTopology('upgrade_test_copy');
-

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -308,9 +308,22 @@ END
 $$;
 
 DO $$
+DECLARE
+  nested_value topology.topoelement;
 BEGIN
   IF (SELECT count(*) FROM upgrade_test.domain_nested_type_test) != 1 THEN
     RAISE EXCEPTION 'nested topology domain storage fixture was not preserved during upgrade';
+  END IF;
+
+  INSERT INTO upgrade_test.domain_nested_type_test DEFAULT VALUES;
+
+  SELECT a::topology.topoelement INTO STRICT nested_value
+    FROM upgrade_test.domain_nested_type_test
+    WHERE id = 2;
+
+  IF nested_value[1] != 89 OR nested_value[2] != 90 THEN
+    RAISE EXCEPTION 'rewritten nested topology domain default did not preserve value: %',
+      nested_value;
   END IF;
 END
 $$;
@@ -333,6 +346,42 @@ BEGIN
     AND rulename = 'domain_external_rule_target_insert'
   ) THEN
     RAISE EXCEPTION 'external dependent topology domain rule was not preserved during upgrade';
+  END IF;
+END
+$$;
+
+DO $$
+DECLARE
+  default_value topology.topoelement[];
+  default_element topology.topoelement;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'upgrade_test.domain_array_inherit_constraint_child'::regclass
+    AND conname = 'domain_array_inherit_constraint_check'
+  ) THEN
+    RAISE EXCEPTION 'inherited child topology domain array constraint was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_class
+    WHERE oid = 'upgrade_test.domain_array_inherit_constraint_expr_idx'::regclass
+  ) THEN
+    RAISE EXCEPTION 'inherited child topology domain array expression index was not preserved during upgrade';
+  END IF;
+
+  INSERT INTO upgrade_test.domain_array_inherit_constraint_parent(id) VALUES (2);
+
+  SELECT a INTO STRICT default_value
+    FROM ONLY upgrade_test.domain_array_inherit_constraint_parent
+    WHERE id = 2;
+  default_element := default_value[1]::topology.topoelement;
+
+  IF default_element[1] != 101 OR default_element[2] != 102 THEN
+    RAISE EXCEPTION 'rewritten inherited topology domain array default did not preserve value: %',
+      default_value;
   END IF;
 END
 $$;

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -34,10 +34,32 @@ BEGIN
     SELECT 1
     FROM pg_catalog.pg_constraint
     WHERE contypid = 'topology.topoelement'::regtype
+    AND conname = 'upgrade_test_topoelement_restored'
+    AND pg_catalog.obj_description(oid, 'pg_constraint')
+      LIKE '%postgis-topology-domain-constraint-not-valid-by-repair-306%'
+  ) THEN
+    RAISE EXCEPTION 'repair-demoted topoelement domain constraint was not marked for complete retry revalidation';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelement'::regtype
     AND conname = 'upgrade_test_topoelement_already_not_valid'
     AND NOT convalidated
   ) THEN
     RAISE EXCEPTION 'pre-existing unvalidated topoelement domain constraint was not restored during incomplete upgrade repair';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelement'::regtype
+    AND conname = 'upgrade_test_topoelement_already_not_valid'
+    AND pg_catalog.obj_description(oid, 'pg_constraint')
+      LIKE '%postgis-topology-domain-constraint-not-valid-by-repair-306%'
+  ) THEN
+    RAISE EXCEPTION 'user-created NOT VALID topoelement domain constraint was incorrectly marked for revalidation';
   END IF;
 
   IF NOT EXISTS (
@@ -151,6 +173,15 @@ BEGIN
     AND polname = 'domain_policy_source_a_policy'
   ) THEN
     RAISE EXCEPTION 'dependent topology domain row-level security policy was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_policy
+    WHERE polrelid = 'upgrade_test.domain_whole_row_policy_source'::regclass
+    AND polname = 'domain_whole_row_policy_source_policy'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain whole-row row-level security policy was not preserved during upgrade';
   END IF;
 
   IF NOT EXISTS (
@@ -360,6 +391,29 @@ BEGIN
     WHERE id = 2
   ) != 45 THEN
     RAISE EXCEPTION 'rewritten RLS-skipped topology domain default did not preserve value';
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_whole_row_policy_source'::regclass
+    AND a.attname = 'a';
+
+  IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+    RAISE EXCEPTION 'whole-row RLS-skipped topology domain column default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_whole_row_policy_source(id) VALUES (2);
+  IF (
+    SELECT a[1]
+    FROM upgrade_test.domain_whole_row_policy_source
+    WHERE id = 2
+  ) != 81 THEN
+    RAISE EXCEPTION 'rewritten whole-row RLS-skipped topology domain default did not preserve value';
   END IF;
 
   SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -270,6 +270,19 @@ BEGIN
     RAISE EXCEPTION 'dependent topology domain array expression index was not preserved during upgrade';
   END IF;
 
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid IN (
+      'topology.topoelement'::regtype,
+      'topology.topoelementarray'::regtype
+    )
+    AND conname IN ('dimensions', 'type_range', 'lower_dimension')
+    AND convalidated
+  ) THEN
+    RAISE EXCEPTION 'topology domain constraints with array-column dependencies were restored as validated';
+  END IF;
+
   IF NOT EXISTS (
     SELECT 1
     FROM pg_catalog.pg_trigger

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -323,6 +323,7 @@ DECLARE
   expected RECORD;
   dependent_generated_value topology.topoelement;
   cross_dependent_generated_value topology.topoelementarray;
+  nested_dependent_generated_value topology.topoelement;
 BEGIN
   IF current_setting('server_version_num')::integer >= 170000 THEN
     CREATE TEMP TABLE domain_generated_storage_probe (
@@ -373,6 +374,16 @@ BEGIN
     THEN
       RAISE EXCEPTION 'generated topology domain cross dependency was not preserved during upgrade: %',
         cross_dependent_generated_value;
+    END IF;
+
+    SELECT g INTO STRICT nested_dependent_generated_value
+      FROM upgrade_test.domain_generated_nested_source_dependency_test;
+
+    IF nested_dependent_generated_value[1] != 97
+      OR nested_dependent_generated_value[2] != 98
+    THEN
+      RAISE EXCEPTION 'generated nested topology domain source dependency was not preserved during upgrade: %',
+        nested_dependent_generated_value;
     END IF;
   END IF;
 END

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -336,6 +336,8 @@ DECLARE
   nested_array_value topology.topoelementarray;
   default_expr text;
   row_carrier_value topology.topoelement;
+  nested_array_default_element topology.topoelement;
+  nested_array_default_value upgrade_test.nested_topoelement[];
 BEGIN
   IF (SELECT count(*) FROM upgrade_test.domain_nested_type_test) != 1 THEN
     RAISE EXCEPTION 'nested topology domain storage fixture was not preserved during upgrade';
@@ -393,6 +395,30 @@ BEGIN
     RAISE EXCEPTION 'nested topology domain constraint was not restored during upgrade';
   END IF;
 
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'upgrade_test.nested_topoelement'::regtype
+    AND conname = 'nested_topoelement_array_carrier_validated'
+    AND NOT convalidated
+    AND pg_catalog.obj_description(oid, 'pg_constraint')
+      LIKE '%postgis-topology-domain-constraint-not-valid-by-repair-306%'
+  ) THEN
+    RAISE EXCEPTION 'nested topology domain array-carrier constraint was not restored unvalidated during incomplete upgrade repair';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'upgrade_test.nested_row_topoelement'::regtype
+    AND conname = 'nested_row_topoelement_validated'
+    AND NOT convalidated
+    AND pg_catalog.obj_description(oid, 'pg_constraint')
+      LIKE '%postgis-topology-domain-constraint-not-valid-by-repair-306%'
+  ) THEN
+    RAISE EXCEPTION 'nested topology domain composite-carrier constraint was not restored unvalidated during incomplete upgrade repair';
+  END IF;
+
   BEGIN
     CREATE TEMP TABLE domain_nested_constraint_probe (
       a upgrade_test.nested_topoelement
@@ -425,6 +451,49 @@ BEGIN
   IF nested_array_value[1][1] != 93 OR nested_array_value[1][2] != 94 THEN
     RAISE EXCEPTION 'rewritten nested topology domain array default did not preserve value: %',
       nested_array_value;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'upgrade_test.domain_nested_array_constraint_test'::regclass
+    AND conname = 'domain_nested_array_constraint_check'
+  ) THEN
+    RAISE EXCEPTION 'dependent nested topology domain array constraint was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'upgrade_test.domain_nested_array_default_test'::regclass
+    AND conname = 'domain_nested_array_default_check'
+  ) THEN
+    RAISE EXCEPTION 'dependent nested topology domain array default constraint was not preserved during upgrade';
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_nested_array_default_test'::regclass
+    AND a.attname = 'a';
+
+  IF default_expr NOT LIKE '%::text[])::upgrade_test.nested_topoelement[]%' THEN
+    RAISE EXCEPTION 'skipped nested topology domain array default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_nested_array_default_test DEFAULT VALUES;
+  SELECT a INTO STRICT nested_array_default_value
+    FROM upgrade_test.domain_nested_array_default_test
+    WHERE id = 2;
+  nested_array_default_element := nested_array_default_value[1]::topology.topoelement;
+
+  IF nested_array_default_element[1] != 123 OR nested_array_default_element[2] != 124 THEN
+    RAISE EXCEPTION 'rewritten skipped nested topology domain array default did not preserve value: %',
+      nested_array_default_value;
   END IF;
 
   IF NOT EXISTS (
@@ -802,6 +871,57 @@ BEGIN
       WHERE id = 2
     ) != 53 THEN
       RAISE EXCEPTION 'rewritten publication-skipped topology domain default did not preserve value';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_publication AS p
+        JOIN pg_catalog.pg_publication_rel AS pr
+          ON pr.prpubid = p.oid
+        WHERE p.pubname = 'upgrade_test_domain_whole_row_publication'
+        AND pr.prrelid = 'upgrade_test.domain_whole_row_publication_source'::regclass
+      )
+    THEN
+      RAISE EXCEPTION 'dependent topology domain whole-row publication relation was not preserved during upgrade';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_depend AS dep
+        JOIN pg_catalog.pg_publication_rel AS pr
+          ON pr.oid = dep.objid
+        JOIN pg_catalog.pg_publication AS p
+          ON p.oid = pr.prpubid
+        WHERE dep.classid = 'pg_catalog.pg_publication_rel'::regclass
+        AND dep.refobjid = 'upgrade_test.domain_whole_row_publication_source'::regclass
+        AND dep.refobjsubid = 0
+        AND p.pubname = 'upgrade_test_domain_whole_row_publication'
+      )
+    THEN
+      RAISE EXCEPTION 'dependent topology domain whole-row publication dependency was not preserved during upgrade';
+    END IF;
+
+    SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+      INTO STRICT default_expr
+      FROM pg_catalog.pg_attribute AS a
+      JOIN pg_catalog.pg_attrdef AS d
+        ON d.adrelid = a.attrelid
+        AND d.adnum = a.attnum
+      WHERE a.attrelid = 'upgrade_test.domain_whole_row_publication_source'::regclass
+      AND a.attname = 'a';
+
+    IF default_expr NOT LIKE '%::text)::bigint[]%' THEN
+      RAISE EXCEPTION 'whole-row publication-skipped topology domain column default was not rewritten during upgrade: %',
+        default_expr;
+    END IF;
+
+    INSERT INTO upgrade_test.domain_whole_row_publication_source(id) VALUES (2);
+    IF (
+      SELECT a[1]
+      FROM upgrade_test.domain_whole_row_publication_source
+      WHERE id = 2
+    ) != 115 THEN
+      RAISE EXCEPTION 'rewritten whole-row publication-skipped topology domain default did not preserve value';
     END IF;
   END IF;
 END

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -65,11 +65,31 @@ BEGIN
   IF NOT EXISTS (
     SELECT 1
     FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelement'::regtype
+    AND conname = 'upgrade_test_topoelement_array_grandfather'
+    AND NOT convalidated
+  ) THEN
+    RAISE EXCEPTION 'grandfathered topoelement domain array constraint was not preserved unvalidated';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
     WHERE contypid = 'topology.topoelementarray'::regtype
     AND conname = 'upgrade_test_topoelementarray_restored'
     AND NOT convalidated
   ) THEN
     RAISE EXCEPTION 'topoelementarray domain constraint was not restored unvalidated during incomplete upgrade repair';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE contypid = 'topology.topoelementarray'::regtype
+    AND conname = 'upgrade_test_topoelementarray_array_grandfather'
+    AND NOT convalidated
+  ) THEN
+    RAISE EXCEPTION 'grandfathered topoelementarray domain array constraint was not preserved unvalidated';
   END IF;
 
   IF (

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -128,6 +128,11 @@ SELECT id, a[1] IS NULL, a[2][1], a[2][2], b[1] IS NULL, b[2][1][1], b[2][1][2]
   FROM upgrade_test.domain_array_test
   ORDER BY id;
 
+INSERT INTO upgrade_test.domain_array_constraint_test DEFAULT VALUES;
+SELECT id, a[1][1], a[1][2]
+  FROM upgrade_test.domain_array_constraint_test
+  WHERE id = 2;
+
 DO $$
 BEGIN
   IF COALESCE(
@@ -195,6 +200,15 @@ BEGIN
 
   IF NOT EXISTS (
     SELECT 1
+    FROM pg_catalog.pg_trigger
+    WHERE tgrelid = 'upgrade_test.domain_whole_row_trigger_source'::regclass
+    AND tgname = 'domain_whole_row_trigger_source_trigger'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain whole-row trigger was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
     FROM pg_catalog.pg_proc
     WHERE pronamespace = 'upgrade_test'::regnamespace
     AND proname = 'domain_function_source_read'
@@ -217,6 +231,23 @@ BEGIN
 
   IF (SELECT count(*) FROM upgrade_test.domain_blocked_partition_child_view) != 1 THEN
     RAISE EXCEPTION 'dependent topology domain partition-child view was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'upgrade_test.domain_array_constraint_test'::regclass
+    AND conname = 'domain_array_constraint_check'
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain array constraint was not preserved during upgrade';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_class
+    WHERE oid = 'upgrade_test.domain_array_constraint_expr_idx'::regclass
+  ) THEN
+    RAISE EXCEPTION 'dependent topology domain array expression index was not preserved during upgrade';
   END IF;
 
   IF NOT EXISTS (

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -323,6 +323,8 @@ $$;
 DO $$
 DECLARE
   nested_value topology.topoelement;
+  default_expr text;
+  row_carrier_value topology.topoelement;
 BEGIN
   IF (SELECT count(*) FROM upgrade_test.domain_nested_type_test) != 1 THEN
     RAISE EXCEPTION 'nested topology domain storage fixture was not preserved during upgrade';
@@ -337,6 +339,52 @@ BEGIN
   IF nested_value[1] != 89 OR nested_value[2] != 90 THEN
     RAISE EXCEPTION 'rewritten nested topology domain default did not preserve value: %',
       nested_value;
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(t.typdefaultbin, 0)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_type AS t
+    WHERE t.oid = 'upgrade_test.nested_topoelement'::regtype;
+
+  IF default_expr IS NULL OR default_expr NOT LIKE '%::text)::upgrade_test.nested_topoelement%' THEN
+    RAISE EXCEPTION 'nested topology domain default was not rewritten during upgrade: %',
+      default_expr;
+  END IF;
+
+  CREATE TEMP TABLE domain_nested_default_probe (
+    a upgrade_test.nested_topoelement
+  ) ON COMMIT DROP;
+  INSERT INTO domain_nested_default_probe DEFAULT VALUES;
+  SELECT a::topology.topoelement INTO STRICT nested_value
+    FROM domain_nested_default_probe;
+
+  IF nested_value[1] != 91 OR nested_value[2] != 92 THEN
+    RAISE EXCEPTION 'rewritten nested topology domain-level default did not preserve value: %',
+      nested_value;
+  END IF;
+
+  SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+    INTO STRICT default_expr
+    FROM pg_catalog.pg_attribute AS a
+    JOIN pg_catalog.pg_attrdef AS d
+      ON d.adrelid = a.attrelid
+      AND d.adnum = a.attnum
+    WHERE a.attrelid = 'upgrade_test.domain_row_carrier_test'::regclass
+    AND a.attname = 'r';
+
+  IF default_expr IS NULL OR default_expr LIKE '%::text)::upgrade_test.domain_row_carrier_source%' THEN
+    RAISE EXCEPTION 'table row-type topology carrier default used unsafe whole-row text rewrite: %',
+      default_expr;
+  END IF;
+
+  INSERT INTO upgrade_test.domain_row_carrier_test DEFAULT VALUES;
+  SELECT (r).a INTO STRICT row_carrier_value
+    FROM upgrade_test.domain_row_carrier_test
+    WHERE id = 2;
+
+  IF row_carrier_value[1] != 105 OR row_carrier_value[2] != 106 THEN
+    RAISE EXCEPTION 'rewritten table row-type topology carrier default did not preserve value: %',
+      row_carrier_value;
   END IF;
 END
 $$;

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -306,10 +306,24 @@ INSERT INTO upgrade_test.domain_blocked_partition_parent VALUES (
 CREATE VIEW upgrade_test.domain_blocked_partition_child_view AS
   SELECT c FROM upgrade_test.domain_blocked_partition_child AS c;
 
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable DISABLE;
+  END IF;
+END
+$$;
 CREATE TABLE upgrade_test.domain_trigger_child_parent (
   id integer,
   a topology.topoelement
 ) PARTITION BY RANGE (id);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable ENABLE;
+  END IF;
+END
+$$;
 CREATE TABLE upgrade_test.domain_trigger_child_child
   PARTITION OF upgrade_test.domain_trigger_child_parent FOR VALUES FROM (0) TO (10);
 INSERT INTO upgrade_test.domain_trigger_child_parent VALUES (

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -224,6 +224,31 @@ INSERT INTO upgrade_test.domain_array_constraint_test (a) VALUES (
 CREATE DOMAIN upgrade_test.nested_topoelement AS topology.topoelement;
 ALTER DOMAIN upgrade_test.nested_topoelement
   SET DEFAULT '{91,92}'::topology.topoelement::upgrade_test.nested_topoelement;
+ALTER DOMAIN upgrade_test.nested_topoelement
+  ADD CONSTRAINT nested_topoelement_positive CHECK (VALUE::text !~ '^\{0,') NOT VALID;
+CREATE DOMAIN upgrade_test.nested_topoelementarray AS topology.topoelementarray;
+ALTER DOMAIN upgrade_test.nested_topoelementarray
+  SET DEFAULT '{{93,94}}'::topology.topoelementarray::upgrade_test.nested_topoelementarray;
+ALTER DOMAIN upgrade_test.nested_topoelementarray
+  ADD CONSTRAINT nested_topoelementarray_positive CHECK (VALUE::text !~ '^\{\{0,') NOT VALID;
+CREATE DOMAIN upgrade_test.unused_nested_topoelement AS topology.topoelement;
+CREATE DOMAIN upgrade_test.unused_nested_topoelementarray AS topology.topoelementarray;
+-- PostgreSQL can recurse too deeply while validating nested-domain checks in
+-- this fixture. Mark these tautological constraints validated in the catalog so
+-- the upgrade can prove unrelated nested domains are not demoted by a base
+-- topology domain array-column repair.
+ALTER DOMAIN upgrade_test.unused_nested_topoelement
+  ADD CONSTRAINT unused_nested_topoelement_validated CHECK (VALUE IS NULL OR VALUE IS NOT NULL) NOT VALID;
+UPDATE pg_catalog.pg_constraint
+  SET convalidated = true
+  WHERE contypid = 'upgrade_test.unused_nested_topoelement'::regtype
+  AND conname = 'unused_nested_topoelement_validated';
+ALTER DOMAIN upgrade_test.unused_nested_topoelementarray
+  ADD CONSTRAINT unused_nested_topoelementarray_validated CHECK (VALUE IS NULL OR VALUE IS NOT NULL) NOT VALID;
+UPDATE pg_catalog.pg_constraint
+  SET convalidated = true
+  WHERE contypid = 'upgrade_test.unused_nested_topoelementarray'::regtype
+  AND conname = 'unused_nested_topoelementarray_validated';
 CREATE TYPE upgrade_test.composite_topoelement AS (
   a topology.topoelement
 );

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -420,6 +420,15 @@ BEGIN
     );
     INSERT INTO upgrade_test.domain_generated_cross_dependency_test(id, a)
       VALUES (1, '{43,44}'::topology.topoelement);
+
+    CREATE TABLE upgrade_test.domain_generated_nested_source_dependency_test (
+      id integer,
+      a upgrade_test.nested_topoelement,
+      g topology.topoelement
+        GENERATED ALWAYS AS (upgrade_test.domain_generated_source_value(a::topology.topoelement)) STORED
+    );
+    INSERT INTO upgrade_test.domain_generated_nested_source_dependency_test(id, a)
+      VALUES (1, '{97,98}'::topology.topoelement::upgrade_test.nested_topoelement);
     UPDATE upgrade_test.domain_generated_source_guard SET fail = true;
   END IF;
 END

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -200,6 +200,10 @@ INSERT INTO upgrade_test.domain_array_test (a, b) VALUES (
   ARRAY[NULL::topology.topoelement, '{67,68}'::topology.topoelement]::topology.topoelement[],
   ARRAY[NULL::topology.topoelementarray, '{{69,70}}'::topology.topoelementarray]::topology.topoelementarray[]
 );
+ALTER DOMAIN topology.topoelement
+  ADD CONSTRAINT upgrade_test_topoelement_array_grandfather CHECK (VALUE IS NULL OR VALUE[1] != 67) NOT VALID;
+ALTER DOMAIN topology.topoelementarray
+  ADD CONSTRAINT upgrade_test_topoelementarray_array_grandfather CHECK (VALUE IS NULL OR VALUE[1][1] != 69) NOT VALID;
 
 CREATE TABLE upgrade_test.domain_array_constraint_test (
   id integer GENERATED ALWAYS AS IDENTITY,

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -13,3 +13,37 @@ INSERT INTO upgrade_test.domain_test values (
   '{{2,3}}'::topology.topoelementarray
 );
 
+CREATE TABLE upgrade_test.domain_default_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  a topology.topoelement DEFAULT '{5,6}'::topology.topoelement,
+  b topology.topoelementarray DEFAULT '{{7,8}}'::topology.topoelementarray
+);
+INSERT INTO upgrade_test.domain_default_test (a, b) VALUES (
+  '{3,4}'::topology.topoelement,
+  '{{4,5}}'::topology.topoelementarray
+);
+
+CREATE TABLE upgrade_test.domain_partition_test (
+  id integer,
+  a topology.topoelement DEFAULT '{9,10}'::topology.topoelement
+) PARTITION BY RANGE (id);
+CREATE TABLE upgrade_test.domain_partition_test_1
+  PARTITION OF upgrade_test.domain_partition_test FOR VALUES FROM (0) TO (10);
+ALTER TABLE upgrade_test.domain_partition_test_1
+  ALTER COLUMN a SET DEFAULT '{13,14}'::topology.topoelement;
+INSERT INTO upgrade_test.domain_partition_test VALUES (
+  1,
+  '{11,12}'::topology.topoelement
+);
+
+-- Simulate databases already touched by the broken 3.6 upgrade path:
+-- their domain catalogs can name bigint array bases while old rows still
+-- carry integer-array storage bytes that must be rewritten.
+UPDATE pg_catalog.pg_type
+  SET typbasetype = 'bigint[]'::regtype::oid
+  WHERE typnamespace = 'topology'::regnamespace
+  AND typname = 'topoelement';
+UPDATE pg_catalog.pg_type
+  SET typbasetype = 'bigint[]'::regtype::oid
+  WHERE typnamespace = 'topology'::regnamespace
+  AND typname = 'topoelementarray';

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -388,10 +388,16 @@ END;
 DO $$
 BEGIN
   IF current_setting('server_version_num')::integer >= 150000 THEN
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+      ALTER EVENT TRIGGER trg_autovac_disable DISABLE;
+    END IF;
     EXECUTE 'CREATE TABLE upgrade_test.domain_publication_child_parent (
       id integer,
       a topology.topoelement
     ) PARTITION BY RANGE (id)';
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+      ALTER EVENT TRIGGER trg_autovac_disable ENABLE;
+    END IF;
     EXECUTE 'CREATE TABLE upgrade_test.domain_publication_child_child
       PARTITION OF upgrade_test.domain_publication_child_parent FOR VALUES FROM (0) TO (10)';
     INSERT INTO upgrade_test.domain_publication_child_parent VALUES (

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -261,7 +261,7 @@ CREATE DOMAIN upgrade_test.nested_topoelement AS topology.topoelement;
 ALTER DOMAIN upgrade_test.nested_topoelement
   SET DEFAULT '{91,92}'::topology.topoelement::upgrade_test.nested_topoelement;
 ALTER DOMAIN upgrade_test.nested_topoelement
-  ADD CONSTRAINT nested_topoelement_positive CHECK (VALUE::text !~ '^\{0,') NOT VALID;
+  ADD CONSTRAINT nested_topoelement_positive CHECK (VALUE::text !~ E'^\\{0,') NOT VALID;
 ALTER DOMAIN upgrade_test.nested_topoelement
   ADD CONSTRAINT nested_topoelement_array_carrier_validated CHECK (VALUE IS NULL OR VALUE IS NOT NULL) NOT VALID;
 UPDATE pg_catalog.pg_constraint
@@ -272,7 +272,7 @@ CREATE DOMAIN upgrade_test.nested_topoelementarray AS topology.topoelementarray;
 ALTER DOMAIN upgrade_test.nested_topoelementarray
   SET DEFAULT '{{93,94}}'::topology.topoelementarray::upgrade_test.nested_topoelementarray;
 ALTER DOMAIN upgrade_test.nested_topoelementarray
-  ADD CONSTRAINT nested_topoelementarray_positive CHECK (VALUE::text !~ '^\{\{0,') NOT VALID;
+  ADD CONSTRAINT nested_topoelementarray_positive CHECK (VALUE::text !~ E'^\\{\\{0,') NOT VALID;
 CREATE DOMAIN upgrade_test.unused_nested_topoelement AS topology.topoelement;
 CREATE DOMAIN upgrade_test.unused_nested_topoelementarray AS topology.topoelementarray;
 CREATE DOMAIN upgrade_test.nested_row_topoelement AS topology.topoelement;

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -15,6 +15,10 @@ ALTER DOMAIN topology.topoelement
 ALTER DOMAIN topology.topoelementarray
   ADD CONSTRAINT upgrade_test_topoelementarray_restored CHECK (VALUE IS NULL OR VALUE IS NOT NULL);
 ALTER DOMAIN topology.topoelement SET DEFAULT '{25,26}'::topology.topoelement;
+-- Simulate upgrade sources older than the canonical topoelementarray
+-- type_range constraint. The repair helper must backfill it with the same
+-- NOT VALID policy used for restored constraints when storage is skipped.
+ALTER DOMAIN topology.topoelementarray DROP CONSTRAINT type_range;
 INSERT INTO upgrade_test.domain_test values (
   '{1,2}'::topology.topoelement,
   '{{2,3}}'::topology.topoelementarray
@@ -99,6 +103,20 @@ CREATE POLICY domain_policy_source_a_policy
   ON upgrade_test.domain_policy_source
   USING (a[1] > 0)
   WITH CHECK (a[1] > 0);
+
+CREATE TABLE upgrade_test.domain_whole_row_policy_source (
+  id integer,
+  a topology.topoelement DEFAULT '{81,82}'::topology.topoelement
+);
+INSERT INTO upgrade_test.domain_whole_row_policy_source VALUES (
+  1,
+  '{83,84}'::topology.topoelement
+);
+ALTER TABLE upgrade_test.domain_whole_row_policy_source ENABLE ROW LEVEL SECURITY;
+CREATE POLICY domain_whole_row_policy_source_policy
+  ON upgrade_test.domain_whole_row_policy_source
+  USING (domain_whole_row_policy_source IS NOT NULL)
+  WITH CHECK (domain_whole_row_policy_source IS NOT NULL);
 
 CREATE TABLE upgrade_test.domain_trigger_source (
   id integer,

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -239,7 +239,7 @@ INSERT INTO upgrade_test.domain_nested_type_test (a, b) VALUES (
 );
 
 CREATE TABLE upgrade_test.domain_row_carrier_source (
-  a topology.topoelement
+  a topology.topoelement DEFAULT '{107,108}'::topology.topoelement
 );
 CREATE TABLE upgrade_test.domain_row_carrier_test (
   id integer GENERATED ALWAYS AS IDENTITY,
@@ -262,6 +262,33 @@ CREATE INDEX domain_array_inherit_constraint_expr_idx
 INSERT INTO upgrade_test.domain_array_inherit_constraint_child VALUES (
   1,
   ARRAY['{103,104}'::topology.topoelement]::topology.topoelement[]
+);
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable DISABLE;
+  END IF;
+END
+$$;
+CREATE TABLE upgrade_test.domain_array_partition_index_parent (
+  id integer,
+  a topology.topoelement[] DEFAULT ARRAY['{111,112}'::topology.topoelement]::topology.topoelement[]
+) PARTITION BY RANGE (id);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable ENABLE;
+  END IF;
+END
+$$;
+CREATE INDEX domain_array_partition_index_expr_idx
+  ON upgrade_test.domain_array_partition_index_parent (((a[1])[2]));
+CREATE TABLE upgrade_test.domain_array_partition_index_child
+  PARTITION OF upgrade_test.domain_array_partition_index_parent FOR VALUES FROM (0) TO (10);
+INSERT INTO upgrade_test.domain_array_partition_index_parent VALUES (
+  1,
+  ARRAY['{113,114}'::topology.topoelement]::topology.topoelement[]
 );
 
 CREATE TABLE upgrade_test.domain_rule_source (
@@ -422,6 +449,23 @@ INSERT INTO upgrade_test.domain_blocked_inherit_grandchild VALUES (
 );
 CREATE VIEW upgrade_test.domain_blocked_inherit_grandchild_view AS
   SELECT g FROM upgrade_test.domain_blocked_inherit_grandchild AS g;
+
+CREATE TABLE upgrade_test.domain_row_type_blocked_parent (
+  id integer,
+  a topology.topoelement
+);
+CREATE TABLE upgrade_test.domain_row_type_blocked_child ()
+  INHERITS (upgrade_test.domain_row_type_blocked_parent);
+CREATE TABLE upgrade_test.domain_row_type_blocked_carrier (
+  r upgrade_test.domain_row_type_blocked_child
+);
+INSERT INTO upgrade_test.domain_row_type_blocked_child VALUES (
+  1,
+  '{115,116}'::topology.topoelement
+);
+INSERT INTO upgrade_test.domain_row_type_blocked_carrier VALUES (
+  ROW(2, '{117,118}'::topology.topoelement)::upgrade_test.domain_row_type_blocked_child
+);
 
 DO $$
 BEGIN

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -8,6 +8,13 @@ CREATE INDEX ON upgrade_test.feature ( id(tg) );
 
 -- Create some TopoGeometry data
 CREATE TABLE upgrade_test.domain_test(a topology.topoelement, b topology.topoelementarray);
+ALTER DOMAIN topology.topoelement
+  ADD CONSTRAINT upgrade_test_topoelement_restored CHECK (VALUE IS NULL OR VALUE IS NOT NULL);
+ALTER DOMAIN topology.topoelement
+  ADD CONSTRAINT upgrade_test_topoelement_already_not_valid CHECK (VALUE IS NULL OR VALUE IS NOT NULL) NOT VALID;
+ALTER DOMAIN topology.topoelementarray
+  ADD CONSTRAINT upgrade_test_topoelementarray_restored CHECK (VALUE IS NULL OR VALUE IS NOT NULL);
+ALTER DOMAIN topology.topoelement SET DEFAULT '{25,26}'::topology.topoelement;
 INSERT INTO upgrade_test.domain_test values (
   '{1,2}'::topology.topoelement,
   '{{2,3}}'::topology.topoelementarray
@@ -23,10 +30,24 @@ INSERT INTO upgrade_test.domain_default_test (a, b) VALUES (
   '{{4,5}}'::topology.topoelementarray
 );
 
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable DISABLE;
+  END IF;
+END
+$$;
 CREATE TABLE upgrade_test.domain_partition_test (
   id integer,
   a topology.topoelement DEFAULT '{9,10}'::topology.topoelement
 ) PARTITION BY RANGE (id);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable ENABLE;
+  END IF;
+END
+$$;
 CREATE TABLE upgrade_test.domain_partition_test_1
   PARTITION OF upgrade_test.domain_partition_test FOR VALUES FROM (0) TO (10);
 ALTER TABLE upgrade_test.domain_partition_test_1
@@ -35,6 +56,325 @@ INSERT INTO upgrade_test.domain_partition_test VALUES (
   1,
   '{11,12}'::topology.topoelement
 );
+
+CREATE TABLE upgrade_test.domain_matview_source (
+  a topology.topoelement,
+  b topology.topoelementarray
+);
+INSERT INTO upgrade_test.domain_matview_source VALUES (
+  '{19,20}'::topology.topoelement,
+  '{{21,22}}'::topology.topoelementarray
+);
+CREATE MATERIALIZED VIEW upgrade_test.domain_matview_test AS
+  SELECT a, b FROM upgrade_test.domain_matview_source;
+
+CREATE TABLE upgrade_test.domain_view_source (
+  a topology.topoelement
+);
+INSERT INTO upgrade_test.domain_view_source VALUES (
+  '{23,24}'::topology.topoelement
+);
+CREATE VIEW upgrade_test.domain_view_test AS
+  SELECT a FROM upgrade_test.domain_view_source;
+
+CREATE TABLE upgrade_test.domain_whole_row_view_source (
+  a topology.topoelement
+);
+INSERT INTO upgrade_test.domain_whole_row_view_source VALUES (
+  '{31,32}'::topology.topoelement
+);
+CREATE VIEW upgrade_test.domain_whole_row_view_test AS
+  SELECT s FROM upgrade_test.domain_whole_row_view_source AS s;
+
+CREATE TABLE upgrade_test.domain_policy_source (
+  id integer,
+  a topology.topoelement DEFAULT '{45,46}'::topology.topoelement
+);
+INSERT INTO upgrade_test.domain_policy_source VALUES (
+  1,
+  '{47,48}'::topology.topoelement
+);
+ALTER TABLE upgrade_test.domain_policy_source ENABLE ROW LEVEL SECURITY;
+CREATE POLICY domain_policy_source_a_policy
+  ON upgrade_test.domain_policy_source
+  USING (a[1] > 0)
+  WITH CHECK (a[1] > 0);
+
+CREATE TABLE upgrade_test.domain_trigger_source (
+  id integer,
+  a topology.topoelement DEFAULT '{49,50}'::topology.topoelement
+);
+INSERT INTO upgrade_test.domain_trigger_source VALUES (
+  1,
+  '{51,52}'::topology.topoelement
+);
+CREATE FUNCTION upgrade_test.domain_trigger_source_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $upgrade$
+BEGIN
+  RETURN NEW;
+END;
+$upgrade$;
+CREATE TRIGGER domain_trigger_source_a_trigger
+  BEFORE UPDATE OF a ON upgrade_test.domain_trigger_source
+  FOR EACH ROW EXECUTE FUNCTION upgrade_test.domain_trigger_source_guard();
+
+CREATE TABLE upgrade_test.domain_function_source (
+  id integer,
+  a topology.topoelement DEFAULT '{61,62}'::topology.topoelement
+);
+INSERT INTO upgrade_test.domain_function_source VALUES (
+  1,
+  '{63,64}'::topology.topoelement
+);
+CREATE FUNCTION upgrade_test.domain_function_source_read()
+RETURNS integer
+LANGUAGE SQL
+BEGIN ATOMIC
+  SELECT a[1]
+    FROM upgrade_test.domain_function_source
+    LIMIT 1;
+END;
+
+DO $$
+BEGIN
+  IF current_setting('server_version_num')::integer >= 150000 THEN
+    EXECUTE 'CREATE TABLE upgrade_test.domain_publication_source (
+      id integer,
+      a topology.topoelement DEFAULT ''{53,54}''::topology.topoelement
+    )';
+    INSERT INTO upgrade_test.domain_publication_source VALUES (
+      1,
+      '{55,56}'::topology.topoelement
+    );
+    EXECUTE 'CREATE PUBLICATION upgrade_test_domain_publication
+      FOR TABLE upgrade_test.domain_publication_source (a)';
+  END IF;
+END
+$$;
+
+CREATE TABLE upgrade_test.domain_level_default_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  a topology.topoelement
+);
+
+CREATE TABLE upgrade_test.domain_array_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  a topology.topoelement[] DEFAULT ARRAY[NULL::topology.topoelement, '{75,76}'::topology.topoelement]::topology.topoelement[],
+  b topology.topoelementarray[] DEFAULT ARRAY[NULL::topology.topoelementarray, '{{77,78}}'::topology.topoelementarray]::topology.topoelementarray[]
+);
+INSERT INTO upgrade_test.domain_array_test (a, b) VALUES (
+  ARRAY[NULL::topology.topoelement, '{67,68}'::topology.topoelement]::topology.topoelement[],
+  ARRAY[NULL::topology.topoelementarray, '{{69,70}}'::topology.topoelementarray]::topology.topoelementarray[]
+);
+
+CREATE TABLE upgrade_test.domain_rule_source (
+  id integer,
+  a topology.topoelement
+);
+CREATE TABLE upgrade_test.domain_rule_log (
+  a topology.topoelement
+);
+CREATE RULE domain_rule_source_insert AS
+  ON INSERT TO upgrade_test.domain_rule_source
+  DO ALSO INSERT INTO upgrade_test.domain_rule_log VALUES (NEW.a);
+INSERT INTO upgrade_test.domain_rule_source VALUES (
+  1,
+  '{27,28}'::topology.topoelement
+);
+
+CREATE TABLE upgrade_test.domain_external_rule_source (
+  id integer,
+  a topology.topoelement
+);
+CREATE TABLE upgrade_test.domain_external_rule_target (
+  id integer
+);
+CREATE RULE domain_external_rule_target_insert AS
+  ON INSERT TO upgrade_test.domain_external_rule_target
+  DO ALSO INSERT INTO upgrade_test.domain_rule_log
+    SELECT a
+    FROM upgrade_test.domain_external_rule_source
+    WHERE id = NEW.id;
+INSERT INTO upgrade_test.domain_external_rule_source VALUES (
+  2,
+  '{29,30}'::topology.topoelement
+);
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable DISABLE;
+  END IF;
+END
+$$;
+CREATE TABLE upgrade_test.domain_blocked_partition_parent (
+  id integer,
+  a topology.topoelement
+) PARTITION BY RANGE (id);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable ENABLE;
+  END IF;
+END
+$$;
+CREATE TABLE upgrade_test.domain_blocked_partition_child
+  PARTITION OF upgrade_test.domain_blocked_partition_parent FOR VALUES FROM (0) TO (10);
+INSERT INTO upgrade_test.domain_blocked_partition_parent VALUES (
+  1,
+  '{33,34}'::topology.topoelement
+);
+CREATE VIEW upgrade_test.domain_blocked_partition_child_view AS
+  SELECT c FROM upgrade_test.domain_blocked_partition_child AS c;
+
+CREATE TABLE upgrade_test.domain_trigger_child_parent (
+  id integer,
+  a topology.topoelement
+) PARTITION BY RANGE (id);
+CREATE TABLE upgrade_test.domain_trigger_child_child
+  PARTITION OF upgrade_test.domain_trigger_child_parent FOR VALUES FROM (0) TO (10);
+INSERT INTO upgrade_test.domain_trigger_child_parent VALUES (
+  1,
+  '{57,58}'::topology.topoelement
+);
+CREATE TRIGGER domain_trigger_child_a_trigger
+  BEFORE UPDATE OF a ON upgrade_test.domain_trigger_child_child
+  FOR EACH ROW EXECUTE FUNCTION upgrade_test.domain_trigger_source_guard();
+
+CREATE TABLE upgrade_test.domain_function_child_parent (
+  id integer,
+  a topology.topoelement
+) PARTITION BY RANGE (id);
+CREATE TABLE upgrade_test.domain_function_child_child
+  PARTITION OF upgrade_test.domain_function_child_parent FOR VALUES FROM (0) TO (10);
+INSERT INTO upgrade_test.domain_function_child_parent VALUES (
+  1,
+  '{65,66}'::topology.topoelement
+);
+CREATE FUNCTION upgrade_test.domain_function_child_read()
+RETURNS integer
+LANGUAGE SQL
+BEGIN ATOMIC
+  SELECT a[1]
+    FROM upgrade_test.domain_function_child_child
+    LIMIT 1;
+END;
+
+DO $$
+BEGIN
+  IF current_setting('server_version_num')::integer >= 150000 THEN
+    EXECUTE 'CREATE TABLE upgrade_test.domain_publication_child_parent (
+      id integer,
+      a topology.topoelement
+    ) PARTITION BY RANGE (id)';
+    EXECUTE 'CREATE TABLE upgrade_test.domain_publication_child_child
+      PARTITION OF upgrade_test.domain_publication_child_parent FOR VALUES FROM (0) TO (10)';
+    INSERT INTO upgrade_test.domain_publication_child_parent VALUES (
+      1,
+      '{59,60}'::topology.topoelement
+    );
+    EXECUTE 'CREATE PUBLICATION upgrade_test_domain_child_publication
+      FOR TABLE upgrade_test.domain_publication_child_child (a)';
+  END IF;
+END
+$$;
+
+CREATE TABLE upgrade_test.domain_blocked_inherit_parent (
+  a topology.topoelement
+);
+CREATE TABLE upgrade_test.domain_blocked_inherit_child ()
+  INHERITS (upgrade_test.domain_blocked_inherit_parent);
+CREATE TABLE upgrade_test.domain_blocked_inherit_grandchild ()
+  INHERITS (upgrade_test.domain_blocked_inherit_child);
+INSERT INTO upgrade_test.domain_blocked_inherit_grandchild VALUES (
+  '{35,36}'::topology.topoelement
+);
+CREATE VIEW upgrade_test.domain_blocked_inherit_grandchild_view AS
+  SELECT g FROM upgrade_test.domain_blocked_inherit_grandchild AS g;
+
+DO $$
+BEGIN
+  IF current_setting('server_version_num')::integer >= 170000 THEN
+    CREATE TABLE upgrade_test.domain_generated_test (
+      id integer,
+      a topology.topoelement
+        GENERATED ALWAYS AS (ARRAY[id, id + 1]::topology.topoelement) STORED,
+      b topology.topoelementarray
+        GENERATED ALWAYS AS (ARRAY[ARRAY[id + 2, id + 3]]::topology.topoelementarray) STORED
+    );
+    INSERT INTO upgrade_test.domain_generated_test(id) VALUES (15);
+
+    CREATE TABLE upgrade_test.domain_generated_source_guard (
+      fail boolean NOT NULL
+    );
+    INSERT INTO upgrade_test.domain_generated_source_guard VALUES (false);
+    CREATE FUNCTION upgrade_test.domain_generated_source_value(value topology.topoelement)
+      RETURNS topology.topoelement
+      LANGUAGE plpgsql
+      IMMUTABLE
+    AS $upgrade$
+    DECLARE
+      fail boolean;
+    BEGIN
+      SELECT g.fail
+        INTO STRICT fail
+        FROM upgrade_test.domain_generated_source_guard AS g;
+      IF fail THEN
+        RAISE EXCEPTION 'generated source dependency was recomputed';
+      END IF;
+      RETURN ARRAY[value[1], value[2]]::topology.topoelement;
+    END;
+    $upgrade$;
+
+    CREATE FUNCTION upgrade_test.domain_generated_source_array_value(value topology.topoelement)
+    RETURNS topology.topoelementarray
+    LANGUAGE 'plpgsql'
+    IMMUTABLE
+    AS $upgrade$
+    DECLARE
+      fail boolean;
+    BEGIN
+      SELECT g.fail
+        INTO STRICT fail
+        FROM upgrade_test.domain_generated_source_guard AS g;
+      IF fail THEN
+        RAISE EXCEPTION 'generated source dependency was recomputed';
+      END IF;
+      RETURN ARRAY[ARRAY[value[1], value[2]]]::topology.topoelementarray;
+    END;
+    $upgrade$;
+
+    CREATE TABLE upgrade_test.domain_generated_source_dependency_test (
+      id integer,
+      a topology.topoelement,
+      g topology.topoelement
+        GENERATED ALWAYS AS (upgrade_test.domain_generated_source_value(a)) STORED
+    );
+    INSERT INTO upgrade_test.domain_generated_source_dependency_test(id, a)
+      VALUES (1, '{39,40}'::topology.topoelement);
+
+    CREATE TABLE upgrade_test.domain_generated_cross_dependency_test (
+      id integer,
+      a topology.topoelement,
+      g topology.topoelementarray
+        GENERATED ALWAYS AS (upgrade_test.domain_generated_source_array_value(a)) STORED
+    );
+    INSERT INTO upgrade_test.domain_generated_cross_dependency_test(id, a)
+      VALUES (1, '{43,44}'::topology.topoelement);
+    UPDATE upgrade_test.domain_generated_source_guard SET fail = true;
+  END IF;
+END
+$$;
+
+CREATE TABLE upgrade_test.domain_generated_dependency_test (
+  id integer,
+  a topology.topoelement DEFAULT '{41,42}'::topology.topoelement,
+  generated_id bigint GENERATED ALWAYS AS (a[1]) STORED
+);
+INSERT INTO upgrade_test.domain_generated_dependency_test(id, a)
+  VALUES (1, '{37,38}'::topology.topoelement);
 
 -- Simulate databases already touched by the broken 3.6 upgrade path:
 -- their domain catalogs can name bigint array bases while old rows still

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -138,6 +138,20 @@ CREATE TRIGGER domain_trigger_source_a_trigger
   BEFORE UPDATE OF a ON upgrade_test.domain_trigger_source
   FOR EACH ROW EXECUTE FUNCTION upgrade_test.domain_trigger_source_guard();
 
+CREATE TABLE upgrade_test.domain_whole_row_trigger_source (
+  id integer,
+  a topology.topoelement DEFAULT '{89,90}'::topology.topoelement
+);
+INSERT INTO upgrade_test.domain_whole_row_trigger_source VALUES (
+  1,
+  '{91,92}'::topology.topoelement
+);
+CREATE TRIGGER domain_whole_row_trigger_source_trigger
+  BEFORE UPDATE ON upgrade_test.domain_whole_row_trigger_source
+  FOR EACH ROW
+  WHEN (OLD IS NOT NULL)
+  EXECUTE FUNCTION upgrade_test.domain_trigger_source_guard();
+
 CREATE TABLE upgrade_test.domain_function_source (
   id integer,
   a topology.topoelement DEFAULT '{61,62}'::topology.topoelement
@@ -185,6 +199,17 @@ CREATE TABLE upgrade_test.domain_array_test (
 INSERT INTO upgrade_test.domain_array_test (a, b) VALUES (
   ARRAY[NULL::topology.topoelement, '{67,68}'::topology.topoelement]::topology.topoelement[],
   ARRAY[NULL::topology.topoelementarray, '{{69,70}}'::topology.topoelementarray]::topology.topoelementarray[]
+);
+
+CREATE TABLE upgrade_test.domain_array_constraint_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  a topology.topoelement[] DEFAULT ARRAY['{93,94}'::topology.topoelement]::topology.topoelement[],
+  CONSTRAINT domain_array_constraint_check CHECK ((a[1])[1] > 0)
+);
+CREATE INDEX domain_array_constraint_expr_idx
+  ON upgrade_test.domain_array_constraint_test (((a[1])[2]));
+INSERT INTO upgrade_test.domain_array_constraint_test (a) VALUES (
+  ARRAY['{95,96}'::topology.topoelement]::topology.topoelement[]
 );
 
 CREATE DOMAIN upgrade_test.nested_topoelement AS topology.topoelement;

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -187,6 +187,42 @@ BEGIN
     );
     EXECUTE 'CREATE PUBLICATION upgrade_test_domain_publication
       FOR TABLE upgrade_test.domain_publication_source (a)';
+    EXECUTE 'CREATE TABLE upgrade_test.domain_whole_row_publication_source (
+      id integer,
+      a topology.topoelement DEFAULT ''{115,116}''::topology.topoelement
+    )';
+    INSERT INTO upgrade_test.domain_whole_row_publication_source VALUES (
+      1,
+      '{117,118}'::topology.topoelement
+    );
+    EXECUTE 'CREATE PUBLICATION upgrade_test_domain_whole_row_publication
+      FOR TABLE upgrade_test.domain_whole_row_publication_source';
+    -- A real whole-row publication filter cannot reference this row type because
+    -- it contains a user-defined domain, but PostgreSQL records such blockers as
+    -- pg_publication_rel dependencies with refobjsubid = 0. Insert that catalog
+    -- dependency so the upgrade helper exercises the same blocker shape.
+    INSERT INTO pg_catalog.pg_depend (
+      classid,
+      objid,
+      objsubid,
+      refclassid,
+      refobjid,
+      refobjsubid,
+      deptype
+    )
+    SELECT
+      'pg_catalog.pg_publication_rel'::regclass,
+      pr.oid,
+      0,
+      'pg_catalog.pg_class'::regclass,
+      'upgrade_test.domain_whole_row_publication_source'::regclass,
+      0,
+      'n'
+    FROM pg_catalog.pg_publication_rel AS pr
+    JOIN pg_catalog.pg_publication AS p
+      ON p.oid = pr.prpubid
+    WHERE p.pubname = 'upgrade_test_domain_whole_row_publication'
+    AND pr.prrelid = 'upgrade_test.domain_whole_row_publication_source'::regclass;
   END IF;
 END
 $$;
@@ -226,6 +262,12 @@ ALTER DOMAIN upgrade_test.nested_topoelement
   SET DEFAULT '{91,92}'::topology.topoelement::upgrade_test.nested_topoelement;
 ALTER DOMAIN upgrade_test.nested_topoelement
   ADD CONSTRAINT nested_topoelement_positive CHECK (VALUE::text !~ '^\{0,') NOT VALID;
+ALTER DOMAIN upgrade_test.nested_topoelement
+  ADD CONSTRAINT nested_topoelement_array_carrier_validated CHECK (VALUE IS NULL OR VALUE IS NOT NULL) NOT VALID;
+UPDATE pg_catalog.pg_constraint
+  SET convalidated = true
+  WHERE contypid = 'upgrade_test.nested_topoelement'::regtype
+  AND conname = 'nested_topoelement_array_carrier_validated';
 CREATE DOMAIN upgrade_test.nested_topoelementarray AS topology.topoelementarray;
 ALTER DOMAIN upgrade_test.nested_topoelementarray
   SET DEFAULT '{{93,94}}'::topology.topoelementarray::upgrade_test.nested_topoelementarray;
@@ -233,6 +275,13 @@ ALTER DOMAIN upgrade_test.nested_topoelementarray
   ADD CONSTRAINT nested_topoelementarray_positive CHECK (VALUE::text !~ '^\{\{0,') NOT VALID;
 CREATE DOMAIN upgrade_test.unused_nested_topoelement AS topology.topoelement;
 CREATE DOMAIN upgrade_test.unused_nested_topoelementarray AS topology.topoelementarray;
+CREATE DOMAIN upgrade_test.nested_row_topoelement AS topology.topoelement;
+ALTER DOMAIN upgrade_test.nested_row_topoelement
+  ADD CONSTRAINT nested_row_topoelement_validated CHECK (VALUE IS NULL OR VALUE IS NOT NULL) NOT VALID;
+UPDATE pg_catalog.pg_constraint
+  SET convalidated = true
+  WHERE contypid = 'upgrade_test.nested_row_topoelement'::regtype
+  AND conname = 'nested_row_topoelement_validated';
 -- PostgreSQL can recurse too deeply while validating nested-domain checks in
 -- this fixture. Mark these tautological constraints validated in the catalog so
 -- the upgrade can prove unrelated nested domains are not demoted by a base
@@ -252,6 +301,9 @@ UPDATE pg_catalog.pg_constraint
 CREATE TYPE upgrade_test.composite_topoelement AS (
   a topology.topoelement
 );
+CREATE TYPE upgrade_test.composite_nested_row_topoelement AS (
+  a upgrade_test.nested_row_topoelement
+);
 CREATE TABLE upgrade_test.domain_nested_type_test (
   id integer GENERATED ALWAYS AS IDENTITY,
   a upgrade_test.nested_topoelement
@@ -261,6 +313,24 @@ CREATE TABLE upgrade_test.domain_nested_type_test (
 INSERT INTO upgrade_test.domain_nested_type_test (a, b) VALUES (
   '{85,86}'::topology.topoelement::upgrade_test.nested_topoelement,
   ROW('{87,88}'::topology.topoelement)::upgrade_test.composite_topoelement
+);
+CREATE TABLE upgrade_test.domain_nested_array_constraint_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  a upgrade_test.nested_topoelement[]
+    DEFAULT ARRAY['{119,120}'::topology.topoelement::upgrade_test.nested_topoelement]::upgrade_test.nested_topoelement[],
+  CONSTRAINT domain_nested_array_constraint_check CHECK ((a[1])::text IS NOT NULL)
+);
+INSERT INTO upgrade_test.domain_nested_array_constraint_test (a) VALUES (
+  ARRAY['{121,122}'::topology.topoelement::upgrade_test.nested_topoelement]::upgrade_test.nested_topoelement[]
+);
+CREATE TABLE upgrade_test.domain_nested_array_default_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  a upgrade_test.nested_topoelement[]
+    DEFAULT ARRAY['{123,124}'::topology.topoelement::upgrade_test.nested_topoelement]::upgrade_test.nested_topoelement[],
+  CONSTRAINT domain_nested_array_default_check CHECK ((a[1])::text IS NOT NULL)
+);
+INSERT INTO upgrade_test.domain_nested_array_default_test (a) VALUES (
+  ARRAY['{125,126}'::topology.topoelement::upgrade_test.nested_topoelement]::upgrade_test.nested_topoelement[]
 );
 
 CREATE TABLE upgrade_test.domain_row_carrier_source (
@@ -272,6 +342,13 @@ CREATE TABLE upgrade_test.domain_row_carrier_test (
 );
 INSERT INTO upgrade_test.domain_row_carrier_test (r) VALUES (
   ROW('{103,104}'::topology.topoelement)::upgrade_test.domain_row_carrier_source
+);
+CREATE TABLE upgrade_test.domain_nested_row_carrier_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  r upgrade_test.composite_nested_row_topoelement
+);
+INSERT INTO upgrade_test.domain_nested_row_carrier_test (r) VALUES (
+  ROW('{127,128}'::topology.topoelement::upgrade_test.nested_row_topoelement)::upgrade_test.composite_nested_row_topoelement
 );
 
 CREATE TABLE upgrade_test.domain_array_inherit_constraint_parent (

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -222,12 +222,28 @@ CREATE TYPE upgrade_test.composite_topoelement AS (
 );
 CREATE TABLE upgrade_test.domain_nested_type_test (
   id integer GENERATED ALWAYS AS IDENTITY,
-  a upgrade_test.nested_topoelement,
+  a upgrade_test.nested_topoelement
+    DEFAULT '{89,90}'::topology.topoelement::upgrade_test.nested_topoelement,
   b upgrade_test.composite_topoelement
 );
 INSERT INTO upgrade_test.domain_nested_type_test (a, b) VALUES (
   '{85,86}'::topology.topoelement::upgrade_test.nested_topoelement,
   ROW('{87,88}'::topology.topoelement)::upgrade_test.composite_topoelement
+);
+
+CREATE TABLE upgrade_test.domain_array_inherit_constraint_parent (
+  id integer,
+  a topology.topoelement[] DEFAULT ARRAY['{101,102}'::topology.topoelement]::topology.topoelement[]
+);
+CREATE TABLE upgrade_test.domain_array_inherit_constraint_child ()
+  INHERITS (upgrade_test.domain_array_inherit_constraint_parent);
+ALTER TABLE upgrade_test.domain_array_inherit_constraint_child
+  ADD CONSTRAINT domain_array_inherit_constraint_check CHECK ((a[1])[1] > 0);
+CREATE INDEX domain_array_inherit_constraint_expr_idx
+  ON upgrade_test.domain_array_inherit_constraint_child (((a[1])[2]));
+INSERT INTO upgrade_test.domain_array_inherit_constraint_child VALUES (
+  1,
+  ARRAY['{103,104}'::topology.topoelement]::topology.topoelement[]
 );
 
 CREATE TABLE upgrade_test.domain_rule_source (

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -187,6 +187,20 @@ INSERT INTO upgrade_test.domain_array_test (a, b) VALUES (
   ARRAY[NULL::topology.topoelementarray, '{{69,70}}'::topology.topoelementarray]::topology.topoelementarray[]
 );
 
+CREATE DOMAIN upgrade_test.nested_topoelement AS topology.topoelement;
+CREATE TYPE upgrade_test.composite_topoelement AS (
+  a topology.topoelement
+);
+CREATE TABLE upgrade_test.domain_nested_type_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  a upgrade_test.nested_topoelement,
+  b upgrade_test.composite_topoelement
+);
+INSERT INTO upgrade_test.domain_nested_type_test (a, b) VALUES (
+  '{85,86}'::topology.topoelement::upgrade_test.nested_topoelement,
+  ROW('{87,88}'::topology.topoelement)::upgrade_test.composite_topoelement
+);
+
 CREATE TABLE upgrade_test.domain_rule_source (
   id integer,
   a topology.topoelement

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -1,5 +1,10 @@
 SELECT topology.createTopology('upgrade_test');
 
+-- The topology upgrade fixture creates many objects before the extension
+-- update. Keep autovacuum from racing the upgrade script's explicit
+-- ANALYZE spatial_ref_sys, which can otherwise deadlock on slow CI workers.
+ALTER TABLE public.spatial_ref_sys SET (autovacuum_enabled = false);
+
 -- Create some TopoGeometry data
 CREATE TABLE upgrade_test.feature(id serial primary key);
 SELECT topology.AddTopoGeometryColumn('upgrade_test', 'upgrade_test', 'feature', 'tg', 'linear');
@@ -217,6 +222,8 @@ INSERT INTO upgrade_test.domain_array_constraint_test (a) VALUES (
 );
 
 CREATE DOMAIN upgrade_test.nested_topoelement AS topology.topoelement;
+ALTER DOMAIN upgrade_test.nested_topoelement
+  SET DEFAULT '{91,92}'::topology.topoelement::upgrade_test.nested_topoelement;
 CREATE TYPE upgrade_test.composite_topoelement AS (
   a topology.topoelement
 );
@@ -229,6 +236,17 @@ CREATE TABLE upgrade_test.domain_nested_type_test (
 INSERT INTO upgrade_test.domain_nested_type_test (a, b) VALUES (
   '{85,86}'::topology.topoelement::upgrade_test.nested_topoelement,
   ROW('{87,88}'::topology.topoelement)::upgrade_test.composite_topoelement
+);
+
+CREATE TABLE upgrade_test.domain_row_carrier_source (
+  a topology.topoelement
+);
+CREATE TABLE upgrade_test.domain_row_carrier_test (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  r upgrade_test.domain_row_carrier_source DEFAULT ROW('{105,106}'::topology.topoelement)::upgrade_test.domain_row_carrier_source
+);
+INSERT INTO upgrade_test.domain_row_carrier_test (r) VALUES (
+  ROW('{103,104}'::topology.topoelement)::upgrade_test.domain_row_carrier_source
 );
 
 CREATE TABLE upgrade_test.domain_array_inherit_constraint_parent (
@@ -334,10 +352,24 @@ CREATE TRIGGER domain_trigger_child_a_trigger
   BEFORE UPDATE OF a ON upgrade_test.domain_trigger_child_child
   FOR EACH ROW EXECUTE FUNCTION upgrade_test.domain_trigger_source_guard();
 
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable DISABLE;
+  END IF;
+END
+$$;
 CREATE TABLE upgrade_test.domain_function_child_parent (
   id integer,
   a topology.topoelement
 ) PARTITION BY RANGE (id);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_event_trigger WHERE evtname = 'trg_autovac_disable') THEN
+    ALTER EVENT TRIGGER trg_autovac_disable ENABLE;
+  END IF;
+END
+$$;
 CREATE TABLE upgrade_test.domain_function_child_child
   PARTITION OF upgrade_test.domain_function_child_parent FOR VALUES FROM (0) TO (10);
 INSERT INTO upgrade_test.domain_function_child_parent VALUES (

--- a/utils/create_upgrade.pl
+++ b/utils/create_upgrade.pl
@@ -344,13 +344,21 @@ END IF;
 END
 \$postgis_domain_upgrade\$;\n
 EOF
-                    foreach my $c (@constraints) {
-                        my ($ctype, $cname, $cdef, $last_updated, $missing, $comment) = @$c;
-
+                    if ($schema eq 'topology' && ($name eq 'topoelement' || $name eq 'topoelementarray')) {
                         print <<"EOF";
+-- Constraints for ${schema}.${name} are restored by _postgis_topology_upgrade_domain_type
+-- so incomplete storage repairs can preserve NOT VALID state.
+
+EOF
+                    } else {
+                        foreach my $c (@constraints) {
+                            my ($ctype, $cname, $cdef, $last_updated, $missing, $comment) = @$c;
+
+                            print <<"EOF";
 ALTER DOMAIN ${schema}.${name} DROP CONSTRAINT IF EXISTS $cname;
 ALTER DOMAIN ${schema}.${name} ADD $cdef;\n
 EOF
+                        }
                     }
 
                 }
@@ -1067,4 +1075,3 @@ BEGIN
 END
 $$
 LANGUAGE 'plpgsql';
-


### PR DESCRIPTION
## Summary

Fixes the topology domain upgrade path introduced for PostGIS 3.6 bigint topology identifiers. The old helper changed the `topology.topoelement` and `topology.topoelementarray` domain base types in `pg_type`, but existing `integer[]` / `integer[][]` table storage was not physically rewritten. Whole-array output could still look correct, while element subscripting read old 4-byte values as 8-byte integers.

This updates `_postgis_topology_upgrade_domain_type` to:

- locate topology domains even when a previous broken 3.6 upgrade already flipped their catalog base type to bigint arrays;
- normalize the repair marker version, so the before-upgrade `3.6.0` path and generated `306` upgrade path share the same `postgis-topology-domain-storage-repaired-306` marker;
- save, backfill, and restore domain-level defaults and custom/canonical domain constraints around the catalog rewrite;
- rewrite repairable table rows, defaults, partition roots, inherited-child defaults, and PostgreSQL 17+ stored generated columns through text into the new bigint-array storage;
- rewrite nested array-of-domain columns such as `topology.topoelement[]` and `topology.topoelementarray[]` by temporarily moving them to `text[]`, then restoring them before domain constraints are re-added so grandfathered rows covered by `NOT VALID` constraints remain unvalidated;
- restore domain constraints as `NOT VALID` when storage was intentionally skipped, and also when rewritten domain-array/container columns still depend on the topology domain and PostgreSQL cannot add a validated domain constraint;
- detect user domains and composite/container types that hide topology domains behind another column type OID, warn for those columns, and withhold the repaired marker instead of marking nested old-width storage as fully repaired;
- skip materialized views, view/rule dependencies, row-level security policy dependencies including whole-row policy dependencies, trigger dependencies including whole-row trigger WHEN dependencies, publication column-list dependencies, generated-source dependencies including generated columns that read nested topology-domain carriers, blocked inherited descendants including trigger/publication-blocked children, and roots that would recurse into blocked children;
- rewrite defaults for skipped columns where possible, including columns skipped because RLS policies, triggers, publication column lists, row-type carriers, nested user-domain carriers, or skipped arrays of nested user domains depend on them;
- mark constraints demoted by an incomplete repair with an internal constraint comment, so a later complete retry revalidates only repair-demoted constraints and preserves user-created `NOT VALID` constraints;
- mark a topology domain as repaired only when no known dependent storage was skipped.

`utils/create_upgrade.pl` no longer emits the generated raw `ALTER DOMAIN topology.topoelement ADD CONSTRAINT ...` / `topology.topoelementarray ADD CONSTRAINT ...` statements after this helper runs. The helper owns restoring and backfilling those constraints so incomplete repairs can keep them `NOT VALID` instead of revalidating skipped old-width storage, while older upgrade sources still gain canonical constraints introduced after their source version.

The topology upgrade hooks cover the original #6016 corruption shape, already-catalog-upgraded 3.6 databases, table/default/domain-default/partition/generated-column storage, nested array-of-domain storage including NULL elements and grandfathered `NOT VALID` domain constraints, user-domain/composite nested storage marker withholding, generated columns that read skipped nested topology-domain storage, custom and canonical domain constraints, missing canonical constraints from older upgrade sources, skipped dependency cases including RLS policies and whole-row RLS policies, triggers including whole-row trigger dependencies, constrained domain arrays with CHECK constraints/expression indexes, partitioned domain-array indexes, publication column lists, roots with trigger/publication/row-type-blocked children, row-type-blocked column defaults, domain-array-dependent constraints restored as `NOT VALID`, unvalidated constraint restoration for incomplete repairs, pre-existing user unvalidated constraints, repair-demoted constraint marker provenance, marker withholding when repair is incomplete, partitioned-table trigger fixtures that do not rely on unsupported partitioned-root storage parameters, and skipped nested user-domain array defaults.

The latest review fixes cover skipped `nested_domain[] DEFAULT ARRAY[...]` carriers by recognizing arrays whose element type is a nested user domain over the topology domains, rebuilding their defaults through `text[]`, and verifying default inserts after upgrade. They also cover skipped composite and table-row carriers by recursively exposing contained topology-domain OIDs before restoring saved domain constraints, with a fixture proving nested-domain constraints stay `NOT VALID` after incomplete composite-carrier repair.

## Release / upgrade notes

NEWS includes a #6016 topology bug-fix entry. The fix affects generated extension upgrade SQL through `postgis/common_before_upgrade.sql`, `postgis/common_after_upgrade.sql`, and `utils/create_upgrade.pl`; no new SQL API is added.

Closes https://trac.osgeo.org/postgis/ticket/6016

## Maintenance Notes

- latest CI fix: the nested-domain regex CHECK fixtures now use explicit escape-string syntax so literal brace escapes survive `standard_conforming_strings=off`
- current head: `d5f388e37fad229496d120d37c7317f44fb09adb`
- local coverage instrumentation was not run because this is SQL upgrade-script behavior; the regression hook directly exercises the affected upgrade path, and GitHub coverage jobs will rerun on the pushed head
- `git diff --check upstream/master..HEAD` is still not useful as final evidence because this PR branch contains unrelated historical raster EOF whitespace outside the topology patch; `git diff --check` on the working tree passed

## Validation

- `perl -c utils/create_upgrade.pl`
- `./utils/check_news.sh .`
- `git diff --check`
- `make -C postgis postgis_upgrade.sql`
- `make -C topology topology_upgrade.sql`
- `make -C extensions/postgis all -j1`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_topology install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --upgrade --verbose" TESTS="$(pwd)/topology/test/regress/upgradetopology $(pwd)/topology/test/regress/topoelement $(pwd)/topology/test/regress/topoelement_cast"`; 4 tests passed on PostgreSQL 18 after adding skipped nested user-domain array default and composite-carrier constraint-demotion coverage
- focused topology upgrade regression with `standard_conforming_strings=off`; 4 tests passed on PostgreSQL 18
- `git clang-format --diff upstream/master -- postgis/common_before_upgrade.sql topology/test/regress/hooks/hook-before-upgrade-topology.sql topology/test/regress/hooks/hook-after-upgrade-topology.sql`
- Prior validation on this PR also ran the focused topology upgrade regression on PostgreSQL 14 and PostgreSQL 18, regenerated/inspected extension upgrade SQL, rebuilt and installed matching `postgis` / `postgis_topology` artifacts, and ran `make -C doc check-xml`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/350



