### PR TITLE
build: avoid PGXS for extension SQL bundles

### DIFF
--- a/extensions/extension-no-pgxs.mk
+++ b/extensions/extension-no-pgxs.mk
@@ -23,7 +23,7 @@ INSTALL ?= install -c
 INSTALL_DATA ?= $(INSTALL) -m 644
 MKDIR_P ?= mkdir -p
 
-.PHONY: all install installdirs uninstall clean
+.PHONY: all install installdirs uninstall clean installcheck
 
 all: $(DATA_built)
 
@@ -73,3 +73,6 @@ endif
 ifdef EXTRA_CLEAN
 	rm -rf $(EXTRA_CLEAN)
 endif
+
+installcheck:
+	@echo "Nothing to installcheck"

--- a/extensions/extension-no-pgxs.mk
+++ b/extensions/extension-no-pgxs.mk
@@ -5,9 +5,18 @@
 # that dependency from generated extension SQL bundles while preserving the
 # installed file layout expected by PostgreSQL.
 
-datadir ?= $(shell $(PG_CONFIG) --sharedir)
+pg_configure_prefix = $(shell $(PG_CONFIG) --configure | sed -n "s/.*'--prefix=\([^']*\)'.*/\1/p")
+pg_configure_sharedir = $(shell $(PG_CONFIG) --sharedir)
+pg_configure_docdir = $(shell $(PG_CONFIG) --docdir)
+pg_configure_default_prefix = $(shell sharedir='$(pg_configure_sharedir)'; default_prefix=$${sharedir%/share}; test "$$default_prefix" != "$$sharedir" && printf '%s' "$$default_prefix")
+pg_configure_effective_prefix = $(if $(pg_configure_prefix),$(pg_configure_prefix),$(pg_configure_default_prefix))
+relocate_pg_config_path = $(if $(pg_configure_effective_prefix),$(patsubst $(pg_configure_effective_prefix)%,$(prefix)%,$(1)),$(1))
+
+# PGXS lets explicit prefix= relocate install directories.  Preserve the
+# suffix reported by pg_config so distro-specific layouts remain intact.
+datadir ?= $(if $(prefix),$(call relocate_pg_config_path,$(pg_configure_sharedir)),$(pg_configure_sharedir))
 datamoduledir ?= extension
-docdir ?= $(shell $(PG_CONFIG) --docdir)
+docdir ?= $(if $(prefix),$(call relocate_pg_config_path,$(pg_configure_docdir)),$(pg_configure_docdir))
 docmoduledir ?= extension
 srcdir ?= .
 INSTALL ?= install -c
@@ -53,7 +62,7 @@ ifneq (,$(DATA)$(DATA_built))
 endif
 ifdef DOCS
 ifdef docdir
-	rm -f $(addprefix '$(DESTDIR)$(docdir)/$(docmoduledir)'/, $(DOCS))
+	rm -f $(addprefix '$(DESTDIR)$(docdir)/$(docmoduledir)'/, $(notdir $(DOCS)))
 endif
 endif
 

--- a/extensions/extension-no-pgxs.mk
+++ b/extensions/extension-no-pgxs.mk
@@ -1,0 +1,66 @@
+# Shared rules for SQL-only extension bundles.
+#
+# These Makefiles used to include PostgreSQL's PGXS makefile only to inherit
+# generic data-file install and clean targets. Keeping those rules local removes
+# that dependency from generated extension SQL bundles while preserving the
+# installed file layout expected by PostgreSQL.
+
+datadir ?= $(shell $(PG_CONFIG) --sharedir)
+datamoduledir ?= extension
+docdir ?= $(shell $(PG_CONFIG) --docdir)
+docmoduledir ?= extension
+srcdir ?= .
+INSTALL ?= install -c
+INSTALL_DATA ?= $(INSTALL) -m 644
+MKDIR_P ?= mkdir -p
+
+.PHONY: all install installdirs uninstall clean
+
+all: $(DATA_built)
+
+install: all installdirs
+ifneq (,$(EXTENSION))
+	$(INSTALL_DATA) $(addprefix $(srcdir)/, $(addsuffix .control, $(EXTENSION))) '$(DESTDIR)$(datadir)/extension/'
+endif
+ifneq (,$(DATA)$(DATA_built))
+	$(INSTALL_DATA) $(addprefix $(srcdir)/, $(DATA)) $(DATA_built) '$(DESTDIR)$(datadir)/$(datamoduledir)/'
+endif
+ifdef DOCS
+ifdef docdir
+	$(INSTALL_DATA) $(addprefix $(srcdir)/, $(DOCS)) '$(DESTDIR)$(docdir)/$(docmoduledir)/'
+endif
+endif
+
+installdirs:
+ifneq (,$(EXTENSION))
+	$(MKDIR_P) '$(DESTDIR)$(datadir)/extension'
+endif
+ifneq (,$(DATA)$(DATA_built))
+	$(MKDIR_P) '$(DESTDIR)$(datadir)/$(datamoduledir)'
+endif
+ifdef DOCS
+ifdef docdir
+	$(MKDIR_P) '$(DESTDIR)$(docdir)/$(docmoduledir)'
+endif
+endif
+
+uninstall:
+ifneq (,$(EXTENSION))
+	rm -f $(addprefix '$(DESTDIR)$(datadir)/extension'/, $(notdir $(addsuffix .control, $(EXTENSION))))
+endif
+ifneq (,$(DATA)$(DATA_built))
+	rm -f $(addprefix '$(DESTDIR)$(datadir)/$(datamoduledir)'/, $(notdir $(DATA) $(DATA_built)))
+endif
+ifdef DOCS
+ifdef docdir
+	rm -f $(addprefix '$(DESTDIR)$(docdir)/$(docmoduledir)'/, $(DOCS))
+endif
+endif
+
+clean:
+ifdef DATA_built
+	rm -f $(DATA_built)
+endif
+ifdef EXTRA_CLEAN
+	rm -rf $(EXTRA_CLEAN)
+endif

