### PR TITLE
Add structured PostGIS full version output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -158,6 +158,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)
+ - #5624, Add postgis_full_version_json for structured version output (Darafei Praliaskouski)
  - #5950, Document POSTGIS_REGRESS_DB_OWNER for sandboxed regression roles (Darafei Praliaskouski)
  - #4332, Clarify the scope of several Function Reference categories (Darafei Praliaskouski)
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #5624, Add postgis_full_version_json for structured version output
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/doc/reference_version.xml
+++ b/doc/reference_version.xml
@@ -122,6 +122,108 @@ NOTICE:  Extension postgis_topology is not available or not packagable for some 
 	  </refsection>
 	</refentry>
 
+	<refentry xml:id="PostGIS_Full_Version_JSON">
+	  <refnamediv>
+		<refname>PostGIS_Full_Version_JSON</refname>
+
+		<refpurpose>Reports full PostGIS version and build configuration
+		information as JSON.</refpurpose>
+	  </refnamediv>
+
+	  <refsynopsisdiv>
+		<funcsynopsis>
+		  <funcprototype>
+			<funcdef>jsonb <function>PostGIS_Full_Version_JSON</function></funcdef>
+
+			<paramdef></paramdef>
+		  </funcprototype>
+		</funcsynopsis>
+	  </refsynopsisdiv>
+
+	  <refsection>
+		<title>Description</title>
+
+		<para>Reports full PostGIS version and build configuration
+		information as a structured JSON object. This is intended for tools
+		that need to inspect PostGIS, PostgreSQL, dependency, and extension
+		version state without parsing the human-readable
+		<xref linkend="PostGIS_Full_Version"/> output.</para>
+
+		<para>The JSON object contains <varname>postgis</varname>,
+		<varname>postgresql</varname>, dependency version members such as
+		<varname>geos</varname> and <varname>proj</varname>, optional extension
+		members such as <varname>topology</varname> and <varname>raster</varname>,
+		and a machine-readable <varname>warnings</varname> array. Optional
+		dependency and extension members are omitted when the corresponding
+		support is not available in the current database.</para>
+
+		<para>Each <varname>warnings</varname> entry is an object with a stable
+		<varname>code</varname> field and a human-readable
+		<varname>message</varname> field. Warning codes include
+		<literal>liblwgeom_version_mismatch</literal>,
+		<literal>postgresql_procs_need_upgrade</literal>,
+		<literal>geos_compiled_version_mismatch</literal>,
+		<literal>proj_compiled_version_mismatch</literal>,
+		<literal>core_procs_need_upgrade</literal>,
+		<literal>topology_procs_need_upgrade</literal>,
+		<literal>topology_unpacked</literal>,
+		<literal>raster_lib_need_upgrade</literal>,
+		<literal>raster_unpacked</literal>,
+		<literal>raster_procs_need_upgrade</literal>,
+		<literal>sfcgal_procs_need_upgrade</literal>, and
+		<literal>deprecated_functions_exist</literal>.</para>
+
+		<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+	  </refsection>
+
+	  <refsection>
+		<title>Examples</title>
+
+		<programlisting>SELECT jsonb_pretty(PostGIS_Full_Version_JSON());
+{
+    "postgis": {
+        "version": "3.7.0dev",
+        "extension": true,
+        "liblwgeom": "3.7.0dev",
+        "needs_upgrade": false,
+        "scripts_released": "3.7.0dev",
+        "scripts_installed": "3.7.0dev"
+    },
+    "geos": {
+        "runtime": "3.14.1-CAPI-1.20.5",
+        "compiled": "3.14.1-CAPI-1.20.5"
+    },
+    "proj": {
+        "runtime": "9.8.1",
+        "compiled": "9.8.1"
+    },
+    "gdal": "GDAL 3.13.1, released 2026/06/01",
+    "libxml": "2.14.6",
+    "libjson": "0.18",
+    "libprotobuf": "1.5.2",
+    "postgresql": {
+        "runtime": "180",
+        "scripts": "180",
+        "procs_need_upgrade": false
+    },
+    "warnings": []
+}</programlisting>
+	  </refsection>
+
+	  <refsection>
+		<title>See Also</title>
+
+		<para>
+		<xref linkend="upgrading"/>,
+		<xref linkend="PostGIS_Full_Version"/>,
+		<xref linkend="PostGIS_GEOS_Version"/>,
+		<xref linkend="PostGIS_Lib_Version"/>,
+		<xref linkend="PostGIS_PROJ_Version"/>,
+		<xref linkend="PostGIS_Version"/>
+		</para>
+	  </refsection>
+	</refentry>
+
 	<refentry xml:id="PostGIS_GEOS_Version">
 	  <refnamediv>
 		<refname>PostGIS_GEOS_Version</refname>

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -3273,6 +3273,258 @@ AS $$
 	FROM pg_catalog.substring(version(), E'PostgreSQL ([0-9\\.]+)') AS s;
 $$ LANGUAGE 'sql' STABLE;
 
