### PR TITLE
Optimize rectangle-covered ST_Intersection

### DIFF
--- a/liblwgeom/cunit/cu_geos.c
+++ b/liblwgeom/cunit/cu_geos.c
@@ -159,6 +159,286 @@ test_geos_makevalid(void)
 	lwgeom_free(geom3);
 }
 
+static void
+test_geos_intersection_rectangle_shortcut(void)
+{
+	LWGEOM *geom1;
+	LWGEOM *geom2;
+	LWGEOM *out;
+	char *out_ewkt;
+
+	geom1 = lwgeom_from_wkt("SRID=3857;LINESTRING ZM(1 1 5 7,2 2 6 8)", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("SRID=3857;POLYGON((0 0,0 3,3 3,3 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	out_ewkt = lwgeom_to_ewkt(out);
+	ASSERT_STRING_EQUAL(out_ewkt, "SRID=3857;LINESTRING(1 1 5,2 2 6)");
+	lwfree(out_ewkt);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("POLYGON((0 0,4 0,4 4,0 4,0 0))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("MULTIPOINT((1 1),(2 2))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	out_ewkt = lwgeom_to_ewkt(out);
+	ASSERT_STRING_EQUAL(out_ewkt, "MULTIPOINT(1 1,2 2)");
+	lwfree(out_ewkt);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+}
+
+static LWGEOM *
+geos_intersection_fallback(const LWGEOM *geom1, const LWGEOM *geom2)
+{
+	GEOSGeometry *g1;
+	GEOSGeometry *g2;
+	GEOSGeometry *g3;
+	LWGEOM *result;
+	uint8_t is3d = FLAGS_GET_Z(geom1->flags) || FLAGS_GET_Z(geom2->flags);
+
+	initGEOS(lwnotice, lwgeom_geos_error);
+	g1 = LWGEOM2GEOS(geom1, LW_TRUE);
+	g2 = LWGEOM2GEOS(geom2, LW_TRUE);
+	if (!g1 || !g2)
+	{
+		if (g1)
+			GEOSGeom_destroy(g1);
+		if (g2)
+			GEOSGeom_destroy(g2);
+		return NULL;
+	}
+
+	g3 = GEOSIntersection(g1, g2);
+	GEOSGeom_destroy(g1);
+	GEOSGeom_destroy(g2);
+	if (!g3)
+		return NULL;
+
+	result = GEOS2LWGEOM(g3, is3d);
+	GEOSGeom_destroy(g3);
+	return result;
+}
+
+static void
+assert_intersection_matches_fallback(const char *geom1_wkt,
+				     const char *geom2_wkt,
+				     uint8_t expected_type,
+				     uint32_t expected_npoints)
+{
+	LWGEOM *geom1 = lwgeom_from_wkt(geom1_wkt, LW_PARSER_CHECK_NONE);
+	LWGEOM *geom2 = lwgeom_from_wkt(geom2_wkt, LW_PARSER_CHECK_NONE);
+	LWGEOM *out = lwgeom_intersection(geom1, geom2);
+	LWGEOM *expected = geos_intersection_fallback(geom1, geom2);
+	char *out_ewkt;
+	char *expected_ewkt;
+
+	CU_ASSERT_PTR_NOT_NULL_FATAL(out);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(expected);
+	out_ewkt = lwgeom_to_ewkt(out);
+	expected_ewkt = lwgeom_to_ewkt(expected);
+	ASSERT_STRING_EQUAL(out_ewkt, expected_ewkt);
+	ASSERT_INT_EQUAL(out->type, expected->type);
+	if (expected_npoints)
+	{
+		ASSERT_INT_EQUAL(out->type, expected_type);
+		ASSERT_INT_EQUAL(lwgeom_count_vertices(out), expected_npoints);
+	}
+	lwfree(expected_ewkt);
+	lwfree(out_ewkt);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom2);
+	lwgeom_free(geom1);
+}
+
+static void
+test_geos_intersection_rectangle_shortcut_guards(void)
+{
+	LWGEOM *geom1;
+	LWGEOM *geom2;
+	LWGEOM *expected;
+	LWGEOM *out;
+	char *out_ewkt;
+
+	geom1 = lwgeom_from_wkt("CIRCULARSTRING(1 1,2 2,3 1)", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	out_ewkt = lwgeom_to_ewkt(out);
+	CU_ASSERT(strncmp(out_ewkt, "LINESTRING(", 11) == 0);
+	lwfree(out_ewkt);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("GEOMETRYCOLLECTION(CIRCULARSTRING(1 1,2 2,3 1))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	out_ewkt = lwgeom_to_ewkt(out);
+	CU_ASSERT_PTR_NULL(strstr(out_ewkt, "CIRCULARSTRING"));
+	lwfree(out_ewkt);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("CURVEPOLYGON((1 1,1 2,2 2,2 1,1 1))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = lwgeom_from_wkt("POLYGON((1 2,2 2,2 1,1 1,1 2))", LW_PARSER_CHECK_NONE);
+	ASSERT_INT_EQUAL(out->type, POLYGONTYPE);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("TRIANGLE((1 1,2 1,1 2,1 1))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = lwgeom_from_wkt("POLYGON((1 2,2 1,1 1,1 2))", LW_PARSER_CHECK_NONE);
+	ASSERT_INT_EQUAL(out->type, POLYGONTYPE);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("TIN(((1 1,2 1,1 2,1 1)))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = lwgeom_from_wkt("POLYGON((1 2,2 1,1 1,1 2))", LW_PARSER_CHECK_NONE);
+	ASSERT_INT_EQUAL(out->type, POLYGONTYPE);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("LINESTRING(1 1,1 1)", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = lwgeom_intersection_prec(geom1, geom2, 1);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("POINT(0 0.5)", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0.0000000000001 1,1 1,1 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	out_ewkt = lwgeom_to_ewkt(out);
+	ASSERT_STRING_EQUAL(out_ewkt, "POINT EMPTY");
+	lwfree(out_ewkt);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("LINESTRING(0.4 0.4,1.6 1.6)", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 2,2 2,2 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection_prec(geom1, geom2, 1);
+	out_ewkt = lwgeom_to_ewkt(out);
+	ASSERT_STRING_EQUAL(out_ewkt, "LINESTRING(0 0,2 2)");
+	lwfree(out_ewkt);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	/* GEOS supplies output Z when only the rectangle has Z. */
+	assert_intersection_matches_fallback("POINT(1 1)", "POLYGON Z((0 0 1,0 4 2,4 4 3,4 0 4,0 0 1))", POINTTYPE, 1);
+	assert_intersection_matches_fallback(
+	    "LINESTRING(1 1,3 3)", "POLYGON Z((0 0 1,0 4 2,4 4 3,4 0 4,0 0 1))", LINETYPE, 2);
+	assert_intersection_matches_fallback(
+	    "LINESTRING Z(0 0 10,4 0 20)", "POLYGON Z((0 0 1,0 4 2,4 4 3,4 0 4,0 0 1))", LINETYPE, 2);
+	assert_intersection_matches_fallback(
+	    "POLYGON Z((0 0 1,0 4 2,4 4 3,4 0 4,0 0 1))", "LINESTRING Z(0 0 10,4 0 20)", LINETYPE, 2);
+	assert_intersection_matches_fallback(
+	    "POLYGON((0 0,0 4,4 4,4 0,0 0))", "POLYGON((1 1,3 1,3 3,1 3,1 1))", POLYGONTYPE, 5);
+
+	/* GEOS nodes simple lines whose internal vertices touch the clip boundary. */
+	/* GEOS versions differ on whether these are split; match this build's fallback exactly. */
+	assert_intersection_matches_fallback("LINESTRING(0 0,4 0,4 4)", "POLYGON((0 0,0 4,4 4,4 0,0 0))", 0, 0);
+	assert_intersection_matches_fallback("LINESTRING(1 1,0 2,1 3)", "POLYGON((0 0,0 4,4 4,4 0,0 0))", 0, 0);
+	assert_intersection_matches_fallback("LINESTRING(0 0,2 0,4 0)", "POLYGON((0 0,0 4,4 4,4 0,0 0))", 0, 0);
+
+	/* GEOS overlay collapses singleton multi-geometries to their base type. */
+	assert_intersection_matches_fallback("MULTIPOINT((1 1))", "POLYGON((0 0,0 4,4 4,4 0,0 0))", POINTTYPE, 1);
+	assert_intersection_matches_fallback(
+	    "MULTILINESTRING((1 1,3 3))", "POLYGON((0 0,0 4,4 4,4 0,0 0))", LINETYPE, 2);
+	assert_intersection_matches_fallback(
+	    "MULTIPOLYGON(((1 1,1 3,3 3,3 1,1 1)))", "POLYGON((0 0,0 4,4 4,4 0,0 0))", POLYGONTYPE, 5);
+
+	/* GEOS overlay removes consecutive duplicate XY vertices. */
+	assert_intersection_matches_fallback("LINESTRING(1 1,1 1,2 2)", "POLYGON((0 0,0 4,4 4,4 0,0 0))", LINETYPE, 2);
+	assert_intersection_matches_fallback(
+	    "POLYGON((1 1,1 3,3 3,3 3,3 1,1 1))", "POLYGON((0 0,0 4,4 4,4 0,0 0))", POLYGONTYPE, 5);
+
+	/* Nonclosed polygon input must keep the legacy GEOS autofix behavior. */
+	geom1 = lwgeom_from_wkt("POLYGON((1 1,1 3,3 3,3 1))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = geos_intersection_fallback(geom1, geom2);
+	ASSERT_INT_EQUAL(out->type, expected->type);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	ASSERT_INT_EQUAL(out->type, POLYGONTYPE);
+	CU_ASSERT(ptarray_is_closed_2d(((LWPOLY *)out)->rings[0]));
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	/* Invalid polygonal inputs must retain the GEOS overlay failure. */
+	geom1 = lwgeom_from_wkt("POLYGON((1 1,3 3,1 3,3 1,1 1))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	CU_ASSERT_PTR_NULL(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("LINESTRING(1 1,3 3,1 3,3 1)", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = geos_intersection_fallback(geom1, geom2);
+	ASSERT_INT_EQUAL(out->type, expected->type);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("LINESTRING(1 1,3 1,2 1,4 1)", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = geos_intersection_fallback(geom1, geom2);
+	ASSERT_INT_EQUAL(out->type, expected->type);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("MULTILINESTRING((1 1,3 1),(2 1,4 1))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 5,5 5,5 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = geos_intersection_fallback(geom1, geom2);
+	ASSERT_INT_EQUAL(out->type, expected->type);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+
+	geom1 = lwgeom_from_wkt("MULTIPOINT((1 1),(1 1))", LW_PARSER_CHECK_NONE);
+	geom2 = lwgeom_from_wkt("POLYGON((0 0,0 4,4 4,4 0,0 0))", LW_PARSER_CHECK_NONE);
+	out = lwgeom_intersection(geom1, geom2);
+	expected = geos_intersection_fallback(geom1, geom2);
+	ASSERT_INT_EQUAL(out->type, expected->type);
+	ASSERT_NORMALIZED_GEOM_SAME(out, expected);
+	lwgeom_free(expected);
+	lwgeom_free(out);
+	lwgeom_free(geom1);
+	lwgeom_free(geom2);
+}
 
 static void test_geos_subdivide(void)
 {
@@ -199,4 +479,6 @@ void geos_suite_setup(void)
 	PG_ADD_TEST(suite, test_geos_offsetcurve);
 	PG_ADD_TEST(suite, test_geos_offsetcurve_crash);
 	PG_ADD_TEST(suite, test_geos_makevalid);
+	PG_ADD_TEST(suite, test_geos_intersection_rectangle_shortcut);
+	PG_ADD_TEST(suite, test_geos_intersection_rectangle_shortcut_guards);
 }

--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -762,6 +762,167 @@ lwgeom_intersection(const LWGEOM* g1, const LWGEOM* g2)
 	return lwgeom_intersection_prec(g1, g2, -1.0);
 }
 
+static int
+point_on_gbox_corner_2d(const POINT2D *pt, const GBOX *gbox)
+{
+	if (FP_EQUALS(pt->x, gbox->xmin))
+	{
+		if (FP_EQUALS(pt->y, gbox->ymin))
+			return 1;
+		if (FP_EQUALS(pt->y, gbox->ymax))
+			return 2;
+	}
+	else if (FP_EQUALS(pt->x, gbox->xmax))
+	{
+		if (FP_EQUALS(pt->y, gbox->ymin))
+			return 4;
+		if (FP_EQUALS(pt->y, gbox->ymax))
+			return 8;
+	}
+
+	return 0;
+}
+
+static int
+lwpoly_is_axis_aligned_rectangle(const LWPOLY *poly, GBOX *gbox)
+{
+	int i;
+	int corners = 0;
+	const POINTARRAY *ring;
+
+	if (!poly || poly->nrings != 1)
+		return LW_FALSE;
+
+	ring = poly->rings[0];
+	if (!ring || ring->npoints != 5 || !ptarray_is_closed_2d(ring))
+		return LW_FALSE;
+
+	if (lwgeom_calculate_gbox_cartesian((const LWGEOM *)poly, gbox) == LW_FAILURE)
+		return LW_FALSE;
+
+	if (FP_EQUALS(gbox->xmin, gbox->xmax) || FP_EQUALS(gbox->ymin, gbox->ymax))
+		return LW_FALSE;
+
+	for (i = 0; i < 4; i++)
+	{
+		POINT2D pt;
+		POINT2D next;
+		int corner;
+
+		if (!getPoint2d_p(ring, i, &pt))
+			return LW_FALSE;
+		if (!getPoint2d_p(ring, i + 1, &next))
+			return LW_FALSE;
+		if (pt.x != next.x && pt.y != next.y)
+			return LW_FALSE;
+
+		corner = point_on_gbox_corner_2d(&pt, gbox);
+		if (!corner || (corners & corner))
+			return LW_FALSE;
+
+		corners |= corner;
+	}
+
+	return corners == 15;
+}
+
+static int
+ptarray_has_repeated_consecutive_xy(const POINTARRAY *points)
+{
+	uint32_t i;
+
+	for (i = 1; i < points->npoints; i++)
+	{
+		if (P2D_SAME_STRICT(getPoint2d_cp(points, i - 1), getPoint2d_cp(points, i)))
+			return LW_TRUE;
+	}
+
+	return LW_FALSE;
+}
+
+static int
+lwgeom_valid_for_rectangle_shortcut(const LWGEOM *geom)
+{
+	GEOSGeometry *geos;
+	char simple;
+
+	switch (geom->type)
+	{
+	case POINTTYPE:
+		return LW_TRUE;
+	case LINETYPE:
+		if (lwline_length_2d((const LWLINE *)geom) == 0.0 ||
+		    ptarray_has_repeated_consecutive_xy(((const LWLINE *)geom)->points))
+			return LW_FALSE;
+		break;
+	default:
+		/* GEOS overlay changes semantics for all other geometry families. */
+		return LW_FALSE;
+	}
+
+	initGEOS(lwgeom_geos_error, lwgeom_geos_error);
+	geos = LWGEOM2GEOS(geom, LW_FALSE);
+	if (!geos)
+		return LW_FALSE;
+
+	simple = GEOSisSimple(geos);
+	GEOSGeom_destroy(geos);
+	return simple == 1;
+}
+
+static LWGEOM *
+lwgeom_intersection_rectangle_shortcut(const LWGEOM *geom1, const LWGEOM *geom2)
+{
+	GBOX rect_box;
+	GBOX geom_box;
+	const LWGEOM *rect;
+	const LWGEOM *geom;
+
+	if (FLAGS_GET_GEODETIC(geom1->flags) || FLAGS_GET_GEODETIC(geom2->flags))
+		return NULL;
+
+	if (geom1->type == POLYGONTYPE && lwpoly_is_axis_aligned_rectangle((const LWPOLY *)geom1, &rect_box))
+	{
+		rect = geom1;
+		geom = geom2;
+	}
+	else if (geom2->type == POLYGONTYPE && lwpoly_is_axis_aligned_rectangle((const LWPOLY *)geom2, &rect_box))
+	{
+		rect = geom2;
+		geom = geom1;
+	}
+	else
+	{
+		return NULL;
+	}
+
+	if (geom == rect)
+		return NULL;
+	/* A 3D clipping polygon can source or interpolate result Z values. */
+	if (FLAGS_GET_Z(rect->flags))
+		return NULL;
+	if (geom->type != POINTTYPE && geom->type != LINETYPE)
+		return NULL;
+
+	if (lwgeom_calculate_gbox_cartesian(geom, &geom_box) == LW_FAILURE)
+		return NULL;
+
+	if (!gbox_contains_2d(&rect_box, &geom_box))
+		return NULL;
+
+	/* GEOS nodes a line at internal vertices which touch the clip boundary. */
+	if (geom->type == LINETYPE &&
+	    (FP_EQUALS(geom_box.xmin, rect_box.xmin) || FP_EQUALS(geom_box.xmax, rect_box.xmax) ||
+	     FP_EQUALS(geom_box.ymin, rect_box.ymin) || FP_EQUALS(geom_box.ymax, rect_box.ymax)))
+		return NULL;
+
+	/* GEOS predicates are only worthwhile after the cheap containment check. */
+	if (!lwgeom_valid_for_rectangle_shortcut(geom))
+		return NULL;
+
+	return lwgeom_force_dims(geom, FLAGS_GET_Z(geom->flags), 0, 0, 0);
+}
+
 LWGEOM*
 lwgeom_intersection_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 {
@@ -779,6 +940,13 @@ lwgeom_intersection_prec(const LWGEOM* geom1, const LWGEOM* geom2, double prec)
 
 	/* Empty.Intersection(A) == Empty */
 	if (lwgeom_is_empty(geom1)) return lwgeom_clone_deep(geom1); /* match empty type? */
+
+	if (prec < 0)
+	{
+		result = lwgeom_intersection_rectangle_shortcut(geom1, geom2);
+		if (result)
+			return result;
+	}
 
 	initGEOS(lwnotice, lwgeom_geos_error);
 


### PR DESCRIPTION
## Summary

- Add a liblwgeom fast path for `ST_Intersection` when one input is an axis-aligned rectangle that fully covers the other geometry.
- Keep the existing GEOS overlay path for precision-grid calls, geodetic inputs, curved geometries, SQL/MM surface inputs, invalid polygonal inputs, and zero-length linear inputs.
- Add CUnit coverage for covered ZM lines, covered polygons, covered multipoints, curve fallback, Triangle/TIN fallback, zero-length line fallback, exact rectangle classification, and grid-size fallback.
- Make the GEOS fallback assertions tolerant of valid ring start/order differences across GEOS versions.

Ticket: https://trac.osgeo.org/postgis/ticket/4688.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `1ff1a850a85f92ed10065cafd277b75395aa7a19`.
- Resolved the current Triangle/TIN and zero-length line review threads after adding/confirming guards and tests.
- Remaining unresolved review threads are outdated on older commits.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `./liblwgeom/cunit/cu_tester geos`
- `make -C liblwgeom/cunit check`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `git clang-format --diff upstream/master -- liblwgeom/lwgeom_geos.c liblwgeom/cunit/cu_geos.c NEWS`
