### PR TITLE
Improve point-only GeometryCollection predicate fast paths (#4749)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,6 +57,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Sandro Santilli)
  - #3743, [raster] Document and test raster2pgsql -s FROM_SRID:SRID
           reprojection support (Darafei Praliaskouski)
+ - #4749, Use point-in-polygon predicate fast paths for point-only
+          GeometryCollections (Darafei Praliaskouski)
 
 * Bug Fixes *
 

--- a/postgis/lwgeom_geos_predicates.c
+++ b/postgis/lwgeom_geos_predicates.c
@@ -18,12 +18,12 @@
  *
  **********************************************************************
  *
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  * Copyright 2009-2014 Sandro Santilli <strk@kbt.io>
  * Copyright 2008 Paul Ramsey <pramsey@cleverelephant.ca>
  * Copyright 2001-2003 Refractions Research Inc.
  *
  **********************************************************************/
-
 
 #include "../postgis_config.h"
 
@@ -73,20 +73,98 @@ is_poly(const GSERIALIZED *g)
 }
 
 /*
- * Utility to quickly check for point geometries
+ * Cheap type gate for geometries that may become point-like.
  */
 static inline uint8_t
-is_point(const GSERIALIZED *g)
+is_point_or_collection(const GSERIALIZED *g)
 {
 	int type = gserialized_get_type(g);
-	return type == POINTTYPE || type == MULTIPOINTTYPE;
+	return type == POINTTYPE || type == MULTIPOINTTYPE || type == COLLECTIONTYPE;
 }
 
+/* Avoid homogenizing mixed collections just to discover that PIP cannot use them. */
+static uint8_t
+lwgeom_is_pointlike(const LWGEOM *lwgeom)
+{
+	const LWCOLLECTION *lwcol;
+	uint32_t i;
 
+	if (lwgeom->type == POINTTYPE || lwgeom->type == MULTIPOINTTYPE)
+		return LW_TRUE;
 
+	if (lwgeom->type != COLLECTIONTYPE)
+		return LW_FALSE;
 
+	lwcol = (const LWCOLLECTION *)lwgeom;
+	if (lwcol->ngeoms == 0)
+		return LW_FALSE;
 
+	for (i = 0; i < lwcol->ngeoms; i++)
+	{
+		if (!lwgeom_is_pointlike(lwcol->geoms[i]))
+			return LW_FALSE;
+	}
 
+	return LW_TRUE;
+}
+
+/*
+ * Return an owned point/multipoint LWGEOM for direct point inputs or for
+ * GeometryCollections whose children are all points.
+ */
+static LWGEOM *
+pointlike_lwgeom_from_gserialized(const GSERIALIZED *g)
+{
+	int type = gserialized_get_type(g);
+	LWGEOM *lwgeom;
+	LWGEOM *hgeom;
+
+	if (type == POINTTYPE || type == MULTIPOINTTYPE)
+		return lwgeom_from_gserialized(g);
+
+	if (type != COLLECTIONTYPE)
+		return NULL;
+
+	lwgeom = lwgeom_from_gserialized(g);
+	if (!lwgeom_is_pointlike(lwgeom))
+	{
+		lwgeom_free(lwgeom);
+		return NULL;
+	}
+
+	hgeom = lwgeom_homogenize(lwgeom);
+	lwgeom_free(lwgeom);
+
+	if (!hgeom)
+		return NULL;
+
+	if (hgeom->type == POINTTYPE || hgeom->type == MULTIPOINTTYPE)
+		return hgeom;
+
+	lwgeom_free(hgeom);
+	return NULL;
+}
+
+typedef bool (*itree_pip_predicate)(const IntervalTree *itree, const LWGEOM *lwpoints);
+
+static bool
+try_itree_pointlike_pip(FunctionCallInfo fcinfo,
+			const GSERIALIZED *gpoints,
+			SHARED_GSERIALIZED *shared_gpoly,
+			itree_pip_predicate predicate,
+			bool *result)
+{
+	LWGEOM *lwpt = pointlike_lwgeom_from_gserialized(gpoints);
+	IntervalTree *itree;
+
+	if (!lwpt)
+		return false;
+
+	itree = GetIntervalTree(fcinfo, shared_gpoly);
+	*result = predicate(itree, lwpt);
+	lwgeom_free(lwpt);
+	return true;
+}
 
 PG_FUNCTION_INFO_V1(ST_Intersects);
 Datum ST_Intersects(PG_FUNCTION_ARGS)