+-- Availability: 3.7.0
+-- Build structured output from the same probes as postgis_full_version()
+-- instead of parsing its human-readable status string.
+CREATE OR REPLACE FUNCTION postgis_full_version_json() RETURNS jsonb
+AS $$
+DECLARE
+	libver text;
+	librev text;
+	projver text;
+	projver_compiled text;
+	projver_compare text;
+	projver_compiled_compare text;
+	geosver text;
+	geosver_compiled text;
+	sfcgalver text := NULL;
+	gdalver text := NULL;
+	libxmlver text;
+	liblwgeomver text;
+	dbproc text;
+	relproc text;
+	rast_lib_ver text := NULL;
+	rast_scr_ver text := NULL;
+	topo_scr_ver text := NULL;
+	json_lib_ver text;
+	protobuf_lib_ver text;
+	wagyu_lib_ver text;
+	sfcgal_scr_ver text := NULL;
+	pgsql_scr_ver text;
+	pgsql_ver text;
+	core_is_extension bool;
+	deprecated_functions_exist bool;
+	warnings jsonb := '[]'::jsonb;
+BEGIN
+	SELECT @extschema@.postgis_lib_version() INTO libver;
+	SELECT @extschema@.postgis_lib_revision() INTO librev;
+	SELECT @extschema@.postgis_liblwgeom_version() INTO liblwgeomver;
+	SELECT @extschema@.postgis_scripts_installed() INTO dbproc;
+	SELECT @extschema@.postgis_scripts_released() INTO relproc;
+	SELECT @extschema@._postgis_scripts_pgsql_version() INTO pgsql_scr_ver;
+	SELECT @extschema@._postgis_pgsql_version() INTO pgsql_ver;
+	SELECT @extschema@.postgis_geos_version() INTO geosver;
+	SELECT @extschema@.postgis_geos_compiled_version() INTO geosver_compiled;
+	SELECT @extschema@.postgis_proj_version() INTO projver;
+	SELECT @extschema@.postgis_proj_compiled_version() INTO projver_compiled;
+	-- Keep projver raw for reporting, but compare only the numeric prefix:
+	-- PROJ runtime status may append configuration details after the version.
+	projver_compare := pg_catalog.split_part(projver, ' ', 1);
+	projver_compiled_compare := pg_catalog.split_part(projver_compiled, ' ', 1);
+	SELECT @extschema@.postgis_libxml_version() INTO libxmlver;
+	SELECT @extschema@.postgis_libjson_version() INTO json_lib_ver;
+	SELECT @extschema@.postgis_libprotobuf_version() INTO protobuf_lib_ver;
+	SELECT @extschema@.postgis_wagyu_version() INTO wagyu_lib_ver;
+
+	core_is_extension := EXISTS (
+		SELECT * FROM pg_catalog.pg_extension
+		WHERE extname = 'postgis');
+
+	BEGIN
+		SELECT @extschema@.postgis_gdal_version() INTO gdalver;
+	EXCEPTION
+		WHEN undefined_function THEN
+			RAISE DEBUG 'Function postgis_gdal_version() not found. Is raster support enabled and rtpostgis.sql installed?';
+	END;
+
+	BEGIN
+		SELECT @extschema@.postgis_sfcgal_full_version() INTO sfcgalver;
+		BEGIN
+			SELECT @extschema@.postgis_sfcgal_scripts_installed() INTO sfcgal_scr_ver;
+		EXCEPTION
+			WHEN undefined_function THEN
+				sfcgal_scr_ver := 'missing';
+		END;
+	EXCEPTION
+		WHEN undefined_function THEN
+			RAISE DEBUG 'Function postgis_sfcgal_full_version() not found. Is sfcgal support enabled and sfcgal.sql installed?';
+	END;
+
+	BEGIN
+		SELECT topology.postgis_topology_scripts_installed() INTO topo_scr_ver;
+	EXCEPTION
+		WHEN undefined_function OR invalid_schema_name THEN
+			RAISE DEBUG 'Function postgis_topology_scripts_installed() not found. Is topology support enabled and topology.sql installed?';
+		WHEN insufficient_privilege THEN
+			RAISE NOTICE 'Topology support cannot be inspected. Is current user granted USAGE on schema "topology" ?';
+		WHEN OTHERS THEN
+			RAISE NOTICE 'Function postgis_topology_scripts_installed() could not be called: % (%)', SQLERRM, SQLSTATE;
+	END;
+
+	BEGIN
+		SELECT @extschema@.postgis_raster_scripts_installed() INTO rast_scr_ver;
+	EXCEPTION
+		WHEN undefined_function THEN
+			RAISE DEBUG 'Function postgis_raster_scripts_installed() not found. Is raster support enabled and rtpostgis.sql installed?';
+		WHEN OTHERS THEN
+			RAISE NOTICE 'Function postgis_raster_scripts_installed() could not be called: % (%)', SQLERRM, SQLSTATE;
+	END;
+
+	BEGIN
+		SELECT @extschema@.postgis_raster_lib_version() INTO rast_lib_ver;
+	EXCEPTION
+		WHEN undefined_function THEN
+			RAISE DEBUG 'Function postgis_raster_lib_version() not found. Is raster support enabled and rtpostgis.sql installed?';
+		WHEN OTHERS THEN
+			RAISE NOTICE 'Function postgis_raster_lib_version() could not be called: % (%)', SQLERRM, SQLSTATE;
+	END;
+
+	deprecated_functions_exist := EXISTS (
+		SELECT oid FROM pg_catalog.pg_proc
+		WHERE proname LIKE '%_deprecated_by_postgis_%');
+
+	IF liblwgeomver != relproc THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'liblwgeom_version_mismatch',
+			'message', pg_catalog.format('liblwgeom version mismatch: "%s"', liblwgeomver)
+		));
+	END IF;
+
+	IF pgsql_scr_ver != pgsql_ver THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'postgresql_procs_need_upgrade',
+			'message', pg_catalog.format('procs need upgrade for use with PostgreSQL "%s"', pgsql_ver)
+		));
+	END IF;
+
+	IF geosver IS NOT NULL
+		AND (pg_catalog.string_to_array(geosver, '.'))[1:2] != (pg_catalog.string_to_array(geosver_compiled, '.'))[1:2]
+	THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'geos_compiled_version_mismatch',
+			'message', pg_catalog.format('compiled against GEOS %s', geosver_compiled)
+		));
+	END IF;
+
+	IF projver IS NOT NULL
+		AND (pg_catalog.string_to_array(projver_compare, '.'))[1:3] != (pg_catalog.string_to_array(projver_compiled_compare, '.'))[1:3]
+	THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'proj_compiled_version_mismatch',
+			'message', pg_catalog.format('compiled against PROJ %s', projver_compiled)
+		));
+	END IF;
+
+	IF dbproc != relproc THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'core_procs_need_upgrade',
+			'message', pg_catalog.format('core procs from "%s" need upgrade', dbproc)
+		));
+	END IF;
+
+	IF topo_scr_ver IS NOT NULL AND topo_scr_ver != relproc THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'topology_procs_need_upgrade',
+			'message', pg_catalog.format('topology procs from "%s" need upgrade', topo_scr_ver)
+		));
+	END IF;
+
+	IF topo_scr_ver IS NOT NULL AND core_is_extension AND NOT EXISTS (
+		SELECT * FROM pg_catalog.pg_extension
+		WHERE extname = 'postgis_topology')
+	THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'topology_unpacked',
+			'message', 'topology support is not packaged as an extension'
+		));
+	END IF;
+
+	IF rast_lib_ver IS NOT NULL AND rast_lib_ver != relproc THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'raster_lib_need_upgrade',
+			'message', pg_catalog.format('raster lib from "%s" need upgrade', rast_lib_ver)
+		));
+	END IF;
+
+	IF rast_lib_ver IS NOT NULL AND core_is_extension AND NOT EXISTS (
+		SELECT * FROM pg_catalog.pg_extension
+		WHERE extname = 'postgis_raster')
+	THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'raster_unpacked',
+			'message', 'raster support is not packaged as an extension'
+		));
+	END IF;
+
+	IF rast_scr_ver IS NOT NULL AND rast_scr_ver != relproc THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'raster_procs_need_upgrade',
+			'message', pg_catalog.format('raster procs from "%s" need upgrade', rast_scr_ver)
+		));
+	END IF;
+
+	IF sfcgal_scr_ver IS NOT NULL AND sfcgal_scr_ver != relproc THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'sfcgal_procs_need_upgrade',
+			'message', pg_catalog.format('sfcgal procs from "%s" need upgrade', sfcgal_scr_ver)
+		));
+	END IF;
+
+	IF deprecated_functions_exist THEN
+		warnings := warnings || pg_catalog.jsonb_build_array(pg_catalog.jsonb_build_object(
+			'code', 'deprecated_functions_exist',
+			'message', 'deprecated functions exist, upgrade is not complete'
+		));
+	END IF;
+
+	RETURN pg_catalog.jsonb_strip_nulls(pg_catalog.jsonb_build_object(
+		'postgis', pg_catalog.jsonb_build_object(
+			'version', libver,
+			'revision', librev,
+			'extension', core_is_extension,
+			'scripts_installed', dbproc,
+			'scripts_released', relproc,
+			'liblwgeom', liblwgeomver,
+			'needs_upgrade', dbproc != relproc OR liblwgeomver != relproc
+		),
+		'postgresql', pg_catalog.jsonb_build_object(
+			'scripts', pgsql_scr_ver,
+			'runtime', pgsql_ver,
+			'procs_need_upgrade', pgsql_scr_ver != pgsql_ver
+		),
+		'geos', pg_catalog.jsonb_build_object('runtime', geosver, 'compiled', geosver_compiled),
+		'proj', pg_catalog.jsonb_build_object('runtime', projver, 'compiled', projver_compiled),
+		'sfcgal', CASE WHEN sfcgalver IS NULL AND sfcgal_scr_ver IS NULL THEN NULL ELSE pg_catalog.jsonb_build_object(
+			'runtime', sfcgalver,
+			'scripts_installed', sfcgal_scr_ver,
+			'needs_upgrade', sfcgal_scr_ver != relproc
+		) END,
+		'gdal', gdalver,
+		'libxml', libxmlver,
+		'libjson', json_lib_ver,
+		'libprotobuf', protobuf_lib_ver,
+		'wagyu', wagyu_lib_ver,
+		'topology', CASE WHEN topo_scr_ver IS NULL THEN NULL ELSE pg_catalog.jsonb_build_object(
+			'scripts_installed', topo_scr_ver,
+			'needs_upgrade', topo_scr_ver != relproc,
+			'unpackaged', core_is_extension AND NOT EXISTS (
+				SELECT * FROM pg_catalog.pg_extension
+				WHERE extname = 'postgis_topology')
+		) END,
+		'raster', CASE WHEN rast_lib_ver IS NULL AND rast_scr_ver IS NULL THEN NULL ELSE pg_catalog.jsonb_build_object(
+			'lib_version', rast_lib_ver,
+			'scripts_installed', rast_scr_ver,
+			'needs_upgrade', rast_lib_ver != relproc OR rast_scr_ver != relproc,
+			'unpackaged', core_is_extension AND NOT EXISTS (
+				SELECT * FROM pg_catalog.pg_extension
+				WHERE extname = 'postgis_raster')
+		) END,
+		'warnings', warnings
+	));
+END
+$$
+LANGUAGE 'plpgsql' STABLE;
+
 -- Availability: 2.5.0
 -- Changed: 3.3.0 support for upgrades from any PostGIS version
 -- Changed: 3.0.1 install from unpackaged should include postgis schema #4581

