### PR TITLE
#6022 Document ST_AsMVTGeom simplification

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5109, Document the meaning of topology.next_left_edge and topology.next_right_edge links (Darafei Praliaskouski)
  - #5889, [topology] Include representative locations in topology build errors (Darafei Praliaskouski)
  - #2614, Use GEOSPreparedDistance and caching to accelerate ST_DWithin (Paul Ramsey)
+ - #6022, Document ST_AsMVTGeom tile-coordinate simplification (Darafei Praliaskouski)
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)
  - #4560, ST_3DInterpolatePoint for M interpolation from XYZ inputs (Paul Ramsey)

--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1364,6 +1364,14 @@ SELECT (ST_AsLatLonText('POINT (-302.2342342 -792.32498)'));
     <para>The function attempts to preserve geometry validity, and corrects it if needed.
         This may cause the result geometry to collapse to a lower dimension.
     </para>
+    <para>The function performs geometry simplification appropriate to the
+        integer tile coordinate space. After transforming to tile coordinates
+        it snaps coordinates to the integer grid, removes repeated points, and
+        removes points that lie on straight lines. It does not perform
+        general-purpose, scale-dependent simplification such as
+        <xref linkend="ST_Simplify"/>. To reduce detail before tile conversion,
+        simplify the geometry in map coordinates before calling
+        <function>ST_AsMVTGeom</function>.</para>
         <para>The rectangular bounds of the tile in the target map coordinate space must be provided,
         so the geometry can be transformed, and clipped if required.
         The bounds can be generated using <xref linkend="ST_TileEnvelope"/>.


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/6022.

This clarifies the simplification performed by `ST_AsMVTGeom`: after transforming geometries into integer tile coordinate space, it snaps to the grid, removes repeated points, and removes collinear points. The documentation now distinguishes that tile-coordinate cleanup from explicit map-coordinate simplification such as `ST_Simplify`, which callers should run before `ST_AsMVTGeom` when they need broader detail reduction.

The branch also adds a `NEWS` entry for the documentation enhancement.

Current head: `3bc54e6c15a13ef1af48c97db2c37dfca8f8f81a`.

Validation:
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check-xml`
- `make -C doc check`
- `git diff --check upstream/master..HEAD`