### PR TITLE
Expose selected C API helpers for MobilityDB

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           reprojection support (Darafei Praliaskouski)
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections (Darafei Praliaskouski)
+ - GH-826, Expose selected liblwgeom and libpgcommon helpers for
+          downstream extension integration (Darafei Praliaskouski)
 
 * Bug Fixes *
 

--- a/liblwgeom/cunit/cu_in_geojson.c
+++ b/liblwgeom/cunit/cu_in_geojson.c
@@ -18,6 +18,10 @@
 #include "liblwgeom_internal.h"
 #include "cu_tester.h"
 
+#if HAVE_LIBJSON
+#include <json.h>
+#endif
+
 static void do_geojson_test(const char * exp, char * in, char * exp_srs)
 {
 	LWGEOM *g;
@@ -235,6 +239,51 @@ static void in_geojson_test_geoms(void)
 	    NULL);
 }
 
+#if HAVE_LIBJSON
+static void
+in_geojson_test_parse_geojson_public_api(void)
+{
+	json_object *obj = json_tokener_parse("{\"type\":\"Point\",\"coordinates\":[1,2]}");
+	int hasz = LW_FALSE;
+	LWGEOM *geom = parse_geojson(obj, &hasz);
+	char *wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
+
+	ASSERT_STRING_EQUAL(wkt, "POINT(1 2)");
+	CU_ASSERT_EQUAL(hasz, LW_FALSE);
+	CU_ASSERT_FALSE(FLAGS_GET_Z(geom->flags));
+
+	lwfree(wkt);
+	lwgeom_free(geom);
+	json_object_put(obj);
+
+	obj = json_tokener_parse("{\"type\":\"Point\",\"coordinates\":[4,5]}");
+	hasz = LW_TRUE;
+	geom = parse_geojson(obj, &hasz);
+	wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
+
+	ASSERT_STRING_EQUAL(wkt, "POINT(4 5)");
+	CU_ASSERT_EQUAL(hasz, LW_FALSE);
+	CU_ASSERT_FALSE(FLAGS_GET_Z(geom->flags));
+
+	lwfree(wkt);
+	lwgeom_free(geom);
+	json_object_put(obj);
+
+	obj = json_tokener_parse("{\"type\":\"Point\",\"coordinates\":[1,2,3]}");
+	hasz = LW_FALSE;
+	geom = parse_geojson(obj, &hasz);
+	wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
+
+	ASSERT_STRING_EQUAL(wkt, "POINT(1 2 3)");
+	CU_ASSERT_EQUAL(hasz, LW_TRUE);
+	CU_ASSERT_TRUE(FLAGS_GET_Z(geom->flags));
+
+	lwfree(wkt);
+	lwgeom_free(geom);
+	json_object_put(obj);
+}
+#endif
+
 /*
 ** Used by test harness to register the tests in this file.
 */
@@ -245,4 +294,7 @@ void in_geojson_suite_setup(void)
 	PG_ADD_TEST(suite, in_geojson_test_srid);
 	PG_ADD_TEST(suite, in_geojson_test_bbox);
 	PG_ADD_TEST(suite, in_geojson_test_geoms);
+#if HAVE_LIBJSON
+	PG_ADD_TEST(suite, in_geojson_test_parse_geojson_public_api);
+#endif
 }

--- a/liblwgeom/cunit/cu_out_wkb.c
+++ b/liblwgeom/cunit/cu_out_wkb.c
@@ -207,6 +207,35 @@ static void test_wkb_out_polyhedralsurface(void)
 //	printf("\nnew: %s\nold: %s\n",s,t);
 }
 
