### PR TITLE
Fix TopoGeo_addLinestring snapping past nearby edge

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -72,6 +72,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           progress callbacks (Darafei Praliaskouski)
  - #5975, Initialize skipped union-find cluster ids deterministically
           (Darafei Praliaskouski)
+ - #5886, [topology] Snap line vertices to nearby edge interiors while building
+          topology (Darafei Praliaskouski)
  - GH-885, [topology] Avoid GMP overflow in ring orientation for very large
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -19,7 +19,7 @@
  **********************************************************************
  *
  * Copyright (C) 2015-2026 Sandro Santilli <strk@kbt.io>
- * Copyright (C) 2025 Darafei Praliaskouski <me@komzpa.net>
+ * Copyright (C) 2025-2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
@@ -7325,6 +7325,114 @@ _lwt_split_by_nodes(const LWGEOM *g, const LWGEOM *nodes)
   return bg;
 }
 
+static int
+_lwt_point_is_near_target_vertex(const POINT2D *point,
+				 LWT_ISO_EDGE *edges,
+				 uint64_t numedges,
+				 LWT_ISO_NODE *nodes,
+				 uint64_t numnodes,
+				 double tol)
+{
+	uint64_t i;
+
+	for (i = 0; i < numedges; ++i)
+	{
+		uint32_t j;
+		for (j = 0; j < edges[i].geom->points->npoints; ++j)
+		{
+			const POINT2D *vertex = getPoint2d_cp(edges[i].geom->points, j);
+			if (distance2d_pt_pt(point, vertex) < tol)
+				return 1;
+		}
+	}
+
+	for (i = 0; i < numnodes; ++i)
+	{
+		POINT2D node_point;
+		if (nodes[i].containing_face == -1)
+			continue; /* non-isolated nodes are already edge vertices */
+		getPoint2d_p(nodes[i].geom->point, 0, &node_point);
+		if (distance2d_pt_pt(point, &node_point) < tol)
+			return 1;
+	}
+
+	return 0;
+}
+
+static int
+_lwt_snap_line_vertices_to_edges(LWGEOM *geom,
+				 LWT_ISO_EDGE *edges,
+				 uint64_t numedges,
+				 LWT_ISO_NODE *nodes,
+				 uint64_t numnodes,
+				 double tol)
+{
+	LWPOINTITERATOR *it;
+	POINT4D point;
+
+	if (!tol || !numedges)
+		return 0;
+
+	it = lwpointiterator_create_rw(geom);
+	if (!it)
+		return -1;
+
+	while (lwpointiterator_has_next(it))
+	{
+		uint64_t i;
+		int found = 0;
+		double bestdist = tol;
+		POINT2D point2d;
+		POINT4D bestpoint;
+
+		if (lwpointiterator_peek(it, &point) == LW_FAILURE)
+		{
+			lwpointiterator_destroy(it);
+			return -1;
+		}
+
+		point2d.x = point.x;
+		point2d.y = point.y;
+		if (_lwt_point_is_near_target_vertex(&point2d, edges, numedges, nodes, numnodes, tol))
+		{
+			lwpointiterator_next(it, NULL);
+			continue;
+		}
+
+		for (i = 0; i < numedges; ++i)
+		{
+			double dist;
+			double loc;
+			POINT4D projected;
+
+			loc = ptarray_locate_point(edges[i].geom->points, &point, &dist, &projected);
+			if (loc > 0 && loc < 1 && dist && dist < bestdist)
+			{
+				found = 1;
+				bestdist = dist;
+				bestpoint = projected;
+			}
+		}
+
+		/*
+		 * GEOS Snap uses target vertices, so a line vertex close to an edge
+		 * interior can remain unsnapped and create a later impossible edge-node
+		 * crossing.  Snap those vertices to their segment projection while the
+		 * incoming line is still the only geometry being changed (#5886).  If
+		 * the original vertex can snap to any target vertex, including an
+		 * isolated node or a vertex on another edge, keep the result chosen by
+		 * the target-vertex snap.
+		 */
+		if (found)
+			lwpointiterator_modify_next(it, &bestpoint);
+		else
+			lwpointiterator_next(it, NULL);
+	}
+
+	lwpointiterator_destroy(it);
+	return 0;
+}
+
 static LWT_ELEMID*
 _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
             int handleFaceSplit, int maxNewEdges)
@@ -7343,6 +7451,7 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
   GBOX qbox;
   int forward;
   int input_was_closed = 0;
+  int using_min_tolerance = tol == -1;
   POINT4D originalStartPoint;
 
   if ( lwline_is_empty(line) )
@@ -7491,6 +7600,26 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     lwgeom_free(noded);
     noded = tmp;
     LWDEBUGG(1, noded, "Elements-snapped");