--- a/regress/core/regress.sql
+++ b/regress/core/regress.sql
@@ -402,3 +402,19 @@ AND proleakproof;
 SELECT 'UNEXPECTED', postgis_full_version()
 	WHERE postgis_full_version() LIKE '%UNPACKAGED%'
 	   OR postgis_full_version() LIKE '%need upgrade%';
+
+WITH full_version AS (
+	SELECT postgis_full_version_json() AS doc
+)
+SELECT 'postgis_full_version_json',
+	(doc ? 'postgis') AS has_postgis,
+	(doc ? 'geos') AS has_geos,
+	(doc #>> '{postgis,version}') = postgis_lib_version() AS version_matches,
+	jsonb_typeof(doc #> '{postgis,extension}') AS extension_type,
+	jsonb_typeof(doc -> 'warnings') AS warnings_type,
+	CASE
+		WHEN pg_catalog.split_part(doc #>> '{proj,runtime}', ' ', 1) = (doc #>> '{proj,compiled}')
+		THEN NOT (doc -> 'warnings' @> '[{"code": "proj_compiled_version_mismatch"}]'::jsonb)
+		ELSE doc -> 'warnings' @> '[{"code": "proj_compiled_version_mismatch"}]'::jsonb
+	END AS proj_version_ok
+FROM full_version;

--- a/regress/core/regress_expected
+++ b/regress/core/regress_expected
@@ -232,3 +232,4 @@ ERROR:  ST_TileEnvelope: Margin must not be less than -50%, margin=-0.510000
 315|0
 316|t|LINESTRING(40 8.660254037844387,35 8.660254037844387)
 leakproof_compare_support|14
+postgis_full_version_json|t|t|t|boolean|array|t


### PR DESCRIPTION
## Summary

- add `postgis_full_version_json()` returning a `jsonb` object built from existing version probes
- expose documented warning codes for version mismatches, upgrade-needed states, unpackaged support, and deprecated functions
- keep PROJ runtime details in the JSON output while normalizing only the numeric version prefix for mismatch detection
- document the JSON shape and add regression coverage for stable keys and PROJ warning behavior

Closes https://trac.osgeo.org/postgis/ticket/5624.

## Notes

This intentionally does not add live GEOS EOL checks or parse `postgis_full_version()` text. The JSON function mirrors the existing local status probes so tooling can inspect installed state without relying on the human-readable string.

`postgis_full_version_json()` is marked `STABLE` because it reads catalog and extension state.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `05d3b71f7b20ab3c04a72dc4a38ed1cb1da2a9ae`.
- Existing review threads are resolved; PROJ runtime-version normalization and mismatch-branch regression checks remain covered after rebase.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make clean`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/postgis.sql.in regress/core/regress.sql regress/core/regress_expected doc/reference_version.xml NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C postgis postgis.sql`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/regress"`
- `make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/regress"`
- `make -C doc check-xml`

Coverage note: this is a SQL/documentation API change; local focused regression covered fresh and upgrade extension paths. Repository coverage shards are left to CI.
