### PR TITLE
Add ST_FilterHolesByArea

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -150,6 +150,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - ST_CoverageEdges, returns MultiLinestring of distinct shared edges in
           polygonal coverage (Paul Ramsey)
  - ST_MinimumSpanningTree, window function to calculate MST (Paul Ramsey)
+ - #5996, ST_FilterHolesByArea removes polygon holes below an area threshold
+          (Darafei Praliaskouski)
  - #5993, [topology] Add max_edges parameter to TopoGeo_AddLinestring
           (Sandro Santilli)
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)

--- a/doc/reference_editor.xml
+++ b/doc/reference_editor.xml
@@ -1808,6 +1808,57 @@ view       | POLYGON((12 12,12 18,18 18,18 12,12 12))</screen>
 
 	</refentry>
 
+	<refentry xml:id="ST_FilterHolesByArea">
+	  <refnamediv>
+		<refname>ST_FilterHolesByArea</refname>
+		<refpurpose>Removes polygon interior rings with an area below a threshold.</refpurpose>
+	  </refnamediv>
+
+	  <refsynopsisdiv>
+		<funcsynopsis>
+		  <funcprototype>
+			<funcdef>geometry <function>ST_FilterHolesByArea</function></funcdef>
+			<paramdef><type>geometry </type> <parameter>geom</parameter></paramdef>
+			<paramdef><type>double precision </type> <parameter>minArea</parameter></paramdef>
+		  </funcprototype>
+		</funcsynopsis>
+	  </refsynopsisdiv>
+
+	  <refsection>
+		<title>Description</title>
+
+		<para>Returns a <xref linkend="geometry"/> with interior rings removed from polygonal components when the ring area is smaller than <parameter>minArea</parameter>.</para>
+		<para>The function evaluates <varname>POLYGON</varname> and <varname>CURVEPOLYGON</varname> components, including components inside collection types. Exterior rings and non-polygonal components remain unchanged.</para>
+		<para>For curved rings, area is evaluated with the same curve linearization used by <xref linkend="ST_Area"/>.</para>
+		<para><parameter>minArea</parameter> is measured in square coordinate-system units of the geometry.</para>
+
+		<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+	  </refsection>
+
+	  <refsection>
+		<title>Examples</title>
+
+		<programlisting>
+			SELECT ST_AsText(
+				ST_FilterHolesByArea(
+					ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),
+						(1 1, 2 1, 2 2, 1 2, 1 1),
+						(4 4, 8 4, 8 8, 4 8, 4 4))'),
+					2.0::float8));
+
+		st_astext
+		---------
+			POLYGON((0 0,10 0,10 10,0 10,0 0),(4 4,8 4,8 8,4 8,4 4))
+		</programlisting>
+
+	  </refsection>
+
+	  <refsection>
+		<title>See Also</title>
+		<para><xref linkend="ST_Area"/>, <xref linkend="ST_RemoveSmallParts"/></para>
+	  </refsection>
+	</refentry>
+
 	<refentry xml:id="ST_Reverse">
 	  <refnamediv>
 		<refname>ST_Reverse</refname>

--- a/doc/reference_editor.xml
+++ b/doc/reference_editor.xml
@@ -1838,18 +1838,13 @@ view       | POLYGON((12 12,12 18,18 18,18 12,12 12))</screen>
 	  <refsection>
 		<title>Examples</title>
 
-		<programlisting>
-			SELECT ST_AsText(
+		<programlisting>SELECT ST_AsText(
 				ST_FilterHolesByArea(
 					ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),
 						(1 1, 2 1, 2 2, 1 2, 1 1),
 						(4 4, 8 4, 8 8, 4 8, 4 4))'),
-					2.0::float8));
-
-		st_astext
-		---------
-			POLYGON((0 0,10 0,10 10,0 10,0 0),(4 4,8 4,8 8,4 8,4 4))
-		</programlisting>
+					2.0::float8));</programlisting>
+<screen>POLYGON((0 0,10 0,10 10,0 10,0 0),(4 4,8 4,8 8,4 8,4 4))</screen>
 
 	  </refsection>
 

--- a/postgis/lwgeom_remove_small_parts.c
+++ b/postgis/lwgeom_remove_small_parts.c
@@ -19,11 +19,14 @@
  **********************************************************************
  *
  * Copyright (C) 2024 Sam Peters <gluser1357@gmx.de>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
 #include "postgres.h"
 #include "funcapi.h"
+#include <math.h>
+#include <string.h>
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -224,6 +227,150 @@ Datum ST_RemoveSmallParts(PG_FUNCTION_ARGS) {
 	}
 
 	// recompute bbox if computed previously (may result in NULL)
