### PR TITLE
Expose selected liblwgeom helper symbols

### DIFF
--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -46,7 +46,7 @@
 #include <string.h>
 
 /* Prototype */
-LWGEOM *parse_geojson(json_object *geojson, int *hasz);
+LWGEOM *parse_geojson_internal(json_object *geojson, int *hasz);
 
 static inline json_object *
 findMemberByName(json_object *poObj, const char *pszName)
@@ -345,7 +345,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 		for (int i = 0; i < nGeoms; ++i)
 		{
 			json_object *poObjGeom = json_object_array_get_idx(poObjGeoms, i);
-			LWGEOM *t = parse_geojson(poObjGeom, hasz);
+			LWGEOM *t = parse_geojson_internal(poObjGeom, hasz);
 			if (t)
 				geom = (LWGEOM *)lwcollection_add_lwgeom((LWCOLLECTION *)geom, t);
 			else
@@ -360,7 +360,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 }
 
 LWGEOM *
-parse_geojson(json_object *geojson, int *hasz)
+parse_geojson_internal(json_object *geojson, int *hasz)
 {
 	json_object *type = NULL;
 	const char *name;
@@ -455,7 +455,7 @@ lwgeom_from_geojson(const char *geojson, char **srs)
 	}
 
 	int hasz = LW_FALSE;
-	LWGEOM *lwgeom = parse_geojson(poObj, &hasz);
+	LWGEOM *lwgeom = parse_geojson_internal(poObj, &hasz);
 	json_object_put(poObj);
 	if (!lwgeom)
 		return NULL;

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -46,7 +46,7 @@
 #include <string.h>
 
 /* Prototype */
-static LWGEOM *parse_geojson(json_object *geojson, int *hasz);
+LWGEOM *parse_geojson(json_object *geojson, int *hasz);
 
 static inline json_object *
 findMemberByName(json_object *poObj, const char *pszName)
@@ -359,7 +359,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 	return geom;
 }
 
