### PR TITLE
Preserve raster_columns ACLs during upgrade

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -115,6 +115,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GH-899, [raster] Honor PostgreSQL interrupts in long-running GDAL
           progress callbacks (Darafei Praliaskouski)
  - #2386, Add missing raster2pgsql man page (Darafei Praliaskouski)
+ - #2823, [raster] Preserve raster_columns privileges across upgrades
+          (Darafei Praliaskouski)
  - #5975, Initialize skipped union-find cluster ids deterministically
           (Darafei Praliaskouski)
  - #5904, [topology] Avoid MinGW format warnings when logging topology ids

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -8934,4 +8934,71 @@ CREATE OR REPLACE FUNCTION postgis_noop(raster)
 -- make views public viewable --
 GRANT SELECT ON TABLE raster_columns TO public;
 GRANT SELECT ON TABLE raster_overviews TO public;
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+	acl_payload json;
+	acl_payload_text text;
+	grant_sql text;
+	rec record;
+BEGIN
+	acl_payload_text := current_setting('postgis.restore_raster_columns_acl', true);
+
+	IF acl_payload_text IS NULL OR acl_payload_text = 'POSTGIS_MISSING' THEN
+		RETURN;
+	END IF;
+
+	acl_payload := acl_payload_text::json;
+
+	-- Replay saved grants under their original grantors so PostgreSQL also
+	-- restores pg_shdepend ACL dependencies for referenced roles.
+	REVOKE ALL PRIVILEGES ON TABLE raster_columns FROM public;
+
+	FOR rec IN
+		SELECT
+			NULL::text AS attname,
+			grantor,
+			grantee,
+			privilege_type,
+			is_grantable
+		FROM pg_catalog.aclexplode((acl_payload->>'relacl')::aclitem[])
+		UNION ALL
+		SELECT
+			att.value->>'attname' AS attname,
+			acl.grantor,
+			acl.grantee,
+			acl.privilege_type,
+			acl.is_grantable
+		FROM json_array_elements(acl_payload->'attacl') AS att(value)
+			CROSS JOIN pg_catalog.aclexplode((att.value->>'attacl')::aclitem[]) AS acl
+		ORDER BY is_grantable DESC
+	LOOP
+		IF rec.grantee = 0 THEN
+			grant_sql := 'public';
+		ELSE
+			grant_sql := quote_ident(pg_get_userbyid(rec.grantee));
+		END IF;
+
+		IF rec.attname IS NULL THEN
+			grant_sql := format(
+				'GRANT %s ON TABLE raster_columns TO %s%s',
+				rec.privilege_type,
+				grant_sql,
+				CASE WHEN rec.is_grantable THEN ' WITH GRANT OPTION' ELSE '' END
+			);
+		ELSE
+			grant_sql := format(
+				'GRANT %s (%I) ON TABLE raster_columns TO %s%s',
+				rec.privilege_type,
+				rec.attname,
+				grant_sql,
+				CASE WHEN rec.is_grantable THEN ' WITH GRANT OPTION' ELSE '' END
+			);
+		END IF;
+
+		EXECUTE format('SET LOCAL ROLE %I', pg_get_userbyid(rec.grantor));
+		EXECUTE grant_sql;
+		RESET ROLE;
+	END LOOP;
+END
+$$;
 COMMIT;

--- a/raster/rt_pg/rtpostgis_upgrade_cleanup.sql.in
+++ b/raster/rt_pg/rtpostgis_upgrade_cleanup.sql.in
@@ -385,6 +385,38 @@ SELECT _rename_raster_tables();
 DROP FUNCTION _rename_raster_tables();
 
 -- inserted new column into view
