### PR TITLE
raster: fix GDAL warp skew for default rasters

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -239,6 +239,10 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           PDF builds while keeping HTML images transparent (Darafei Praliaskouski)
  - #2838, Emit valid X3D Coordinate nodes for 2D polygon output
           (Darafei Praliaskouski)
+ - #2924, [raster] Preserve requested GDAL warp skew for rasters with
+          default geotransforms (Darafei Praliaskouski)
+ - #3103, Add regression coverage for exact-schema find_srid and
+          geometry_columns lookups (Darafei Praliaskouski)
  - #1705, Infer constraint metadata for direct view and materialized view
           geometry columns (Darafei Praliaskouski)
  - GH-899, [raster] Honor PostgreSQL interrupts in long-running GDAL

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ These are only changes since 3.7.0beta2.
 
 * Bug Fixes *
 
+ - #2924, [raster] Preserve requested GDAL warp skew for rasters with
+          default geotransforms (Darafei Praliaskouski)
+ - #3103, Add regression coverage for exact-schema find_srid and
+          geometry_columns lookups (Darafei Praliaskouski)
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 

--- a/raster/rt_core/rt_warp.c
+++ b/raster/rt_core/rt_warp.c
@@ -10,6 +10,7 @@
  * Copyright (C) 2009-2011 Pierre Racine <pierre.racine@sbf.ulaval.ca>
  * Copyright (C) 2009-2011 Mateusz Loskot <mateusz@loskot.net>
  * Copyright (C) 2008-2009 Sandro Santilli <strk@kbt.io>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -205,6 +206,14 @@ rt_raster rt_raster_gdal_warp(
 	int use_init_dest_nodata = 0;
 
 	int subspatial = 0;
+	/*
+	 * GDAL Warp rejects default-geotransform rasters as ungeoreferenced, so
+	 * temporarily place them in a small synthetic projected frame.  Requested
+	 * scale and skew values are converted into that frame before warping and
+	 * converted back to PostGIS raster metadata after GDAL computes the output
+	 * extent.
+	 */
+	double subspatial_gt[6] = {166021.4431, 0.1, 0, 10000000.0000, 0, -0.1};
 
 	RASTER_DEBUG(3, "rt_raster_gdal_warp: starting");
 
@@ -404,10 +413,9 @@ rt_raster rt_raster_gdal_warp(
 		if (FLT_EQ(gt[0], 0.0) && FLT_EQ(gt[3], 0.0) && FLT_EQ(gt[1], 1.0) && FLT_EQ(gt[5], -1.0) &&
 		    FLT_EQ(gt[2], 0.0) && FLT_EQ(gt[4], 0.0))
 		{
-			double ngt[6] = {166021.4431, 0.1, 0, 10000000.0000, 0, -0.1};
 			rtwarn("Raster has default geotransform. Adjusting metadata for use of GDAL Warp API");
 			subspatial = 1;
-			GDALSetGeoTransform(arg->src.ds, ngt);
+			GDALSetGeoTransform(arg->src.ds, subspatial_gt);
 			GDALFlushCache(arg->src.ds);
 			arg->src.srs = rt_util_gdal_convert_sr("EPSG:32731", 0);
 			arg->dst.srs = rt_util_gdal_convert_sr("EPSG:32731", 0);
@@ -524,11 +532,15 @@ rt_raster rt_raster_gdal_warp(
 		_skew[0] = *skew_x;
 		if (NULL != scale_x && *scale_x < 0.)
 			_skew[0] *= -1;
+		if (subspatial)
+			_skew[0] /= 10;
 	}
 	if (NULL != skew_y) {
 		_skew[1] = *skew_y;
 		if (NULL != scale_y && *scale_y > 0)
 			_skew[1] *= -1;
+		if (subspatial)
+			_skew[1] /= 10;
 	}
 
 	RASTER_DEBUGF(4, "rt_raster_gdal_warp: Using skew: %f x %f", _skew[0], _skew[1]);
@@ -536,10 +548,33 @@ rt_raster rt_raster_gdal_warp(
 	/* Compute the output grid parameters when skew is requested. */
 	if (FLT_NEQ(_skew[0], 0.0) || FLT_NEQ(_skew[1], 0.0)) {
 		rt_raster skewedrast;
+		rt_envelope skew_extent = extent;
+		double compute_scale[2] = {_scale[0], _scale[1]};
+		double compute_skew[2] = {_skew[0], _skew[1]};
 
 		RASTER_DEBUG(3, "rt_raster_gdal_warp: Computing skewed extent");
 
-		skewedrast = rt_raster_compute_skewed_raster(extent, _skew, _scale);
+		if (subspatial)
+		{
+			/*
+			 * The synthetic frame keeps GDAL happy, but its large origin can
+			 * round edge pixels out of the determinant math below.  Solve
+			 * dimensions in the raster's default coordinate frame, then convert
+			 * the computed upper-left back to GDAL's synthetic frame.
+			 */
+			skew_extent.MinX = (skew_extent.MinX - subspatial_gt[0]) * 10;
+			skew_extent.MaxX = (skew_extent.MaxX - subspatial_gt[0]) * 10;
+			skew_extent.MinY = (skew_extent.MinY - subspatial_gt[3]) * 10;
+			skew_extent.MaxY = (skew_extent.MaxY - subspatial_gt[3]) * 10;
+			skew_extent.UpperLeftX = (skew_extent.UpperLeftX - subspatial_gt[0]) * 10;
+			skew_extent.UpperLeftY = (skew_extent.UpperLeftY - subspatial_gt[3]) * 10;
+			compute_scale[0] *= 10;
+			compute_scale[1] *= 10;
+			compute_skew[0] *= 10;
+			compute_skew[1] *= 10;
+		}
+
+		skewedrast = rt_raster_compute_skewed_raster(skew_extent, compute_skew, compute_scale);
 		if (skewedrast == NULL) {
 			rterror("rt_raster_gdal_warp: Could not compute skewed extent");
 			_rti_warp_arg_destroy(arg);
@@ -551,6 +586,11 @@ rt_raster rt_raster_gdal_warp(
 
 		extent.UpperLeftX = rt_raster_get_x_offset(skewedrast);
 		extent.UpperLeftY = rt_raster_get_y_offset(skewedrast);
+		if (subspatial)
+		{
+			extent.UpperLeftX = subspatial_gt[0] + (extent.UpperLeftX / 10);
+			extent.UpperLeftY = subspatial_gt[3] + (extent.UpperLeftY / 10);
+		}
 
 		RASTER_DEBUGF(3, "rt_raster_gdal_warp: Skewed extent: UL=(%f,%f) dim=%dx%d",
 			extent.UpperLeftX, extent.UpperLeftY, _dim[0], _dim[1]);
@@ -584,7 +624,15 @@ rt_raster rt_raster_gdal_warp(
 	/* user-defined upper-left corner */
 	if (NULL != ul_xw && NULL != ul_yw) {
 		ul_user = 1;
-		rt_raster_set_offsets(rast, *ul_xw, *ul_yw);
+		/*
+		 * Default-geotransform rasters are warped in a synthetic projected
+		 * frame. Keep the caller-visible extent in raster coordinates, but
+		 * move GDAL's temporary raster to the matching synthetic frame.
+		 */
+		if (subspatial)
+			rt_raster_set_offsets(rast, subspatial_gt[0] + (*ul_xw / 10), subspatial_gt[3] + (*ul_yw / 10));
+		else
+			rt_raster_set_offsets(rast, *ul_xw, *ul_yw);
 		extent.UpperLeftX = *ul_xw;
 		extent.UpperLeftY = *ul_yw;
 	}
@@ -599,37 +647,45 @@ rt_raster rt_raster_gdal_warp(
 	}
 
 	/* alignment only considered if upper-left corner not provided */
-	if (
-		!ul_user && (
-			(NULL != grid_xw) || (NULL != grid_yw)
-		)
-	) {
+	if (!ul_user && ((NULL != grid_xw) || (NULL != grid_yw)))
+	{
+		double grid_x = 0;
+		double grid_y = 0;
 
-		if (
-			((NULL != grid_xw) && (NULL == grid_yw)) ||
-			((NULL == grid_xw) && (NULL != grid_yw))
-		) {
+		if (((NULL != grid_xw) && (NULL == grid_yw)) || ((NULL == grid_xw) && (NULL != grid_yw)))
+		{
 			rterror("rt_raster_gdal_warp: Both X and Y alignment values must be provided");
 			rt_raster_destroy(rast);
 			_rti_warp_arg_destroy(arg);
 			return NULL;
 		}
 
-		RASTER_DEBUGF(4, "Aligning extent to user-specified grid: %f, %f", *grid_xw, *grid_yw);
+		/*
+		 * Alignment is computed in the temporary raster's coordinate
+		 * frame.  Default-geotransform rasters are warped in a synthetic
+		 * projected frame, so convert the caller's raster-coordinate grid
+		 * origin before snapping.
+		 */
+		grid_x = subspatial ? (subspatial_gt[0] + (*grid_xw / 10)) : *grid_xw;
+		grid_y = subspatial ? (subspatial_gt[3] + (*grid_yw / 10)) : *grid_yw;
 
-		do {
+		RASTER_DEBUGF(4, "Aligning extent to user-specified grid: %f, %f", grid_x, grid_y);
+
+		do
+		{
 			double _r[2] = {0};
 			double _w[2] = {0};
 
 			/* raster is already aligned */
-			if (FLT_EQ(*grid_xw, extent.UpperLeftX) && FLT_EQ(*grid_yw, extent.UpperLeftY)) {
+			if (FLT_EQ(grid_x, extent.UpperLeftX) && FLT_EQ(grid_y, extent.UpperLeftY))
+			{
 				RASTER_DEBUG(3, "Skipping raster alignment as it is already aligned to grid");
 				break;
 			}
 
 			extent.UpperLeftX = rast->ipX;
 			extent.UpperLeftY = rast->ipY;
-			rt_raster_set_offsets(rast, *grid_xw, *grid_yw);
+			rt_raster_set_offsets(rast, grid_x, grid_y);
 
 			/* process upper-left corner */
 			if (rt_raster_geopoint_to_cell(
@@ -708,8 +764,7 @@ rt_raster rt_raster_gdal_warp(
 
 			rt_raster_set_offsets(rast, _w[0], _w[1]);
 			RASTER_DEBUGF(4, "aligned offsets: %f x %f", _w[0], _w[1]);
-		}
-		while (0);
+		} while (0);
 	}
 
 	/* get key attributes */
@@ -728,9 +783,9 @@ rt_raster rt_raster_gdal_warp(
 				return NULL;
 			}
 			_gt[0] = _w[0];
-			_gt[1] = *scale_x;
+			_gt[1] = subspatial ? (*scale_x / 10) : *scale_x;
 			if (NULL != skew_x && FLT_NEQ(*skew_x, 0.0))
-				_gt[2] = *skew_x;
+				_gt[2] = subspatial ? (*skew_x / 10) : *skew_x;
 		}
 		if (NULL != scale_y && *scale_y > 0) {
 			if (rt_raster_cell_to_geopoint(rast, 0, rast->height, &(_w[0]), &(_w[1]), NULL) != ES_NONE) {
@@ -740,9 +795,9 @@ rt_raster rt_raster_gdal_warp(
 				return NULL;
 			}
 			_gt[3] = _w[1];
-			_gt[5] = *scale_y;
+			_gt[5] = subspatial ? (*scale_y / 10) : *scale_y;
 			if (NULL != skew_y && FLT_NEQ(*skew_y, 0.0))
-				_gt[4] = *skew_y;
+				_gt[4] = subspatial ? (*skew_y / 10) : *skew_y;
 		}
 	}
 
@@ -948,8 +1003,17 @@ rt_raster rt_raster_gdal_warp(
 	/* reset spatial info for default-geotransform rasters */
 	if (subspatial) {
 		double gt[6] = {0, 1, 0, 0, 0, -1};
-		gt[1] = _scale[0] * 10;
-		gt[5] = -1 * _scale[1] * 10;
+		/*
+		 * Convert the finalized GDAL grid, not the pre-alignment extent:
+		 * grid alignment may have moved _gt after the synthetic-frame extent
+		 * was computed.
+		 */
+		gt[0] = (_gt[0] - subspatial_gt[0]) * 10;
+		gt[1] = _gt[1] * 10;
+		gt[2] = _gt[2] * 10;
+		gt[3] = (_gt[3] - subspatial_gt[3]) * 10;
+		gt[4] = _gt[4] * 10;
+		gt[5] = _gt[5] * 10;
 		rt_raster_set_geotransform_matrix(rast, gt);
 		rt_raster_set_srid(rast, SRID_UNKNOWN);
 	}

--- a/raster/test/cunit/cu_gdal.c
+++ b/raster/test/cunit/cu_gdal.c
@@ -558,6 +558,48 @@ static void test_gdal_warp(void) {
 	cu_free_raster(raster);
 }
 
+static void
+test_gdal_warp_default_upperleft(void)
+{
+	rt_band band = NULL;
+	rt_raster raster = NULL;
+	rt_raster rast = NULL;
+	int width = 10;
+	int height = 10;
+	double ul_x = 0;
+	double ul_y = 0;
+
+	raster = rt_raster_new(width, height);
+	CU_ASSERT(raster != NULL);
+
+	band = cu_add_band(raster, PT_8BUI, 1, 0);
+	CU_ASSERT(band != NULL);
+
+	rast = rt_raster_gdal_warp(raster,
+				   NULL,
+				   NULL,
+				   NULL,
+				   NULL,
+				   &width,
+				   &height,
+				   &ul_x,
+				   &ul_y,
+				   NULL,
+				   NULL,
+				   NULL,
+				   NULL,
+				   GRA_NearestNeighbour,
+				   -1);
+	CU_ASSERT(rast != NULL);
+	CU_ASSERT_EQUAL(rt_raster_get_width(rast), 10);
+	CU_ASSERT_EQUAL(rt_raster_get_height(rast), 10);
+	CU_ASSERT_DOUBLE_EQUAL(rt_raster_get_x_offset(rast), 0, DBL_EPSILON);
+	CU_ASSERT_DOUBLE_EQUAL(rt_raster_get_y_offset(rast), 0, DBL_EPSILON);
+
+	cu_free_raster(rast);
+	cu_free_raster(raster);
+}
+
 static void test_gdal_warp_preserves_data(void) {
 	const char *filename = POSTGIS_TOP_SRC_DIR "/raster/test/regress/loader/Projected.tif";
 
@@ -637,6 +679,6 @@ void gdal_suite_setup(void)
 	PG_ADD_TEST(suite, test_raster_to_gdal);
 	PG_ADD_TEST(suite, test_gdal_to_raster);
 	PG_ADD_TEST(suite, test_gdal_warp);
+	PG_ADD_TEST(suite, test_gdal_warp_default_upperleft);
 	PG_ADD_TEST(suite, test_gdal_warp_preserves_data);
 }
-

--- a/raster/test/regress/rt_gdalwarp.sql
+++ b/raster/test/regress/rt_gdalwarp.sql
@@ -793,6 +793,51 @@ FROM (
 DROP TABLE raster_gdalwarp_src;
 DROP TABLE raster_gdalwarp_dst;
 
+WITH foo AS MATERIALIZED (
+	SELECT _st_gdalwarp(
+		ST_AddBand(ST_MakeEmptyRaster(10, 10, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 1, NULL),
+		'NearestNeighbor', 0.125,
+		NULL, NULL,
+		NULL, NULL,
+		NULL,
+		1, 1
+	) AS rast
+)
+SELECT '#2924',
+	(metadata).width,
+	(metadata).height,
+	round((metadata).skewx::numeric, 3),
+	round((metadata).skewy::numeric, 3),
+	round((metadata).upperleftx::numeric, 3),
+	round((metadata).upperlefty::numeric, 3)
+FROM (
+	SELECT ST_MetaData(rast) AS metadata
+	FROM foo
+) bar;
+
+WITH foo AS MATERIALIZED (
+	SELECT _st_gdalwarp(
+		ST_AddBand(ST_MakeEmptyRaster(10, 10, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 1, NULL),
+		'NearestNeighbor', 0.125,
+		NULL,
+		NULL, NULL,
+		2, 2,
+		1, 1
+	) AS rast
+)
+SELECT '#2924-grid',
+	(metadata).width,
+	(metadata).height,
+	round((metadata).skewx::numeric, 3),
+	round((metadata).skewy::numeric, 3),
+	round((metadata).upperleftx::numeric, 3),
+	round((metadata).upperlefty::numeric, 3),
+	ST_SameAlignment(rast, ST_MakeEmptyRaster(1, 1, 2, 2, 1, -1, 1, 1, 0))
+FROM (
+	SELECT rast, ST_MetaData(rast) AS metadata
+	FROM foo
+) bar;
+
 WITH foo AS (
 	SELECT 0 AS rid, ST_AddBand(ST_MakeEmptyRaster(2, 2, -500000, 600000, 100, -100, 0, 0, 992163), 1, '16BUI', 1, 0) AS rast UNION ALL
 	SELECT 1, ST_AddBand(ST_MakeEmptyRaster(2, 2, -499800, 600000, 100, -100, 0, 0, 992163), 1, '16BUI', 2, 0) AS rast UNION ALL

--- a/raster/test/regress/rt_gdalwarp_expected
+++ b/raster/test/regress/rt_gdalwarp_expected
@@ -94,6 +94,10 @@ NOTICE:  Values must be provided for both X and Y when specifying the scale.  Re
 5.7|992163|10|11|1|1000.000|-1000.000|0.000|0.000|-500000.000|600991.000|t|t|t
 5.8|992163|10|11|1|1000.000|-1000.000|0.000|0.000|-500000.000|600001.000|t|t|t
 5.9|992163|10|11|1|1000.000|-1000.000|0.000|0.000|-500000.000|600009.000|t|t|t
+NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL Warp API
+#2924|11|11|1.000|1.000|-5.000|-5.000
+NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL Warp API
+#2924-grid|11|11|1.000|1.000|-5.000|-5.000|t
 NOTICE:  The rasters (pixel corner coordinates) are not aligned
 t|f|t
 NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL Warp API
@@ -106,6 +110,6 @@ NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL War
 4|0|0|500|500|2|-2|0|0|0|1|250000|63750000|255|0|255|255
 NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL Warp API
 NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL Warp API
-(0,0,5,5,2,-2,0,0,0,1)|(0,0,5,5,2,-2,0,0,0,1)
+(0,-10,5,5,2,2,0,0,0,1)|(0,0,5,5,2,-2,0,0,0,1)
 t|t|f|NaN|t
 t|t


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/2924.

## Summary
- preserve requested skew values when GDAL warp is applied to default-geotransform rasters through the synthetic subspatial frame
- compute skewed output dimensions for default-geotransform rasters in the raster's local default coordinate frame, avoiding large-origin cancellation in the synthetic subspatial frame
- convert requested grid origins into that synthetic frame before alignment, so `ST_SnapToGrid` / `ST_Resample` outputs remain aligned to the caller's raster-coordinate grid
- convert explicit caller-provided upper-left coordinates into that synthetic frame before assigning the temporary GDAL raster offsets
- restore the finalized GDAL warp origin, scale, and skew back into PostGIS raster metadata, including grid-alignment adjustments made after the temporary projected extent is computed
- keep scale/skew adjustment branches in the same synthetic coordinate frame until the final conversion back to PostGIS raster metadata
- keep the temporary geotransform mutable for older GDAL C headers whose `GDALSetGeoTransform` argument is not const-qualified
- add regressions for the default-geotransform skew case from https://trac.osgeo.org/postgis/ticket/2924, including the non-cropped `11x11` result and grid-alignment verification
- add CUnit coverage for default-geotransform rasters with an explicit upper-left of `(0, 0)`
- add a 3.7.0 NEWS entry

## Maintenance Notes
- rebased on current Gitea `master` `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- current head: `e35ab73a452fe93bce6d0e2bc40271074fffd914`
- review threads are resolved
- GitHub Actions are queued for the pushed head
- local coverage was not regenerated; focused CUnit and raster regression validation passed

## Validation
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `make check-news`
- `git clang-format --diff upstream/master -- raster/rt_core/rt_warp.c raster/test/cunit/cu_gdal.c raster/test/regress/rt_gdalwarp.sql raster/test/regress/rt_gdalwarp_expected NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C raster/rt_core -j32`
- `make -C raster/test/cunit cu_tester -j32`
- `./raster/test/cunit/cu_tester gdal`
- `make -C raster/rt_pg -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C raster/rt_pg install`
- `sudo -n make -C extensions/postgis_raster install`
- `make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/raster/test/regress/rt_gdalwarp"`
- `make -C raster/test/regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/raster/test/regress/rt_gdalwarp"`

## Coverage
- Not run: lcov/coverage build.