+	lwgeom_drop_bbox(geom);
+	lwgeom_add_bbox(geom);
+
+	serialized_out = gserialized_from_lwgeom(geom, 0);
+	lwgeom_free(geom);
+
+	PG_FREE_IF_COPY(serialized_in, 0);
+	PG_RETURN_POINTER(serialized_out);
+}
+
+static int
+lwpoly_filter_holes_by_area(LWPOLY *polygon, double min_area)
+{
+	uint32_t i, iw;
+
+	if (!polygon || polygon->nrings <= 1)
+		return LW_FALSE;
+
+	iw = 1;
+	for (i = 1; i < polygon->nrings; i++)
+	{
+		const double ring_area = fabs(ptarray_signed_area(polygon->rings[i]));
+
+		if (ring_area >= min_area)
+			polygon->rings[iw++] = polygon->rings[i];
+		else
+			ptarray_free(polygon->rings[i]);
+	}
+
+	if (iw == polygon->nrings)
+		return LW_FALSE;
+
+	polygon->nrings = iw;
+	return LW_TRUE;
+}
+
+static double
+lwcurvepoly_ring_area(const LWCURVEPOLY *curvepoly, LWGEOM *ring)
+{
+	LWGEOM *rings[1] = {ring};
+	LWCURVEPOLY ringpoly;
+
+	/*
+	 * Curved ring area is measured through the same stroking path as ST_Area,
+	 * so the filtering threshold has the same semantics users already see.
+	 */
+	memset(&ringpoly, 0, sizeof(LWCURVEPOLY));
+	ringpoly.type = CURVEPOLYTYPE;
+	ringpoly.flags = curvepoly->flags;
+	ringpoly.srid = curvepoly->srid;
+	ringpoly.nrings = 1;
+	ringpoly.maxrings = 1;
+	ringpoly.rings = rings;
+
+	return fabs(lwcurvepoly_area(&ringpoly));
+}
+
+static int
+lwcurvepoly_filter_holes_by_area(LWCURVEPOLY *curvepoly, double min_area)
+{
+	uint32_t i, iw;
+
+	if (!curvepoly || curvepoly->nrings <= 1)
+		return LW_FALSE;
+
+	iw = 1;
+	for (i = 1; i < curvepoly->nrings; i++)
+	{
+		const double ring_area = lwcurvepoly_ring_area(curvepoly, curvepoly->rings[i]);
+
+		if (ring_area >= min_area)
+			curvepoly->rings[iw++] = curvepoly->rings[i];
+		else
+			lwgeom_free(curvepoly->rings[i]);
+	}
+
+	if (iw == curvepoly->nrings)
+		return LW_FALSE;
+
+	curvepoly->nrings = iw;
+	return LW_TRUE;
+}
+
+static int
+lwgeom_filter_holes_by_area(LWGEOM *geom, double min_area)
+{
+	uint32_t i;
+	int changed = LW_FALSE;
+
+	if (!geom)
+		return LW_FALSE;
+
+	switch (geom->type)
+	{
+	case POLYGONTYPE:
+		return lwpoly_filter_holes_by_area((LWPOLY *)geom, min_area);
+	case CURVEPOLYTYPE:
+		return lwcurvepoly_filter_holes_by_area((LWCURVEPOLY *)geom, min_area);
+	default:
+		if (lwgeom_is_collection(geom))
+		{
+			LWCOLLECTION *collection = (LWCOLLECTION *)geom;
+			for (i = 0; i < collection->ngeoms; i++)
+				changed |= lwgeom_filter_holes_by_area(collection->geoms[i], min_area);
+		}
+		return changed;
+	}
+}
+
+PG_FUNCTION_INFO_V1(ST_FilterHolesByArea);
+Datum
+ST_FilterHolesByArea(PG_FUNCTION_ARGS)
+{
+	double min_area;
+	GSERIALIZED *serialized_in;
+	GSERIALIZED *serialized_out;
+	LWGEOM *geom;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+
+	min_area = PG_GETARG_FLOAT8(1);
+
+	/*
+	 * NaN would make every ring-area comparison false, removing all holes.
+	 * Infinite thresholds are rejected for the same reason: callers should use
+	 * a finite area cutoff whose comparison semantics are explicit.
+	 */
+	if (!isfinite(min_area))
+		elog(ERROR, "ST_FilterHolesByArea: area threshold must be finite");
+
+	serialized_in = (GSERIALIZED *)PG_DETOAST_DATUM_COPY(PG_GETARG_DATUM(0));
+
+	if (min_area <= 0)
+		PG_RETURN_POINTER(serialized_in);
+
+	geom = lwgeom_from_gserialized(serialized_in);
+
+	if (!lwgeom_filter_holes_by_area(geom, min_area))
+	{
+		lwgeom_free(geom);
+		PG_RETURN_POINTER(serialized_in);
+	}
+
 	lwgeom_drop_bbox(geom);
 	lwgeom_add_bbox(geom);
 

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -7382,6 +7382,15 @@ AS 'MODULE_PATHNAME','ST_RemoveSmallParts'
 LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_MEDIUM;
 
+-----------------------------------------------------------------------
+-- ST_FilterHolesByArea
+-----------------------------------------------------------------------
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_FilterHolesByArea(geometry, double precision)
+RETURNS geometry
+AS 'MODULE_PATHNAME','ST_FilterHolesByArea'
+LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_MEDIUM;
 
 #include "postgis_nurbs.sql.in"
 

--- a/regress/core/filter_holes_by_area.sql
+++ b/regress/core/filter_holes_by_area.sql
@@ -1,0 +1,54 @@
+SELECT 1, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1), (4 4, 8 4, 8 8, 4 8, 4 4))'),
+    2.0::float8));
+
+SELECT 2, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)), ((20 0, 30 0, 30 10, 20 10, 20 0), (21 1, 25 1, 25 5, 21 5, 21 1)))'),
+    2.0::float8));
+
+SELECT 3, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('CURVEPOLYGON((0 0, 10 0, 10 10, 0 10, 0 0), CIRCULARSTRING(1 1, 2 2, 3 1, 2 0, 1 1), CIRCULARSTRING(5 5, 7 7, 9 5, 7 3, 5 5))'),
+    4.0::float8));
+
+SELECT 4, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1), POLYGON((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)))'),
+    2.0::float8));
+
+SELECT 5, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'),
+    0.0::float8));
+
+SELECT 6, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('LINESTRING(0 0, 1 1)'),
+    2.0::float8));
+
+SELECT 7, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'),
+    1.0::float8));
+
+SELECT 8, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'),
+    -1.0::float8));
+
+SELECT 9, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'),
+    'NaN'::float8));
+
+SELECT 10, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'),
+    'Infinity'::float8));
+
+SELECT 11, ST_AsText(
+    ST_FilterHolesByArea(
+    ST_GeomFromText('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))'),
+    '-Infinity'::float8));

