### PR TITLE
Add ST_AsX3D bounding box output option

### DIFF
--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1594,7 +1594,7 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
         <para>Below is how we currently map PostGIS 2D/3D types to X3D types</para>
     </note>
 
-        <para>The 'options' argument is a bitfield that denotes whether to represent coordinates with the X3D GeoCoordinates geospatial node and whether to flip the x/y axis.  By default, <code>ST_AsX3D</code> outputs in database form (long,lat or X,Y), but the X3D default of lat/lon, y/x may be preferred.</para>
+        <para>The 'options' argument is a bitfield that denotes whether to represent coordinates with the X3D GeoCoordinates geospatial node, whether to flip the x/y axis, and whether to output the axis-aligned bounding box instead of the input geometry.  By default, <code>ST_AsX3D</code> outputs in database form (long,lat or X,Y), but the X3D default of lat/lon, y/x may be preferred.</para>
 
         <itemizedlist>
             <listitem>
@@ -1608,6 +1608,10 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
             <listitem>
               <para>2: Output coordinates in GeoSpatial GeoCoordinates.  This option will throw an error if geometries are not in WGS 84 long lat (srid: 4326). This is currently the only GeoCoordinate type supported.  <link xlink:href="http://www.web3d.org/documents/specifications/19775-1/V3.2/Part01/components/geodata.html#Specifyingaspatialreference">Refer to X3D specs specifying a spatial reference system.</link>. Default output will be <code>GeoCoordinate geoSystem='"GD" "WE" "longitude_first"'</code>.  If
               you prefer the X3D default of  <code>GeoCoordinate geoSystem='"GD" "WE" "latitude_first"'</code> use <code>(2 + 1)</code> = <code>3</code> </para>
+            </listitem>
+
+            <listitem>
+              <para>4: Output the axis-aligned bounding box of the geometry. This may be combined with the coordinate-flipping and GeoCoordinates options.  For 2D inputs, the bounding box is emitted with Z=0 coordinates.</para>
             </listitem>
         </itemizedlist>
 
@@ -1660,6 +1664,7 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
     <para>There is also a nice open source X3D viewer you can use to view rendered geometries. Free Wrl <link xlink:href="http://freewrl.sourceforge.net/">http://freewrl.sourceforge.net/</link> binaries available for Mac, Linux, and Windows. Use the FreeWRL_Launcher packaged to view the geometries.</para>
     <para>Also check out <link xlink:href="https://git.osgeo.org/gitea/robe/postgis_x3d_viewer">PostGIS minimalist X3D viewer</link>  that utilizes this function and <link xlink:href="http://www.x3dom.org/">x3dDom html/js open source toolkit</link>.</para>
     <para role="availability" conformance="2.0.0">Availability: 2.0.0: ISO-IEC-19776-1.2-X3DEncodings-XML</para>
+    <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0: Support for axis-aligned bounding box output with option 4.</para>
     <para role="enhanced" conformance="2.2.0">Enhanced: 2.2.0: Support for GeoCoordinates and axis (x/y, long/lat) flipping.  Look at options for details.</para>
     <!-- Optionally mention 3d support -->
     <para>&Z_support;</para>

--- a/liblwgeom/cunit/cu_out_x3d.c
+++ b/liblwgeom/cunit/cu_out_x3d.c
@@ -196,6 +196,12 @@ static void out_x3d3_test_option(void)
 	    0,
 	    4);
 
+	do_x3d3_test(
+	    "LINESTRING(0 0,5e-13 1)",
+	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3'><Coordinate point='0 0 0 0 1 0 5e-13 1 0 5e-13 0 0 ' /></IndexedFaceSet>",
+	    15,
+	    4);
+
 	/* bounding box with flipped coordinates */
 	do_x3d3_test(
 	    "LINESTRING(2 8,3 7,10 11)",

--- a/liblwgeom/cunit/cu_out_x3d.c
+++ b/liblwgeom/cunit/cu_out_x3d.c
@@ -188,6 +188,27 @@ static void out_x3d3_test_option(void)
 	    "SRID=4326;POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"latitude_first\"' point='10 15 3 6.464 13.536 3 5 10 3 6.464 6.464 3 10 5 3 13.536 6.464 3 15 10 3 13.536 13.536 3 ' /></IndexedFaceSet>",
 	    3, 3);