+DO $postgis_upgrade$
+DECLARE
+	raster_columns_acl text;
+BEGIN
+	SELECT CASE
+			WHEN c.oid IS NULL THEN 'POSTGIS_MISSING'
+			ELSE json_build_object(
+				'relacl', c.relacl::text,
+				'attacl', COALESCE((
+					SELECT json_agg(json_build_object(
+						'attname', a.attname,
+						'attacl', a.attacl::text
+					) ORDER BY a.attnum)
+					FROM pg_catalog.pg_attribute a
+					WHERE a.attrelid = c.oid
+						AND a.attnum > 0
+						AND NOT a.attisdropped
+						AND a.attacl IS NOT NULL
+				), '[]'::json)
+			)::text
+		END INTO raster_columns_acl
+	FROM pg_catalog.pg_class c
+	WHERE c.oid = to_regclass('raster_columns')
+		AND c.relkind = 'v';
+
+	PERFORM set_config(
+		'postgis.restore_raster_columns_acl',
+		COALESCE(raster_columns_acl, 'POSTGIS_MISSING'),
+		true
+	);
+END
+$postgis_upgrade$;
 DROP VIEW IF EXISTS raster_columns;
 
 -- functions no longer supported

--- a/raster/test/regress/hooks/hook-after-upgrade-raster.sql
+++ b/raster/test/regress/hooks/hook-after-upgrade-raster.sql
@@ -8,5 +8,81 @@ DROP TABLE upgrade_test_raster_with_regular_blocking;
 DROP VIEW upgrade_test_raster_view_st_slope;
 DROP VIEW upgrade_test_raster_view_st_aspect;
 
+-- See https://trac.osgeo.org/postgis/ticket/2823
+DO $$
+DECLARE
+	column_acl_preserved boolean;
+	grantor_acl_preserved boolean;
+	grantee_dependency_preserved boolean;
+	public_has_select boolean;
+BEGIN
+	IF NOT has_table_privilege('upgrade_test_raster_acl_user', current_schema() || '.raster_columns', 'SELECT') THEN
+		RAISE EXCEPTION 'raster_columns SELECT grant was not preserved';
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM pg_class c
+		CROSS JOIN aclexplode(c.relacl) AS acl
+		WHERE c.oid = (current_schema() || '.raster_columns')::regclass
+			AND acl.grantee = 0
+			AND acl.privilege_type = 'SELECT'
+	) INTO public_has_select;
+
+	IF public_has_select THEN
+		RAISE EXCEPTION 'raster_columns public SELECT grant was unexpectedly restored';
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM pg_catalog.pg_class c
+		CROSS JOIN aclexplode(c.relacl) AS acl
+		WHERE c.oid = (current_schema() || '.raster_columns')::regclass
+			AND acl.grantor = 'upgrade_test_raster_acl_grantor'::regrole
+			AND acl.grantee = 'upgrade_test_raster_acl_user'::regrole
+			AND acl.privilege_type = 'SELECT'
+	) INTO grantor_acl_preserved;
+
+	IF NOT grantor_acl_preserved THEN
+		RAISE EXCEPTION 'raster_columns SELECT grantor was not preserved';
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM pg_catalog.pg_attribute a
+		CROSS JOIN aclexplode(a.attacl) AS acl
+		WHERE a.attrelid = (current_schema() || '.raster_columns')::regclass
+			AND a.attname = 'r_table_name'
+			AND acl.grantor = 'upgrade_test_raster_acl_grantor'::regrole
+			AND acl.grantee = 'upgrade_test_raster_acl_user'::regrole
+			AND acl.privilege_type = 'SELECT'
+	) INTO column_acl_preserved;
+
+	IF NOT column_acl_preserved THEN
+		RAISE EXCEPTION 'raster_columns column SELECT grant was not preserved';
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM pg_catalog.pg_shdepend d
+		WHERE d.dbid = (SELECT oid FROM pg_catalog.pg_database WHERE datname = current_database())
+			AND d.classid = 'pg_catalog.pg_class'::regclass
+			AND d.objid = (current_schema() || '.raster_columns')::regclass
+			AND d.refclassid = 'pg_catalog.pg_authid'::regclass
+			AND d.refobjid = 'upgrade_test_raster_acl_user'::regrole
+			AND d.deptype = 'a'
+	) INTO grantee_dependency_preserved;
+
+	IF NOT grantee_dependency_preserved THEN
+		RAISE EXCEPTION 'raster_columns ACL dependency was not preserved';
+	END IF;
+
+	GRANT SELECT ON TABLE raster_columns TO public;
+	REVOKE SELECT (r_table_name) ON TABLE raster_columns FROM upgrade_test_raster_acl_user;
+	REVOKE ALL ON TABLE raster_columns FROM upgrade_test_raster_acl_user;
+	REVOKE ALL ON TABLE raster_columns FROM upgrade_test_raster_acl_grantor CASCADE;
+END
+$$;
+
 -- Drop deprecated functions
 \i :regdir/hooks/drop-deprecated-functions.sql

