### PR TITLE
doc: add raster2pgsql man page

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -68,6 +68,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           deprecated-function cleanup (Darafei Praliaskouski)
  - GH-899, [raster] Honor PostgreSQL interrupts in long-running GDAL
           progress callbacks (Darafei Praliaskouski)
+ - #2386, Add missing raster2pgsql man page (Darafei Praliaskouski)
  - #5975, Initialize skipped union-find cluster ids deterministically
           (Darafei Praliaskouski)
  - GH-885, [topology] Avoid GMP overflow in ring orientation for very large

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -558,7 +558,7 @@ endif
 comments-uninstall:
 	$(MAKE) -f Makefile.comments uninstall
 
-man-install: man/shp2pgsql.1 man/pgsql2shp.1 man/pgtopo_export.1 man/pgtopo_import.1 man/postgis.1 man/postgis_restore.1
+man-install: man/shp2pgsql.1 man/pgsql2shp.1 man/raster2pgsql.1 man/pgtopo_export.1 man/pgtopo_import.1 man/postgis.1 man/postgis_restore.1
 	mkdir -p $(DESTDIR)$(mandir)/man1
 	for f in $^; do \
 		$(INSTALL_DATA) $$f $(DESTDIR)$(mandir)/man1/`basename $$f`; \
@@ -567,6 +567,7 @@ man-install: man/shp2pgsql.1 man/pgsql2shp.1 man/pgtopo_export.1 man/pgtopo_impo
 man-uninstall:
 	rm -f $(DESTDIR)$(mandir)/man1/shp2pgsql.1
 	rm -f $(DESTDIR)$(mandir)/man1/pgsql2shp.1
+	rm -f $(DESTDIR)$(mandir)/man1/raster2pgsql.1
 	rm -f $(DESTDIR)$(mandir)/man1/pgtopo_export.1
 	rm -f $(DESTDIR)$(mandir)/man1/pgtopo_import.1
 	rm -f $(DESTDIR)$(mandir)/man1/postgis.1