@@ -98,6 +176,7 @@ Datum ST_Intersects(PG_FUNCTION_ARGS)
 	int8_t result;
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
+	bool pip_result;
 
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
@@ -117,20 +196,18 @@ Datum ST_Intersects(PG_FUNCTION_ARGS)
 	}
 
 	/*
-	 * Short-circuit 2: if the geoms are a point and a polygon,
-	 * call the itree_pip_intersects function.
+	 * Short-circuit 2: if one geometry is polygonal and the other is a
+	 * point or point-only collection, use the IntervalTree PIP fast path.
 	 */
-	if ((is_point(geom1) && is_poly(geom2)) ||
-	    (is_point(geom2) && is_poly(geom1)))
+	if (is_point_or_collection(geom1) && is_poly(geom2) &&
+	    try_itree_pointlike_pip(fcinfo, geom1, shared_geom2, itree_pip_intersects, &pip_result))
 	{
-		SHARED_GSERIALIZED *shared_gpoly = is_poly(geom1) ? shared_geom1 : shared_geom2;
-		SHARED_GSERIALIZED *shared_gpoint = is_point(geom1) ? shared_geom1 : shared_geom2;
-		const GSERIALIZED *gpoint = shared_gserialized_get(shared_gpoint);
-		LWGEOM *lwpt = lwgeom_from_gserialized(gpoint);
-		IntervalTree *itree = GetIntervalTree(fcinfo, shared_gpoly);
-		bool result = itree_pip_intersects(itree, lwpt);
-		lwgeom_free(lwpt);
-		PG_RETURN_BOOL(result);
+		PG_RETURN_BOOL(pip_result);
+	}
+	else if (is_point_or_collection(geom2) && is_poly(geom1) &&
+		 try_itree_pointlike_pip(fcinfo, geom2, shared_geom1, itree_pip_intersects, &pip_result))
+	{
+		PG_RETURN_BOOL(pip_result);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -504,6 +581,7 @@ Datum contains(PG_FUNCTION_ARGS)
 	GEOSGeometry *g1, *g2;
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
+	bool pip_result;
 
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
@@ -525,17 +603,13 @@ Datum contains(PG_FUNCTION_ARGS)
 	}
 
 	/*
-	** Short-circuit 2: if geom2 is a point and geom1 is a polygon
-	** call the point-in-polygon function.
+	** Short-circuit 2: if geom1 is polygonal and geom2 is a point
+	** or point-only collection, use the IntervalTree PIP fast path.
 	*/
-	if (is_poly(geom1) && is_point(geom2))
+	if (is_poly(geom1) && is_point_or_collection(geom2) &&
+	    try_itree_pointlike_pip(fcinfo, geom2, shared_geom1, itree_pip_contains, &pip_result))
 	{
-		const GSERIALIZED *gpoint = shared_gserialized_get(shared_geom2);
-		LWGEOM *lwpt = lwgeom_from_gserialized(gpoint);
-		IntervalTree *itree = GetIntervalTree(fcinfo, shared_geom1);
-		bool result = itree_pip_contains(itree, lwpt);
-		lwgeom_free(lwpt);
-		PG_RETURN_BOOL(result);
+		PG_RETURN_BOOL(pip_result);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -585,6 +659,7 @@ Datum within(PG_FUNCTION_ARGS)
 	GEOSGeometry *g1, *g2;
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
+	bool pip_result;
 
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
@@ -606,17 +681,13 @@ Datum within(PG_FUNCTION_ARGS)
 	}
 
 	/*
-	** Short-circuit 2: if geom2 is a polygon and geom1 is a point
-	** call the point-in-polygon function.
+	** Short-circuit 2: if geom2 is polygonal and geom1 is a point
+	** or point-only collection, use the IntervalTree PIP fast path.
 	*/