+
+	/* axis-aligned bounding box */
+	do_x3d3_test(
+	    "LINESTRING(2 8,3 7,10 11)",
+	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3'><Coordinate point='2 7 0 2 11 0 10 11 0 10 7 0 ' /></IndexedFaceSet>",
+	    0,
+	    4);
+
+	/* bounding box with flipped coordinates */
+	do_x3d3_test(
+	    "LINESTRING(2 8,3 7,10 11)",
+	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3'><Coordinate point='7 2 0 11 2 0 11 10 0 7 10 0 ' /></IndexedFaceSet>",
+	    0,
+	    5);
+
+	/* bounding box of a planar 3D input */
+	do_x3d3_test(
+	    "LINESTRING Z(1 2 3,4 6 3)",
+	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3'><Coordinate point='1 2 3 1 6 3 4 6 3 4 2 3 ' /></IndexedFaceSet>",
+	    0,
+	    4);
 }
 
 

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -1749,6 +1749,7 @@ LWCOLLECTION* lwgeom_clip_to_ordinate_range(const LWGEOM *lwin, char ordinate, d
 /** For flip X/Y coordinates to Y/X */
 #define LW_X3D_FLIP_XY     (1<<0)
 #define LW_X3D_USE_GEOCOORDS     (1<<1)
+#define LW_X3D_USE_BBOX     (1<<2)
 #define X3D_USE_GEOCOORDS(x) ((x) & LW_X3D_USE_GEOCOORDS)
 
 

--- a/liblwgeom/lwout_x3d.c
+++ b/liblwgeom/lwout_x3d.c
@@ -56,9 +56,9 @@ lwgeom_x3d_bbox_as_lwgeom(const LWGEOM *geom)
 		box.zmax = 0.0;
 	}
 
-	xeq = FP_EQUALS(box.xmin, box.xmax);
-	yeq = FP_EQUALS(box.ymin, box.ymax);
-	zeq = FP_EQUALS(box.zmin, box.zmax);
+	xeq = (box.xmin == box.xmax);
+	yeq = (box.ymin == box.ymax);
+	zeq = (box.zmin == box.zmax);
 	varying = (!xeq) + (!yeq) + (!zeq);
 
 	if (varying == 0)

--- a/liblwgeom/lwout_x3d.c
+++ b/liblwgeom/lwout_x3d.c
@@ -30,6 +30,105 @@
 
 #include "lwout_x3d.h"
 
