### PR TITLE
topology: accept single TopoElement inputs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -117,6 +117,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #2386, Add missing raster2pgsql man page (Darafei Praliaskouski)
  - #5975, Initialize skipped union-find cluster ids deterministically
           (Darafei Praliaskouski)
+ - #5932, #5933, [topology] Add TopoElementArray constructor and
+          CreateTopoGeom support for single TopoElements
+          (Darafei Praliaskouski)
  - GH-885, [topology] Avoid GMP overflow in ring orientation for very large
           finite coordinates (Darafei Praliaskouski)
  - GH-892, Add OSS-Fuzz coverage for TWKB and serialized raster inputs,

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -248,6 +248,13 @@ SELECT ARRAY[ARRAY[1,2], ARRAY[4,3]]::topology.topoelementarray As tea;
 -------
 {{1,2},{4,3}}
 
+-- Construct a TopoElementArray from a single TopoElement --
+SELECT topology.TopoElementArray(ARRAY[1,2]::topology.topoelement) As tea;
+
+   tea
+---------
+ {{1,2}}
+
 --using the array agg function packaged with topology --
 SELECT topology.TopoElementArray_Agg(ARRAY[e,t]) As tea
   FROM generate_series(1,4) As e CROSS JOIN generate_series(1,3) As t;
@@ -3760,6 +3767,7 @@ are expanded to include merged faces (upon removing edges) or healed edges
                 <para>punctal layers are formed from set of nodes, lineal layers are formed from a set of edges, areal layers are formed from a set of faces,
 	and collections can be formed from a mixture of nodes, edges, and faces.</para>
                 <para>Omitting the array of components generates an empty TopoGeometry object.</para>
+                <para>A single <varname>TopoElement</varname> may be supplied where a one-element <varname>TopoElementArray</varname> is expected.</para>
                 <!-- use this format if new function -->
                 <para role="availability" conformance="1.1">Availability: 1.1</para>
 			</refsection>

--- a/topology/test/regress/topoelement.sql
+++ b/topology/test/regress/topoelement.sql
@@ -3,6 +3,7 @@ SELECT '1','{101,1}'::topology.TopoElement;
 SELECT '2','{101,2}'::topology.TopoElement;
 SELECT '3','{101,3}'::topology.TopoElement;
 SELECT '4','{1,104}'::topology.TopoElement; -- layer id has no higher limit
+SELECT '5',topology.TopoElementArray('{101,2}'::topology.TopoElement);
 -- Invalid: has 3 elements
 SELECT '[0:2]={1,2,3}'::topology.TopoElement;
 -- Invalid: 0 is both an invalid primitive element id and an invalid layer id

--- a/topology/test/regress/topoelement_cast.sql
+++ b/topology/test/regress/topoelement_cast.sql
@@ -55,5 +55,29 @@ SELECT 't1', lbl, ST_AsText(g::geometry)
 FROM tt.f_hier_point
 ORDER BY lbl;
 
+SELECT 't5933.explicit', id(topology.CreateTopoGeom(
+  'tt',
+  1,
+  layer_id(findLayer('tt','f_hier_point', 'g')),
+  (SELECT g::topology.TopoElement FROM tt.f_point WHERE lbl = '5090'),
+  5933
+));
+
+SELECT 't5933.implicit', ST_AsText(
+  topology.CreateTopoGeom(
+    'tt',
+    1,
+    layer_id(findLayer('tt','f_hier_point', 'g')),
+    (SELECT g::topology.TopoElement FROM tt.f_point WHERE lbl = '5070')
+  )::geometry
+);
+
+SELECT 't5933.malformed', topology.CreateTopoGeom(
+  'tt',
+  1,
+  layer_id(findLayer('tt','f_hier_point', 'g')),
+  ARRAY[1,2,3]::topology.TopoElementArray
+);
+
 -- Cleanup
 SELECT NULL FROM DropTopology('tt');

--- a/topology/test/regress/topoelement_cast_expected
+++ b/topology/test/regress/topoelement_cast_expected
@@ -2,3 +2,6 @@ t1|bycast:50|MULTIPOINT((50 70),(50 90))
 t1|bycast:60|MULTIPOINT((60 70),(60 90))
 t1|byfunc:70|MULTIPOINT((50 70),(60 70))
 t1|byfunc:90|MULTIPOINT((50 90),(60 90))
