### PR TITLE
fuzzers: pass configured include paths to smoke builds

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - #6083, Pass configured dependency include paths to fuzzer smoke builds
+          (Darafei Praliaskouski)
  - #3103, Add regression coverage for exact-schema find_srid and
           geometry_columns lookups (Darafei Praliaskouski)
  - #5655, [doc] Skip XML validation during `make check` when xsltproc is

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -6,7 +6,11 @@ FUZZER_WORK ?= $(FUZZER_OUT)/postgis-fuzzer-check
 FUZZER_SOURCES := $(notdir $(wildcard $(FUZZER_SRC_DIR)/*_fuzzer.cpp $(FUZZER_SRC_DIR)/*_fuzzer.c))
 FUZZER_NAMES := $(basename $(FUZZER_SOURCES))
 SEED_CORPORA := $(wildcard $(FUZZER_SRC_DIR)/*_seed_corpus.zip)
+# The standalone fuzzer smoke build includes liblwgeom.h outside liblwgeom's
+# Makefile, so it must inherit the configured dependency include paths.
+POSTGIS_CONFIGURED_CPPFLAGS := $(shell sed -n 's/^CPPFLAGS = //p' $(POSTGIS_BUILD_DIR)/liblwgeom/Makefile 2>/dev/null | sed 's/$$(RYU_INCLUDE)//g; s/-I$$(builddir)//g; s/-I$$(srcdir)//g' | sed 1q)
 POSTGIS_CONFIGURED_LDFLAGS := $(shell sed -n 's/^LDFLAGS = //p' $(POSTGIS_BUILD_DIR)/liblwgeom/Makefile 2>/dev/null | sed 1q)
+POSTGIS_FUZZER_CPPFLAGS = $(POSTGIS_CONFIGURED_CPPFLAGS) $(CPPFLAGS)
 POSTGIS_FUZZER_LDFLAGS = $(POSTGIS_CONFIGURED_LDFLAGS) $(LDFLAGS)
 
 .PHONY: clean dummyfuzzers check check-corpus
@@ -20,7 +24,7 @@ fuzzingengine.o: $(FUZZER_SRC_DIR)/fuzzingengine.c
 dummyfuzzers: fuzzingengine.o
 	mkdir -p "$(FUZZER_OUT)"
 	$(AR) r libFuzzingEngine.a fuzzingengine.o
-	CC="${CC}" CXX="${CXX}" CXXFLAGS="-L$(CURDIR) ${CXXFLAGS}" LDFLAGS="$(POSTGIS_FUZZER_LDFLAGS)" POSTGIS_BUILD_DIR="$(POSTGIS_BUILD_DIR)" SRC="$(FUZZER_SRC_DIR)" OUT="$(FUZZER_OUT)" $(FUZZER_SRC_DIR)/build_google_oss_fuzzers.sh
+	CC="${CC}" CXX="${CXX}" CPPFLAGS="$(POSTGIS_FUZZER_CPPFLAGS)" CXXFLAGS="-L$(CURDIR) ${CXXFLAGS}" LDFLAGS="$(POSTGIS_FUZZER_LDFLAGS)" POSTGIS_BUILD_DIR="$(POSTGIS_BUILD_DIR)" SRC="$(FUZZER_SRC_DIR)" OUT="$(FUZZER_OUT)" $(FUZZER_SRC_DIR)/build_google_oss_fuzzers.sh
 	OUT="$(FUZZER_OUT)" $(FUZZER_SRC_DIR)/build_seed_corpus.sh
 
 check:

--- a/fuzzers/build_google_oss_fuzzers.sh
+++ b/fuzzers/build_google_oss_fuzzers.sh
@@ -33,11 +33,20 @@ GDAL_LIBS=$(gdal-config --libs)
 POSTGIS_FUZZER_LIBS="$JSON_C_LIBS $GEOS_LIBS $PROJ_XML2_LIBS"
 POSTGIS_PACKAGE_RUNTIME_LIBS="${POSTGIS_PACKAGE_RUNTIME_LIBS:-1}"
 
+target_local_cflags()
+{
+    case "$1" in
+        raster_deserialize_fuzzer)
+            echo "-I$POSTGIS_SOURCE_DIR/raster/rt_core -I$POSTGIS_BUILD_DIR/raster/rt_core -I$POSTGIS_SOURCE_DIR/raster -I$POSTGIS_BUILD_DIR/raster -I$POSTGIS_SOURCE_DIR -I$POSTGIS_BUILD_DIR"
+            ;;
+    esac
+}
+
 target_cflags()
 {
     case "$1" in
         raster_deserialize_fuzzer)
-            echo "-I$POSTGIS_SOURCE_DIR/raster/rt_core -I$POSTGIS_BUILD_DIR/raster/rt_core -I$POSTGIS_SOURCE_DIR/raster -I$POSTGIS_BUILD_DIR/raster -I$POSTGIS_SOURCE_DIR -I$POSTGIS_BUILD_DIR $GDAL_CFLAGS"
+            echo "$GDAL_CFLAGS"
             ;;
     esac
 }
@@ -62,12 +71,12 @@ build_fuzzer()
 
     if [ "$extension" = "c" ]; then
         objectFile=$(mktemp)
-        "$CC" $CFLAGS -I"$POSTGIS_SOURCE_DIR/liblwgeom" -I"$POSTGIS_BUILD_DIR/liblwgeom" $(target_cflags "$fuzzerName") \
+        "$CC" $CFLAGS -I"$POSTGIS_SOURCE_DIR/liblwgeom" -I"$POSTGIS_BUILD_DIR/liblwgeom" $(target_local_cflags "$fuzzerName") $CPPFLAGS $(target_cflags "$fuzzerName") \
             -c "$sourceFilename" -o "$objectFile"
         sourceFilename=$objectFile
     fi
 
-    "$CXX" $CXXFLAGS -std=c++11 -I"$POSTGIS_SOURCE_DIR/liblwgeom" -I"$POSTGIS_BUILD_DIR/liblwgeom" \
+    "$CXX" $CXXFLAGS -std=c++11 -I"$POSTGIS_SOURCE_DIR/liblwgeom" -I"$POSTGIS_BUILD_DIR/liblwgeom" $CPPFLAGS \
         "$sourceFilename" -o "$OUT/$fuzzerName" \
         $LDFLAGS \
         -lFuzzingEngine -lstdc++ $(target_libs "$fuzzerName") \


### PR DESCRIPTION
## Summary

- pass configured liblwgeom dependency include flags through the standalone fuzzer smoke build
- keep source/build-tree liblwgeom include paths before configured dependency include flags so installed headers cannot shadow this tree
- keep raster source/build-tree include paths before configured dependency include flags for C fuzzer smoke builds
- keep liblwgeom-local Make variables out of the shell command line when reusing those flags
- add a NEWS entry for https://trac.osgeo.org/postgis/ticket/6083

## Notes

The ticket discussion also mentions separate OSS-Fuzz runtime findings in a later comment. Those are not needed for the Winnie compile failure fixed here, because this branch targets the missing `proj.h` include path reported in the ticket body.

## Validation

- `bash -n fuzzers/build_google_oss_fuzzers.sh`
- `git diff --check`
- `make check-news`
- `make check-fuzzers`
- `make -C fuzzers check-corpus`
