### PR TITLE
Add geography union and difference wrappers

### DIFF
--- a/doc/reference_overlay.xml
+++ b/doc/reference_overlay.xml
@@ -74,6 +74,11 @@
             <paramdef><type>geometry </type> <parameter>geomB</parameter></paramdef>
             <paramdef choice="opt"><type>float8 </type> <parameter>gridSize = -1</parameter></paramdef>
           </funcprototype>
+          <funcprototype>
+            <funcdef>geography <function>ST_Difference</function></funcdef>
+            <paramdef><type>geography </type> <parameter>geogA</parameter></paramdef>
+            <paramdef><type>geography </type> <parameter>geogB</parameter></paramdef>
+          </funcprototype>
         </funcsynopsis>
       </refsynopsisdiv>
 
@@ -91,6 +96,11 @@
         &overlay_gridsize_arg;
 
         <para>Performed by the GEOS module</para>
+        <para>For geography, this function is a thin wrapper around the geometry implementation.
+            It first determines a best-fit planar spatial reference system for the bounding box
+            of the two geography objects, computes the difference in that planar space, and
+            transforms the result back to WGS 84 geography.</para>
+        <para role="availability" conformance="3.7.0">Availability: 3.7.0 - support for geography.</para>
         <para role="enhanced" conformance="3.1.0">Enhanced: 3.1.0 accept a gridSize parameter.</para>
         <para role="geos_requirement" conformance="3.9.0">Requires GEOS &gt;= 3.9.0 to use the gridSize parameter.</para>
 
