### PR TITLE
Clarify incomplete PostGIS upgrade cleanup errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - #5487, Improve error detail for repeated upgrades after an incomplete
+          deprecated-function cleanup (Darafei Praliaskouski)
  - GH-885, [topology] Avoid GMP overflow in ring orientation for very large
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,

--- a/utils/Makefile.in
+++ b/utils/Makefile.in
@@ -123,7 +123,10 @@ check-regress:
 
 check: check-unit
 
-check-unit: postgis_restore-check
+create_upgrade-check:
+	srcdir=$(srcdir) PERL=$(PERL) $(SHELL) $(srcdir)/check_create_upgrade.sh
+
+check-unit: postgis_restore-check create_upgrade-check
 
 installdir:
 	@mkdir -p $(DESTDIR)$(bindir)

--- a/utils/check_create_upgrade.sh
+++ b/utils/check_create_upgrade.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+TMPDIR="${TMPDIR:-/tmp}/check_create_upgrade.$$"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+mkdir -p "${TMPDIR}"
+
+cat > "${TMPDIR}/postgis.sql" <<'SQL'
+-- INSTALL VERSION: 3.7.0dev
+-- Availability: 1.0.0
+-- Changed: 3.1.0 add a default argument
+-- Replaces ST_Test(geometry) deprecated in 3.1.0
+CREATE OR REPLACE FUNCTION ST_Test(geometry, float8 DEFAULT 0.0) RETURNS geometry
+AS 'MODULE_PATHNAME', 'ST_Test'
+LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+SQL
+
+"${PERL:-perl}" "${srcdir:-.}/create_upgrade.pl" "${TMPDIR}/postgis.sql" > "${TMPDIR}/upgrade.sql"
+
+# The duplicate-function branch turns a PostgreSQL rename collision from a
+# partially completed upgrade into an actionable PostGIS diagnostic.
+grep -Fq \
+	"PostGIS upgrade cannot rename replaced function st_test(geometry): leftover deprecated function st_test_deprecated_by_postgis_301(geometry) already exists" \
+	"${TMPDIR}/upgrade.sql"
+
+grep -Fq \
+	"retry SELECT postgis_extensions_upgrade()" \
+	"${TMPDIR}/upgrade.sql"

--- a/utils/create_upgrade.pl
+++ b/utils/create_upgrade.pl
@@ -505,6 +505,12 @@ EOF
     EXCEPTION
     WHEN undefined_function THEN
         RAISE DEBUG 'Replaced function $name($args) does not exist';
+    WHEN duplicate_function THEN
+        -- The target name is left behind when an earlier upgrade could not drop
+        -- a deprecated function still referenced by user objects.
+        RAISE EXCEPTION 'PostGIS upgrade cannot rename replaced function $name($args): leftover deprecated function ${replacement} already exists'
+            USING DETAIL = 'A previous upgrade likely left ${replacement} because a user object still depends on it.',
+                  HINT = 'Run SELECT postgis_full_version(); and inspect objects depending on functions named *_deprecated_by_postgis_*. Drop or update those objects, then retry SELECT postgis_extensions_upgrade().';
     WHEN OTHERS THEN
         GET STACKED DIAGNOSTICS detail := PG_EXCEPTION_DETAIL;
         RAISE EXCEPTION 'Attempting to rename replaced function $name($args) got % (%)', SQLERRM, SQLSTATE
@@ -1061,5 +1067,4 @@ BEGIN
 END
 $$
 LANGUAGE 'plpgsql';
-
 


### PR DESCRIPTION
Fixes Trac #5487 by making repeated upgrades after an incomplete deprecated-function cleanup fail with a PostGIS-specific diagnostic instead of the raw PostgreSQL duplicate-function rename error.

The upgrade generator now catches `duplicate_function` in generated `Replaces` rename blocks. That is the state left when an earlier upgrade renamed an old signature but could not drop the deprecated alias because user objects still depended on it. The new error names the leftover deprecated function and hints at `postgis_full_version()` plus dependent objects named `*_deprecated_by_postgis_*`.

I also added a small `utils` generator check so the emitted PL/pgSQL keeps the new diagnostic.

Validation:

- `srcdir=utils PERL=perl sh utils/check_create_upgrade.sh`
- `make -C utils check`
- `make -j32 && sudo -n make install`
- manual #5487 repro using `st_force3d(geometry)` plus `st_force3d_deprecated_by_postgis_301(geometry)` confirmed the installed upgrade script now raises `PostGIS upgrade cannot rename replaced function ... leftover deprecated function ... already exists` with DETAIL and HINT
- `make -C regress check-locked-upgrade RUNTESTFLAGS='--extension --verbose'`
- `make -C regress check-regress RUNTESTFLAGS='--extension --verbose --upgrade --upgrade --before-upgrade-script ../regress/hooks/use-all-functions.sql --after-upgrade-script ../regress/hooks/hook-after-upgrade.sql' TESTS=../regress/core/regress.sql`
- `git diff --cached --check`
- `git clang-format gh/master --diff -- NEWS utils/Makefile.in utils/check_create_upgrade.sh utils/create_upgrade.pl` (no modified files to format)

Closes https://trac.osgeo.org/postgis/ticket/5487