-	if (is_poly(geom2) && is_point(geom1))
+	if (is_poly(geom2) && is_point_or_collection(geom1) &&
+	    try_itree_pointlike_pip(fcinfo, geom1, shared_geom2, itree_pip_contains, &pip_result))
 	{
-		const GSERIALIZED *gpoint = shared_gserialized_get(shared_geom1);
-		LWGEOM *lwpt = lwgeom_from_gserialized(gpoint);
-		IntervalTree *itree = GetIntervalTree(fcinfo, shared_geom2);
-		bool result = itree_pip_contains(itree, lwpt);
-		lwgeom_free(lwpt);
-		PG_RETURN_BOOL(result);
+		PG_RETURN_BOOL(pip_result);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -729,6 +800,7 @@ Datum covers(PG_FUNCTION_ARGS)
 	int8_t result;
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
+	bool pip_result;
 
 	POSTGIS_DEBUGF(3, "Covers: type1: %d, type2: %d", gserialized_get_type(geom1), gserialized_get_type(geom2));
 
@@ -751,17 +823,13 @@ Datum covers(PG_FUNCTION_ARGS)
 		}
 	}
 	/*
-	 * Short-circuit 2: if geom2 is a point and geom1 is a polygon
-	 * call the point-in-polygon function.
+	 * Short-circuit 2: if geom1 is polygonal and geom2 is a point
+	 * or point-only collection, use the IntervalTree PIP fast path.
 	 */
-	if (is_poly(geom1) && is_point(geom2))
+	if (is_poly(geom1) && is_point_or_collection(geom2) &&
+	    try_itree_pointlike_pip(fcinfo, geom2, shared_geom1, itree_pip_covers, &pip_result))
 	{
-		const GSERIALIZED *gpoint = shared_gserialized_get(shared_geom2);
-		LWGEOM *lwpt = lwgeom_from_gserialized(gpoint);
-		IntervalTree *itree = GetIntervalTree(fcinfo, shared_geom1);
-		bool result = itree_pip_covers(itree, lwpt);
-		lwgeom_free(lwpt);
-		PG_RETURN_BOOL(result);
+		PG_RETURN_BOOL(pip_result);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -813,6 +881,7 @@ Datum coveredby(PG_FUNCTION_ARGS)
 	int8_t result;
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
+	bool pip_result;
 
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
@@ -835,17 +904,13 @@ Datum coveredby(PG_FUNCTION_ARGS)
 		}
 	}
 	/*
-	 * Short-circuit 2: if geom1 is a point and geom2 is a polygon
-	 * call the point-in-polygon function.
+	 * Short-circuit 2: if geom2 is polygonal and geom1 is a point
+	 * or point-only collection, use the IntervalTree PIP fast path.
 	 */
-	if (is_point(geom1) && is_poly(geom2))
+	if (is_point_or_collection(geom1) && is_poly(geom2) &&
+	    try_itree_pointlike_pip(fcinfo, geom1, shared_geom2, itree_pip_covers, &pip_result))
 	{
-		const GSERIALIZED *gpoint = shared_gserialized_get(shared_geom1);
-		IntervalTree *itree = GetIntervalTree(fcinfo, shared_geom2);
-		LWGEOM *lwpt = lwgeom_from_gserialized(gpoint);
-		bool result = itree_pip_covers(itree, lwpt);
-		lwgeom_free(lwpt);
-		PG_RETURN_BOOL(result);
+		PG_RETURN_BOOL(pip_result);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1243,6 +1243,72 @@ SELECT 'equals212', ST_equals('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))'::geometry
 SELECT 'equals213', ST_equals('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))'::geometry,
 'GEOMETRYCOLLECTION (POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)),MULTIPOINT(0 2, 5 5))'::geometry);
 
+-- #4749 point-only GeometryCollections in polygon predicates use the PIP path
+WITH g AS (
+	SELECT
+		'POLYGON((0 0,0 10,10 10,10 0,0 0))'::geometry AS poly,
+		'GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(5 5)),MULTIPOINT((7 7),(8 8)))'::geometry AS pts_inside,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(0 0))'::geometry AS pts_boundary,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(11 11))'::geometry AS pts_outside
+)
+SELECT '#4749.contains',
+	ST_Contains(poly, pts_inside),
+	ST_Contains(poly, pts_boundary),
+	ST_Contains(poly, pts_outside)
+FROM g;
+
+WITH g AS (
+	SELECT
+		'POLYGON((0 0,0 10,10 10,10 0,0 0))'::geometry AS poly,
+		'GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(5 5)),MULTIPOINT((7 7),(8 8)))'::geometry AS pts_inside,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(0 0))'::geometry AS pts_boundary,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(11 11))'::geometry AS pts_outside
+)
+SELECT '#4749.within',
+	ST_Within(pts_inside, poly),
+	ST_Within(pts_boundary, poly),
+	ST_Within(pts_outside, poly)
+FROM g;
+
+WITH g AS (
+	SELECT
+		'POLYGON((0 0,0 10,10 10,10 0,0 0))'::geometry AS poly,
+		'GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(5 5)),MULTIPOINT((7 7),(8 8)))'::geometry AS pts_inside,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(0 0))'::geometry AS pts_boundary,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(11 11))'::geometry AS pts_outside
+)
+SELECT '#4749.covers',
+	ST_Covers(poly, pts_inside),
+	ST_Covers(poly, pts_boundary),
+	ST_Covers(poly, pts_outside)
+FROM g;
+
+WITH g AS (
+	SELECT
+		'POLYGON((0 0,0 10,10 10,10 0,0 0))'::geometry AS poly,
+		'GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(5 5)),MULTIPOINT((7 7),(8 8)))'::geometry AS pts_inside,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(0 0))'::geometry AS pts_boundary,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(11 11))'::geometry AS pts_outside
+)
+SELECT '#4749.coveredby',
+	ST_CoveredBy(pts_inside, poly),
+	ST_CoveredBy(pts_boundary, poly),
+	ST_CoveredBy(pts_outside, poly)
+FROM g;
+
+WITH g AS (
+	SELECT
+		'POLYGON((0 0,0 10,10 10,10 0,0 0))'::geometry AS poly,
+		'GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(5 5)),MULTIPOINT((7 7),(8 8)))'::geometry AS pts_inside,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(0 0))'::geometry AS pts_boundary,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(11 11))'::geometry AS pts_outside
+)
+SELECT '#4749.intersects',
+	ST_Intersects(poly, pts_inside),
+	ST_Intersects(pts_boundary, poly),
+	ST_Intersects(poly, pts_outside)
+FROM g;
+
 -- #4299
 SELECT '#4299', ST_Disjoint(ST_GeneratePoints(g, 1000), ST_GeneratePoints(g, 1000))
 FROM (SELECT 'POLYGON((0 0,1 0,1 1,0 1,0 0))'::geometry AS g) AS f;

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -383,6 +383,11 @@ equals210|t
 equals211|t
 equals212|t
 equals213|t
