### PR TITLE
Fix TopoGeo_addPoint snapping near edge endpoint

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -145,6 +145,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #5948, [topology] Prevent MakeTopologyPrecise from erasing edges when
           grid size exceeds their extent (Darafei Praliaskouski)
+ - #5797, [topology] Preserve snapped edge endpoints when TopoGeo_addPoint
+          splits a nearby edge (Darafei Praliaskouski)
  - #5959, Prevent histogram target overflow when analysing massive tables (Darafei Praliaskouski)
  - GH-901, Stop loader upgrade helper from marking postgis_tiger_geocoder
           for extension upgrade (Darafei Praliaskouski)

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -19,7 +19,7 @@
  **********************************************************************
  *
  * Copyright (C) 2015-2026 Sandro Santilli <strk@kbt.io>
- * Copyright (C) 2025 Darafei Praliaskouski <me@komzpa.net>
+ * Copyright (C) 2025-2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
@@ -6878,6 +6878,38 @@ _lwt_SplitAllEdgesToNewNode(LWT_TOPOLOGY* topo, LWT_ISO_EDGE *edges, uint64_t nu
 #if POSTGIS_DEBUG_LEVEL > 0
       else {
         LWDEBUG(1, "Snapping did not move first point");
+      }
+#endif
+
+      /*
+      -- lwt_ChangeEdgeGeom requires replacement edges to keep both original
+      -- endpoints. lwgeom_snap may move either endpoint when it falls within
+      -- tolerance of the projected split point.
+      */
+      getPoint4d_p(e->geom->points, e->geom->points->npoints - 1, &p1);
+      getPoint4d_p(snapline->points, snapline->points->npoints - 1, &p2);
+      LWDEBUGF(1,
+	       "Edge last point is %g %g, "
+	       "snapline last point is %g %g",
+	       p1.x,
+	       p1.y,
+	       p2.x,
+	       p2.y);
+      if (p1.x != p2.x || p1.y != p2.y)
+      {
+	      LWDEBUG(1, "Snapping moved last point, re-adding it");
+	      if (LW_SUCCESS != ptarray_append_point(snapline->points, &p1, LW_TRUE))
+	      {
+		      lwgeom_free(prj);
+		      lwgeom_free(snapedge);
+		      lwerror("Could not preserve snapped edge endpoint");
+		      return -1;
+	      }
+      }
+#if POSTGIS_DEBUG_LEVEL > 0
+      else
+      {
+	      LWDEBUG(1, "Snapping did not move last point");
       }
 #endif
 

--- a/topology/test/regress/topogeo_addpoint.sql
+++ b/topology/test/regress/topogeo_addpoint.sql
@@ -87,6 +87,14 @@ SELECT 't5794', 'N', topology.TopoGeo_addPoint('t', 'POINT(9 5)', 5);
 SELECT 't5794', 'V', * FROM ValidateTopology('t');
 ROLLBACK;
 
+-- See https://trac.osgeo.org/postgis/ticket/5797
+BEGIN;
+SELECT NULL FROM topology.CreateTopology ('t');
+SELECT NULL FROM topology.TopoGeo_addLinestring('t', 'LINESTRING(0 0, 5 1, 10 0)');
+SELECT 't5797', 'N', topology.TopoGeo_addPoint('t', 'POINT(9 5)', 5);
+SELECT 't5797', 'V', * FROM ValidateTopology('t');
+ROLLBACK;
+
 -- See https://trac.osgeo.org/postgis/ticket/5925
 BEGIN;
 SELECT NULL FROM topology.CreateTopology ('t');

--- a/topology/test/regress/topogeo_addpoint_expected
+++ b/topology/test/regress/topogeo_addpoint_expected
@@ -33,4 +33,5 @@ tt5394|N|3
 t5698|E|1
 t5698|N|3
 t5794|N|3
+t5797|N|3
 ERROR:  Corrupted topology: geometry of edge 1 is EMPTY


### PR DESCRIPTION
## Summary

- fixes `TopoGeo_addPoint` failing with `SQL/MM Spatial exception - end node not geometry end point` when snapping a bent edge near its end point before splitting it
- mirrors the existing snapped start-point preservation for the edge end point before `lwt_ChangeEdgeGeom`, keeping topology edge endpoints exact while still allowing the projected split point to be inserted
- adds the exact Trac #5797 repro to the `topogeo_addpoint` regression file and records the bug fix in `NEWS`

Ticket: https://trac.osgeo.org/postgis/ticket/5797

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make install`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/topogeo_addpoint"`
- exact Trac repro smoke: `TopoGeo_addPoint(...)` returned node `3` and `topology.ValidateTopology('topo')` returned `0` rows
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- liblwgeom/topo/lwgeom_topo.c topology/test/regress/topogeo_addpoint.sql topology/test/regress/topogeo_addpoint_expected NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/349