@@ -933,6 +943,11 @@ SELECT ST_AsEWKT(ST_SymDifference(ST_GeomFromEWKT('LINESTRING(1 2 1, 1 4 2)'),
         <paramdef><type>geometry</type> <parameter>g2</parameter></paramdef>
       </funcprototype>
       <funcprototype>
+        <funcdef>geography <function>ST_Union</function></funcdef>
+        <paramdef><type>geography</type> <parameter>geog1</parameter></paramdef>
+        <paramdef><type>geography</type> <parameter>geog2</parameter></paramdef>
+      </funcprototype>
+      <funcprototype>
         <funcdef>geometry <function>ST_Union</function></funcdef>
         <paramdef><type>geometry</type> <parameter>g1</parameter></paramdef>
         <paramdef><type>geometry</type> <parameter>g2</parameter></paramdef>
@@ -965,6 +980,11 @@ SELECT ST_AsEWKT(ST_SymDifference(ST_GeomFromEWKT('LINESTRING(1 2 1, 1 4 2)'),
         returns a geometry that is the union of two input geometries.
         If either input is NULL, then NULL is returned.
         </para>
+    <para>The two-input variant also accepts geography values. The geography
+        implementation is a thin wrapper around the geometry implementation.
+        It first determines a best-fit planar spatial reference system for the bounding box
+        of the two geography objects, computes the union in that planar space, and
+        transforms the result back to WGS 84 geography.</para>
 
     <para><emphasis role="bold">Array variant:</emphasis>
         returns a geometry that is the union of an array of geometries.
@@ -1001,6 +1021,7 @@ SELECT ST_AsEWKT(ST_SymDifference(ST_GeomFromEWKT('LINESTRING(1 2 1, 1 4 2)'),
     <para role="enhanced" conformance="3.1.0">Enhanced: 3.1.0 accept a gridSize parameter.</para>
     <para role="geos_requirement" conformance="3.9.0">Requires GEOS &gt;= 3.9.0 to use the gridSize parameter</para>
     <para role="changed" conformance="3.0.0">Changed: 3.0.0 does not depend on SFCGAL.</para>
+    <para role="availability" conformance="3.7.0">Availability: 3.7.0 - support for binary geography union.</para>
     <para role="availability" conformance="1.4.0">Availability: 1.4.0 - ST_Union was enhanced. ST_Union(geomarray) was introduced and also faster aggregate collection in PostgreSQL.</para>
 
     <para>&sfs_compliant; s2.1.1.3</para>

--- a/postgis/geography.sql.in
+++ b/postgis/geography.sql.in
@@ -833,10 +833,36 @@ CREATE OR REPLACE FUNCTION ST_Intersection(geography, geography)
 	AS 'SELECT @extschema@.geography(@extschema@.ST_Transform(@extschema@.ST_Intersection(@extschema@.ST_Transform(@extschema@.geometry($1), @extschema@._ST_BestSRID($1, $2)), @extschema@.ST_Transform(@extschema@.geometry($2), @extschema@._ST_BestSRID($1, $2))), @extschema@.ST_SRID($1)))'
 	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_Difference(geography, geography)
+	RETURNS geography
+	AS 'SELECT @extschema@.geography(@extschema@.ST_Transform(@extschema@.ST_Difference(@extschema@.ST_Transform(@extschema@.geometry($1), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1))), @extschema@.ST_Transform(@extschema@.geometry($2), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1)))), @extschema@.ST_SRID($1)))'
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_Union(geography, geography)
+	RETURNS geography
+	AS 'SELECT @extschema@.geography(@extschema@.ST_Transform(@extschema@.ST_Union(@extschema@.ST_Transform(@extschema@.geometry($1), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1))), @extschema@.ST_Transform(@extschema@.geometry($2), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1)))), @extschema@.ST_SRID($1)))'
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
 -- Availability: 1.5.0 - this is just a hack to prevent unknown from causing ambiguous name because of geography
 CREATE OR REPLACE FUNCTION ST_Intersection(text, text)
 	RETURNS geometry AS
 	$$ SELECT @extschema@.ST_Intersection($1::@extschema@.geometry, $2::@extschema@.geometry);  $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_HIGH;
+
+-- Availability: 3.7.0 - this is just a hack to prevent unknown from causing ambiguous name because of geography
+CREATE OR REPLACE FUNCTION ST_Difference(text, text)
+	RETURNS geometry AS
+	$$ SELECT @extschema@.ST_Difference($1::@extschema@.geometry, $2::@extschema@.geometry);  $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_HIGH;
+
+-- Availability: 3.7.0 - this is just a hack to prevent unknown from causing ambiguous name because of geography
+CREATE OR REPLACE FUNCTION ST_Union(text, text)
+	RETURNS geometry AS
+	$$ SELECT @extschema@.ST_Union($1::@extschema@.geometry, $2::@extschema@.geometry);  $$
 	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_HIGH;
 

--- a/postgis/geography.sql.in
+++ b/postgis/geography.sql.in
@@ -836,13 +836,20 @@ CREATE OR REPLACE FUNCTION ST_Intersection(geography, geography)
 -- Availability: 3.7.0
 CREATE OR REPLACE FUNCTION ST_Difference(geography, geography)
 	RETURNS geography
-	AS 'SELECT @extschema@.geography(@extschema@.ST_Transform(@extschema@.ST_Difference(@extschema@.ST_Transform(@extschema@.geometry($1), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1))), @extschema@.ST_Transform(@extschema@.geometry($2), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1)))), @extschema@.ST_SRID($1)))'
+	AS $$ SELECT CASE
+		WHEN @extschema@.ST_IsEmpty(@extschema@.geometry($1)) OR @extschema@.ST_IsEmpty(@extschema@.geometry($2)) THEN $1
+		ELSE @extschema@.geography(@extschema@.ST_Transform(@extschema@.ST_Difference(@extschema@.ST_Transform(@extschema@.geometry($1), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1))), @extschema@.ST_Transform(@extschema@.geometry($2), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1)))), @extschema@.ST_SRID($1)))
+	END; $$
 	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
 
 -- Availability: 3.7.0
 CREATE OR REPLACE FUNCTION ST_Union(geography, geography)
 	RETURNS geography
-	AS 'SELECT @extschema@.geography(@extschema@.ST_Transform(@extschema@.ST_Union(@extschema@.ST_Transform(@extschema@.geometry($1), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1))), @extschema@.ST_Transform(@extschema@.geometry($2), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1)))), @extschema@.ST_SRID($1)))'
+	AS $$ SELECT CASE
+		WHEN @extschema@.ST_IsEmpty(@extschema@.geometry($1)) THEN $2
+		WHEN @extschema@.ST_IsEmpty(@extschema@.geometry($2)) THEN $1
+		ELSE @extschema@.geography(@extschema@.ST_Transform(@extschema@.ST_Union(@extschema@.ST_Transform(@extschema@.geometry($1), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1))), @extschema@.ST_Transform(@extschema@.geometry($2), COALESCE(@extschema@._ST_BestSRID($1, $2), @extschema@.ST_SRID($1)))), @extschema@.ST_SRID($1)))
+	END; $$
 	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
 
 -- Availability: 1.5.0 - this is just a hack to prevent unknown from causing ambiguous name because of geography

--- a/postgis/uninstall_geography.sql.in
+++ b/postgis/uninstall_geography.sql.in
@@ -51,6 +51,8 @@ DROP FUNCTION IF EXISTS ST_CoveredBy(text, text);
 DROP FUNCTION IF EXISTS ST_Intersects(text, text);
 DROP FUNCTION IF EXISTS ST_Buffer(text, float8);
 DROP FUNCTION IF EXISTS ST_Intersection(text, text);