+static LWGEOM *
+lwgeom_x3d_bbox_poly(int32_t srid, int hasz, POINT4D *p1, POINT4D *p2, POINT4D *p3, POINT4D *p4)
+{
+	LWPOLY *poly = lwpoly_construct_rectangle(hasz, LW_FALSE, p1, p2, p3, p4);
+	LWGEOM *geom = lwpoly_as_lwgeom(poly);
+	lwgeom_set_srid(geom, srid);
+	return geom;
+}
+
+static LWGEOM *
+lwgeom_x3d_bbox_as_lwgeom(const LWGEOM *geom)
+{
+	GBOX box;
+	POINT4D pt;
+	int geom_hasz = lwgeom_has_z(geom);
+	int hasz = LW_TRUE;
+	int xeq, yeq, zeq, varying;
+
+	if (lwgeom_calculate_gbox(geom, &box) == LW_FAILURE)
+		return NULL;
+	if (!geom_hasz)
+	{
+		box.zmin = 0.0;
+		box.zmax = 0.0;
+	}
+
+	xeq = FP_EQUALS(box.xmin, box.xmax);
+	yeq = FP_EQUALS(box.ymin, box.ymax);
+	zeq = FP_EQUALS(box.zmin, box.zmax);
+	varying = (!xeq) + (!yeq) + (!zeq);
+
+	if (varying == 0)
+	{
+		POINTARRAY *pa = ptarray_construct_empty(hasz, LW_FALSE, 1);
+		pt = (POINT4D){box.xmin, box.ymin, box.zmin, 0.0};
+		ptarray_append_point(pa, &pt, LW_TRUE);
+		return lwpoint_as_lwgeom(lwpoint_construct(geom->srid, NULL, pa));
+	}
+
+	if (varying == 1)
+	{
+		POINTARRAY *pa = ptarray_construct_empty(hasz, LW_FALSE, 2);
+		pt = (POINT4D){box.xmin, box.ymin, box.zmin, 0.0};
+		ptarray_append_point(pa, &pt, LW_TRUE);
+		pt = (POINT4D){box.xmax, box.ymax, box.zmax, 0.0};
+		ptarray_append_point(pa, &pt, LW_TRUE);
+		return lwline_as_lwgeom(lwline_construct(geom->srid, NULL, pa));
+	}
+
+	if (zeq)
+	{
+		POINT4D points[4] = {{box.xmin, box.ymin, box.zmin, 0.0},
+				     {box.xmin, box.ymax, box.zmin, 0.0},
+				     {box.xmax, box.ymax, box.zmin, 0.0},
+				     {box.xmax, box.ymin, box.zmin, 0.0}};
+		return lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[0], &points[1], &points[2], &points[3]);
+	}
+
+	if (xeq)
+	{
+		POINT4D points[4] = {{box.xmin, box.ymin, box.zmin, 0.0},
+				     {box.xmin, box.ymax, box.zmin, 0.0},
+				     {box.xmin, box.ymax, box.zmax, 0.0},
+				     {box.xmin, box.ymin, box.zmax, 0.0}};
+		return lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[0], &points[1], &points[2], &points[3]);
+	}
+
+	if (yeq)
+	{
+		POINT4D points[4] = {{box.xmin, box.ymin, box.zmin, 0.0},
+				     {box.xmax, box.ymin, box.zmin, 0.0},
+				     {box.xmax, box.ymin, box.zmax, 0.0},
+				     {box.xmin, box.ymin, box.zmax, 0.0}};
+		return lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[0], &points[1], &points[2], &points[3]);
+	}
+
+	POINT4D points[8] = {{box.xmin, box.ymin, box.zmin, 0.0},
+			     {box.xmin, box.ymax, box.zmin, 0.0},
+			     {box.xmax, box.ymax, box.zmin, 0.0},
+			     {box.xmax, box.ymin, box.zmin, 0.0},
+			     {box.xmin, box.ymin, box.zmax, 0.0},
+			     {box.xmin, box.ymax, box.zmax, 0.0},
+			     {box.xmax, box.ymax, box.zmax, 0.0},
+			     {box.xmax, box.ymin, box.zmax, 0.0}};
+	LWGEOM **geoms = lwalloc(sizeof(LWGEOM *) * 6);
+	LWGEOM *bbox_geom;
+
+	geoms[0] = lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[0], &points[1], &points[2], &points[3]);
+	geoms[1] = lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[4], &points[7], &points[6], &points[5]);
+	geoms[2] = lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[0], &points[4], &points[5], &points[1]);
+	geoms[3] = lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[3], &points[2], &points[6], &points[7]);
+	geoms[4] = lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[0], &points[3], &points[7], &points[4]);
+	geoms[5] = lwgeom_x3d_bbox_poly(geom->srid, hasz, &points[1], &points[5], &points[6], &points[2]);
+
+	bbox_geom = (LWGEOM *)lwcollection_construct(POLYHEDRALSURFACETYPE, geom->srid, NULL, 6, geoms);
+	FLAGS_SET_SOLID(bbox_geom->flags, 1);
+	return bbox_geom;
+}
+
 /*
  * VERSION X3D 3.0.2 http://www.web3d.org/specifications/x3d-3.0.dtd
  */