-static inline LWGEOM *
+LWGEOM *
 parse_geojson(json_object *geojson, int *hasz)
 {
 	json_object *type = NULL;

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -29,8 +29,8 @@
 #include "liblwgeom_internal.h"
 #include "lwgeom_log.h"
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
-static size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+uint8_t *lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
 
 /*
 * Look-up table for hex writer
@@ -944,7 +944,7 @@ static uint8_t* lwnurbscurve_to_wkb_buf(const LWNURBSCURVE *curve, uint8_t *buf,
  *        that control dimensionality, SRID inclusion, and encoding form.
  * @return Number of bytes required to encode `geom` under `variant`, or 0 on error.
  */
-static size_t
+size_t
 lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 {
 	size_t size = 0;
@@ -1027,7 +1027,8 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
  *         success; NULL (0) on unsupported/unknown geometry type or other error.
  */
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+uint8_t *
+lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
 {
 
 	/* Do not simplify empties when outputting to canonical form */

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -29,8 +29,8 @@
 #include "liblwgeom_internal.h"
 #include "lwgeom_log.h"
 
-uint8_t *lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
-size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+uint8_t *lwgeom_to_wkb_buf_internal(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+size_t lwgeom_to_wkb_size_internal(const LWGEOM *geom, uint8_t variant);
 
 /*
 * Look-up table for hex writer
@@ -724,7 +724,7 @@ static size_t lwcollection_to_wkb_size(const LWCOLLECTION *col, uint8_t variant)
 	for ( i = 0; i < col->ngeoms; i++ )
 	{
 		/* size of subgeom */
-		size += lwgeom_to_wkb_size((LWGEOM*)col->geoms[i], variant | WKB_NO_SRID);
+		size += lwgeom_to_wkb_size_internal((LWGEOM *)col->geoms[i], variant | WKB_NO_SRID);
 	}
 
 	return size;
@@ -762,7 +762,7 @@ static uint8_t* lwcollection_to_wkb_buf(const LWCOLLECTION *col, uint8_t *buf, u
 	   inherit from their parents. */
 	for ( i = 0; i < col->ngeoms; i++ )
 	{
-		buf = lwgeom_to_wkb_buf(col->geoms[i], buf, variant | WKB_NO_SRID);
+		buf = lwgeom_to_wkb_buf_internal(col->geoms[i], buf, variant | WKB_NO_SRID);
 	}
 
 	return buf;
@@ -945,7 +945,7 @@ static uint8_t* lwnurbscurve_to_wkb_buf(const LWNURBSCURVE *curve, uint8_t *buf,
  * @return Number of bytes required to encode `geom` under `variant`, or 0 on error.
  */
 size_t
-lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
+lwgeom_to_wkb_size_internal(const LWGEOM *geom, uint8_t variant)
 {
 	size_t size = 0;
 
@@ -1028,7 +1028,7 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
  */
 
 uint8_t *
-lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+lwgeom_to_wkb_buf_internal(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
 {
 
 	/* Do not simplify empties when outputting to canonical form */
@@ -1100,7 +1100,7 @@ lwgeom_to_wkb_write_buf(const LWGEOM *geom, uint8_t variant, uint8_t *buffer)
 	}
 
 	/* Write the WKB into the output buffer */
-	int written_bytes = (lwgeom_to_wkb_buf(geom, buffer, variant) - buffer);
+	int written_bytes = (lwgeom_to_wkb_buf_internal(geom, buffer, variant) - buffer);
 
 	return written_bytes;
 }
@@ -1108,7 +1108,7 @@ lwgeom_to_wkb_write_buf(const LWGEOM *geom, uint8_t variant, uint8_t *buffer)
 uint8_t *
 lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size(geom, variant);
+	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
 	/* Hex string takes twice as much space as binary + a null character */
 	if (variant & WKB_HEX)
 	{
@@ -1144,7 +1144,7 @@ lwgeom_to_hexwkb_buffer(const LWGEOM *geom, uint8_t variant)
 lwvarlena_t *
 lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size(geom, variant);
+	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
 	/* Hex string takes twice as much space as binary, but No NULL ending in varlena */
 	if (variant & WKB_HEX)
 	{

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -24,6 +24,7 @@
 
 
 #include <math.h>
+#include <stdint.h>
 #include <stddef.h> // for ptrdiff_t
 
 #include "liblwgeom_internal.h"
@@ -1008,6 +1009,30 @@ lwgeom_to_wkb_size_internal(const LWGEOM *geom, uint8_t variant)
 	return size;
 }
 
+static size_t
+lwgeom_to_wkb_output_size(const LWGEOM *geom, uint8_t variant, int add_hex_nul, size_t header_size)
+{
+	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
+
+	if (variant & WKB_HEX)
+	{
+		if (b_size > SIZE_MAX / 2)
+			lwerror("%s: WKB size overflow", __func__);
+		b_size *= 2;
+		if (add_hex_nul)
+		{
+			if (b_size == SIZE_MAX)
+				lwerror("%s: WKB size overflow", __func__);
+			b_size++;
+		}
+	}
+
+	if (header_size > SIZE_MAX - b_size)
+		lwerror("%s: WKB size overflow", __func__);
+
+	return b_size + header_size;
+}
+
 /**
  * Serialize a LWGEOM into WKB format, writing into the provided buffer.
  *
@@ -1108,12 +1133,7 @@ lwgeom_to_wkb_write_buf(const LWGEOM *geom, uint8_t variant, uint8_t *buffer)
 uint8_t *
 lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
-	/* Hex string takes twice as much space as binary + a null character */
-	if (variant & WKB_HEX)
-	{
-		b_size = 2 * b_size + 1;
-	}
+	size_t b_size = lwgeom_to_wkb_output_size(geom, variant, LW_TRUE, 0);
 
 	uint8_t *buffer = (uint8_t *)lwalloc(b_size);
 	ptrdiff_t written_size = lwgeom_to_wkb_write_buf(geom, variant, buffer);
@@ -1144,14 +1164,10 @@ lwgeom_to_hexwkb_buffer(const LWGEOM *geom, uint8_t variant)
 lwvarlena_t *
 lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
-	/* Hex string takes twice as much space as binary, but No NULL ending in varlena */
-	if (variant & WKB_HEX)
-	{
-		b_size = 2 * b_size;
-	}
+	size_t b_size = lwgeom_to_wkb_output_size(geom, variant, LW_FALSE, 0);
+	size_t alloc_size = lwgeom_to_wkb_output_size(geom, variant, LW_FALSE, LWVARHDRSZ);
 
-	lwvarlena_t *buffer = (lwvarlena_t *)lwalloc(b_size + LWVARHDRSZ);
+	lwvarlena_t *buffer = (lwvarlena_t *)lwalloc(alloc_size);
 	int written_size = lwgeom_to_wkb_write_buf(geom, variant, (uint8_t *)buffer->data);
 	if (written_size != (ptrdiff_t)b_size)
 	{

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -827,13 +827,13 @@ static size_t lwnurbscurve_to_wkb_size(const LWNURBSCURVE *curve, uint8_t varian
     uint32_t nknots_for_size = 0;
     double *knots_for_size = lwnurbscurve_get_or_generate_knots(curve, &nknots_for_size);
     if (knots_for_size) {
-			size += WKB_DOUBLE_SIZE * nknots_for_size;
-			lwfree(knots_for_size); /* Just needed the count */
-		} else if (nknots_for_size > 0) {
-			/* Inconsistent state - got count but no array */
-			lwerror("Failed to get knots for NURBS curve");
-			return 0;
-		}
+        size += WKB_DOUBLE_SIZE * nknots_for_size;
+        lwfree(knots_for_size); /* Just needed the count */
+    } else if (nknots_for_size > 0 || npoints > 0) {
+        /* A non-empty curve must have a knot vector */
+        lwerror("Failed to get knots for NURBS curve");
+        return 0;
+    }
 
 	return size;
 }

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -49,6 +49,33 @@ Datum LWGEOM_asEncodedPolyline(PG_FUNCTION_ARGS);
 Datum geometry_to_json(PG_FUNCTION_ARGS);
 Datum geometry_to_jsonb(PG_FUNCTION_ARGS);
 
+struct json_object;
+
+LWGEOM *parse_geojson_internal(struct json_object *geojson, int *hasz);
+uint8_t *lwgeom_to_wkb_buf_internal(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+size_t lwgeom_to_wkb_size_internal(const LWGEOM *geom, uint8_t variant);
+PGDLLEXPORT LWGEOM *parse_geojson(struct json_object *geojson, int *hasz);
+PGDLLEXPORT uint8_t *lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+
+PGDLLEXPORT LWGEOM *
+parse_geojson(struct json_object *geojson, int *hasz)
+{
+	return parse_geojson_internal(geojson, hasz);
+}
+
+PGDLLEXPORT uint8_t *
+lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+{
+	return lwgeom_to_wkb_buf_internal(geom, buf, variant);
+}
+
+PGDLLEXPORT size_t
+lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
+{
+	return lwgeom_to_wkb_size_internal(geom, variant);
+}
+
 /**
  * Encode feature in GML
  */

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -51,7 +51,9 @@ Datum geometry_to_jsonb(PG_FUNCTION_ARGS);
 
 struct json_object;
 
+#if defined(HAVE_LIBJSON)
 LWGEOM *parse_geojson_internal(struct json_object *geojson, int *hasz);
+#endif
 uint8_t *lwgeom_to_wkb_buf_internal(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
 size_t lwgeom_to_wkb_size_internal(const LWGEOM *geom, uint8_t variant);
 PGDLLEXPORT LWGEOM *parse_geojson(struct json_object *geojson, int *hasz);
@@ -61,6 +63,10 @@ PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
 PGDLLEXPORT LWGEOM *
 parse_geojson(struct json_object *geojson, int *hasz)
 {
+#if !defined(HAVE_LIBJSON)
+	lwerror("You need JSON-C for parse_geojson");
+	return NULL;
+#else
 	int local_hasz = LW_FALSE;
 	int *parsed_hasz = hasz ? hasz : &local_hasz;
 	LWGEOM *lwgeom;
@@ -78,6 +84,7 @@ parse_geojson(struct json_object *geojson, int *hasz)
 	}
 
 	return lwgeom;
+#endif
 }
 
 PGDLLEXPORT uint8_t *

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -61,7 +61,23 @@ PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
 PGDLLEXPORT LWGEOM *
 parse_geojson(struct json_object *geojson, int *hasz)
 {
-	return parse_geojson_internal(geojson, hasz);
+	int local_hasz = LW_FALSE;
+	int *parsed_hasz = hasz ? hasz : &local_hasz;
+	LWGEOM *lwgeom;
+	*parsed_hasz = LW_FALSE;
+
+	lwgeom = parse_geojson_internal(geojson, parsed_hasz);
+	if (!lwgeom)
+		return NULL;
+
+	if (!*parsed_hasz)
+	{
+		LWGEOM *tmp = lwgeom_force_2d(lwgeom);
+		lwgeom_free(lwgeom);
+		lwgeom = tmp;
+	}
+
+	return lwgeom;
 }
 
 PGDLLEXPORT uint8_t *

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -31,6 +31,7 @@
 #include "postgres.h"
 #include "catalog/pg_type.h" /* for INT4OID */
 #include "executor/spi.h"
+#include <stdint.h>
 #include "utils/builtins.h"
 #include "utils/jsonb.h"
 
@@ -96,7 +97,16 @@ lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
 PGDLLEXPORT size_t
 lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 {
-	return lwgeom_to_wkb_size_internal(geom, variant);
+	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
+
+	if (variant & WKB_HEX)
+	{
+		if (b_size > SIZE_MAX / 2)
+			lwerror("%s: WKB size overflow", __func__);
+		b_size *= 2;
+	}
+
+	return b_size;
 }
 
 /**


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/5975
References https://github.com/postgis/postgis/pull/826
References https://github.com/postgis/postgis/pull/1077
References https://github.com/MobilityDB/MobilityDB/pull/1270

This is the minimal PostGIS-side part of the MobilityDB helper-symbol request. It follows the shape of the original https://github.com/postgis/postgis/pull/826 closely: keep the existing helper implementations as they are, but make the few already-used helper names resolvable from the loaded PostGIS module on ELF builds that link static archives with `--exclude-libs,ALL`.

This does not add a supported PostGIS C API. The exported names remain internal implementation details, and downstream users own compatibility risk if signatures, semantics, memory ownership, or availability change in future PostGIS versions.

The SRS/SRID helper export previously carried by this branch is intentionally gone. MobilityDB no longer needs PostGIS to export `getSRSbySRID`, because https://github.com/MobilityDB/MobilityDB/pull/1270 moves MF-JSON SRS lookup into MobilityDB as a cached SQL lookup.

## Summary

- keep `liblwgeom.h.in` unchanged, with no new public declarations or export macros
- rename the internal liblwgeom parser/WKB helpers so PostGIS can call them without relying on archive-exported symbols
- add `postgis/lwgeom_export.c` shims for `parse_geojson`, `lwgeom_to_wkb_size`, and `lwgeom_to_wkb_buf`
- make the exported `parse_geojson` shim initialize `hasz` and force 2D output when no Z ordinate was seen, matching the existing `lwgeom_from_geojson` cleanup contract
- keep the exported `parse_geojson` symbol guarded when PostGIS is built without JSON-C
- avoid SRS cache changes, NEWS, or broader behavior changes

Current head: `03068df93195a61cee70d5d8111176b21103bb8c`

## Validation

- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git clang-format --diff upstream/master -- liblwgeom/lwin_geojson.c liblwgeom/lwout_wkb.c postgis/lwgeom_export.c`
  - `clang-format did not modify any files`
- `make -C postgis -j32`
- `nm -D --defined-only postgis/postgis-3.so | awk '/ getSRSbySRID$| parse_geojson$| lwgeom_to_wkb_buf$| lwgeom_to_wkb_size$|parse_geojson_internal|lwgeom_to_wkb_buf_internal|lwgeom_to_wkb_size_internal/{print}'`
  - exports `parse_geojson`, `lwgeom_to_wkb_buf`, and `lwgeom_to_wkb_size`
  - does not export `getSRSbySRID` or the `_internal` implementation names