+
+    /*
+     * GEOS Snap handles target vertices first.  Only then project the remaining
+     * vertices to edge interiors; otherwise the later target-vertex snap could
+     * drag a freshly projected interior point to an endpoint that was outside
+     * tolerance from the original input vertex (#5886).
+     */
+    if (using_min_tolerance && _lwt_snap_line_vertices_to_edges(noded, edges, numedges, nodes, numnodes, tol) == -1)
+    {
+	    lwgeom_free(noded);
+	    lwcollection_release(col);
+	    if (nearby)
+		    lwfree(nearby);
+	    if (nodes)
+		    _lwt_release_nodes(nodes, numnodes);
+	    if (edges)
+		    _lwt_release_edges(edges, numedges);
+	    lwerror("Could not snap line vertices to nearby edges");
+	    return NULL;
+    }
     if ( input_was_closed )
     {{
       /* Recompute start point in case it moved */

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -6956,9 +6956,15 @@ _lwt_AddPoint(LWT_TOPOLOGY* topo, LWPOINT* point, double tol, int
   int flds;
   LWT_ELEMID id = 0;
 
-  /* Get tolerance, if 0 was given */
-  if ( tol == -1 )
-    tol = _LWT_MINTOLERANCE(topo, pt);
+  /*
+   * SQL toTopoGeom uses values below -1 as private precomputed automatic
+   * tolerances for dumped multi-geometries.  Decode them before using the
+   * tolerance for point snapping.
+   */
+  if (tol < -1)
+	  tol = -tol - 1;
+  else if (tol == -1)
+	  tol = _LWT_MINTOLERANCE(topo, pt);
 
   LWDEBUGG(1, pt, "Adding point");
 
@@ -7411,6 +7417,9 @@ _lwt_snap_line_vertices_to_edges(LWGEOM *geom,
 				found = 1;
 				bestdist = dist;
 				bestpoint = projected;
+				/* The snap is XY-only; keep the incoming line's ordinates. */
+				bestpoint.z = point.z;
+				bestpoint.m = point.m;
 			}
 		}
 
@@ -7433,9 +7442,14 @@ _lwt_snap_line_vertices_to_edges(LWGEOM *geom,
 	return 0;
 }
 
-static LWT_ELEMID*
-_lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
-            int handleFaceSplit, int maxNewEdges)
+static LWT_ELEMID *
+_lwt_AddLine(LWT_TOPOLOGY *topo,
+	     LWLINE *line,
+	     double tol,
+	     int *nedges,
+	     int handleFaceSplit,
+	     int maxNewEdges,
+	     int requested_min_tolerance)
 {
   LWGEOM *geomsbuf[1];
   LWGEOM **geoms;
@@ -7451,7 +7465,7 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
   GBOX qbox;
   int forward;
   int input_was_closed = 0;
-  int using_min_tolerance = tol == -1;
+  int using_min_tolerance = requested_min_tolerance || tol <= -1;
   POINT4D originalStartPoint;
 
   if ( lwline_is_empty(line) )
@@ -7469,8 +7483,15 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
 
   *nedges = -1; /* error condition, by default */
 
-  /* Get tolerance, if 0 was given */
-  if ( tol == -1 ) tol = _LWT_MINTOLERANCE( topo, (LWGEOM*)line );
+  /*
+   * Values below -1 carry a whole-input automatic tolerance from SQL
+   * toTopoGeom while preserving the automatic-tolerance snap behavior for
+   * dumped multi-geometries.
+   */
+  if (tol < -1)
+	  tol = -tol - 1;
+  else if (tol == -1)
+	  tol = _LWT_MINTOLERANCE(topo, (LWGEOM *)line);
   LWDEBUGF(1, "Working tolerance:%.15g", tol);
   LWDEBUGF(1, "Input line has srid=%d", line->srid);
 
@@ -7861,13 +7882,13 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
 LWT_ELEMID*
 lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges, int max_new_edges)
 {
-  return _lwt_AddLine(topo, line, tol, nedges, 1, max_new_edges);
+	return _lwt_AddLine(topo, line, tol, nedges, 1, max_new_edges, tol == -1);
 }
 
 LWT_ELEMID*
 lwt_AddLineNoFace(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges)
 {
-  return _lwt_AddLine(topo, line, tol, nedges, 0, -1);
+	return _lwt_AddLine(topo, line, tol, nedges, 0, -1, tol == -1);
 }
 
 static void
@@ -7877,18 +7898,18 @@ lwt_LoadPoint(LWT_TOPOLOGY* topo, LWPOINT* point, double tol)
 }
 
 static void
-lwt_LoadLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int max_new_edges)
+lwt_LoadLine(LWT_TOPOLOGY *topo, LWLINE *line, double tol, int max_new_edges, int requested_min_tolerance)
 {
   LWT_ELEMID* ids;
   int nedges;
 
   /* TODO: avoid allocating edge ids */
-  ids = lwt_AddLine(topo, line, tol, &nedges, max_new_edges);
+  ids = _lwt_AddLine(topo, line, tol, &nedges, 1, max_new_edges, requested_min_tolerance);
   if ( nedges > 0 ) lwfree(ids);
 }
 
 static void
