### PR TITLE
#3472 Add ST_AsX3D collection fragment option

### DIFF
--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1594,7 +1594,7 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
         <para>Below is how we currently map PostGIS 2D/3D types to X3D types</para>
     </note>
 
-        <para>The 'options' argument is a bitfield that denotes whether to represent coordinates with the X3D GeoCoordinates geospatial node and whether to flip the x/y axis.  By default, <code>ST_AsX3D</code> outputs in database form (long,lat or X,Y), but the X3D default of lat/lon, y/x may be preferred.</para>
+        <para>The 'options' argument is a bitfield that denotes whether to represent coordinates with the X3D GeoCoordinates geospatial node, whether to flip the x/y axis, and whether GeometryCollection members should be emitted as geometry nodes without enclosing Shape tags.  By default, <code>ST_AsX3D</code> outputs in database form (long,lat or X,Y), but the X3D default of lat/lon, y/x may be preferred.</para>
 
         <itemizedlist>
             <listitem>
@@ -1608,6 +1608,10 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
             <listitem>
               <para>2: Output coordinates in GeoSpatial GeoCoordinates.  This option will throw an error if geometries are not in WGS 84 long lat (srid: 4326). This is currently the only GeoCoordinate type supported.  <link xlink:href="http://www.web3d.org/documents/specifications/19775-1/V3.2/Part01/components/geodata.html#Specifyingaspatialreference">Refer to X3D specs specifying a spatial reference system.</link>. Default output will be <code>GeoCoordinate geoSystem='"GD" "WE" "longitude_first"'</code>.  If
               you prefer the X3D default of  <code>GeoCoordinate geoSystem='"GD" "WE" "latitude_first"'</code> use <code>(2 + 1)</code> = <code>3</code> </para>
+            </listitem>
+
+            <listitem>
+              <para>4: For GeometryCollection output, omit the default Shape wrappers around child geometry nodes.</para>
             </listitem>
         </itemizedlist>
 
@@ -1644,7 +1648,7 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
             </row>
             <row>
             <entry>(MULTI) POLYGON, POLYHEDRALSURFACE</entry>
-            <entry>Invalid X3D markup</entry>
+            <entry>IndexedFaceSet with Z set to 0</entry>
             <entry>IndexedFaceSet (inner rings currently output as another faceset)</entry>
             </row>
             <row>
@@ -1661,6 +1665,7 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
     <para>Also check out <link xlink:href="https://git.osgeo.org/gitea/robe/postgis_x3d_viewer">PostGIS minimalist X3D viewer</link>  that utilizes this function and <link xlink:href="http://www.x3dom.org/">x3dDom html/js open source toolkit</link>.</para>
     <para role="availability" conformance="2.0.0">Availability: 2.0.0: ISO-IEC-19776-1.2-X3DEncodings-XML</para>
     <para role="enhanced" conformance="2.2.0">Enhanced: 2.2.0: Support for GeoCoordinates and axis (x/y, long/lat) flipping.  Look at options for details.</para>
+    <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0: Option 4 can emit GeometryCollection child geometry nodes without Shape wrappers.</para>
     <!-- Optionally mention 3d support -->
     <para>&Z_support;</para>
         <!-- Optionally mention supports Polyhedral Surface  -->

--- a/liblwgeom/cunit/cu_out_x3d.c
+++ b/liblwgeom/cunit/cu_out_x3d.c
@@ -151,6 +151,20 @@ static void out_x3d3_test_geoms(void)
 	    0,
 	    0);
 
