### PR TITLE
doc: validate manual with DocBook XMLSchema

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           reprojection support (Darafei Praliaskouski)
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections (Darafei Praliaskouski)
+ - #5532, Validate the manual against DocBook XMLSchema in check-xml
+          (Darafei Praliaskouski)
 
 * Bug Fixes *
 

--- a/configure.ac
+++ b/configure.ac
@@ -398,6 +398,19 @@ fi
 AC_SUBST([DOCBOOK5_RNG])
 
 dnl
+dnl Ensure DocBook XMLSchema can be found
+dnl
+DOCBOOK5_XSD=http://docbook.org/xml/5.0/xsd/docbook.xsd
+if test "x$XMLCATALOG" = "x"; then
+  DOCBOOK5_XSD=
+else
+  if $XMLCATALOG '' "${DOCBOOK5_XSD}" > /dev/null; then :
+  else DOCBOOK5_XSD=
+  fi
+fi
+AC_SUBST([DOCBOOK5_XSD])
+
+dnl
 dnl Ensure DocBook DTD can be found
 dnl
 DOCBOOK5_DTD=http://docbook.org/xml/5.0/rng/docbook.dtd

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -64,6 +64,7 @@ XMLCATALOG=@XMLCATALOG@
 XSLTPROC=@XSLTPROC@
 XSLBASE=@XSLBASE@
 DOCBOOK5_RNG=@DOCBOOK5_RNG@
+DOCBOOK5_XSD=@DOCBOOK5_XSD@
 DOCBOOK5_DTD=@DOCBOOK5_DTD@
 CAN_UPDATE_TRANSLATIONS=@CAN_UPDATE_TRANSLATIONS@
 XMLLINT=@XMLLINT@
@@ -284,6 +285,11 @@ CAN_CHECK_XML = no
 endif
 
 ifeq ($(DOCBOOK5_RNG),)
+CAN_CHECK_XML = no
+endif
+
+ifeq ($(DOCBOOK5_XSD),)
+check-xml: requirements_not_met_docbook5_xsd
 CAN_CHECK_XML = no
 endif
 
@@ -624,6 +630,9 @@ check-xml: postgis-out.xml
 		--valid --loaddtd \
 		--relaxng $(DOCBOOK5_RNG) \
 		$<
+	$(XMLLINT) --noout --nonet \
+		--schema $(DOCBOOK5_XSD) \
+		$<
 
 check-cheatsheets: cheatsheets
 	for f in $(html_builddir)/*_cheatsheet-en.html; do \
@@ -654,6 +663,13 @@ requirements_not_met_xmlcatalog:
 	@echo "configure was unable to find 'xmlcatalog' which is required"
 	@echo "to check the postgis documentation."
 	@echo "Install xmlcatalog and then re-run configure."
+	@echo
+	@false
+
+requirements_not_met_docbook5_xsd:
+	@echo
+	@echo "configure was unable to locate DocBook XMLSchema (docbook.xsd)."
+	@echo "Install DocBook 5 schemas/catalog entries and then re-run configure."
 	@echo
 	@false
 

--- a/doc/README
+++ b/doc/README
@@ -68,7 +68,8 @@ Make targets
   XML files. See ``make check-localized``
 
 ``make check``
-  check structural correctness of XML documentation
+  check structural correctness of XML documentation with DocBook DTD,
+  RelaxNG, and XMLSchema validation
 
 ``make check-localized``
   check structural correctness of localized (translated)


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/5532

## Summary

- Detect the DocBook 5 XMLSchema through `xmlcatalog` during configure.
- Make `doc/check-xml` validate `postgis-out.xml` with XMLSchema after the existing DTD and RelaxNG checks.
- Give direct `make check-xml` a clear unmet-requirement error when DocBook XMLSchema is unavailable.
- Document the expanded validation in `doc/README` and add a `NEWS` entry.

## Testing

- `./autogen.sh`
- `./configure --without-raster --without-topology --without-sfcgal --without-protobuf --without-json`
- `make -C doc check-xml`
- `make -C doc check-xml DOCBOOK5_XSD=` exits non-zero with:
  `configure was unable to locate DocBook XMLSchema (docbook.xsd).`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git clang-format --diff upstream/master -- configure.ac doc/Makefile.in doc/README NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`

Coverage is not applicable: this change only extends the documentation validation target.