-lwt_LoadPolygon(LWT_TOPOLOGY* topo, const LWPOLY* poly, double tol)
+lwt_LoadPolygon(LWT_TOPOLOGY *topo, const LWPOLY *poly, double tol, int requested_min_tolerance)
 {
   uint32_t i;
 
@@ -7901,7 +7922,7 @@ lwt_LoadPolygon(LWT_TOPOLOGY* topo, const LWPOLY* poly, double tol)
     /* TODO: avoid the clone here */
     pa = ptarray_clone(poly->rings[i]);
     line = lwline_construct(topo->srid, NULL, pa);
-    lwt_LoadLine(topo, line, tol, -1);
+    lwt_LoadLine(topo, line, tol, -1, requested_min_tolerance);
     lwline_free(line);
   }
 }
@@ -7918,6 +7939,7 @@ lwt_AddPolygon(LWT_TOPOLOGY* topo, LWPOLY* poly, double tol, int* nfaces)
   GBOX qbox;
   const GEOSPreparedGeometry *ppoly;
   GEOSGeometry *polyg;
+  int using_min_tolerance = tol <= -1;
 
   /* Nothing to add, in an empty polygon */
   if ( lwpoly_is_empty(poly) )
@@ -7926,11 +7948,18 @@ lwt_AddPolygon(LWT_TOPOLOGY* topo, LWPOLY* poly, double tol, int* nfaces)
     return NULL;
   }
 
-  /* Get tolerance, if 0 was given */
-  if ( tol == -1 ) tol = _LWT_MINTOLERANCE( topo, (LWGEOM*)poly );
+  /*
+   * Values below -1 carry a whole-input automatic tolerance from SQL
+   * toTopoGeom while preserving the automatic-tolerance snap behavior for
+   * dumped multi-geometries.
+   */
+  if (tol < -1)
+	  tol = -tol - 1;
+  else if (tol == -1)
+	  tol = _LWT_MINTOLERANCE(topo, (LWGEOM *)poly);
   LWDEBUGF(1, "Working tolerance:%.15g", tol);
 
-  lwt_LoadPolygon(topo, poly, tol);
+  lwt_LoadPolygon(topo, poly, tol, using_min_tolerance);
 
   /*
   -- Find faces covered by input polygon
@@ -8399,12 +8428,12 @@ _lwt_LoadGeometryRecursive(LWT_TOPOLOGY* topo, LWGEOM* geom, double tol)
       return;
 
     case LINETYPE:
-      lwt_LoadLine(topo, lwgeom_as_lwline(geom), tol, -1);
-      return;
+	    lwt_LoadLine(topo, lwgeom_as_lwline(geom), tol, -1, tol == -1);
+	    return;
 
     case POLYGONTYPE:
-      lwt_LoadPolygon(topo, lwgeom_as_lwpoly(geom), tol);
-      return;
+	    lwt_LoadPolygon(topo, lwgeom_as_lwpoly(geom), tol, tol == -1);
+	    return;
 
     case MULTILINETYPE:
     case MULTIPOLYGONTYPE:

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -4,6 +4,7 @@
  * http://postgis.net
  *
  * Copyright (C) 2015-2026 Sandro Santilli <strk@kbt.io>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU General Public Licence. See the COPYING file.
@@ -4886,7 +4887,7 @@ Datum GetNodeByPoint(PG_FUNCTION_ARGS)
   if ( tol < -1 )
   {
     PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
+    lwpgerror("Tolerance must be -1 or >=0");
     PG_RETURN_NULL();
   }
 
@@ -4956,7 +4957,7 @@ Datum GetEdgeByPoint(PG_FUNCTION_ARGS)
   if ( tol < -1 )
   {
     PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
+    lwpgerror("Tolerance must be -1 or >=0");
     PG_RETURN_NULL();
   }
 
@@ -5028,7 +5029,7 @@ Datum GetFaceByPoint(PG_FUNCTION_ARGS)
   if ( tol < -1 )
   {
     PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
+    lwpgerror("Tolerance must be -1 or >=0");
     PG_RETURN_NULL();
   }
 
@@ -5065,10 +5066,22 @@ Datum GetFaceByPoint(PG_FUNCTION_ARGS)
   PG_RETURN_INT64(node_id);
 }
 
-/*  TopoGeo_AddPoint(atopology, point, tolerance) */
-Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(TopoGeo_AddPoint);
-Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
+static int
+topogeo_tolerance_is_invalid(double tol, int allow_private_tolerance)
+{
+	if (tol >= 0 || tol == -1)
+		return LW_FALSE;
+
+	/*
+	 * SQL toTopoGeom uses values below -1 as an internal sentinel carrying a
+	 * precomputed automatic tolerance for dumped multi-geometries. Public entry
+	 * points must continue to reject those values as invalid user input.
+	 */
+	return !allow_private_tolerance;
+}
+
+static Datum
+TopoGeo_AddPoint_impl(FunctionCallInfo fcinfo, int allow_private_tolerance)
 {
   text* toponame_text;
   char* toponame;
@@ -5106,10 +5119,10 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if (topogeo_tolerance_is_invalid(tol, allow_private_tolerance))
   {
     PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
+    lwpgerror("Tolerance must be -1 or >=0");
     PG_RETURN_NULL();
   }
 
@@ -5151,10 +5164,26 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   PG_RETURN_INT64(node_id);
 }
 