+static void
+test_wkb_out_public_buffer_api(void)
+{
+	static const uint8_t expected[] = {
+	    0x00, 0x00, 0x00, 0x00, 0x01,                   /* XDR POINT */
+	    0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* X = 1 */
+	    0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  /* Y = 2 */
+	};
+	LWGEOM *geom = lwgeom_from_wkt("POINT(1 2)", LW_PARSER_CHECK_NONE);
+	size_t wkb_size = lwgeom_to_wkb_size(geom, WKB_XDR);
+	size_t hex_size = lwgeom_to_wkb_size(geom, WKB_XDR | WKB_HEX);
+	uint8_t *buffer = lwalloc(wkb_size);
+	uint8_t *hex_buffer = lwalloc(hex_size + 1);
+	uint8_t *end = lwgeom_to_wkb_buf(geom, buffer, WKB_XDR);
+	uint8_t *hex_end = lwgeom_to_wkb_buf(geom, hex_buffer, WKB_XDR | WKB_HEX);
+
+	CU_ASSERT_EQUAL(wkb_size, sizeof(expected));
+	CU_ASSERT_PTR_EQUAL(end, buffer + wkb_size);
+	CU_ASSERT_EQUAL(memcmp(buffer, expected, sizeof(expected)), 0);
+	CU_ASSERT_EQUAL(hex_size, 2 * sizeof(expected));
+	CU_ASSERT_PTR_EQUAL(hex_end, hex_buffer + hex_size);
+	hex_buffer[hex_size] = '\0';
+	ASSERT_STRING_EQUAL((char *)hex_buffer, "00000000013FF00000000000004000000000000000");
+
+	lwfree(hex_buffer);
+	lwfree(buffer);
+	lwgeom_free(geom);
+}
+
 /*
 ** Used by test harness to register the tests in this file.
 */
@@ -227,4 +256,5 @@ void wkb_out_suite_setup(void)
 	PG_ADD_TEST(suite, test_wkb_out_multicurve);
 	PG_ADD_TEST(suite, test_wkb_out_multisurface);
 	PG_ADD_TEST(suite, test_wkb_out_polyhedralsurface);
+	PG_ADD_TEST(suite, test_wkb_out_public_buffer_api);
 }

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -38,6 +38,14 @@
 
 #include "proj.h"
 
+#ifndef PGDLLEXPORT
+#if defined(_WIN32)
+#define PGDLLEXPORT __declspec(dllexport)
+#else
+#define PGDLLEXPORT
+#endif
+#endif
+
 /* For PROJ6 we cache several extra values to avoid calls to proj_get_source_crs
  * or proj_get_target_crs since those are very costly
  */
@@ -1796,6 +1804,18 @@ extern lwvarlena_t* lwgeom_to_encoded_polyline(const LWGEOM *geom, int precision
  */
 extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
 
+#if defined(HAVE_LIBJSON)
+struct json_object;
+/**
+ * Parse a GeoJSON geometry object from an existing json-c object.
+ *
+ * @param geojson GeoJSON geometry object.
+ * @param hasz Optional output parameter set to LW_TRUE when any coordinate
+ *             contains a Z value. 2D inputs are returned as 2D geometries.
+ */
+extern PGDLLEXPORT LWGEOM* parse_geojson(struct json_object *geojson, int *hasz);
+#endif /* HAVE_LIBJSON */
+
 /**
  * Create an LWGEOM object from an Encoded Polyline representation
  *
@@ -2296,8 +2316,13 @@ extern lwvarlena_t* lwgeom_to_wkt_varlena(const LWGEOM *geom, uint8_t variant, i
 /**
 * @param geom geometry to convert to WKB
 * @param variant output format to use
-*                (WKB_ISO, WKB_SFSQL, WKB_EXTENDED, WKB_NDR, WKB_XDR)
+*                (WKB_ISO, WKB_SFSQL, WKB_EXTENDED, WKB_NDR, WKB_XDR,
+*                 WKB_HEX)
+* @return bytes written by lwgeom_to_wkb_buf for this variant. For WKB_HEX,
+*         this is the hex character count and does not include a null terminator.
 */
+extern PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+extern PGDLLEXPORT uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
 extern uint8_t* lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant);
 extern lwvarlena_t* lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant);
 

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -46,7 +46,7 @@
 #include <string.h>
 
 /* Prototype */
-static LWGEOM *parse_geojson(json_object *geojson, int *hasz);
+static LWGEOM *parse_geojson_internal(json_object *geojson, int *hasz);
 
 static inline json_object *
 findMemberByName(json_object *poObj, const char *pszName)
@@ -345,7 +345,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 		for (int i = 0; i < nGeoms; ++i)
 		{
 			json_object *poObjGeom = json_object_array_get_idx(poObjGeoms, i);
-			LWGEOM *t = parse_geojson(poObjGeom, hasz);
+			LWGEOM *t = parse_geojson_internal(poObjGeom, hasz);
 			if (t)
 				geom = (LWGEOM *)lwcollection_add_lwgeom((LWCOLLECTION *)geom, t);
 			else
@@ -359,8 +359,8 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 	return geom;
 }
 