+DROP FUNCTION IF EXISTS ST_Difference(text, text);
+DROP FUNCTION IF EXISTS ST_Union(text, text);
 
 -- functions
 DROP FUNCTION IF EXISTS ST_AsText(geography);
@@ -127,6 +129,8 @@ DROP FUNCTION IF EXISTS _ST_BestSRID(geography, geography);
 DROP FUNCTION IF EXISTS _ST_BestSRID(geography);
 DROP FUNCTION IF EXISTS ST_Buffer(geography, float8);
 DROP FUNCTION IF EXISTS ST_Intersection(geography, geography);
+DROP FUNCTION IF EXISTS ST_Difference(geography, geography);
+DROP FUNCTION IF EXISTS ST_Union(geography, geography);
 DROP FUNCTION IF EXISTS geography(geography, integer, boolean);
 
 --DROP FUNCTION IF EXISTS geography_in(cstring, oid, integer);
@@ -139,4 +143,3 @@ DROP FUNCTION IF EXISTS geography_analyze(internal);
 -- DROP FUNCTION IF EXISTS gidx_in(cstring);
 -- DROP FUNCTION IF EXISTS gidx_out(gidx);
 DROP TYPE gidx CASCADE;
-

--- a/regress/core/geography.sql
+++ b/regress/core/geography.sql
@@ -113,6 +113,8 @@ WITH geogs AS (
 SELECT 'geography_difference', GeometryType(difference::geometry), ST_Area(difference) > 0, ST_Area(difference) < ST_Area(a) FROM overlay;
 SELECT 'geography_difference_text', ST_AsText(ST_Normalize(ST_Difference('POLYGON((0 0,0 1,1 1,1 0,0 0))', 'POLYGON((0.5 0,0.5 1,1.5 1,1.5 0,0.5 0))')));
 SELECT 'geography_difference_empty', ST_AsText(ST_Difference('POLYGON EMPTY'::geography, 'POLYGON EMPTY'::geography)::geometry);
+SELECT 'geography_difference_empty_rhs', ST_Equals(ST_Difference(a, 'POLYGON EMPTY'::geography)::geometry, a::geometry) FROM (SELECT 'SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'::geography AS a) AS empty_overlay;
+SELECT 'geography_difference_empty_lhs', ST_AsText(ST_Difference('POLYGON EMPTY'::geography, 'SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'::geography)::geometry);
 
 WITH geogs AS (
 	SELECT
@@ -124,6 +126,8 @@ WITH geogs AS (
 SELECT 'geography_union', GeometryType(unioned::geometry), ST_Area(unioned) > ST_Area(a), ST_Area(unioned) < ST_Area(a) + ST_Area(b), ST_Covers(unioned, a), ST_Covers(unioned, b) FROM overlay;
 SELECT 'geography_union_text', ST_AsText(ST_Normalize(ST_Union('POINT(0 0)', 'POINT(1 1)')));
 SELECT 'geography_union_empty', ST_AsText(ST_Union('POLYGON EMPTY'::geography, 'POLYGON EMPTY'::geography)::geometry);
+SELECT 'geography_union_empty_lhs', ST_Equals(ST_Union('POINT EMPTY'::geography, 'SRID=4326;POINT(1 1)'::geography)::geometry, 'SRID=4326;POINT(1 1)'::geometry);
+SELECT 'geography_union_empty_rhs', ST_Equals(ST_Union('SRID=4326;POINT(1 1)'::geography, 'POINT EMPTY'::geography)::geometry, 'SRID=4326;POINT(1 1)'::geometry);
 
 -- typmod checks
 select 'typmod_point_4326', geography_typmod_out(geography_typmod_in('{Point,4326}'));

--- a/regress/core/geography.sql
+++ b/regress/core/geography.sql
@@ -103,6 +103,28 @@ SELECT 'segmentize_geography2', st_dwithin(st_pointn(st_segmentize('linestring(1
 SELECT 'segmentize_geography_3667', abs(ST_Length(geog) - ST_Length(ST_Segmentize(geog, 30000))) < 0.00001
   FROM (SELECT ST_GeographyFromText('LINESTRING(38.769917 10.780694, 38.769917 9.106194)') As geog) AS f;
 
+WITH geogs AS (
+	SELECT
+		'SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'::geography AS a,
+		'SRID=4326;POLYGON((0.5 0, 0.5 1, 1.5 1, 1.5 0, 0.5 0))'::geography AS b
+), overlay AS (
+	SELECT a, b, ST_Difference(a, b) AS difference FROM geogs
+)
+SELECT 'geography_difference', GeometryType(difference::geometry), ST_Area(difference) > 0, ST_Area(difference) < ST_Area(a) FROM overlay;
+SELECT 'geography_difference_text', ST_AsText(ST_Normalize(ST_Difference('POLYGON((0 0,0 1,1 1,1 0,0 0))', 'POLYGON((0.5 0,0.5 1,1.5 1,1.5 0,0.5 0))')));
+SELECT 'geography_difference_empty', ST_AsText(ST_Difference('POLYGON EMPTY'::geography, 'POLYGON EMPTY'::geography)::geometry);
+
+WITH geogs AS (
+	SELECT
+		'SRID=4326;POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'::geography AS a,
+		'SRID=4326;POLYGON((0.5 0, 0.5 1, 1.5 1, 1.5 0, 0.5 0))'::geography AS b
+), overlay AS (
+	SELECT a, b, ST_Union(a, b) AS unioned FROM geogs
+)
+SELECT 'geography_union', GeometryType(unioned::geometry), ST_Area(unioned) > ST_Area(a), ST_Area(unioned) < ST_Area(a) + ST_Area(b), ST_Covers(unioned, a), ST_Covers(unioned, b) FROM overlay;
+SELECT 'geography_union_text', ST_AsText(ST_Normalize(ST_Union('POINT(0 0)', 'POINT(1 1)')));
+SELECT 'geography_union_empty', ST_AsText(ST_Union('POLYGON EMPTY'::geography, 'POLYGON EMPTY'::geography)::geometry);
+
 -- typmod checks
 select 'typmod_point_4326', geography_typmod_out(geography_typmod_in('{Point,4326}'));
 select 'typmod_point_0', geography_typmod_out(geography_typmod_in('{Point,0}'));

--- a/regress/core/geography_expected
+++ b/regress/core/geography_expected
@@ -33,9 +33,13 @@ segmentize_geography_3667|t
 geography_difference|POLYGON|t|t
 geography_difference_text|POLYGON((0 0,0 1,0.5 1,0.5 0,0 0))
 geography_difference_empty|POLYGON EMPTY
+geography_difference_empty_rhs|t
+geography_difference_empty_lhs|POLYGON EMPTY
 geography_union|POLYGON|t|t|t|t
 geography_union_text|MULTIPOINT((1 1),(0 0))
 geography_union_empty|POLYGON EMPTY
+geography_union_empty_lhs|t
+geography_union_empty_rhs|t
 typmod_point_4326|(Point,4326)
 typmod_point_0|(Point,4326)
 NOTICE:  SRID value -1 converted to the officially unknown SRID value 0

--- a/regress/core/geography_expected
+++ b/regress/core/geography_expected
@@ -30,6 +30,12 @@ geog_precision_pazafir|0|0
 segmentize_geography|39092
 segmentize_geography2|t
 segmentize_geography_3667|t
+geography_difference|POLYGON|t|t
+geography_difference_text|POLYGON((0 0,0 1,0.5 1,0.5 0,0 0))
+geography_difference_empty|POLYGON EMPTY
+geography_union|POLYGON|t|t|t|t
+geography_union_text|MULTIPOINT((1 1),(0 0))
+geography_union_empty|POLYGON EMPTY
 typmod_point_4326|(Point,4326)
 typmod_point_0|(Point,4326)
 NOTICE:  SRID value -1 converted to the officially unknown SRID value 0


### PR DESCRIPTION
## Summary

Adds binary geography overloads for `ST_Union(geography, geography)` and `ST_Difference(geography, geography)`.

Both wrappers follow the existing geography `ST_Intersection` pattern: choose `_ST_BestSRID($1, $2)`, transform both geography inputs to that planar CRS, run the geometry overlay operation, then transform back to the input geography SRID. Empty operand cases short-circuit before projection so identity and all-empty overlays keep normal overlay semantics.

Tickets:

- https://trac.osgeo.org/postgis/ticket/5325
- https://trac.osgeo.org/postgis/ticket/5326

This PR deliberately does not revive the older custom C overlay implementation from https://trac.osgeo.org/postgis/ticket/3973 or https://github.com/postgis/postgis/pull/191.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `baa1daaece9685b61ad9d6e6895a87396d9b73cb`.
- Resolved the current WKT-literal ambiguity review threads; the `text,text` shims are present.
- The empty-geography review threads are outdated after the empty fast-path commit and regression additions.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/regress/core/geography"`
- `make check-news`
- `make -C doc check`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