+t5933.explicit|5933
+t5933.implicit|MULTIPOINT((50 70))
+ERROR:  Invalid TopoElementArray element: expected 2 values, got 3

--- a/topology/test/regress/topoelement_expected
+++ b/topology/test/regress/topoelement_expected
@@ -2,5 +2,6 @@
 2|{101,2}
 3|{101,3}
 4|{1,104}
+5|{{101,2}}
 ERROR:  value for domain topoelement violates check constraint "lower_dimension"
 ERROR:  value for domain topoelement violates check constraint "type_range"

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -696,6 +696,14 @@ BEGIN
     RAISE EXCEPTION 'Invalid Topogeo ID % (must be > 0)', tg_id;
   END IF;
 
+  IF array_ndims(tg_objs) = 1 THEN
+    IF array_length(tg_objs, 1) != 2 THEN
+      RAISE EXCEPTION 'Invalid TopoElementArray element: expected 2 values, got %',
+        array_length(tg_objs, 1);
+    END IF;
+    tg_objs := ARRAY[ARRAY[tg_objs[1], tg_objs[2]]]::topology.TopoElementArray;
+  END IF;
+
   IF tg_type < 1 OR tg_type > 4 THEN
     RAISE EXCEPTION 'Invalid TopoGeometry type % (must be in the range 1..4)', tg_type;
   END IF;
@@ -1265,6 +1273,20 @@ CREATE OR REPLACE FUNCTION topology.TopoElement(topo topology.TopoGeometry)
     IMMUTABLE PARALLEL SAFE
 AS  $$SELECT ARRAY[topo.id::bigint,topo.layer_id::bigint]::topology.topoelement;$$;
 --} TopoElement(TopoGeometry)
+
+--{
+-- TopoElementArray(TopoElement)
+--
+-- Construct a TopoElementArray from a single TopoElement.
+--
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION topology.TopoElementArray(element topology.TopoElement)
+    RETURNS topology.TopoElementArray
+    LANGUAGE sql
+    COST 1
+    IMMUTABLE PARALLEL SAFE
+AS  $$SELECT ARRAY[element::bigint[]]::topology.TopoElementArray;$$;
+--} TopoElementArray(TopoElement)
 
 --{
 -- TopoGeometry(bigint[])


### PR DESCRIPTION
## Summary
- add `topology.TopoElementArray(topology.TopoElement)` to construct a one-element TopoElementArray
- normalize single TopoElement-shaped inputs in `CreateTopoGeom` before relation insertion
- document the constructor and single-element `CreateTopoGeom` behavior

Closes https://trac.osgeo.org/postgis/ticket/5932
Closes https://trac.osgeo.org/postgis/ticket/5933

## Review notes
- rebased on current `upstream/master` (`902880616da9cf054786b24bd243a7e454c3c34a`)
- refreshed head: `2454cf3ea9203ed3726f4e6ad14d9ee387472cc0`
- the one-dimensional input path validates that a TopoElement-shaped array has exactly two entries before wrapping it, so malformed input such as `{1,2,3}` is rejected instead of truncated
- the constructor-order concern remains obsolete: `topology.TopoElementArray(topology.TopoElement)` constructs `ARRAY[element::bigint[]]::topology.TopoElementArray` directly and does not reference `TopoElementArray_append`

## Validation
- `make -C topology topology.sql topology_upgrade.sql`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C doc check-xml`
- `dropdb --if-exists postgis_reg && make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/topoelement $(pwd)/topology/test/regress/topoelement_cast"` (fresh and automatic-upgrade)
- direct smoke asserting malformed `{1,2,3}` TopoElementArray input raises `Invalid TopoElementArray element: expected 2 values, got 3`
- `./utils/check_news.sh .`
- `git diff --check`
- `git diff upstream/master..HEAD --check`
- `git clang-format --diff upstream/master -- topology/topology.sql.in topology/test/regress/topoelement.sql topology/test/regress/topoelement_cast.sql topology/test/regress/topoelement_cast_expected topology/test/regress/topoelement_expected doc/extras_topology.xml NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/346