-static inline LWGEOM *
-parse_geojson(json_object *geojson, int *hasz)
+static LWGEOM *
+parse_geojson_internal(json_object *geojson, int *hasz)
 {
 	json_object *type = NULL;
 	const char *name;
@@ -403,6 +403,27 @@ parse_geojson(json_object *geojson, int *hasz)
 
 	lwerror("invalid GeoJson representation");
 	return NULL; /* Never reach */
+}
+
+PGDLLEXPORT LWGEOM *
+parse_geojson(json_object *geojson, int *hasz)
+{
+	int local_hasz = LW_FALSE;
+	LWGEOM *geom;
+
+	if (hasz)
+		*hasz = LW_FALSE;
+
+	geom = parse_geojson_internal(geojson, hasz ? hasz : &local_hasz);
+
+	if (geom && !*(hasz ? hasz : &local_hasz))
+	{
+		LWGEOM *tmp = lwgeom_force_2d(geom);
+		lwgeom_free(geom);
+		geom = tmp;
+	}
+
+	return geom;
 }
 
 #endif /* HAVE_LIBJSON */
@@ -460,12 +481,6 @@ lwgeom_from_geojson(const char *geojson, char **srs)
 	if (!lwgeom)
 		return NULL;
 
-	if (!hasz)
-	{
-		LWGEOM *tmp = lwgeom_force_2d(lwgeom);
-		lwgeom_free(lwgeom);
-		lwgeom = tmp;
-	}
 	lwgeom_add_bbox(lwgeom);
 	return lwgeom;
 #endif /* HAVE_LIBJSON */

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -29,8 +29,9 @@
 #include "liblwgeom_internal.h"
 #include "lwgeom_log.h"
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
-static size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+PGDLLEXPORT uint8_t *lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+static size_t lwgeom_to_wkb_size_binary(const LWGEOM *geom, uint8_t variant);
 
 /*
 * Look-up table for hex writer
@@ -724,7 +725,7 @@ static size_t lwcollection_to_wkb_size(const LWCOLLECTION *col, uint8_t variant)
 	for ( i = 0; i < col->ngeoms; i++ )
 	{
 		/* size of subgeom */
-		size += lwgeom_to_wkb_size((LWGEOM*)col->geoms[i], variant | WKB_NO_SRID);
+		size += lwgeom_to_wkb_size_binary((LWGEOM *)col->geoms[i], variant | WKB_NO_SRID);
 	}
 
 	return size;