@@ -38,6 +137,8 @@ lwvarlena_t *
 lwgeom_to_x3d3(const LWGEOM *geom, int precision, int opts, const char *defid)
 {
 	stringbuffer_t *sb;
+	LWGEOM *bbox_geom = NULL;
+	const LWGEOM *x3d_geom = geom;
 	int rv;
 
 	/* Empty varlena for empties */
@@ -48,16 +149,32 @@ lwgeom_to_x3d3(const LWGEOM *geom, int precision, int opts, const char *defid)
 		return v;
 	}
 
+	if (opts & LW_X3D_USE_BBOX)
+	{
+		bbox_geom = lwgeom_x3d_bbox_as_lwgeom(geom);
+		if (!bbox_geom)
+		{
+			lwvarlena_t *v = lwalloc(LWVARHDRSZ);
+			LWSIZE_SET(v->size, LWVARHDRSZ);
+			return v;
+		}
+		x3d_geom = bbox_geom;
+	}
+
 	sb = stringbuffer_create();
-	rv = lwgeom_to_x3d3_sb(geom, precision, opts, defid, sb);
+	rv = lwgeom_to_x3d3_sb(x3d_geom, precision, opts, defid, sb);
 
 	if ( rv == LW_FAILURE )
 	{
+		if (bbox_geom)
+			lwgeom_free(bbox_geom);
 		stringbuffer_destroy(sb);
 		return NULL;
 	}
 
 	lwvarlena_t *v = stringbuffer_getvarlenacopy(sb);
+	if (bbox_geom)
+		lwgeom_free(bbox_geom);
 	stringbuffer_destroy(sb);
 
 	return v;

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1012,6 +1012,10 @@ SELECT '#3627b', ST_Equals(geom, ST_LineFromEncodedPolyline(ST_AsEncodedPolyline
 -- #3704
 SELECT '#3704', ST_AsX3D('LINESTRING EMPTY') = '';
 
+-- #1332
+SELECT '#1332a', ST_AsX3D('LINESTRING(2 8,3 7,10 11)', 0, 4);
+SELECT '#1332b', ST_AsX3D('LINESTRING(2 8,3 7,10 11)', 0, 5);
+
 -- #3709
 select '#3709', ST_SnapToGrid(ST_Project('SRID=4326;POINT(1 1)'::geography, 100000, 20)::geometry, 0.0001) = ST_SnapToGrid(ST_Project('SRID=4326;POINT(1 1)'::geography, -100000, 20+pi())::geometry, 0.0001);
 

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -306,6 +306,8 @@ ERROR:  invalid KML representation
 #3627a|o}~~|AdshNoSsBgd@eGoBlm@wKhj@~@?
 #3627b|t
 #3704|t
+#1332a|<IndexedFaceSet  convex='false' coordIndex='0 1 2 3'><Coordinate point='2 7 0 2 11 0 10 11 0 10 7 0 ' /></IndexedFaceSet>
+#1332b|<IndexedFaceSet  convex='false' coordIndex='0 1 2 3'><Coordinate point='7 2 0 11 2 0 11 10 0 7 10 0 ' /></IndexedFaceSet>
 #3709|t
 NOTICE:  Hole lies outside shell at or near point 25495368.044100001 6671726.9312000005
 #3719a|f


### PR DESCRIPTION
## Summary

Adds option `4` to `ST_AsX3D` to output the input geometry's axis-aligned bounding box instead of the geometry itself.

The bbox output uses BOX3D-style coordinates, so 2D inputs are emitted with `Z=0`, and the option composes with the existing coordinate-flipping and GeoCoordinate options.

Ticket: https://trac.osgeo.org/postgis/ticket/1332.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `e7d6af70b0d4200939be615a88c2a1f80c45e3e1`.
- The exact-comparison bbox dimensionality review thread remains outdated after this rebase.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make clean`
- `make -j32`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- liblwgeom/lwout_x3d.c liblwgeom/lwout_x3d.h liblwgeom/cunit/cu_out_x3d.c postgis/lwgeom_export.c regress/core/tickets.sql regress/core/tickets_expected doc/reference_output.xml NEWS`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `./liblwgeom/cunit/cu_tester x3d_output`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C liblwgeom install`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C doc check-xml`
