### PR TITLE
Initialize skipped union-find cluster ids

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - #5975, Initialize skipped union-find cluster ids deterministically
+          (Darafei Praliaskouski)
  - GH-885, [topology] Avoid GMP overflow in ring orientation for very large
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,

--- a/liblwgeom/cunit/cu_unionfind.c
+++ b/liblwgeom/cunit/cu_unionfind.c
@@ -4,6 +4,7 @@
  * http://postgis.net
  *
  * Copyright 2015 Daniel Baston
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU General Public Licence. See the COPYING file.
@@ -148,15 +149,13 @@ static void test_unionfind_collapse_cluster_ids(void)
 	lwfree(collapsed_ids);
 
 	uint8_t is_in_cluster[] = {0, 1, 1, 1, 0, 1, 0, 0, 0, 0};
-	uint32_t expected_collapsed_ids2[] = { 8, 0, 0, 0, 7, 0, 8, 7, 8, 7 };
+	uint32_t expected_collapsed_ids2[] = {
+	    UINT32_MAX, 0, 0, 0, UINT32_MAX, 0, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX};
 
 	collapsed_ids = UF_get_collapsed_cluster_ids(uf, is_in_cluster);
 	uint32_t i;
 	for (i = 0; i < uf->N; i++)
-	{
-		if (is_in_cluster[i])
-			ASSERT_INT_EQUAL(expected_collapsed_ids2[i], collapsed_ids[i]);
-	}
+		ASSERT_INT_EQUAL(expected_collapsed_ids2[i], collapsed_ids[i]);
 
 	lwfree(collapsed_ids);
 	UF_destroy(uf);

--- a/liblwgeom/lwunionfind.c
+++ b/liblwgeom/lwunionfind.c
@@ -19,9 +19,9 @@
  **********************************************************************
  *
  * Copyright 2015 Daniel Baston <dbaston@gmail.com>
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
-
 
 #include "liblwgeom.h"
 #include "lwunionfind.h"
@@ -149,6 +149,8 @@ UF_get_collapsed_cluster_ids(UNIONFIND *uf, const uint8_t *is_in_cluster)
 	uint32_t* new_ids = lwalloc(uf->N * sizeof(uint32_t));
 	uint32_t last_old_id, current_new_id, i;
 	uint8_t encountered_cluster = LW_FALSE;
+
+	memset(new_ids, 0xFF, uf->N * sizeof(uint32_t));
 
 	current_new_id = 0; last_old_id = 0;
 	for (i = 0; i < uf->N; i++)


### PR DESCRIPTION
## Summary
- initialize `UF_get_collapsed_cluster_ids` results to `UINT32_MAX` before filling clustered entries
- assert skipped entries from `is_in_cluster` are deterministic in the union-find CUnit test

This fixes the initialization issue mentioned in https://trac.osgeo.org/postgis/ticket/5975 without changing the public symbol export surface from the older MobilityDB PR #826.

## Tests
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester`
- `./liblwgeom/cunit/cu_tester clustering_unionfind`
- `./liblwgeom/cunit/cu_tester clustering`
- `git clang-format --diff HEAD -- liblwgeom/lwunionfind.c liblwgeom/cunit/cu_unionfind.c`
- `git diff --check`

Refs https://trac.osgeo.org/postgis/ticket/5975