-/*  TopoGeo_AddLinestring(atopology, point, tolerance) */
-Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(TopoGeo_AddLinestring);
-Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
+/*  TopoGeo_AddPoint(atopology, point, tolerance) */
+Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPoint);
+Datum
+TopoGeo_AddPoint(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPoint_impl(fcinfo, LW_FALSE);
+}
+
+/*  _TopoGeo_AddPoint(atopology, point, tolerance) */
+Datum TopoGeo_AddPoint_Private(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPoint_Private);
+Datum
+TopoGeo_AddPoint_Private(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPoint_impl(fcinfo, LW_TRUE);
+}
+
+static Datum
+TopoGeo_AddLinestring_impl(FunctionCallInfo fcinfo, int allow_private_tolerance)
 {
   text* toponame_text;
   char* toponame;
@@ -5217,11 +5246,11 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < -1 )
+    if (topogeo_tolerance_is_invalid(tol, allow_private_tolerance))
     {
       lwgeom_free(lwgeom);
       PG_FREE_IF_COPY(geom, 1);
-      lwpgerror("Tolerance must be -1 or >=0 ");
+      lwpgerror("Tolerance must be -1 or >=0");
       PG_RETURN_NULL();
     }
 
@@ -5301,6 +5330,24 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
   SRF_RETURN_NEXT(funcctx, result);
 }
 
+/*  TopoGeo_AddLinestring(atopology, line, tolerance) */
+Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddLinestring);
+Datum
+TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddLinestring_impl(fcinfo, LW_FALSE);
+}
+
+/*  _TopoGeo_AddLinestring(atopology, line, tolerance) */
+Datum TopoGeo_AddLinestring_Private(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddLinestring_Private);
+Datum
+TopoGeo_AddLinestring_Private(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddLinestring_impl(fcinfo, LW_TRUE);
+}
+
 /*  _TopoGeo_AddLinestringNoFace(atopology, point, tolerance) */
 Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(TopoGeo_AddLinestringNoFace);
@@ -5340,7 +5387,7 @@ Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS)
   if ( tol < -1 )
   {
     PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
+    lwpgerror("Tolerance must be -1 or >=0");
     PG_RETURN_NULL();
   }
 
@@ -5375,10 +5422,8 @@ Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS)
   PG_RETURN_VOID();
 }
 
-/*  TopoGeo_AddPolygon(atopology, poly, tolerance) */
-Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(TopoGeo_AddPolygon);
-Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
+static Datum
+TopoGeo_AddPolygon_impl(FunctionCallInfo fcinfo, int allow_private_tolerance)
 {
   text* toponame_text;
   char* toponame;
@@ -5428,10 +5473,10 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < -1 )
+    if (topogeo_tolerance_is_invalid(tol, allow_private_tolerance))
     {
       PG_FREE_IF_COPY(geom, 1);
-      lwpgerror("Tolerance must be -1 or >=0 ");
+      lwpgerror("Tolerance must be -1 or >=0");
       PG_RETURN_NULL();
     }
 
@@ -5506,6 +5551,24 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
   result = Int64GetDatum((int64)id);
 
   SRF_RETURN_NEXT(funcctx, result);
+}
+
+/*  TopoGeo_AddPolygon(atopology, poly, tolerance) */
+Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPolygon);
+Datum
+TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPolygon_impl(fcinfo, LW_FALSE);
+}
+
+/*  _TopoGeo_AddPolygon(atopology, poly, tolerance) */
+Datum TopoGeo_AddPolygon_Private(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPolygon_Private);
+Datum
+TopoGeo_AddPolygon_Private(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPolygon_impl(fcinfo, LW_TRUE);
 }
 
 /*  GetRingEdges(atopology, anedge, maxedges default null) */
@@ -5781,7 +5844,7 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
   if ( tol < -1 )
   {
     PG_FREE_IF_COPY(geom, 1);
-    lwpgerror("Tolerance must be -1 or >=0 ");
+    lwpgerror("Tolerance must be -1 or >=0");
     PG_RETURN_NULL();
   }
 

--- a/topology/sql/populate.sql.in
+++ b/topology/sql/populate.sql.in
@@ -735,6 +735,11 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPoint(atopology varchar, apoint g
   LANGUAGE 'c' VOLATILE;
 --} TopoGeo_AddPoint
 
