### PR TITLE
ptarray_from_twkb_state(): avoid signed integer overflow

### DIFF
--- a/liblwgeom/cunit/cu_in_twkb.c
+++ b/liblwgeom/cunit/cu_in_twkb.c
@@ -306,6 +306,42 @@ test_twkb_in_count_exceeds_payload(void)
 	cu_error_msg_reset();
 }
 
+static void
+test_twkb_in_coordinate_delta_overflow(void)
+{
+	const uint8_t twkb[] = {0x02, /* LINESTRING with default precision. */
+				0x00,
+				0x02, /* Two points. */
+				0xfe,
+				0xff,
+				0xff,
+				0xff,
+				0xff,
+				0xff, /* X = INT64_MAX. */
+				0xff,
+				0xff,
+				0xff,
+				0x01,
+				0x00, /* Y = 0. */
+				0x02, /* X delta = 1. */
+				0x00};
+	LWGEOM *geom;
+
+	cu_error_msg_reset();
+
+	geom = lwgeom_from_twkb(twkb, sizeof(twkb), LW_PARSER_CHECK_NONE);
+
+	/* TWKB stores coordinate deltas as signed integers. Malformed or fuzzed
+	 * inputs can wrap the accumulated delta; the parser must make that wrap
+	 * explicit instead of relying on undefined signed-overflow behaviour.
+	 */
+	ASSERT_STRING_EQUAL(cu_error_msg, "");
+	CU_ASSERT_PTR_NOT_NULL(geom);
+	if (geom != NULL)
+		lwgeom_free(geom);
+	cu_error_msg_reset();
+}
+
 /*
 ** Used by test harness to register the tests in this file.
 */
@@ -324,4 +360,5 @@ void twkb_in_suite_setup(void)
 	PG_ADD_TEST(suite, test_twkb_in_truncated_extended_dims);
 	PG_ADD_TEST(suite, test_twkb_in_overlong_varint);
 	PG_ADD_TEST(suite, test_twkb_in_count_exceeds_payload);
+	PG_ADD_TEST(suite, test_twkb_in_coordinate_delta_overflow);
 }

--- a/liblwgeom/lwin_twkb.c
+++ b/liblwgeom/lwin_twkb.c
@@ -201,6 +201,19 @@ static uint8_t byte_from_twkb_state(twkb_parse_state *s)
 	return val;
 }
 
+/** Implements *pa += b in a sanitizer friendly way, using wrap around
+ * logic in case of overflow
+ */
+#if __clang_major__ >= 4
+__attribute__((no_sanitize("unsigned-integer-overflow")))
+#endif
+static inline void safe_add_int64(int64_t* pa, int64_t b)
+{
+	uint64_t u_a = (uint64_t)*pa;
+	uint64_t u_b = (uint64_t)b;
+	u_a += u_b;
+	memcpy(pa, &u_a, sizeof(int64_t));
+}
 
 /**
 * POINTARRAY
@@ -229,24 +242,24 @@ static POINTARRAY* ptarray_from_twkb_state(twkb_parse_state *s, uint32_t npoints
 	{
 		int j = 0;
 		/* X */
-		s->coords[j] += twkb_parse_state_varint(s);
+		safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 		dlist[ndims*i + j] = s->coords[j] / s->factor;
 		j++;
 		/* Y */
-		s->coords[j] += twkb_parse_state_varint(s);
+		safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 		dlist[ndims*i + j] = s->coords[j] / s->factor;
 		j++;
 		/* Z */
 		if ( s->has_z )
 		{
-			s->coords[j] += twkb_parse_state_varint(s);
+			safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 			dlist[ndims*i + j] = s->coords[j] / s->factor_z;
 			j++;
 		}
 		/* M */
 		if ( s->has_m )
 		{
-			s->coords[j] += twkb_parse_state_varint(s);
+			safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 			dlist[ndims*i + j] = s->coords[j] / s->factor_m;
 			j++;
 		}


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/525554772

I'd expect any reasonable optimizer to transform that to the same assembly code as the plain addition instruction.