### PR TITLE
#4208 Add single-geometry distance wrappers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * New Features *
 
+ - #4208, Add single-geometry variants of ST_MaxDistance and ST_LongestLine
+          (Darafei Praliaskouski)
  - [topology] FindVertexSegmentPairsBelowDistance function (Sandro Santilli)
  - ST_CoverageEdges, returns MultiLinestring of distinct shared edges in
           polygonal coverage (Paul Ramsey)

--- a/doc/reference_measure.xml
+++ b/doc/reference_measure.xml
@@ -1246,6 +1246,12 @@ CAST('SPHEROID["GRS_1980",6378137,298.257222101]' As spheroid) As sph_m)  as foo
 			<funcdef>geometry <function>ST_LongestLine</function></funcdef>
 
 			<paramdef><type>geometry </type>
+			<parameter>g</parameter></paramdef>
+		  </funcprototype>
+		  <funcprototype>
+			<funcdef>geometry <function>ST_LongestLine</function></funcdef>
+
+			<paramdef><type>geometry </type>
 			<parameter>g1</parameter></paramdef>
 
 			<paramdef><type>geometry </type>
@@ -1265,10 +1271,11 @@ CAST('SPHEROID["GRS_1980",6378137,298.257222101]' As spheroid) As sph_m)  as foo
 		The length of the line is equal to the distance returned by <xref linkend="ST_MaxDistance"/>.
 		</para>
         <para>
-        If g1 and g2 are the same geometry, returns the line between the two vertices farthest apart in the geometry.
+        If only one geometry is provided, or g1 and g2 are the same geometry, returns the line between the two vertices farthest apart in the geometry.
         The endpoints of the line lie on the circle computed by <xref linkend="ST_MinimumBoundingCircle"/>.
         </para>
 		<para role="availability" conformance="1.5.0">Availability: 1.5.0</para>
+		<para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 - support for a single geometry input.</para>
 
 	  </refsection>
 
@@ -1322,9 +1329,9 @@ LINESTRING(20 10,105.3073372946034 186.95518130045156)
         </mediaobject>
         </informalfigure>
 <programlisting>
-SELECT ST_AsText( ST_LongestLine( geom, geom)) AS llinewkt,
-                  ST_MaxDistance( geom, geom) AS max_dist,
-                  ST_Length( ST_LongestLine(geom, geom)) AS lenll
+SELECT ST_AsText( ST_LongestLine( geom)) AS llinewkt,
+                  ST_MaxDistance( geom) AS max_dist,
+                  ST_Length( ST_LongestLine(geom)) AS lenll
 FROM (SELECT 'POLYGON ((40 180, 110 160, 180 180, 180 120, 140 90, 160 40, 80 10, 70 40, 20 50, 40 180),
               (60 140, 99 77.5, 90 140, 60 140))'::geometry AS geom) AS t;
 
@@ -1454,6 +1461,10 @@ SELECT ST_AsEWKT(ST_3DLongestLine(line,pt)) AS lol3d_line_pt,
     <funcsynopsis>
       <funcprototype>
         <funcdef>float <function>ST_MaxDistance</function></funcdef>
+        <paramdef><type>geometry </type> <parameter>g</parameter></paramdef>
+      </funcprototype>
+      <funcprototype>
+        <funcdef>float <function>ST_MaxDistance</function></funcdef>
         <paramdef><type>geometry </type> <parameter>g1</parameter></paramdef>
         <paramdef><type>geometry </type> <parameter>g2</parameter></paramdef>
       </funcprototype>
@@ -1468,11 +1479,12 @@ SELECT ST_AsEWKT(ST_3DLongestLine(line,pt)) AS lol3d_line_pt,
     The maximum distance always occurs between two vertices.
     This is the length of the line returned by <xref linkend="ST_LongestLine"/>.
     </para>
-    <para>If g1 and g2 are the same geometry, returns the distance between
+    <para>If only one geometry is provided, or g1 and g2 are the same geometry, returns the distance between
     the two vertices farthest apart in that geometry.
     </para>
 
 	<para role="availability" conformance="1.5.0">Availability: 1.5.0</para>
+	<para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 - support for a single geometry input.</para>
   </refsection>
   <refsection>
     <title>Examples</title>