--- a/doc/man/raster2pgsql.1
+++ b/doc/man/raster2pgsql.1
@@ -1,0 +1,146 @@
+.TH "raster2pgsql" "1" "" "" "PostGIS"
+.SH "NAME"
+.LP
+raster2pgsql - raster to postgis loader
+
+.SH "SYNTAX"
+.LP
+raster2pgsql [\fIoptions\fR] \fIraster\fR [\fIraster\fR ...] [[\fIschema\fR\fB.\fR]\fItable\fR]
+
+.SH "DESCRIPTION"
+.LP
+The raster2pgsql data loader converts raster files supported by GDAL into SQL
+suitable for insertion into a PostGIS raster table. Multiple raster files may
+be passed on the command line, and shell wildcards can be used to select input
+files.
+
+.SH "OPTIONS"
+.LP
+The commandline options are:
+.TP
+\fB\-s\fR [<\fIFROM_SRID\fR>:]<\fISRID\fR>
+Set the SRID field. If FROM_SRID is given, the input raster is treated as that
+source SRID before being transformed to SRID. If no SRID is provided, or if SRID
+is 0, raster metadata is used when possible.
+.TP
+\fB\-b\fR <\fIband\fR>
+Index, starting from 1, of the band to extract from the raster. Separate
+multiple band indexes with commas. Ranges can be written with a dash. If this
+option is omitted, all bands are extracted.
+.TP
+\fB\-t\fR <\fItile_size\fR>
+Cut each raster into tiles inserted one per table row. The tile size is written
+as WIDTHxHEIGHT. Use "auto" to let the loader choose a tile size from the first
+raster and apply it to all rasters.
+.TP
+\fB\-P\fR
+Pad right-most and bottom-most tiles so all tiles have the same width and
+height.
+.TP
+\fB\-R\fR
+Register the raster as an out-of-db filesystem raster. Input raster paths must
+be absolute.
+.TP
+\fB\-d\fR
+Drop the table, recreate it, and populate it with the raster data.
+.TP
+\fB\-a\fR
+Append raster data into the existing table. The target table must have the same
+schema.
+.TP
+\fB\-c\fR
+Create a new table and populate it. This is the default mode.
+.TP
+\fB\-p\fR
+Prepare mode. Only emit SQL to create the table.
+.TP
+\fB\-f\fR <\fIcolumn\fR>
+Specify the name of the raster column.
+.TP
+\fB\-F\fR
+Add a column containing the source raster filename.
+.TP
+\fB\-n\fR <\fIcolumn\fR>
+Specify the filename column name. This implies \-F.
+.TP
+\fB\-l\fR <\fIoverview_factor\fR>
+Create overview tables for the raster. Separate multiple factors with commas.
+Overview table names follow the pattern o_<overview factor>_<table>. Created
+overviews are stored in the database and are not affected by \-R.
+.TP
+\fB\-q\fR
+Wrap PostgreSQL identifiers in quotes.
+.TP
+\fB\-I\fR
+Create a GiST spatial index on the raster column.
+.TP
+\fB\-M\fR
+Run VACUUM ANALYZE on the raster table. This is most useful when appending to an
+existing table with \-a.
+.TP
+\fB\-C\fR
+Set the standard raster constraints after the rasters are loaded. Some
+constraints may fail if one or more input rasters violate the constraint.
+.TP
+\fB\-x\fR
+Disable setting the max extent constraint. Only applies with \-C.
+.TP
+\fB\-r\fR
+Set spatially unique and coverage tile constraints for regular blocking. Only
+applies with \-C.
+.TP
+\fB\-T\fR <\fItablespace\fR>
+Specify the tablespace for the new table.
+.TP
+\fB\-X\fR <\fItablespace\fR>
+Specify the tablespace for the new table's indexes. This applies to the primary
+key and the spatial index when \-I is used.
+.TP
+\fB\-N\fR <\fInodata\fR>
+NODATA value to use on bands without a NODATA value.
+.TP
+\fB\-k\fR
+Keep empty tiles by skipping NODATA value checks for each raster band.
+.TP
+\fB\-E\fR <\fIendian\fR>
+Control endianness of generated binary raster output. Use 0 for XDR and 1 for
+NDR. Only NDR is currently supported.
+.TP
+\fB\-V\fR <\fIversion\fR>
+Specify the output WKB format version. Only version 0 is currently supported.
+.TP
+\fB\-e\fR
+Execute each statement individually instead of wrapping the load in a
+transaction.
+.TP
+\fB\-Y\fR [<\fImax_rows_per_copy\fR>]
+Use COPY statements instead of INSERT statements. If no row limit is provided,
+50 rows are written per COPY.
+.TP
+\fB\-G\fR
+Print the supported GDAL raster formats.
+.TP
+\fB\-?\fR
+Display version and usage information.
+
+.SH "EXAMPLES"
+.LP
+Create SQL for a tiled raster table and load it into a database:
+
+# \fBraster2pgsql \-s 4326 \-I \-C \-t 100x100 input.tif public.dem | psql \-d gis\fR
+
+.LP
+Append multiple rasters to an existing table:
+
+# \fBraster2pgsql \-a \-Y *.tif public.dem | psql \-d gis\fR
+
+.SH "AUTHORS"
+.LP
+Originally written by WKTRaster/PostGIS Raster contributors.
+Improved and maintained by the PostGIS project.
+
+.SH "SEE ALSO"
+.LP
+shp2pgsql(1), pgsql2shp(1)
+
+More information is available at http://postgis.net


### PR DESCRIPTION
## Summary
- add a raster2pgsql(1) man page alongside the existing loader/dumper man pages
- include raster2pgsql.1 in documentation man-install and man-uninstall
- add a NEWS entry for the packaging/documentation fix

Closes https://trac.osgeo.org/postgis/ticket/2386

## Validation
- Rebased on `postgis:master` at `63cbf4f069afebe50cb520b7abe6440c898842e9`.
- `git diff --check upstream/master..HEAD`
- `MANWIDTH=100 man -l doc/man/raster2pgsql.1 | col -b`
- `make -C doc check-xml`
- `make -C doc man-install DESTDIR="$tmpdir"`
- `make -C doc man-uninstall DESTDIR="$tmpdir"`