--- a/raster/test/regress/hooks/hook-before-upgrade-raster.sql
+++ b/raster/test/regress/hooks/hook-before-upgrade-raster.sql
@@ -71,3 +71,33 @@ CREATE VIEW upgrade_test_raster_view_st_aspect AS
 SELECT
 	st_aspect(NULL::raster, NULL::int, NULL::raster) sig1,
 	st_aspect(NULL::raster) sig2;
+
+-- See https://trac.osgeo.org/postgis/ticket/2823
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_roles
+		WHERE rolname = 'upgrade_test_raster_acl_grantor'
+	) THEN
+		CREATE ROLE upgrade_test_raster_acl_grantor;
+	END IF;
+
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_roles
+		WHERE rolname = 'upgrade_test_raster_acl_user'
+	) THEN
+		CREATE ROLE upgrade_test_raster_acl_user;
+	END IF;
+
+	REVOKE ALL ON TABLE raster_columns FROM upgrade_test_raster_acl_user;
+	REVOKE ALL ON TABLE raster_columns FROM upgrade_test_raster_acl_grantor CASCADE;
+	REVOKE ALL ON TABLE raster_columns FROM public;
+	GRANT SELECT ON TABLE raster_columns TO upgrade_test_raster_acl_grantor WITH GRANT OPTION;
+	SET LOCAL ROLE upgrade_test_raster_acl_grantor;
+	GRANT SELECT ON TABLE raster_columns TO upgrade_test_raster_acl_user;
+	GRANT SELECT (r_table_name) ON TABLE raster_columns TO upgrade_test_raster_acl_user;
+	RESET ROLE;
+END
+$$;


### PR DESCRIPTION
Closes [Trac #2823](https://trac.osgeo.org/postgis/ticket/2823).

## Summary

- preserve existing `raster_columns` privileges across raster upgrade scripts even though the view is dropped and recreated
- save relation-level and column-level ACL payloads before upgrade cleanup drops the old view
- replay saved relation and column grants under their original grantors after recreating `raster_columns`
- let PostgreSQL maintain `pg_shdepend` ACL dependencies through normal `GRANT` execution instead of directly updating catalog ACL arrays
- keep the generated public grant as the install default, but replace it with the saved ACL when an upgrade captured one
- add raster upgrade hook coverage for revoked `PUBLIC`, delegated table grantor, column-level ACL preservation, and restored ACL dependency tracking

## Maintenance

- rebased onto `a4ecc46176c3fc0ab3fa69cf117d408bc622e592`
- no Gitea mirror PR was found for this branch
- the previous broad CI failures were stale loader expectation failures (`LongOptions` / `TestANALYZE`) on the old base; the branch-specific `check_raster_columns` regression was passing there and passes after rebase

## Validation

- `make -C postgis -j32`
- `make -C raster/rt_pg -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C raster/rt_pg install`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_raster install`
- `make -C raster/test/regress check RUNTESTFLAGS='--upgrade --extension --verbose' TESTS="$(pwd)/raster/test/regress/check_raster_columns"`
- `make -C raster/test/regress check RUNTESTFLAGS="--upgrade --extension --verbose --after-create-db-script $(pwd)/regress/hooks/standard-conforming-strings-off.sql" TESTS="$(pwd)/raster/test/regress/check_raster_columns"`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