@@ -1489,8 +1501,7 @@ SELECT ST_MaxDistance('POINT(0 0)'::geometry, 'LINESTRING ( 2 2, 2 2 )'::geometr
 
      <para>Maximum distance between vertices of a single geometry.</para>
 <programlisting>
-SELECT ST_MaxDistance('POLYGON ((10 10, 10 0, 0 0, 10 10))'::geometry,
-                      'POLYGON ((10 10, 10 0, 0 0, 10 10))'::geometry);
+SELECT ST_MaxDistance('POLYGON ((10 10, 10 0, 0 0, 10 10))'::geometry);
 ------------------
  14.142135623730951
 </programlisting>

--- a/doc/rfc/postgis_rfc_03_sheet.txt
+++ b/doc/rfc/postgis_rfc_03_sheet.txt
@@ -188,6 +188,8 @@ FUNCTION	"distance(geometry,geometry)"	PUBLIC	DEPRECATE
 FUNCTION	"ST_Distance(geometry,geometry)"	PUBLIC	KEEP		
 FUNCTION	"max_distance(geometry,geometry)"	PUBLIC	DEPRECATE		
 FUNCTION	"ST_max_distance(geometry,geometry)"	PUBLIC	KEEP		
+FUNCTION	"ST_MaxDistance(geometry)"	PUBLIC	KEEP
+FUNCTION	"ST_LongestLine(geometry)"	PUBLIC	KEEP
 FUNCTION	"point_inside_circle(geometry,float8,float8,float8)"	PUBLIC	DEPRECATE
 FUNCTION	"ST_point_inside_circle(geometry,float8,float8,float8)"	PUBLIC	KEEP
 FUNCTION	"azimuth(geometry,geometry)"	PUBLIC	DEPRECATE

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -6135,6 +6135,12 @@ CREATE OR REPLACE FUNCTION ST_MaxDistance(geom1 geometry, geom2 geometry)
 	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_HIGH;
 
+CREATE OR REPLACE FUNCTION ST_MaxDistance(geom geometry)
+	RETURNS float8
+	AS 'SELECT @extschema@.ST_MaxDistance($1, $1)'
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_HIGH;
+
 CREATE OR REPLACE FUNCTION ST_ClosestPoint(geom1 geometry, geom2 geometry)
 	RETURNS geometry
 	AS 'MODULE_PATHNAME', 'LWGEOM_closestpoint'
@@ -6156,6 +6162,12 @@ CREATE OR REPLACE FUNCTION _ST_LongestLine(geom1 geometry, geom2 geometry)
 CREATE OR REPLACE FUNCTION ST_LongestLine(geom1 geometry, geom2 geometry)
 	RETURNS geometry
 	AS 'SELECT @extschema@._ST_LongestLine(@extschema@.ST_ConvexHull($1), @extschema@.ST_ConvexHull($2))'
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_HIGH;
+
+CREATE OR REPLACE FUNCTION ST_LongestLine(geom geometry)
+	RETURNS geometry
+	AS 'SELECT @extschema@.ST_LongestLine($1, $1)'
 	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_HIGH;
 

--- a/regress/core/measures.sql
+++ b/regress/core/measures.sql
@@ -45,6 +45,7 @@ select 'st_maxdistance_134', st_maxdistance('POINT(1 2)', 'POINT(1 2)');
 select 'st_maxdistance_135', st_maxdistance('POINT(5 0)', 'POINT(10 12)');
 
 select 'st_maxdistance_136', st_maxdistance('POINT(0 0)', ST_translate('POINT(0 0)', 5, 12, 0));
+select 'st_maxdistance_1arg', st_maxdistance('LINESTRING(0 0,3 4,6 0)'::geometry);
 
 -- postgis-users/2006-May/012174.html
 select 'st_maxdistance_dist', st_maxdistance(a,b)::numeric(12,6), st_maxdistance(b,a)::numeric(12,6) from (
@@ -59,6 +60,7 @@ select 'st_longestline_134', st_astext(st_longestline('POINT(1 2)', 'POINT(1 2)'
 select 'st_longestline_135', st_astext(st_longestline('POINT(5 0)', 'POINT(10 12)'));
 
 select 'st_longestline_136', st_astext(st_longestline('POINT(0 0)', ST_translate('POINT(0 0)', 5, 12, 0)));
+select 'st_longestline_1arg', st_astext(st_longestline('LINESTRING(0 0,3 4,6 0)'::geometry));
 
 -- postgis-users/2006-May/012174.html
 select 'st_longestline_dist', st_astext(st_longestline(a,b)), st_astext(st_longestline(b,a)) from (

--- a/regress/core/measures_expected
+++ b/regress/core/measures_expected
@@ -16,10 +16,12 @@ st_shortestline_dist|LINESTRING(10 0,11 0)|LINESTRING(11 0,10 0)
 st_maxdistance_134|0
 st_maxdistance_135|13
 st_maxdistance_136|13
+st_maxdistance_1arg|6
 st_maxdistance_dist|22.360680|22.360680
 st_longestline_134|LINESTRING(1 2,1 2)
 st_longestline_135|LINESTRING(5 0,10 12)
 st_longestline_136|LINESTRING(0 0,5 12)
+st_longestline_1arg|LINESTRING(0 0,6 0)
 st_longestline_dist|LINESTRING(0 0,20 10)|LINESTRING(20 10,0 0)
 distancetest1|1|50|LINESTRING(17 18,17 19)|LINESTRING(17 19,17 18)|LINESTRING(29 39,-1 -1)|LINESTRING(-1 -1,29 39)
 distancetest2|0|50|0.0000000000|0.0000000000|0.0000000000|0.0000000000|LINESTRING(-40 -20,-10 20)|LINESTRING(-10 20,-40 -20)


### PR DESCRIPTION
## Summary
- add one-argument ST_MaxDistance and ST_LongestLine SQL wrappers
- document the single-geometry variants and update examples that previously passed the same geometry twice
- add focused measures regression coverage plus NEWS/RFC entries

Closes #4208

## Validation
- ./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal
- make -C postgis postgis.sql -j32
- make -C doc check-xml
- rm -rf regress/00-regress-install && make -C regress staged-install-core
- sudo -n make -C postgis install
- PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--verbose" TESTS="$(pwd)/regress/core/measures"
- make -C extensions postgis_extension_helper.sql && make -C extensions/postgis all && sudo -n make -C extensions/postgis install
- PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/measures"
- git diff --check && git diff --cached --check