### PR TITLE
doc: correct ST_BandIsNoData forceChecking default

### DIFF
--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -3976,12 +3976,12 @@ WHERE rid = 2;
                     <funcdef>boolean <function>ST_BandIsNoData</function></funcdef>
                     <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                     <paramdef><type>integer </type> <parameter>band</parameter></paramdef>
-                    <paramdef choice="opt"><type>boolean </type> <parameter>forceChecking=true</parameter></paramdef>
+                    <paramdef choice="opt"><type>boolean </type> <parameter>forceChecking=false</parameter></paramdef>
                   </funcprototype>
                  <funcprototype>
                     <funcdef>boolean <function>ST_BandIsNoData</function></funcdef>
                     <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
-                    <paramdef choice="opt"><type>boolean </type> <parameter>forceChecking=true</parameter></paramdef>
+                    <paramdef choice="opt"><type>boolean </type> <parameter>forceChecking=false</parameter></paramdef>
                   </funcprototype>
                 </funcsynopsis>
             </refsynopsisdiv>


### PR DESCRIPTION
## Summary

Corrects the `ST_BandIsNoData` synopsis to show `forceChecking=false`, matching the actual SQL default and the existing description text.

This helps users looking at https://trac.osgeo.org/postgis/ticket/5176 find the cheap metadata path instead of seeing the expensive forced pixel scan advertised as the default. It is intentionally documentation-only; changing raster no-data scan behavior would be a larger semantic change.

References https://trac.osgeo.org/postgis/ticket/5176

## Validation

- Rebased on `postgis:master` at `63cbf4f069afebe50cb520b7abe6440c898842e9`.
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `xmllint --noout doc/reference_raster.xml`
- `make -C doc comments`
- `make -C doc check-xml`

SQL regression tests were not run because this only changes manual text.