+#4749.contains|t|t|f
+#4749.within|t|t|f
+#4749.covers|t|t|f
+#4749.coveredby|t|t|f
+#4749.intersects|t|t|t
 #4299|t
 #4304|t|t|t
 ERROR:  BOX3D_construct: args can not be empty points


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/4749

## Summary

Improves the polygon-vs-point predicate fast paths for the simple point-only `GEOMETRYCOLLECTION` case from https://trac.osgeo.org/postgis/ticket/4749.

This adds an internal helper that first rejects mixed or non-point collections recursively, then homogenizes only point-side `GEOMETRYCOLLECTION` inputs when they reduce to `POINT` or `MULTIPOINT`. The existing point-in-polygon interval-tree predicates are then used for:

- `ST_Intersects`
- `ST_Contains`
- `ST_Within`
- `ST_Covers`
- `ST_CoveredBy`

The patch intentionally does not homogenize polygon-side GeometryCollections or mixed-dimension collections before GEOS. A valid polygon GeometryCollection can homogenize into an invalid MultiPolygon, so doing that inside every predicate would change semantics beyond this narrow fast-path improvement.

NEWS includes a #4749 enhancement entry. This addresses one simple handled case in https://trac.osgeo.org/postgis/ticket/4749, but it does not close the full ticket.

## Validation

- `git diff --check gitea/master..HEAD`
- `git clang-format --diff gitea/master -- postgis/lwgeom_geos_predicates.c`
- `make -C postgis -j32`
- `sudo -n make -C postgis install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/regress/core/tickets"`; passed normal and automatic upgrade reruns
- Coverage attempt: rebuilt with `CC=gcc CFLAGS='-g -O0 --coverage' LDFLAGS='--coverage' ./configure --enable-debug --with-jsondir=/usr --with-projdir=/usr --without-raster --with-topology --without-sfcgal --without-protobuf --without-json` and reran the focused regression. The local tree could not produce a trustworthy fresh `lcov` report because PostgreSQL bitcode installation regenerates Clang `.gcno` files over GCC native coverage notes while runtime `.gcda` data is not emitted for the installed shared library in this setup. The focused regression coverage path itself was exercised; previous current-head coverage on the same test slice reported `lwgeom_geos_predicates.c` at 82.1% lines and 100.0% functions.