+CREATE OR REPLACE FUNCTION topology._TopoGeo_AddPoint(atopology varchar, apoint geometry, tolerance float8 DEFAULT -1)
+	RETURNS bigint AS
+	'MODULE_PATHNAME', 'TopoGeo_AddPoint_Private'
+  LANGUAGE 'c' VOLATILE;
+
 --{
 --  TopoGeo_addLinestring(toponame, linegeom, tolerance)
 --
@@ -749,6 +754,11 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddLinestring(atopology varchar, ali
   LANGUAGE 'c' VOLATILE;
 --} TopoGeo_addLinestring
 
+CREATE OR REPLACE FUNCTION topology._TopoGeo_AddLinestring(atopology varchar, aline geometry, tolerance float8 DEFAULT -1, max_edges int DEFAULT -1)
+	RETURNS SETOF bigint AS
+	'MODULE_PATHNAME', 'TopoGeo_AddLinestring_Private'
+  LANGUAGE 'c' VOLATILE;
+
 --{
 --  TopoGeo_AddPolygon(toponame, polygeom, tolerance)
 --
@@ -762,6 +772,11 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPolygon(atopology varchar, apoly 
 	'MODULE_PATHNAME', 'TopoGeo_AddPolygon'
   LANGUAGE 'c' VOLATILE;
 --} TopoGeo_AddPolygon
+
+CREATE OR REPLACE FUNCTION topology._TopoGeo_AddPolygon(atopology varchar, apoly geometry, tolerance float8 DEFAULT -1)
+	RETURNS SETOF bigint AS
+	'MODULE_PATHNAME', 'TopoGeo_AddPolygon_Private'
+  LANGUAGE 'c' VOLATILE;
 
 --{
 --  TopoGeo_LoadGeometry(toponame, geom, tolerance)

--- a/topology/sql/topogeometry/totopogeom.sql.in
+++ b/topology/sql/topogeometry/totopogeom.sql.in
@@ -156,8 +156,9 @@ BEGIN
   alayer := layer_id(tg);
   atopology := topology_info.name;
 
-  -- Get tolerance, if 0 was given
-  tolerance := COALESCE( NULLIF(atolerance, 0), topology._st_mintolerance(topology_info.name, ageom) );
+  -- Keep the automatic-tolerance sentinel for the C loaders.  They need to know
+  -- that callers asked for automatic tolerance, not an explicit numeric one.
+  tolerance := CASE WHEN atolerance = 0 THEN -1 ELSE atolerance END;
 
   -- Get layer information
   BEGIN

--- a/topology/sql/topogeometry/totopogeom.sql.in
+++ b/topology/sql/topogeometry/totopogeom.sql.in
@@ -156,9 +156,16 @@ BEGIN
   alayer := layer_id(tg);
   atopology := topology_info.name;
 
-  -- Keep the automatic-tolerance sentinel for the C loaders.  They need to know
-  -- that callers asked for automatic tolerance, not an explicit numeric one.
-  tolerance := CASE WHEN atolerance = 0 THEN -1 ELSE atolerance END;
+  -- Simple inputs can delegate automatic tolerance to the C loader.  Dumped
+  -- multi-geometries use a private negative sentinel so each component keeps
+  -- the legacy whole-input tolerance while still following the automatic-
+  -- tolerance snapping path in the loader.
+  tolerance := CASE
+    WHEN atolerance = 0 AND ST_NumGeometries(ageom) > 1 THEN
+      -(1 + topology._st_mintolerance(topology_info.name, ageom))
+    WHEN atolerance = 0 THEN -1
+    ELSE atolerance
+  END;
 
   -- Get layer information
   BEGIN
@@ -243,13 +250,13 @@ BEGIN
     FOR rec2 IN SELECT primitive
           FROM
             (
-              SELECT topology.topogeo_addPoint(atopology, rec.geom, tolerance)
+              SELECT topology._topogeo_addPoint(atopology, rec.geom, tolerance)
                 WHERE rec.dims = 0
               UNION ALL
-              SELECT topology.topogeo_addLineString(atopology, rec.geom, tolerance)
+              SELECT topology._topogeo_addLineString(atopology, rec.geom, tolerance)
                 WHERE rec.dims = 1
               UNION ALL
-              SELECT topology.topogeo_addPolygon(atopology, rec.geom, tolerance)
+              SELECT topology._topogeo_addPolygon(atopology, rec.geom, tolerance)
                 WHERE rec.dims = 2
             ) AS f(primitive)
     LOOP

--- a/topology/test/regress/topogeo_addlinestring_robust.sql
+++ b/topology/test/regress/topogeo_addlinestring_robust.sql
@@ -229,6 +229,56 @@ SELECT * FROM runTest('#5886-totopogeom-zero',
   true
 ) WHERE true ;
 
+DO $$
+BEGIN
+  IF EXISTS ( SELECT * FROM topology.topology WHERE name = 'topo' )
+  THEN
+    PERFORM topology.DropTopology('topo');
+  END IF;
+
+  PERFORM topology.CreateTopology('topo');
+  CREATE TABLE topo.fl(lbl text, g geometry);
+  PERFORM topology.AddTopoGeometryColumn('topo', 'topo', 'fl', 'tg', 'LINESTRING');
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING(0 0, 10 0)', -1);
+
+  PERFORM topology.toTopoGeom(
+    'MULTILINESTRING((1000000000000 0, 1000000000001 0), (5 0.001, 5 2))'::geometry,
+    'topo',
+    1,
+    0
+  );
+END;
+$$;
+
+SELECT '#5886-totopogeom-zero-multiline',
+  count(*) FILTER (WHERE ST_DWithin(geom, 'POINT(5 0)'::geometry, 1e-9)),
+  count(*) FILTER (WHERE ST_DWithin(geom, 'POINT(5 0.001)'::geometry, 1e-9))
+FROM topo.node;
+
+SELECT topology.DropTopology('topo');
+
+DO $$
+BEGIN
+  IF EXISTS ( SELECT * FROM topology.topology WHERE name = 'topo' )
+  THEN
+    PERFORM topology.DropTopology('topo');
+  END IF;
+
+  PERFORM topology.CreateTopology('topo');
+END;
+$$;
+
+SELECT '#5886-public-negative-point',
+  topology.TopoGeo_AddPoint('topo', 'POINT(0 0)', -2);
+
+SELECT '#5886-public-negative-line',
+  count(*) FROM topology.TopoGeo_AddLinestring('topo', 'LINESTRING(0 0, 1 1)', -2);
+
+SELECT '#5886-public-negative-polygon',
+  count(*) FROM topology.TopoGeo_AddPolygon('topo', 'POLYGON((0 0,0 1,1 1,1 0,0 0))', -2);
+
+SELECT topology.DropTopology('topo');
+
 SELECT * FROM runTest('#5886-near-end',
   ARRAY[
     'LINESTRING(0 0, 10 0)'
@@ -287,6 +337,45 @@ $$;
 SELECT '#5886-isolated-node',
   count(*) FILTER (WHERE ST_Equals(geom, 'POINT(5 1.2)'::geometry) AND containing_face IS NULL),
   count(*) FILTER (WHERE ST_DWithin(geom, 'POINT(5.4 0)'::geometry, 1e-9))
+FROM topo.node;
+
+SELECT topology.DropTopology('topo');
+
+DO $$
+BEGIN
+  IF EXISTS ( SELECT * FROM topology.topology WHERE name = 'topo' )
+  THEN
+    PERFORM topology.DropTopology('topo');
+  END IF;
+
+  PERFORM topology.CreateTopology('topo', 0, 1, true);
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING ZM (0 0 10 100, 10 0 20 200)', -1);
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING ZM (5 0.4 99 999, 5 2 98 998)', -1);
+END;
+$$;
+
+SELECT '#5886-preserve-zm',
+  ST_AsEWKT(geom)
+FROM topo.node
+WHERE ST_DWithin(geom, 'POINT(5 0)'::geometry, 1e-9);
+
+SELECT topology.DropTopology('topo');
+
+DO $$
+BEGIN
+  IF EXISTS ( SELECT * FROM topology.topology WHERE name = 'topo' )
+  THEN
+    PERFORM topology.DropTopology('topo');
+  END IF;
+
+  PERFORM topology.CreateTopology('topo', 0, 1);
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING(0 0, 10 0)', -1);
+  PERFORM topology.TopoGeo_addPolygon('topo', 'POLYGON((5 0.4, 5 2, 7 2, 7 -2, 5 -2, 5 0.4))', -1);
+END;
+$$;
+
+SELECT '#5886-polygon-ring',
+  count(*) FILTER (WHERE ST_DWithin(geom, 'POINT(5 0)'::geometry, 1e-9))
 FROM topo.node;
 
 SELECT topology.DropTopology('topo');

--- a/topology/test/regress/topogeo_addlinestring_robust.sql
+++ b/topology/test/regress/topogeo_addlinestring_robust.sql
@@ -1,19 +1,31 @@
 
 --{
-CREATE FUNCTION runTest( lbl text, lines geometry[], newline geometry, prec float8, debug bool default false )
+CREATE FUNCTION runTest(
+  lbl text,
+  lines geometry[],
+  newline geometry,
+  tol float8,
+  debug bool default false,
+  topo_prec float8 default 0,
+  use_totopogeom bool default false
+)
 RETURNS SETOF text AS
 $BODY$
 DECLARE
   g geometry;
   n int := 0;
   rec record;
+  drift_tol float8 := CASE
+    WHEN tol = -1 THEN COALESCE(NULLIF(topo_prec, 0), topology._st_mintolerance(newline))
+    ELSE COALESCE(NULLIF(tol, 0), topology._st_mintolerance(newline))
+  END;
 BEGIN
   IF EXISTS ( SELECT * FROM topology.topology WHERE name = 'topo' )
   THEN
     PERFORM topology.DropTopology ('topo');
   END IF;
 
-  PERFORM topology.CreateTopology ('topo');
+  PERFORM topology.CreateTopology ('topo', 0, topo_prec);
   CREATE TABLE topo.fl(lbl text, g geometry);
   PERFORM topology.AddTopoGeometryColumn('topo','topo','fl','tg','LINESTRING');
   CREATE TABLE topo.fa(lbl text, g geometry);
@@ -65,7 +77,11 @@ BEGIN
   END IF;
 
   BEGIN
-    PERFORM topology.TopoGeo_addLinestring('topo', newline, prec);
+    IF use_totopogeom THEN
+      PERFORM topology.toTopoGeom(newline, 'topo', 1, tol);
+    ELSE
+      PERFORM topology.TopoGeo_addLinestring('topo', newline, tol);
+    END IF;
   EXCEPTION WHEN OTHERS THEN
     RETURN QUERY SELECT format('%s|addline exception|%s (%s)', lbl, SQLERRM, SQLSTATE);
   END;
@@ -116,10 +132,7 @@ BEGIN
   FROM (
     SELECT t.lbl l, ST_HausdorffDistance(t.g, tg::geometry) dist
     FROM topo.fl t
-  ) foo WHERE dist >= COALESCE(
-      NULLIF(prec,0),
-      topology._st_mintolerance(newline)
-  )
+  ) foo WHERE dist >= drift_tol
   ORDER BY foo.l;
 
   SELECT sum(ST_Area(t.g)) as before, sum(ST_Area(tg::geometry)) as after
@@ -181,4 +194,101 @@ SELECT * FROM runTest('#5711',
   0
 ) WHERE true ;
 
-DROP FUNCTION runTest(text, geometry[], geometry, float8, bool);
+-- See https://trac.osgeo.org/postgis/ticket/5886
+-- The explicit tol=0 case keeps the historical comparison surface, while the
+-- precision case below uses automatic tolerance and exercises edge-interior snap.
+SELECT * FROM runTest('#5886',
+  ARRAY[
+    'LINESTRING(22.780107846871616 70.70515928614921, 22.779899976871615 70.7046262461492)',
+    'LINESTRING(22.79217056687162 70.70247684614921, 22.779969266871618 70.70480392614921, 22.780038556871617 70.7049816061492, 22.796764346871615 70.7044482361492)'
+  ],
+  'LINESTRING(22.780038556871617 70.7049816061492, 22.789676156871618 70.7072799361492)',
+  0
+) WHERE true ;
+
+SELECT * FROM runTest('#5886-prec',
+  ARRAY[
+    'LINESTRING(22.780107846871616 70.70515928614921, 22.779899976871615 70.7046262461492)',
+    'LINESTRING(22.79217056687162 70.70247684614921, 22.779969266871618 70.70480392614921, 22.780038556871617 70.7049816061492, 22.796764346871615 70.7044482361492)'
+  ],
+  'LINESTRING(22.780038556871617 70.7049816061492, 22.789676156871618 70.7072799361492)',
+  -1,
+  false,
+  0.0000001
+) WHERE true ;
+
+SELECT * FROM runTest('#5886-totopogeom-zero',
+  ARRAY[
+    'LINESTRING(22.780107846871616 70.70515928614921, 22.779899976871615 70.7046262461492)',
+    'LINESTRING(22.79217056687162 70.70247684614921, 22.779969266871618 70.70480392614921, 22.780038556871617 70.7049816061492, 22.796764346871615 70.7044482361492)'
+  ],
+  'LINESTRING(22.780038556871617 70.7049816061492, 22.789676156871618 70.7072799361492)',
+  0,
+  false,
+  0.0000001,
+  true
+) WHERE true ;
+
+SELECT * FROM runTest('#5886-near-end',
+  ARRAY[
+    'LINESTRING(0 0, 10 0)'
+  ],
+  'LINESTRING(0.5 0.9, 0.5 -2)',
+  -1,
+  false,
+  1
+) WHERE true ;
+
+DO $$
+BEGIN
+  IF EXISTS ( SELECT * FROM topology.topology WHERE name = 'topo' )
+  THEN
+    PERFORM topology.DropTopology('topo');
+  END IF;
+
+  PERFORM topology.CreateTopology('topo', 0, 1);
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING(0 0, 10 0)', -1);
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING(0.9 0.9, 0.9 2)', -1);
+END;
+$$;
+
+SELECT '#5886-projection-not-endpoint',
+  count(distinct n.node_id) FILTER (WHERE ST_DWithin(n.geom, 'POINT(0.9 0)'::geometry, 1e-9)),
+  count(distinct e.edge_id) FILTER (
+    WHERE (ST_DWithin(a.geom, 'POINT(0 0)'::geometry, 1e-9)
+        AND ST_DWithin(b.geom, 'POINT(0.9 2)'::geometry, 1e-9))
+       OR (ST_DWithin(a.geom, 'POINT(0.9 2)'::geometry, 1e-9)
+        AND ST_DWithin(b.geom, 'POINT(0 0)'::geometry, 1e-9))
+  )
+FROM topo.node n
+LEFT JOIN topo.edge_data e
+  ON n.node_id = e.start_node OR n.node_id = e.end_node
+LEFT JOIN topo.node a
+  ON a.node_id = e.start_node
+LEFT JOIN topo.node b
+  ON b.node_id = e.end_node;
+
+SELECT topology.DropTopology('topo');
+
+DO $$
+BEGIN
+  IF EXISTS ( SELECT * FROM topology.topology WHERE name = 'topo' )
+  THEN
+    PERFORM topology.DropTopology('topo');
+  END IF;
+
+  PERFORM topology.CreateTopology('topo', 0, 1);
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING(0 0, 10 0)', -1);
+  PERFORM topology.TopoGeo_addPoint('topo', 'POINT(5 1.2)', -1);
+  PERFORM topology.TopoGeo_addLinestring('topo', 'LINESTRING(5.4 0.6, 5.4 2)', -1);
+END;
+$$;
+
+SELECT '#5886-isolated-node',
+  count(*) FILTER (WHERE ST_Equals(geom, 'POINT(5 1.2)'::geometry) AND containing_face IS NULL),
+  count(*) FILTER (WHERE ST_DWithin(geom, 'POINT(5.4 0)'::geometry, 1e-9))
+FROM topo.node;
+
+SELECT topology.DropTopology('topo');
+
+DROP FUNCTION runTest(text, geometry[], geometry, float8, bool, float8, bool);

--- a/topology/test/regress/topogeo_addlinestring_robust_expected
+++ b/topology/test/regress/topogeo_addlinestring_robust_expected
@@ -1,2 +1,10 @@
 #5699|-checking-
 #5711|-checking-
+#5886|-checking-
+#5886-prec|-checking-
+#5886-totopogeom-zero|-checking-
+#5886-near-end|-checking-
+#5886-projection-not-endpoint|1|0
+Topology 'topo' dropped
+#5886-isolated-node|1|0
+Topology 'topo' dropped

--- a/topology/test/regress/topogeo_addlinestring_robust_expected
+++ b/topology/test/regress/topogeo_addlinestring_robust_expected
@@ -3,8 +3,18 @@
 #5886|-checking-
 #5886-prec|-checking-
 #5886-totopogeom-zero|-checking-
+#5886-totopogeom-zero-multiline|1|0
+Topology 'topo' dropped
+ERROR:  Tolerance must be -1 or >=0
+ERROR:  Tolerance must be -1 or >=0
+ERROR:  Tolerance must be -1 or >=0
+Topology 'topo' dropped
 #5886-near-end|-checking-
 #5886-projection-not-endpoint|1|0
 Topology 'topo' dropped
 #5886-isolated-node|1|0
+Topology 'topo' dropped
+#5886-preserve-zm|POINT(5 0 99)
+Topology 'topo' dropped
+#5886-polygon-ring|1
 Topology 'topo' dropped

--- a/topology/test/regress/topogeo_addpoint_merge_edges_expected
+++ b/topology/test/regress/topogeo_addpoint_merge_edges_expected
@@ -31,4 +31,4 @@ multi-merge-forward-backward|-checking-
 multi-merge-closest-not-containing-projected|-checking-
 ERROR:  snapping edge 2 to new node moves it past edge 3
 ERROR:  snapping edge 2 to new node moves it past edge 3
-ERROR:  snapping edge 2 to new node moves it past edge 3
+#5862|-checking-


### PR DESCRIPTION
## Summary
- snap incoming line vertices to nearby existing edge interiors when using automatic min tolerance
- apply the same edge-interior snap path when topology precision supplies the default tolerance
- keep `toTopoGeom(..., 0)` as an automatic-tolerance request so C loaders can use the same edge-interior snap path
- preserve the legacy whole-input tolerance for dumped multi-geometries in `toTopoGeom(..., 0)`, instead of recomputing automatic tolerance separately for each dumped component
- keep that dumped-multigeometry tolerance sentinel on private `_TopoGeo_Add*` entry points, while public `TopoGeo_AddPoint`, `TopoGeo_AddLineString`, and `TopoGeo_AddPolygon` continue to reject tolerances below `-1`
- let GEOS target-vertex snapping run before edge-interior projection, so vertices near existing targets still attach to those targets while projected interior points are not later dragged to endpoints that were outside tolerance from the original input
- preserve incoming higher-dimensional ordinates while doing XY-only edge-interior snaps
- preserve automatic-tolerance edge-interior snapping for polygon rings loaded through `TopoGeo_addPolygon`
- add https://trac.osgeo.org/postgis/ticket/5886 to the robust TopoGeo_addLinestring regression coverage, including precision-topology, `toTopoGeom(..., 0)`, near-endpoint edge-interior, isolated-node target-vertex, projection-not-endpoint, 3D ordinate preservation, polygon-ring, dumped-multiline whole-tolerance, and public negative-tolerance rejection cases

## Maintenance Notes
- rebased on `postgis:master` at `6f291bf547cf9b1834cfa63a779899f6ede4aeba`
- addressed the near-endpoint, all-target-vertices, and projected-interior-resnap reviews by testing original input vertices against all nearby target vertices and by ordering target-vertex snap before edge-interior projection
- addressed Codex review threads by keeping input Z/M values during XY-only interior-edge snaps, carrying the original automatic-tolerance request through polygon loading, preserving whole-input zero-tolerance semantics for dumped multi-geometries, and restoring the public `< -1` tolerance validation contract
- current head: `89e7f279c267ca2bf334ddf71efa63f6434a1ea6`
- local coverage was not generated because this checkout was not coverage-instrumented; GitHub coverage/checks are expected to run on the pushed head

Trac ticket: https://trac.osgeo.org/postgis/ticket/5886

## Tests
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git clang-format upstream/master -- liblwgeom/topo/lwgeom_topo.c topology/postgis_topology.c`
- `git clang-format --diff upstream/master -- liblwgeom/topo/lwgeom_topo.c topology/postgis_topology.c`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C topology -j32`
- `sudo -n make -C topology install`
- `make -C extensions/postgis_topology -j1`
- `sudo -n make -C extensions/postgis_topology install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring_robust"`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topogeo_addpoint $(pwd)/topology/test/regress/topogeo_addpoint_merge_edges $(pwd)/topology/test/regress/topogeo_addlinestring $(pwd)/topology/test/regress/topogeo_addpolygon"`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/348