--- a/extensions/postgis/Makefile.in
+++ b/extensions/postgis/Makefile.in
@@ -156,13 +156,9 @@ distclean: clean
 	rm -f Makefile
 
 PG_CONFIG := @PG_CONFIG@
-PGXS := @PGXS@
-include $(PGXS)
 PERL = @PERL@
 INSTALL=@INSTALL@
 INSTALL_DATA=@INSTALL_DATA@
-
-
 ifneq (@MKDIR_P@,)
 	MKDIR_P = @MKDIR_P@
 endif
@@ -174,3 +170,5 @@ VPATH = @srcdir@
 top_srcdir = @top_srcdir@
 top_builddir = @top_builddir@
 abs_topbuilddir=$(abspath $(top_builddir))
+
+include @srcdir@/../extension-no-pgxs.mk

--- a/extensions/postgis_raster/Makefile.in
+++ b/extensions/postgis_raster/Makefile.in
@@ -123,8 +123,6 @@ distclean: clean
 	rm -f Makefile
 
 PG_CONFIG := @PG_CONFIG@
-PGXS := @PGXS@
-include $(PGXS)
 PERL = @PERL@
 INSTALL=@INSTALL@
 INSTALL_DATA=@INSTALL_DATA@
@@ -137,3 +135,5 @@ VPATH = @srcdir@
 top_srcdir = @top_srcdir@
 top_builddir = @top_builddir@
 abs_topbuilddir=$(abspath $(top_builddir))
+
+include @srcdir@/../extension-no-pgxs.mk

--- a/extensions/postgis_sfcgal/Makefile.in
+++ b/extensions/postgis_sfcgal/Makefile.in
@@ -93,8 +93,6 @@ distclean: clean
 	rm Makefile
 
 PG_CONFIG := @PG_CONFIG@
-PGXS := @PGXS@
-include $(PGXS)
 PERL = @PERL@
 INSTALL=@INSTALL@
 INSTALL_DATA=@INSTALL_DATA@
@@ -107,3 +105,5 @@ VPATH = @srcdir@
 top_srcdir = @top_srcdir@
 top_builddir = @top_builddir@
 abs_topbuilddir=$(abspath $(top_builddir))
+
+include @srcdir@/../extension-no-pgxs.mk

--- a/extensions/postgis_topology/Makefile.in
+++ b/extensions/postgis_topology/Makefile.in
@@ -94,8 +94,6 @@ distclean: clean
 	rm Makefile
 
 PG_CONFIG := @PG_CONFIG@
-PGXS := @PGXS@
-include $(PGXS)
 PERL=@PERL@
 INSTALL=@INSTALL@
 INSTALL_DATA=@INSTALL_DATA@
@@ -108,3 +106,5 @@ VPATH = @srcdir@
 top_srcdir = @top_srcdir@
 top_builddir = @top_builddir@
 abs_topbuilddir=$(abspath $(top_builddir))
+
+include @srcdir@/../extension-no-pgxs.mk


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/5796.

## Summary

- add a shared `extensions/extension-no-pgxs.mk` fragment for SQL-only extension bundle install, uninstall, clean, and installcheck rules
- stop including PostgreSQL PGXS from the generated SQL extension Makefiles for `postgis`, `postgis_raster`, `postgis_topology`, and `postgis_sfcgal`
- keep the installed PostgreSQL extension file layout unchanged while removing this narrow PGXS dependency from generated extension SQL bundles
- preserve PGXS-style `prefix=` relocation for extension SQL/control/docs paths, including source-built PostgreSQL installations whose `pg_config --configure` does not include an explicit `--prefix`

## Scope

This is a partial step toward https://trac.osgeo.org/postgis/ticket/5796, not the full PGXS removal. `configure.ac` and the compiled module Makefiles still rely on PGXS for server-module build/link/install semantics and need a separate build-system replacement before the ticket can be closed.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `a4dc80b57b808260b932d384d3815720c37602c6`.
- Current-line review threads are resolved. One unresolved thread about default source-build prefix inference remains outdated after this rebase.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make clean`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- extensions/extension-no-pgxs.mk extensions/postgis/Makefile.in extensions/postgis_raster/Makefile.in extensions/postgis_topology/Makefile.in extensions/postgis_sfcgal/Makefile.in NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C topology topology.sql topology_upgrade.sql`
- `make -C sfcgal sfcgal.sql sfcgal_upgrade.sql`
- `make -C extensions -j1`
- `make -C extensions DESTDIR=/tmp/postgis-5796-install install -j1`
- `make -C extensions DESTDIR=/tmp/postgis-5796-install uninstall -j1`
- final installed-file count after default uninstall: `0`
- `make -C extensions DESTDIR=/tmp/postgis-5796-prefix-install prefix=/tmp/postgis-5796-prefix install -j1`
- verified prefixed install created `/tmp/postgis-5796-prefix-install/tmp/postgis-5796-prefix/share/postgresql/18/extension/postgis.control`
- `make -C extensions DESTDIR=/tmp/postgis-5796-prefix-install prefix=/tmp/postgis-5796-prefix uninstall -j1`
- final installed-file count after prefixed uninstall: `0`
- `make -C extensions/postgis installcheck`
- `make -C extensions installcheck`