--- a/regress/core/filter_holes_by_area_expected
+++ b/regress/core/filter_holes_by_area_expected
@@ -1,0 +1,11 @@
+1|POLYGON((0 0,10 0,10 10,0 10,0 0),(4 4,8 4,8 8,4 8,4 4))
+2|MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)),((20 0,30 0,30 10,20 10,20 0),(21 1,25 1,25 5,21 5,21 1)))
+3|CURVEPOLYGON((0 0,10 0,10 10,0 10,0 0),CIRCULARSTRING(5 5,7 7,9 5,7 3,5 5))
+4|GEOMETRYCOLLECTION(POINT(1 1),POLYGON((0 0,5 0,5 5,0 5,0 0)))
+5|POLYGON((0 0,5 0,5 5,0 5,0 0),(1 1,2 1,2 2,1 2,1 1))
+6|LINESTRING(0 0,1 1)
+7|POLYGON((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))
+8|POLYGON((0 0,5 0,5 5,0 5,0 0),(1 1,2 1,2 2,1 2,1 1))
+ERROR:  ST_FilterHolesByArea: area threshold must be finite
+ERROR:  ST_FilterHolesByArea: area threshold must be finite
+ERROR:  ST_FilterHolesByArea: area threshold must be finite

--- a/regress/core/tests.mk.in
+++ b/regress/core/tests.mk.in
@@ -47,6 +47,7 @@ TESTS += \
 	$(top_srcdir)/regress/core/dumpsegments \
 	$(top_srcdir)/regress/core/empty \
 	$(top_srcdir)/regress/core/estimatedextent \
+	$(top_srcdir)/regress/core/filter_holes_by_area \
 	$(top_srcdir)/regress/core/filterm \
 	$(top_srcdir)/regress/core/fixedoverlay \
 	$(top_srcdir)/regress/core/flatgeobuf \


### PR DESCRIPTION
## Summary

- Adds `ST_FilterHolesByArea(geometry, double precision)` to remove polygon and curve-polygon interior rings whose area is below the given threshold.
- Recurses through geometry collections while leaving non-polygonal members unchanged.
- Documents the function, registers it in SQL, adds regression coverage, and notes the feature in `NEWS`.
- Rejects non-finite area thresholds (`NaN`, `Infinity`, `-Infinity`) before filtering so comparisons cannot silently drop all holes.

Closes https://trac.osgeo.org/postgis/ticket/5996.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `a9192a60041d630380065ab4ed95a7125cb6acb7`.
- Existing review threads are resolved; the NaN/non-finite threshold, squared-unit documentation, and negative-threshold regression cases remain covered after rebase.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make clean`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/lwgeom_remove_small_parts.c postgis/postgis.sql.in regress/core/filter_holes_by_area.sql regress/core/filter_holes_by_area_expected doc/reference_editor.xml NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/filter_holes_by_area"`
- `make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/filter_holes_by_area"`
- `make -C doc check-xml`
