### PR TITLE
Add ST_AsGeoJSONAgg

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #5775, Add ST_AsGeoJSONAgg for FeatureCollection output
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/NEWS
+++ b/NEWS
@@ -158,6 +158,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)
+ - #5775, Add ST_AsGeoJSONAgg for FeatureCollection output (Darafei Praliaskouski)
  - #5950, Document POSTGIS_REGRESS_DB_OWNER for sandboxed regression roles (Darafei Praliaskouski)
  - #4332, Clarify the scope of several Function Reference categories (Darafei Praliaskouski)
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)

--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -715,7 +715,7 @@ FROM ( VALUES (1, 'one', 'POINT(1 1)'::geometry),
               (2, 'two', 'POINT(2 2)'),
               (3, 'three', 'POINT(3 3)')
      ) as t(id, name, geom);</programlisting>
-<screen role="text-primary">{"type": "FeatureCollection", "features" : [{"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "id": 1, "properties": {"name": "one"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[2,2]}, "id": 2, "properties": {"name": "two"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[3,3]}, "id": 3, "properties": {"name": "three"}}]}</screen>
+<screen role="text-primary">{"type": "FeatureCollection", "features": [{"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "id": 1, "properties": {"name": "one"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[2,2]}, "id": 2, "properties": {"name": "two"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[3,3]}, "id": 3, "properties": {"name": "three"}}]}</screen>
 
 <para>Generate a Feature:</para>
     <programlisting language="sql">SELECT ST_AsGeoJSON(t.*, id_column => 'id')

--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -710,15 +710,12 @@ Conversely, passing the parameter will save column type lookups.
     <title>Examples</title>
 
 <para>Generate a FeatureCollection:</para>
-<programlisting language="sql">SELECT json_build_object(
-    'type', 'FeatureCollection',
-    'features', json_agg(ST_AsGeoJSON(t.*, id_column => 'id')::json)
-    )
+<programlisting language="sql">SELECT ST_AsGeoJSONAgg(t.*, 'id')
 FROM ( VALUES (1, 'one', 'POINT(1 1)'::geometry),
               (2, 'two', 'POINT(2 2)'),
               (3, 'three', 'POINT(3 3)')
      ) as t(id, name, geom);</programlisting>
-<screen role="text-primary">{"type" : "FeatureCollection", "features" : [{"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "id": 1, "properties": {"name": "one"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[2,2]}, "id": 2, "properties": {"name": "two"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[3,3]}, "id": 3, "properties": {"name": "three"}}]}</screen>
+<screen role="text-primary">{"type": "FeatureCollection", "features" : [{"type": "Feature", "geometry": {"type":"Point","coordinates":[1,1]}, "id": 1, "properties": {"name": "one"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[2,2]}, "id": 2, "properties": {"name": "two"}}, {"type": "Feature", "geometry": {"type":"Point","coordinates":[3,3]}, "id": 3, "properties": {"name": "three"}}]}</screen>
 
 <para>Generate a Feature:</para>
     <programlisting language="sql">SELECT ST_AsGeoJSON(t.*, id_column => 'id')

--- a/postgis/lwgeom_out_geojson.c
+++ b/postgis/lwgeom_out_geojson.c
@@ -1,6 +1,10 @@
 
 #include "../postgis_config.h"
 
+/*
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
+ */
+
 /* PostgreSQL headers */
 #include "postgres.h"
 #include "funcapi.h"
@@ -48,6 +52,25 @@ typedef struct GeoJsonPropKey {
 	char key[NAMEDATALEN];
 } GeoJsonPropKey;
 
+typedef struct GeoJsonAggState {
+	StringInfoData features;
+	uint64 feature_count;
+} GeoJsonAggState;
+
+#define GEOJSON_RECORD_DEFAULT_DECIMAL_DIGITS 9
+
+static void
+pgis_asgeojsonagg_check_input_type(FunctionCallInfo fcinfo, int argno)
+{
+	/*
+	 * The transition and final functions both need this guard.  FILTER
+	 * clauses and empty result sets can bypass the transition function
+	 * entirely, so the final function must reject scalar aggregate inputs too.
+	 */
+	if (!type_is_rowtype(get_fn_expr_argtype(fcinfo->flinfo, argno)))
+		elog(ERROR, "ST_AsGeoJSONAgg: input must be a record or composite row");
+}
+
 static void array_dim_to_json(StringInfo result,
 			      int dim,
 			      int ndims,
@@ -87,6 +110,119 @@ static int postgis_timetz2tm(TimeTzADT *time, struct pg_tm *tm, fsec_t *fsec, in
 
 Datum row_to_geojson(PG_FUNCTION_ARGS);
 extern Datum LWGEOM_asGeoJson(PG_FUNCTION_ARGS);
+
+PG_FUNCTION_INFO_V1(pgis_asgeojsonagg_transfn);
+Datum
+pgis_asgeojsonagg_transfn(PG_FUNCTION_ARGS)
+{
+	MemoryContext aggcontext, oldcontext;
+	GeoJsonAggState *state;
+	char *geom_column = NULL;
+	char *id_column = NULL;
+	int32 maxdecimaldigits = GEOJSON_RECORD_DEFAULT_DECIMAL_DIGITS;
+	bool do_pretty = false;
+
+	if (!AggCheckCallContext(fcinfo, &aggcontext))
+		elog(ERROR, "%s called in non-aggregate context", __func__);
+
+	/* The row encoder needs cached PostGIS type OIDs to find geometry columns. */
+	postgis_initialize_cache();
+
+	oldcontext = MemoryContextSwitchTo(aggcontext);
+
+	if (PG_ARGISNULL(0))
+	{
+		state = palloc0(sizeof(*state));
+		initStringInfo(&state->features);
+	}
+	else
+		state = (GeoJsonAggState *)PG_GETARG_POINTER(0);
+
+	MemoryContextSwitchTo(oldcontext);
+
+	/*
+	 * Validate the declared input type before skipping NULL rows.  Otherwise
+	 * scalar calls such as NULL::geometry would be accepted when all rows are
+	 * NULL, even though non-NULL scalar input is rejected below.
+	 */
+	pgis_asgeojsonagg_check_input_type(fcinfo, 1);
+
+	if (PG_ARGISNULL(1))
+	{
+		PG_RETURN_POINTER(state);
+	}
+
+	if (PG_NARGS() == 3 && !PG_ARGISNULL(2))
+		id_column = text_to_cstring(PG_GETARG_TEXT_P(2));
+	else if (PG_NARGS() == 4)
+	{
+		if (!PG_ARGISNULL(2))
+			geom_column = text_to_cstring(PG_GETARG_TEXT_P(2));
+		if (!PG_ARGISNULL(3))
+			id_column = text_to_cstring(PG_GETARG_TEXT_P(3));
+	}
+	else if (PG_NARGS() == 6)
+	{
+		if (!PG_ARGISNULL(2))
+			geom_column = text_to_cstring(PG_GETARG_TEXT_P(2));
+		if (!PG_ARGISNULL(3))
+			maxdecimaldigits = PG_GETARG_INT32(3);
+		if (!PG_ARGISNULL(4))
+			do_pretty = PG_GETARG_BOOL(4);
+		if (!PG_ARGISNULL(5))
+			id_column = text_to_cstring(PG_GETARG_TEXT_P(5));
+	}
+
+	if (geom_column && strlen(geom_column) == 0)
+		geom_column = NULL;
+	if (id_column && strlen(id_column) == 0)
+		id_column = NULL;
+
+	/*
+	 * The aggregate state owns one growing StringInfo in the aggregate memory
+	 * context.  Appending each feature there avoids the quadratic behavior of
+	 * repeatedly building a new SQL text value from the whole prefix.
+	 */
+	if (state->feature_count > 0)
+		appendStringInfoString(&state->features, ", ");
+	composite_to_geojson(fcinfo,
+			     PG_GETARG_DATUM(1),
+			     geom_column,
+			     id_column,
+			     maxdecimaldigits,
+			     &state->features,
+			     do_pretty,
+			     postgis_oid(GEOMETRYOID),
+			     postgis_oid(GEOGRAPHYOID));
+	state->feature_count++;
+
+	PG_RETURN_POINTER(state);
+}
+
+PG_FUNCTION_INFO_V1(pgis_asgeojsonagg_finalfn);
+Datum
+pgis_asgeojsonagg_finalfn(PG_FUNCTION_ARGS)
+{
+	StringInfoData result;
+	GeoJsonAggState *state;
+
+	if (!AggCheckCallContext(fcinfo, NULL))
+		elog(ERROR, "%s called in non-aggregate context", __func__);
+
+	pgis_asgeojsonagg_check_input_type(fcinfo, 1);
+
+	initStringInfo(&result);
+	appendStringInfoString(&result, "{\"type\": \"FeatureCollection\", \"features\": [");
+
+	if (!PG_ARGISNULL(0))
+	{
+		state = (GeoJsonAggState *)PG_GETARG_POINTER(0);
+		appendBinaryStringInfo(&result, state->features.data, state->features.len);
+	}
+
+	appendStringInfoString(&result, "]}");
+	PG_RETURN_TEXT_P(cstring_to_text_with_len(result.data, result.len));
+}
 
 /*
  * SQL function row_to_geojson(row)

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -5270,6 +5270,104 @@ CREATE OR REPLACE FUNCTION ST_AsGeoJson(r record, geom_column text DEFAULT '', m
 	LANGUAGE 'c' STABLE STRICT PARALLEL SAFE
 	_COST_MEDIUM;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_transfn(internal, anyelement)
+	RETURNS internal
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' STABLE PARALLEL SAFE
+	_COST_MEDIUM;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_transfn(internal, anyelement, text)
+	RETURNS internal
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' STABLE PARALLEL SAFE
+	_COST_MEDIUM;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_transfn(internal, anyelement, text, text)
+	RETURNS internal
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' STABLE PARALLEL SAFE
+	_COST_MEDIUM;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_transfn(internal, anyelement, text, integer, boolean, text)
+	RETURNS internal
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' STABLE PARALLEL SAFE
+	_COST_MEDIUM;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_finalfn(internal, anyelement)
+	RETURNS text
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE
+	_COST_LOW;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_finalfn(internal, anyelement, text)
+	RETURNS text
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE
+	_COST_LOW;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_finalfn(internal, anyelement, text, text)
+	RETURNS text
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE
+	_COST_LOW;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION pgis_asgeojsonagg_finalfn(internal, anyelement, text, integer, boolean, text)
+	RETURNS text
+	AS 'MODULE_PATHNAME'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE
+	_COST_LOW;
+
+-- PostgreSQL aggregates cannot use default or named arguments, so provide
+-- focused positional overloads for common row-to-feature options.
+-- Availability: 3.7.0
+CREATE AGGREGATE ST_AsGeoJSONAgg(anyelement)
+(
+	sfunc = pgis_asgeojsonagg_transfn,
+	stype = internal,
+	parallel = safe,
+	finalfunc = pgis_asgeojsonagg_finalfn,
+	finalfunc_extra
+);
+
+-- Availability: 3.7.0
+CREATE AGGREGATE ST_AsGeoJSONAgg(anyelement, text)
+(
+	sfunc = pgis_asgeojsonagg_transfn,
+	stype = internal,
+	parallel = safe,
+	finalfunc = pgis_asgeojsonagg_finalfn,
+	finalfunc_extra
+);
+
+-- Availability: 3.7.0
+CREATE AGGREGATE ST_AsGeoJSONAgg(anyelement, text, text)
+(
+	sfunc = pgis_asgeojsonagg_transfn,
+	stype = internal,
+	parallel = safe,
+	finalfunc = pgis_asgeojsonagg_finalfn,
+	finalfunc_extra
+);
+
+-- Availability: 3.7.0
+CREATE AGGREGATE ST_AsGeoJSONAgg(anyelement, text, integer, boolean, text)
+(
+	sfunc = pgis_asgeojsonagg_transfn,
+	stype = internal,
+	parallel = safe,
+	finalfunc = pgis_asgeojsonagg_finalfn,
+	finalfunc_extra
+);
+
 -- Availability: 3.0.0
 CREATE OR REPLACE FUNCTION "json"(geometry)
 	RETURNS json

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1606,6 +1606,58 @@ FROM (VALUES
 
 SELECT '#5597', ST_AsGeoJSON(r.*) from (values (null::geometry)) as r(geom);
 
+SELECT '#5775.1', ST_AsGeoJSONAgg(t.*, 'id')::jsonb
+FROM (VALUES
+    (1, 'one', 'POINT(1 1)'::geometry),
+    (2, 'two', 'POINT(2 2)'::geometry))
+    AS t(id, name, geom);
+
+SELECT '#5775.2', ST_AsGeoJSONAgg(t.*, 'geom2', 'id')::jsonb
+FROM (VALUES
+    (1, 'one', 'POINT(0 0)'::geometry, 'POINT(1 1)'::geometry),
+    (2, 'two', 'POINT(0 0)'::geometry, 'POINT(2 2)'::geometry))
+    AS t(id, name, geom1, geom2);
+
+SELECT '#5775.3', ST_AsGeoJSONAgg(t.*)::jsonb
+FROM (SELECT 1, 'POINT(1 1)'::geometry) AS t(id, geom)
+WHERE false;
+
+SELECT '#5775.4', ST_AsGeoJSONAgg(t.*, 'geom2', 1, false, 'id')::jsonb
+FROM (VALUES
+    (1, 'one', 'POINT(0 0)'::geometry, 'POINT(1.11 1.19)'::geometry))
+    AS t(id, name, geom1, geom2);
+
+WITH geojson AS (
+    SELECT ST_AsGeoJSONAgg(r.*, 'id' ORDER BY l.id)::jsonb AS doc
+    FROM (VALUES (1), (2), (3)) AS l(id)
+    LEFT JOIN (VALUES
+        (1, 'one', 'POINT(1 1)'::geometry),
+        (3, 'three', 'POINT(3 3)'::geometry))
+        AS r(id, name, geom)
+    USING (id)
+)
+SELECT '#5775.5',
+    jsonb_array_length(doc -> 'features'),
+    doc #>> '{features,0,id}',
+    doc #>> '{features,1,id}'
+FROM geojson;
+
+SELECT '#5775.6', ST_AsGeoJSONAgg(r.*, 'id')::jsonb
+FROM (VALUES (1), (2)) AS l(id)
+LEFT JOIN (SELECT 1::integer AS id, 'none'::text AS name, 'POINT(0 0)'::geometry AS geom WHERE false) AS r
+USING (id);
+
+SELECT '#5775.7', ST_AsGeoJSONAgg('POINT(0 0)'::geometry)::jsonb;
+
+SELECT '#5775.8', count(*), bool_and(aggtranstype = 'internal'::regtype)
+FROM pg_catalog.pg_aggregate
+JOIN pg_catalog.pg_proc ON pg_proc.oid = pg_aggregate.aggfnoid
+WHERE proname = 'st_asgeojsonagg';
+
+SELECT '#5775.9', ST_AsGeoJSONAgg(NULL::geometry)::jsonb;
+
+SELECT '#5775.10', (ST_AsGeoJSONAgg('POINT(0 0)'::geometry) FILTER (WHERE false))::jsonb;
+
 SELECT '#5677',
  st_asewkt(st_normalize(
    st_union(

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1625,6 +1625,58 @@ FROM (VALUES
 
 SELECT '#5597', ST_AsGeoJSON(r.*) from (values (null::geometry)) as r(geom);
 
+SELECT '#5775.1', ST_AsGeoJSONAgg(t.*, 'id')::jsonb
+FROM (VALUES
+    (1, 'one', 'POINT(1 1)'::geometry),
+    (2, 'two', 'POINT(2 2)'::geometry))
+    AS t(id, name, geom);
+
+SELECT '#5775.2', ST_AsGeoJSONAgg(t.*, 'geom2', 'id')::jsonb
+FROM (VALUES
+    (1, 'one', 'POINT(0 0)'::geometry, 'POINT(1 1)'::geometry),
+    (2, 'two', 'POINT(0 0)'::geometry, 'POINT(2 2)'::geometry))
+    AS t(id, name, geom1, geom2);
+
+SELECT '#5775.3', ST_AsGeoJSONAgg(t.*)::jsonb
+FROM (SELECT 1, 'POINT(1 1)'::geometry) AS t(id, geom)
+WHERE false;
+
+SELECT '#5775.4', ST_AsGeoJSONAgg(t.*, 'geom2', 1, false, 'id')::jsonb
+FROM (VALUES
+    (1, 'one', 'POINT(0 0)'::geometry, 'POINT(1.11 1.19)'::geometry))
+    AS t(id, name, geom1, geom2);
+
+WITH geojson AS (
+    SELECT ST_AsGeoJSONAgg(r.*, 'id' ORDER BY l.id)::jsonb AS doc
+    FROM (VALUES (1), (2), (3)) AS l(id)
+    LEFT JOIN (VALUES
+        (1, 'one', 'POINT(1 1)'::geometry),
+        (3, 'three', 'POINT(3 3)'::geometry))
+        AS r(id, name, geom)
+    USING (id)
+)
+SELECT '#5775.5',
+    jsonb_array_length(doc -> 'features'),
+    doc #>> '{features,0,id}',
+    doc #>> '{features,1,id}'
+FROM geojson;
+
+SELECT '#5775.6', ST_AsGeoJSONAgg(r.*, 'id')::jsonb
+FROM (VALUES (1), (2)) AS l(id)
+LEFT JOIN (SELECT 1::integer AS id, 'none'::text AS name, 'POINT(0 0)'::geometry AS geom WHERE false) AS r
+USING (id);
+
+SELECT '#5775.7', ST_AsGeoJSONAgg('POINT(0 0)'::geometry)::jsonb;
+
+SELECT '#5775.8', count(*), bool_and(aggtranstype = 'internal'::regtype)
+FROM pg_catalog.pg_aggregate
+JOIN pg_catalog.pg_proc ON pg_proc.oid = pg_aggregate.aggfnoid
+WHERE proname = 'st_asgeojsonagg';
+
+SELECT '#5775.9', ST_AsGeoJSONAgg(NULL::geometry)::jsonb;
+
+SELECT '#5775.10', (ST_AsGeoJSONAgg('POINT(0 0)'::geometry) FILTER (WHERE false))::jsonb;
+
 SELECT '#5677',
  st_asewkt(st_normalize(
    st_union(

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -489,6 +489,16 @@ ERROR:  Geometry contains invalid coordinates
 #5639|fullywithin6|f
 #5639|fullywithin7|t
 #5597|{"type": "Feature", "geometry": null, "properties": {}}
+#5775.1|{"type": "FeatureCollection", "features": [{"id": 1, "type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"name": "one"}}, {"id": 2, "type": "Feature", "geometry": {"type": "Point", "coordinates": [2, 2]}, "properties": {"name": "two"}}]}
+#5775.2|{"type": "FeatureCollection", "features": [{"id": 1, "type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"name": "one", "geom1": {"type": "Point", "coordinates": [0, 0]}}}, {"id": 2, "type": "Feature", "geometry": {"type": "Point", "coordinates": [2, 2]}, "properties": {"name": "two", "geom1": {"type": "Point", "coordinates": [0, 0]}}}]}
+#5775.3|{"type": "FeatureCollection", "features": []}
+#5775.4|{"type": "FeatureCollection", "features": [{"id": 1, "type": "Feature", "geometry": {"type": "Point", "coordinates": [1.1, 1.2]}, "properties": {"name": "one", "geom1": {"type": "Point", "coordinates": [0, 0]}}}]}
+#5775.5|2|1|3
+#5775.6|{"type": "FeatureCollection", "features": []}
+ERROR:  ST_AsGeoJSONAgg: input must be a record or composite row
+#5775.8|4|t
+ERROR:  ST_AsGeoJSONAgg: input must be a record or composite row
+ERROR:  ST_AsGeoJSONAgg: input must be a record or composite row
 #5677|POLYGON((0 0,0 10,20 22,20 30,30 30,30 20,22 20,10 0,0 0))
 #5686|0
 #5747|0

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -505,6 +505,16 @@ ERROR:  Geometry contains invalid coordinates
 #5639|fullywithin6|f
 #5639|fullywithin7|t
 #5597|{"type": "Feature", "geometry": null, "properties": {}}
+#5775.1|{"type": "FeatureCollection", "features": [{"id": 1, "type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"name": "one"}}, {"id": 2, "type": "Feature", "geometry": {"type": "Point", "coordinates": [2, 2]}, "properties": {"name": "two"}}]}
+#5775.2|{"type": "FeatureCollection", "features": [{"id": 1, "type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"name": "one", "geom1": {"type": "Point", "coordinates": [0, 0]}}}, {"id": 2, "type": "Feature", "geometry": {"type": "Point", "coordinates": [2, 2]}, "properties": {"name": "two", "geom1": {"type": "Point", "coordinates": [0, 0]}}}]}
+#5775.3|{"type": "FeatureCollection", "features": []}
+#5775.4|{"type": "FeatureCollection", "features": [{"id": 1, "type": "Feature", "geometry": {"type": "Point", "coordinates": [1.1, 1.2]}, "properties": {"name": "one", "geom1": {"type": "Point", "coordinates": [0, 0]}}}]}
+#5775.5|2|1|3
+#5775.6|{"type": "FeatureCollection", "features": []}
+ERROR:  ST_AsGeoJSONAgg: input must be a record or composite row
+#5775.8|4|t
+ERROR:  ST_AsGeoJSONAgg: input must be a record or composite row
+ERROR:  ST_AsGeoJSONAgg: input must be a record or composite row
 #5677|POLYGON((0 0,0 10,20 22,20 30,30 30,30 20,22 20,10 0,0 0))
 #5686|0
 #5747|0


### PR DESCRIPTION
## Summary

- add `ST_AsGeoJSONAgg` aggregate returning GeoJSON FeatureCollection text
- reuse row-mode `ST_AsGeoJSON` feature construction from C so duplicate-key warnings and Feature object semantics match the scalar row function
- keep aggregate state in an internal `StringInfo` accumulator instead of SQL text concatenation, avoiding repeated full-prefix copies for large FeatureCollections
- skip NULL row input without discarding accumulated aggregate state, while still validating the declared aggregate input type before the NULL-row fast path
- reject scalar geometry/geography input in both transition and final functions, including all-NULL and empty/FILTERed aggregate groups, so the aggregate always emits Feature objects inside the FeatureCollection
- use `finalfunc_extra` on every aggregate overload so the final function can validate the aggregate input type even when no transition row ran
- document positional aggregate overloads because PostgreSQL aggregates cannot use named/default arguments
- add regression coverage for ordinary rows, empty/all-null composite inputs, nullable-side joins, scalar-input rejection, all-NULL scalar rejection, empty filtered scalar rejection, deterministic aggregate ordering, and the internal aggregate state

Closes https://trac.osgeo.org/postgis/ticket/5775.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `0c783356bd80afca28cf69df8a61866fe3de1b78`.
- Existing review threads are resolved; the null-row state preservation, scalar-input rejection, deterministic ordering, internal aggregate state, and empty aggregate validation cases remain covered after rebase.
- Local coverage was not generated because this checkout is not coverage-instrumented; GitHub CI and coverage jobs are queued on the pushed head.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make clean`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/lwgeom_out_geojson.c postgis/postgis.sql.in regress/core/tickets.sql regress/core/tickets_expected doc/reference_output.xml NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C doc check-xml`