+	/* 2D PolyhedralSurface still needs 3D Coordinate tuples */
+	do_x3d3_test(
+	    "POLYHEDRALSURFACE(((0 0,0 1,1 1,0 0)))",
+	    "<IndexedFaceSet convex='false'  coordIndex='0 1 2'><Coordinate point='0 0 0 0 1 0 1 1 0' /></IndexedFaceSet>",
+	    0,
+	    0);
+
+	/* GeometryCollection */
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1 3),LINESTRING(2 3 3,4 5 3))",
+	    "<Shape>0 1 3</Shape><Shape><LineSet  vertexCount='2'><Coordinate point='2 3 3 4 5 3' /></LineSet></Shape>",
+	    0,
+	    0);
+
 	/* TODO:  Implement Empty GeometryCollection correctly or throw a not-implemented */
 	/** do_x3d3_test(
 	    "GEOMETRYCOLLECTION EMPTY",
@@ -188,6 +202,42 @@ static void out_x3d3_test_option(void)
 	    "SRID=4326;POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"latitude_first\"' point='10 15 3 6.464 13.536 3 5 10 3 6.464 6.464 3 10 5 3 13.536 6.464 3 15 10 3 13.536 13.536 3 ' /></IndexedFaceSet>",
 	    3, 3);
+
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1 3),LINESTRING(2 3 3,4 5 3))",
+	    "<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <LineSet  vertexCount='2'><Coordinate point='2 3 3 4 5 3' /></LineSet>",
+	    0,
+	    LW_X3D_SKIP_COLLECTION_SHAPES);
+
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1 3),POINT(2 3 4))",
+	    "<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <PointSet ><Coordinate point='2 3 4 ' /></PointSet>",
+	    0,
+	    LW_X3D_SKIP_COLLECTION_SHAPES);
+
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1 3),POLYGON((2 3 3,4 5 3,6 7 3,2 3 3)))",
+	    "<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <IndexedFaceSet  convex='false' coordIndex='0 1 2'><Coordinate point='2 3 3 4 5 3 6 7 3 ' /></IndexedFaceSet>",
+	    0,
+	    LW_X3D_SKIP_COLLECTION_SHAPES);
+
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1),POLYGON((2 3,4 5,6 7,2 3)))",
+	    "<Polypoint2D  point='0 1 ' /> <IndexedFaceSet  convex='false' coordIndex='0 1 2'><Coordinate point='2 3 0 4 5 0 6 7 0 ' /></IndexedFaceSet>",
+	    0,
+	    LW_X3D_SKIP_COLLECTION_SHAPES);
+
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1),LINESTRING(2 3,4 5))",
+	    "<Polypoint2D  point='0 1 ' /> <LineSet  vertexCount='2'><Coordinate point='2 3 0 4 5 0' /></LineSet>",
+	    0,
+	    LW_X3D_SKIP_COLLECTION_SHAPES);
+
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1 3),GEOMETRYCOLLECTION(LINESTRING(2 3 3,4 5 3)))",
+	    "<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <LineSet  vertexCount='2'><Coordinate point='2 3 3 4 5 3' /></LineSet>",
+	    0,
+	    LW_X3D_SKIP_COLLECTION_SHAPES);
 }
 
 

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1749,7 +1749,10 @@ LWCOLLECTION* lwgeom_clip_to_ordinate_range(const LWGEOM *lwin, char ordinate, d
 /** For flip X/Y coordinates to Y/X */
 #define LW_X3D_FLIP_XY     (1<<0)
 #define LW_X3D_USE_GEOCOORDS     (1<<1)
+/** For GeometryCollection, output child geometry nodes without Shape wrappers */
+#define LW_X3D_SKIP_COLLECTION_SHAPES     (1<<2)
 #define X3D_USE_GEOCOORDS(x) ((x) & LW_X3D_USE_GEOCOORDS)
+#define X3D_SKIP_COLLECTION_SHAPES(x) ((x) & LW_X3D_SKIP_COLLECTION_SHAPES)
 
 
 

--- a/liblwgeom/lwout_x3d.c
+++ b/liblwgeom/lwout_x3d.c
@@ -74,7 +74,7 @@ lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid
 		return asx3d3_point_sb((LWPOINT *)geom, precision, opts, defid, sb);
 
 	case LINETYPE:
-		return asx3d3_line_sb((LWLINE *)geom, precision, opts, defid, sb);
+		return asx3d3_line_sb((LWLINE *)geom, precision, opts, defid, 0, sb);
 
 	case POLYGONTYPE:
 	{
@@ -223,6 +223,7 @@ asx3d3_line_sb(const LWLINE *line,
 	       int precision,
 	       int opts,
 	       __attribute__((__unused__)) const char *defid,
+	       int force_3d,
 	       stringbuffer_t *sb)
 {
 
@@ -253,13 +254,14 @@ asx3d3_poly_sb(const LWPOLY *poly,
 	       int opts,
 	       __attribute__((__unused__)) int is_patch,
 	       __attribute__((__unused__)) const char *defid,
+	       int force_3d,
 	       stringbuffer_t *sb)
 {
 	uint32_t i;
 	for (i=0; i<poly->nrings; i++)
 	{
 		if (i) stringbuffer_aprintf(sb, " "); /* inner ring points start */
-		ptarray_to_x3d3_sb(poly->rings[i], precision, opts, 1, LW_TRUE, sb);
+		ptarray_to_x3d3_sb(poly->rings[i], precision, opts, 1, force_3d, sb);
 	}
 	return LW_SUCCESS;
 }
@@ -352,7 +354,14 @@ asx3d3_multi_sb(const LWCOLLECTION *col, int precision, int opts, const char *de
 		}
 		else if (subgeom->type == POLYGONTYPE)
 		{
-			asx3d3_poly_sb((LWPOLY *)subgeom, precision, opts, 0, defid, sb);
+			LWPOLY *poly = (LWPOLY *)subgeom;
+			uint32_t j;
+			for (j = 0; j < poly->nrings; j++)
+			{
+				if (j)
+					stringbuffer_aprintf(sb, " ");
+				ptarray_to_x3d3_sb(poly->rings[j], precision, opts, 1, has_coordinate_node, sb);
+			}
 			stringbuffer_aprintf(sb, " ");
 		}
 	}
@@ -409,7 +418,7 @@ asx3d3_psurface_sb(const LWPSURFACE *psur, int precision, int opts, const char *
 
 	for (i=0; i<psur->ngeoms; i++)
 	{
-		asx3d3_poly_sb(psur->geoms[i], precision, opts, 1, defid, sb);
+		asx3d3_poly_sb(psur->geoms[i], precision, opts, 1, defid, 1, sb);
 		if (i < (psur->ngeoms - 1) )
 		{
 			stringbuffer_aprintf(sb, " "); /* only add a trailing space if its not the last polygon in the set */
@@ -465,6 +474,7 @@ asx3d3_collection_sb(const LWCOLLECTION *col, int precision, int opts, const cha
 {
 	uint32_t i;
 	LWGEOM *subgeom;
+	int wrap_shapes = !X3D_SKIP_COLLECTION_SHAPES(opts);
 
 	/* Open outmost tag */
 	/** @TODO: if collection should be grouped, we'll wrap in a group tag.  Still needs cleanup
@@ -476,14 +486,24 @@ asx3d3_collection_sb(const LWCOLLECTION *col, int precision, int opts, const cha
 	for (i=0; i<col->ngeoms; i++)
 	{
 		subgeom = col->geoms[i];
-		stringbuffer_aprintf(sb, "<Shape%s>", defid);
+		if (wrap_shapes)
+			stringbuffer_aprintf(sb, "<Shape%s>", defid);
+		else if (i > 0)
+			stringbuffer_aprintf(sb, " ");
 		if ( subgeom->type == POINTTYPE )
 		{
-			asx3d3_point_sb((LWPOINT *)subgeom, precision, opts, defid, sb);
+			if (wrap_shapes)
+				asx3d3_point_sb((LWPOINT *)subgeom, precision, opts, defid, sb);
+			else
+			{
+				LWCOLLECTION *tmp = (LWCOLLECTION *)lwgeom_as_multi(subgeom);
+				asx3d3_multi_sb(tmp, precision, opts, defid, sb);
+				lwcollection_free(tmp);
+			}
 		}
-		else if ( subgeom->type == LINETYPE )
+		else if (subgeom->type == LINETYPE)
 		{
-			asx3d3_line_sb((LWLINE *)subgeom, precision, opts, defid, sb);
+			asx3d3_line_sb((LWLINE *)subgeom, precision, opts, defid, !wrap_shapes, sb);
 		}
 		else if ( subgeom->type == POLYGONTYPE )
 		{
@@ -509,7 +529,8 @@ asx3d3_collection_sb(const LWCOLLECTION *col, int precision, int opts, const cha
 		else
 			lwerror("asx3d3_collection_buf: unknown geometry type");
 
-		stringbuffer_aprintf(sb, "</Shape>");
+		if (wrap_shapes)
+			stringbuffer_aprintf(sb, "</Shape>");
 	}
 
 	/* Close outmost tag */
@@ -546,9 +567,9 @@ ptarray_to_x3d3_sb(POINTARRAY *pa, int precision, int opts, int is_closed, int f
 				if ( i ) stringbuffer_append_len(sb," ",1);
 
 				if ( ( opts & LW_X3D_FLIP_XY) )
-					stringbuffer_aprintf(sb, "%s %s", y, x);
+					stringbuffer_aprintf(sb, force_3d ? "%s %s 0" : "%s %s", y, x);
 				else
-					stringbuffer_aprintf(sb, "%s %s", x, y);
+					stringbuffer_aprintf(sb, force_3d ? "%s %s 0" : "%s %s", x, y);
 			}
 		}
 	}

--- a/liblwgeom/lwout_x3d.h
+++ b/liblwgeom/lwout_x3d.h
@@ -35,7 +35,8 @@
 static int lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid, stringbuffer_t *sb);
 
 static int asx3d3_point_sb(const LWPOINT *point, int precision, int opts, const char *defid, stringbuffer_t *sb);
-static int asx3d3_line_sb(const LWLINE *line, int precision, int opts, const char *defid, stringbuffer_t *sb);
+static int
+asx3d3_line_sb(const LWLINE *line, int precision, int opts, const char *defid, int force_3d, stringbuffer_t *sb);
 
 static int
 asx3d3_triangle_sb(const LWTRIANGLE *triangle, int precision, int opts, const char *defid, stringbuffer_t *sb);

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -819,6 +819,23 @@ SELECT '#2424', ST_AsText(ST_SnapToGrid(ST_CurveToLine(
 
 SELECT '#2427', st_astext(st_pointn(ST_CurveToLine('CIRCULARSTRING(-1 0,0 1,0 -1)'),1));
 
+SELECT '#3472.1', ST_AsX3D(
+  'GEOMETRYCOLLECTION(POINT(0 1 3),LINESTRING(2 3 3,4 5 3))'::geometry, 0);
+SELECT '#3472.2', ST_AsX3D(
+  'GEOMETRYCOLLECTION(POINT(0 1 3),LINESTRING(2 3 3,4 5 3))'::geometry, 0, 4);
+SELECT '#3472.3', ST_AsX3D(
+  'GEOMETRYCOLLECTION(POINT(0 1 3),POINT(2 3 4))'::geometry, 0, 4);
+SELECT '#3472.4', ST_AsX3D(
+  'GEOMETRYCOLLECTION(POINT(0 1 3),POLYGON((2 3 3,4 5 3,6 7 3,2 3 3)))'::geometry, 0, 4);
+SELECT '#3472.5', ST_AsX3D(
+  'GEOMETRYCOLLECTION(POINT(0 1),POLYGON((2 3,4 5,6 7,2 3)))'::geometry, 0, 4);
+SELECT '#3472.6', ST_AsX3D(
+  'GEOMETRYCOLLECTION(POINT(0 1),LINESTRING(2 3,4 5))'::geometry, 0, 4);
+SELECT '#3472.7', ST_AsX3D(
+  'GEOMETRYCOLLECTION(POINT(0 1 3),GEOMETRYCOLLECTION(LINESTRING(2 3 3,4 5 3)))'::geometry, 0, 4);
+SELECT '#3472.8', ST_AsX3D(
+  'POLYHEDRALSURFACE(((0 0,0 1,1 1,0 0)))'::geometry, 0);
+
 SELECT '#2168',  ST_Distance(g1,g2)::numeric(16,8)  As dist_g1_g2, ST_Distance(g2,g1)::numeric(16,8) AS dist_g2_g1,ST_Distance(g1,g2) - ST_Distance(g2,g1)
   FROM (SELECT 'POINT(18.5107234 54.7587757)'::geography As g1, 'POINT(18.58218 54.7344227)'::geography As g2) As a;
 

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -259,6 +259,14 @@ CURVEPOLYGON(COMPOUNDCURVE((1070163.61 711540.35,1070166.54 711523.82,1070164.14
 #2423|POLYGON((-10 0,-9.239 3.827,-7.071 7.071,-3.827 9.239,0 10,3.827 9.239,7.071 7.071,9.239 3.827,10 0,-10 0))
 #2424|MULTILINESTRING((0 0,10 0,24 3,30 10))
 #2427|POINT(-1 0)
+#3472.1|<Shape>0 1 3</Shape><Shape><LineSet  vertexCount='2'><Coordinate point='2 3 3 4 5 3' /></LineSet></Shape>
+#3472.2|<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <LineSet  vertexCount='2'><Coordinate point='2 3 3 4 5 3' /></LineSet>
+#3472.3|<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <PointSet ><Coordinate point='2 3 4 ' /></PointSet>
+#3472.4|<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <IndexedFaceSet  convex='false' coordIndex='0 1 2'><Coordinate point='2 3 3 4 5 3 6 7 3 ' /></IndexedFaceSet>
+#3472.5|<Polypoint2D  point='0 1 ' /> <IndexedFaceSet  convex='false' coordIndex='0 1 2'><Coordinate point='2 3 0 4 5 0 6 7 0 ' /></IndexedFaceSet>
+#3472.6|<Polypoint2D  point='0 1 ' /> <LineSet  vertexCount='2'><Coordinate point='2 3 0 4 5 0' /></LineSet>
+#3472.7|<PointSet ><Coordinate point='0 1 3 ' /></PointSet> <LineSet  vertexCount='2'><Coordinate point='2 3 3 4 5 3' /></LineSet>
+#3472.8|<IndexedFaceSet convex='false'  coordIndex='0 1 2'><Coordinate point='0 0 0 0 1 0 1 1 0' /></IndexedFaceSet>
 #2168|5340.76237395|5340.76237395|0
 #2556|47409|20623
 #2556|1|0


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/3472.

## Summary

- add `ST_AsX3D` option bit 4 to omit `GeometryCollection` `Shape` wrappers for fragment embedding
- keep the default `GeometryCollection` output unchanged
- force 3D coordinate tuples for 2D geometry emitted inside X3D `Coordinate` elements, including 2D `POLYHEDRALSURFACE`
- cover the option with CUnit, SQL regression output, documentation, and `NEWS`

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `855c674239125b086ae60a749cee16f2d2497b5c`.
- The remaining current PolyhedralSurface review thread is addressed by making `asx3d3_psurface_sb()` call `asx3d3_poly_sb()` with forced 3D coordinate tuples, plus matching CUnit and `tickets` regression coverage for 2D `POLYHEDRALSURFACE` output with `Z=0` triples.
- Preserves the newer Trac ticket 2838 X3D fixes during rebase: default collection polygon output still uses an indexed face node, and 2D line/polygon `Coordinate` output still emits `Z=0`.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- liblwgeom/cunit/cu_out_x3d.c liblwgeom/lwout_x3d.c liblwgeom/lwout_x3d.h liblwgeom/liblwgeom.h.in regress/core/tickets.sql regress/core/tickets_expected doc/reference_output.xml NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `./liblwgeom/cunit/cu_tester x3d_output`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C doc check-xml`
