### PR TITLE
garden: store output logs as JSONB

### DIFF
--- a/doc/xsl/postgis_gardentest.sql.xsl
+++ b/doc/xsl/postgis_gardentest.sql.xsl
@@ -41,10 +41,10 @@
 		FROM (SELECT logid FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC limit 1) As foo
 		WHERE <xsl:value-of select="$var_logtable" />.logid = foo.logid  AND <xsl:value-of select="$var_logtable" />.log_end IS NULL;</xsl:variable>
 
-	<!-- for queries that result data, we first log the sql in our log table and then use query_to_xml to output it as xml for easy storage
-	    with this approach our run statement is always exactly the same -->
-	<xsl:variable name='var_logresultsasxml'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
-				SELECT logid, query_to_xml(log_sql, false,false,'') As log_output
+		<!-- for queries that result data, we first log the sql in our log table and then output it as jsonb for easy storage
+		    with this approach our run statement is always exactly the same -->
+	<xsl:variable name='var_logresultsasjsonb'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
+				SELECT logid, <xsl:value-of select="$var_logtable" />_query_to_jsonb(log_sql) As log_output
 				    FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC LIMIT 1;</xsl:variable>
 	<pgis:gardens>
 		<pgis:gset ID='POINT' GeometryType='POINT'>(SELECT ST_SetSRID(ST_Point(i,j),4326) As the_geom
@@ -366,7 +366,19 @@ FROM (VALUES ( ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON(((-71.0821 42.3036 2,-71.
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />;
 CREATE TABLE <xsl:value-of select="$var_logtable" />(logid serial PRIMARY KEY, log_label text, spatial_class text, func text, g1 text, g2 text, log_start timestamp, log_end timestamp, log_sql text);
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />_output;
-CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output xml);
+CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output jsonb);
+CREATE OR REPLACE FUNCTION <xsl:value-of select="$var_logtable" />_query_to_jsonb(query text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	result jsonb;
+BEGIN
+	EXECUTE format('SELECT COALESCE(jsonb_agg(to_jsonb(q)), ''[]''::jsonb) FROM (%s) AS q',
+		regexp_replace(query, ';\s*$', '')) INTO result;
+	RETURN result;
+END;
+$$;
 
                 <xsl:apply-templates select="/db:book/db:chapter[@xml:id='reference']" />
         </xsl:template>
@@ -424,7 +436,7 @@ SELECT '<xsl:value-of select="$log_label" /> Geometry index overlaps: Start Test
 INSERT INTO <xsl:value-of select="$var_logtable" />(log_label, func, g1, log_start, log_sql) VALUES('<xsl:value-of select="$log_label" /> gist index Geometry overlaps test','Gist index overlap', '<xsl:value-of select="@ID" />', clock_timestamp(),
     'SELECT count(*) As result FROM pgis_garden As foo1 INNER JOIN pgis_garden As foo2 ON foo1.the_geom &amp;&amp; foo2.the_geom');
 BEGIN;
-	<xsl:value-of select="$var_logresultsasxml" />
+	<xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 
@@ -535,7 +547,7 @@ SELECT '<xsl:value-of select="$log_label" /> Geography: End Testing';
 
 			SELECT 'Geography <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />: Start Testing <xsl:value-of select="$geom1id" />, <xsl:value-of select="@ID" />';
 			BEGIN;
-			    <xsl:value-of select="$var_logresultsasxml" />
+			    <xsl:value-of select="$var_logresultsasjsonb" />
 				<xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:when>
@@ -550,7 +562,7 @@ SELECT '<xsl:value-of select="$log_label" /> Geography: End Testing';
 						(foo1.the_geom <xsl:value-of select="$fnname" /> foo2.the_geom) = false;</xsl:with-param></xsl:call-template>');
 
 			BEGIN;
-				<xsl:value-of select="$var_logresultsasxml" />
+				<xsl:value-of select="$var_logresultsasjsonb" />
 				<xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:otherwise>
@@ -613,7 +625,7 @@ INSERT INTO <xsl:value-of select="$var_logtable" />(log_label, func, log_start, 
  <xsl:with-param name="arg1">SELECT  <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of select="$fnfakeparams" />) As output;</xsl:with-param></xsl:call-template>');
 
 BEGIN;
-    <xsl:value-of select="$var_logresultsasxml" />
+    <xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 SELECT  'Ending <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of select="$fnargs" />)';
@@ -632,7 +644,7 @@ SELECT  'Ending <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of s
 							FROM (<xsl:value-of select="." />) As foo1
 				LIMIT 10;</xsl:with-param></xsl:call-template>');
 BEGIN;
-    <xsl:value-of select="$var_logresultsasxml" />
+    <xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 			SELECT '<xsl:value-of select="$geoftype" /> <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />: End Testing';
@@ -658,7 +670,7 @@ SELECT '<xsl:value-of select="$fnname" /> <xsl:text> </xsl:text><xsl:value-of se
 			LIMIT 10;</xsl:with-param></xsl:call-template>');
 
 			BEGIN;
-				 <xsl:value-of select="$var_logresultsasxml" />
+				 <xsl:value-of select="$var_logresultsasjsonb" />
 				 <xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:when>
@@ -670,7 +682,7 @@ SELECT '<xsl:value-of select="$fnname" /> <xsl:text> </xsl:text><xsl:value-of se
 
 				SELECT 'Other <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />(<xsl:value-of select="$fnargs" />): Start Testing <xsl:value-of select="$geom1id" />, <xsl:value-of select="@GeometryType" />';
 				BEGIN;
-				 <xsl:value-of select="$var_logresultsasxml" />
+				 <xsl:value-of select="$var_logresultsasjsonb" />
 				 <xsl:value-of select="$var_logupdatesql" />
 				COMMIT;
 			  </xsl:otherwise>

--- a/doc/xsl/raster_gardentest.sql.xsl
+++ b/doc/xsl/raster_gardentest.sql.xsl
@@ -47,8 +47,8 @@
 		FROM (SELECT logid FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC limit 1) As foo
 		WHERE <xsl:value-of select="$var_logtable" />.logid = foo.logid  AND <xsl:value-of select="$var_logtable" />.log_end IS NULL;</xsl:variable>
 
-	<xsl:variable name='var_logresultsasxml'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
-				SELECT logid, query_to_xml(log_sql, false,false,'') As log_output
+	<xsl:variable name='var_logresultsasjsonb'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
+				SELECT logid, <xsl:value-of select="$var_logtable" />_query_to_jsonb(log_sql) As log_output
 				    FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC LIMIT 1;</xsl:variable>
 
 	<pgis:gardens>
@@ -132,7 +132,19 @@
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />;
 CREATE TABLE <xsl:value-of select="$var_logtable" />(logid serial PRIMARY KEY, log_label text, spatial_class text DEFAULT 'raster', func text, g1 text, g2 text, log_start timestamp, log_end timestamp, log_sql text);
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />_output;
-CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output xml);
+CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output jsonb);
+CREATE OR REPLACE FUNCTION <xsl:value-of select="$var_logtable" />_query_to_jsonb(query text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	result jsonb;
+BEGIN
+	EXECUTE format('SELECT COALESCE(jsonb_agg(to_jsonb(q)), ''[]''::jsonb) FROM (%s) AS q',
+		regexp_replace(query, ';\s*$', '')) INTO result;
+	RETURN result;
+END;
+$$;
 			<xsl:apply-templates select="/db:book/db:chapter[@xml:id='RT_reference']" />
 
         </xsl:template>
@@ -215,7 +227,7 @@ COMMIT;
 
 			BEGIN;
 				<!--  log query result to output table -->
-				<xsl:value-of select="$var_logresultsasxml" />
+				<xsl:value-of select="$var_logresultsasjsonb" />
 				<xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:when>
@@ -229,7 +241,7 @@ COMMIT;
 
 			BEGIN;
 				<!--  log query result to output table -->
-				<xsl:value-of select="$var_logresultsasxml" />
+				<xsl:value-of select="$var_logresultsasjsonb" />
 				<xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:otherwise>
@@ -299,7 +311,7 @@ INSERT INTO <xsl:value-of select="$var_logtable" />(log_label, func, log_start, 
 
 	BEGIN;
 		<!--  log query result to output table -->
-		<xsl:value-of select="$var_logresultsasxml" />
+		<xsl:value-of select="$var_logresultsasjsonb" />
 		<!-- log completion -->
 		<xsl:value-of select="$var_logupdatesql" />
 	COMMIT;
@@ -331,7 +343,7 @@ SELECT  'Ending <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of s
 
 		BEGIN;
 		<!--  log query result to output table -->
-		<xsl:value-of select="$var_logresultsasxml" />
+		<xsl:value-of select="$var_logresultsasjsonb" />
 			<!-- log completion -->
 		<xsl:value-of select="$var_logupdatesql" />
 		  COMMIT;

--- a/doc/xsl/sfcgal_gardentest.sql.xsl
+++ b/doc/xsl/sfcgal_gardentest.sql.xsl
@@ -41,10 +41,10 @@
 		FROM (SELECT logid FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC limit 1) As foo
 		WHERE <xsl:value-of select="$var_logtable" />.logid = foo.logid  AND <xsl:value-of select="$var_logtable" />.log_end IS NULL;</xsl:variable>
 
-	<!-- for queries that result data, we first log the sql in our log table and then use query_to_xml to output it as xml for easy storage
-	    with this approach our run statement is always exactly the same -->
-	<xsl:variable name='var_logresultsasxml'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
-				SELECT logid, query_to_xml(log_sql, false,false,'') As log_output
+		<!-- for queries that result data, we first log the sql in our log table and then output it as jsonb for easy storage
+		    with this approach our run statement is always exactly the same -->
+	<xsl:variable name='var_logresultsasjsonb'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
+				SELECT logid, <xsl:value-of select="$var_logtable" />_query_to_jsonb(log_sql) As log_output
 				    FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC LIMIT 1;</xsl:variable>
 	<pgis:gardens>
 		<pgis:gset ID='POINT' GeometryType='POINT'>(SELECT ST_SetSRID(ST_Point(i,j),4326) As the_geom
@@ -361,7 +361,19 @@ FROM (VALUES ( ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON(((-71.0821 42.3036 2,-71.
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />;
 CREATE TABLE <xsl:value-of select="$var_logtable" />(logid serial PRIMARY KEY, log_label text, spatial_class text, func text, g1 text, g2 text, log_start timestamp, log_end timestamp, log_sql text);
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />_output;
-CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output xml);
+CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output jsonb);
+CREATE OR REPLACE FUNCTION <xsl:value-of select="$var_logtable" />_query_to_jsonb(query text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	result jsonb;
+BEGIN
+	EXECUTE format('SELECT COALESCE(jsonb_agg(to_jsonb(q)), ''[]''::jsonb) FROM (%s) AS q',
+		regexp_replace(query, ';\s*$', '')) INTO result;
+	RETURN result;
+END;
+$$;
 
                 <xsl:apply-templates select="/db:book/db:chapter[@xml:id='reference_sfcgal']" />
         </xsl:template>
@@ -419,7 +431,7 @@ SELECT '<xsl:value-of select="$log_label" /> Geometry index overlaps: Start Test
 INSERT INTO <xsl:value-of select="$var_logtable" />(log_label, func, g1, log_start, log_sql) VALUES('<xsl:value-of select="$log_label" /> gist index Geometry overlaps test','Gist index overlap', '<xsl:value-of select="@ID" />', clock_timestamp(),
     'SELECT count(*) As result FROM pgis_garden As foo1 INNER JOIN pgis_garden As foo2 ON foo1.the_geom &amp;&amp; foo2.the_geom');
 BEGIN;
-	<xsl:value-of select="$var_logresultsasxml" />
+	<xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 
@@ -530,7 +542,7 @@ SELECT '<xsl:value-of select="$log_label" /> Geography: End Testing';
 
 			SELECT 'Geography <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />: Start Testing <xsl:value-of select="$geom1id" />, <xsl:value-of select="@ID" />';
 			BEGIN;
-			    <xsl:value-of select="$var_logresultsasxml" />
+			    <xsl:value-of select="$var_logresultsasjsonb" />
 				<xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:when>
@@ -545,7 +557,7 @@ SELECT '<xsl:value-of select="$log_label" /> Geography: End Testing';
 						(foo1.the_geom <xsl:value-of select="$fnname" /> foo2.the_geom) = false;</xsl:with-param></xsl:call-template>');
 
 			BEGIN;
-				<xsl:value-of select="$var_logresultsasxml" />
+				<xsl:value-of select="$var_logresultsasjsonb" />
 				<xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:otherwise>
@@ -608,7 +620,7 @@ INSERT INTO <xsl:value-of select="$var_logtable" />(log_label, func, log_start, 
  <xsl:with-param name="arg1">SELECT  <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of select="$fnfakeparams" />) As output;</xsl:with-param></xsl:call-template>');
 
 BEGIN;
-    <xsl:value-of select="$var_logresultsasxml" />
+    <xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 SELECT  'Ending <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of select="$fnargs" />)';
@@ -627,7 +639,7 @@ SELECT  'Ending <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of s
 							FROM (<xsl:value-of select="." />) As foo1
 				LIMIT 10;</xsl:with-param></xsl:call-template>');
 BEGIN;
-    <xsl:value-of select="$var_logresultsasxml" />
+    <xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 			SELECT '<xsl:value-of select="$geoftype" /> <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />: End Testing';
@@ -653,7 +665,7 @@ SELECT '<xsl:value-of select="$fnname" /> <xsl:text> </xsl:text><xsl:value-of se
 			LIMIT 10;</xsl:with-param></xsl:call-template>');
 
 			BEGIN;
-				 <xsl:value-of select="$var_logresultsasxml" />
+				 <xsl:value-of select="$var_logresultsasjsonb" />
 				 <xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:when>
@@ -665,7 +677,7 @@ SELECT '<xsl:value-of select="$fnname" /> <xsl:text> </xsl:text><xsl:value-of se
 
 				SELECT 'Other <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />(<xsl:value-of select="$fnargs" />): Start Testing <xsl:value-of select="$geom1id" />, <xsl:value-of select="@GeometryType" />';
 				BEGIN;
-				 <xsl:value-of select="$var_logresultsasxml" />
+				 <xsl:value-of select="$var_logresultsasjsonb" />
 				 <xsl:value-of select="$var_logupdatesql" />
 				COMMIT;
 			  </xsl:otherwise>

--- a/doc/xsl/topology_gardentest.sql.xsl
+++ b/doc/xsl/topology_gardentest.sql.xsl
@@ -44,10 +44,10 @@
 		FROM (SELECT logid FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC limit 1) As foo
 		WHERE <xsl:value-of select="$var_logtable" />.logid = foo.logid  AND <xsl:value-of select="$var_logtable" />.log_end IS NULL;</xsl:variable>
 
-	<!-- for queries that result data, we first log the sql in our log table and then use query_to_xml to output it as xml for easy storage
-	    with this approach our run statement is always exactly the same -->
-	<xsl:variable name='var_logresultsasxml'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
-				SELECT logid, query_to_xml(log_sql, false,false,'') As log_output
+		<!-- for queries that result data, we first log the sql in our log table and then output it as jsonb for easy storage
+		    with this approach our run statement is always exactly the same -->
+	<xsl:variable name='var_logresultsasjsonb'>INSERT INTO <xsl:value-of select="$var_logtable" />_output(logid, log_output)
+				SELECT logid, <xsl:value-of select="$var_logtable" />_query_to_jsonb(log_sql) As log_output
 				    FROM <xsl:value-of select="$var_logtable" /> ORDER BY logid DESC LIMIT 1;</xsl:variable>
 	<pgis:gardens>
 		<pgis:gset ID='POINT' GeometryType='POINT' createtable="true">(SELECT ST_SetSRID(ST_Point(i,j),4326) As the_geom
@@ -364,7 +364,19 @@ FROM (VALUES ( ST_GeomFromEWKT('SRID=4326;MULTIPOLYGON(((-71.0821 42.3036 2,-71.
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />;
 CREATE TABLE <xsl:value-of select="$var_logtable" />(logid serial PRIMARY KEY, log_label text, spatial_class text, func text, g1 text, g2 text, log_start timestamp, log_end timestamp, log_sql text);
 DROP TABLE IF EXISTS <xsl:value-of select="$var_logtable" />_output;
-CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output xml);
+CREATE TABLE <xsl:value-of select="$var_logtable" />_output(logid integer PRIMARY KEY, log_output jsonb);
+CREATE OR REPLACE FUNCTION <xsl:value-of select="$var_logtable" />_query_to_jsonb(query text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	result jsonb;
+BEGIN
+	EXECUTE format('SELECT COALESCE(jsonb_agg(to_jsonb(q)), ''[]''::jsonb) FROM (%s) AS q',
+		regexp_replace(query, ';\s*$', '')) INTO result;
+	RETURN result;
+END;
+$$;
 
             <xsl:apply-templates select="/db:book/db:chapter[@xml:id='Topology']" />
         </xsl:template>
@@ -469,7 +481,7 @@ INSERT INTO <xsl:value-of select="$var_logtable" />(log_label, func, log_start, 
  <xsl:with-param name="arg1">SELECT  <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of select="$fnfakeparams" />) As output;</xsl:with-param></xsl:call-template>');
 
 BEGIN;
-    <xsl:value-of select="$var_logresultsasxml" />
+    <xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 SELECT  'Ending <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of select="$fnargs" />)';
@@ -488,7 +500,7 @@ SELECT  'Ending <xsl:value-of select="db:funcdef/db:function" />(<xsl:value-of s
 							FROM (<xsl:value-of select="." />) As foo1
 				LIMIT 10;</xsl:with-param></xsl:call-template>');
 BEGIN;
-    <xsl:value-of select="$var_logresultsasxml" />
+    <xsl:value-of select="$var_logresultsasjsonb" />
 	<xsl:value-of select="$var_logupdatesql" />
 COMMIT;
 			SELECT '<xsl:value-of select="$geoftype" /> <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />: End Testing';
@@ -514,7 +526,7 @@ SELECT '<xsl:value-of select="$fnname" /> <xsl:text> </xsl:text><xsl:value-of se
 			LIMIT 10;</xsl:with-param></xsl:call-template>');
 
 			BEGIN;
-				 <xsl:value-of select="$var_logresultsasxml" />
+				 <xsl:value-of select="$var_logresultsasjsonb" />
 				 <xsl:value-of select="$var_logupdatesql" />
 			COMMIT;
 			</xsl:when>
@@ -526,7 +538,7 @@ SELECT '<xsl:value-of select="$fnname" /> <xsl:text> </xsl:text><xsl:value-of se
 
 				SELECT 'Other <xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of select="@ID" />(<xsl:value-of select="$fnargs" />): Start Testing <xsl:value-of select="$geom1id" />, <xsl:value-of select="@GeometryType" />';
 				BEGIN;
-				 <xsl:value-of select="$var_logresultsasxml" />
+				 <xsl:value-of select="$var_logresultsasjsonb" />
 				 <xsl:value-of select="$var_logupdatesql" />
 				COMMIT;
 			  </xsl:otherwise>


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/3610

## Summary
- Switch generated garden `_output.log_output` columns from `xml` to `jsonb`.
- Replace generated `query_to_xml(...)` calls with per-log-table helpers that execute the stored SQL and aggregate result rows using `jsonb_agg(to_jsonb(...))`.
- Apply the change consistently to the PostGIS, Raster, SFCGAL, and Topology garden generators.

## Current branch
- Base: `postgis/postgis` `master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- Head: `c48d6024c3fa2228bc2ebd69cec9214c1892e96c`

## Validation
- `make -C doc garden`
- `make -C doc check-xml`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- Regenerated garden SQL smoke checks:
  - each generated garden file emits one `log_output jsonb` table definition
  - generated files contain `query_to_jsonb` and `jsonb_agg(to_jsonb(...))`
  - generated files contain no `query_to_xml`
- Disposable PostgreSQL database smoke test for the generated JSONB helper shape:
  - multiple result rows become a JSONB array
  - empty result sets become `[]`

I did not run the full `make garden` suite locally; the GitHub garden CI check has been queued for this refreshed head.