@@ -945,7 +946,7 @@ static uint8_t* lwnurbscurve_to_wkb_buf(const LWNURBSCURVE *curve, uint8_t *buf,
  * @return Number of bytes required to encode `geom` under `variant`, or 0 on error.
  */
 static size_t
-lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
+lwgeom_to_wkb_size_binary(const LWGEOM *geom, uint8_t variant)
 {
 	size_t size = 0;
 
@@ -1008,6 +1009,18 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 	return size;
 }
 
+PGDLLEXPORT size_t
+lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
+{
+	size_t size = lwgeom_to_wkb_size_binary(geom, variant);
+
+	/* The raw writer emits two ASCII bytes for each binary byte in HEX mode. */
+	if (variant & WKB_HEX)
+		return 2 * size;
+
+	return size;
+}
+
 /**
  * Serialize a LWGEOM into WKB format, writing into the provided buffer.
  *
@@ -1027,7 +1040,8 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
  *         success; NULL (0) on unsupported/unknown geometry type or other error.
  */
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+PGDLLEXPORT uint8_t *
+lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
 {
 
 	/* Do not simplify empties when outputting to canonical form */
@@ -1107,7 +1121,7 @@ lwgeom_to_wkb_write_buf(const LWGEOM *geom, uint8_t variant, uint8_t *buffer)
 uint8_t *
 lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size(geom, variant);
+	size_t b_size = lwgeom_to_wkb_size_binary(geom, variant);
 	/* Hex string takes twice as much space as binary + a null character */
 	if (variant & WKB_HEX)
 	{
@@ -1143,7 +1157,7 @@ lwgeom_to_hexwkb_buffer(const LWGEOM *geom, uint8_t variant)
 lwvarlena_t *
 lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size(geom, variant);
+	size_t b_size = lwgeom_to_wkb_size_binary(geom, variant);
 	/* Hex string takes twice as much space as binary, but No NULL ending in varlena */
 	if (variant & WKB_HEX)
 	{

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -263,7 +263,7 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
  * or as long one: (i.e urn:ogc:def:crs:EPSG::4326)
  */
 static char *
-getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
+getSRSbySRID_uncached(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
 {
 	static const uint16_t max_query_size = 512;
 	char query[512];
@@ -356,9 +356,20 @@ GetSRSCacheBySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
 		arg->short_mode = short_crs;
 		if (arg->srs)
 			pfree(arg->srs);
-		arg->srs = getSRSbySRID(fcinfo, srid, short_crs);
+		arg->srs = getSRSbySRID_uncached(fcinfo, srid, short_crs);
 	}
 	return arg->srs;
+}
+
+PGDLLEXPORT const char *
+getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
+{
+	/*
+	 * Public callers need stable ownership semantics. Route through the
+	 * existing function-call cache so repeated row-level calls do not leak
+	 * one PostgisCacheContext allocation per lookup.
+	 */
+	return GetSRSCacheBySRID(fcinfo, srid, short_crs);
 }
 
 /*

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -120,6 +120,9 @@ typedef struct {
 } SRSDescCache;
 
 const char *GetSRSCacheBySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);
+/* Returns cache-owned text; callers must not free or modify it, and a later
+ * SRS lookup in the same function call may evict the returned pointer. */
+PGDLLEXPORT const char *getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);
 
 /******************************************************************************/
 
@@ -135,4 +138,3 @@ typedef struct {
 } SRIDCache;
 
 int32_t GetSRIDCacheBySRS(FunctionCallInfo fcinfo, const char *srs);
-


### PR DESCRIPTION
Supersedes https://github.com/postgis/postgis/pull/826.

The original MobilityDB branch is not directly maintainable from this repository (`maintainerCanModify=false`), is based on an old `master`, has an empty PR body, and is now conflicting. This branch reconstructs the useful API-export part against current Gitea `master` for PostGIS 3.7, where the earlier maintainer concern about micro-release header changes no longer applies.

## What changed

- Expose `parse_geojson` through `liblwgeom.h.in` when JSON-C support is enabled.
- Expose `lwgeom_to_wkb_size` and `lwgeom_to_wkb_buf` through `liblwgeom.h.in`.
- Expose `getSRSbySRID` through `libpgcommon/lwgeom_cache.h` with cache-owned `const char *` return semantics.
- Add focused CUnit coverage for the newly public GeoJSON and WKB buffer entry points.
- Add a `NEWS` entry for the downstream extension integration API surface.

## Review notes

- This branch intentionally does not reference https://trac.osgeo.org/postgis/ticket/5974; that ticket appears unrelated to these API exports.
- The union-find sentinel cleanup from the old PR is already addressed on current `master` by earlier work, so this branch leaves `liblwgeom/lwunionfind.c` untouched.
- `parse_geojson` keeps the existing symbol name used by the original branch rather than inventing a new compatibility layer in this superseding pass.
- Current review comments are addressed:
  - public `parse_geojson` resets the optional `hasz` output before each parse and applies the same 2D cleanup as `lwgeom_from_geojson`
  - recursive GeometryCollection parsing stays on an internal helper
  - public `lwgeom_to_wkb_size` reports the actual raw-writer byte count for `WKB_HEX`, while existing allocation wrappers keep using binary sizing internally
  - public `getSRSbySRID` now routes through the existing function-call SRS cache, so callers get a non-freeable cache-owned pointer without leaking one allocation per row

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- liblwgeom/cunit/cu_out_wkb.c liblwgeom/cunit/cu_in_geojson.c liblwgeom/liblwgeom.h.in liblwgeom/lwin_geojson.c liblwgeom/lwout_wkb.c libpgcommon/lwgeom_cache.c libpgcommon/lwgeom_cache.h`
- `make -C liblwgeom -j32`
- `make -C libpgcommon all -j32`
- `make -C liblwgeom/cunit cu_tester -j32 && ./liblwgeom/cunit/cu_tester geojson_input wkb_output`
  - `geojson_input`: 4 tests, 35 asserts passed
  - `wkb_output`: 14 tests, 45 asserts passed
- `make -j32`
- `nm -g --defined-only liblwgeom/.libs/liblwgeom.a | rg ' (parse_geojson|lwgeom_to_wkb_buf|lwgeom_to_wkb_size)$'`
- `nm -g --defined-only libpgcommon/libpgcommon.a | rg ' (getSRSbySRID|GetSRSCacheBySRID)$'`

Local coverage reports were not generated for this C API-only change; the PR keeps the focused CUnit coverage local and leaves the broader coverage matrix to CI.
