### PR TITLE
Add raster binary protocol hooks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -185,6 +185,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #3111, [raster] Add PostgreSQL binary send/receive support for the
+          raster type (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #3111, [raster] Add PostgreSQL binary send/receive support for the
+          raster type (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/raster/rt_pg/rtpg_inout.c
+++ b/raster/rt_pg/rtpg_inout.c
@@ -29,13 +29,16 @@
 
 #include <postgres.h>
 #include <fmgr.h>
+#include "lib/stringinfo.h"
 
 #include "rtpostgis.h"
 
 Datum RASTER_in(PG_FUNCTION_ARGS);
 Datum RASTER_out(PG_FUNCTION_ARGS);
+Datum RASTER_recv(PG_FUNCTION_ARGS);
+Datum RASTER_send(PG_FUNCTION_ARGS);
 
-Datum RASTER_to_bytea(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum RASTER_to_bytea(PG_FUNCTION_ARGS);
 
 Datum RASTER_noop(PG_FUNCTION_ARGS);
 
@@ -61,7 +64,7 @@ Datum RASTER_in(PG_FUNCTION_ARGS)
 	if (result == NULL)
 		PG_RETURN_NULL();
 
-	SET_VARSIZE(result, ((rt_pgraster*)result)->size);
+	SET_VARSIZE(result, ((rt_pgraster *) result)->size);
 	PG_RETURN_POINTER(result);
 }
 
@@ -102,6 +105,55 @@ Datum RASTER_out(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(pgraster, 0);
 
 	PG_RETURN_CSTRING(hexwkb);
+}
+
+/*
+ * Binary input is WKB.
+ * Used as the receive function of the raster type.
+ */
+PG_FUNCTION_INFO_V1(RASTER_recv);
+Datum RASTER_recv(PG_FUNCTION_ARGS)
+{
+	StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+	rt_raster raster = NULL;
+	void *result = NULL;
+
+	POSTGIS_RT_DEBUG(3, "Starting");
+
+	raster = rt_raster_from_wkb((uint8_t *) buf->data, buf->len);
+	if (raster == NULL) {
+		ereport(ERROR, (errmsg("recv error - invalid raster")));
+		PG_RETURN_NULL();
+	}
+
+	buf->cursor = buf->len;
+
+	result = rt_raster_serialize(raster);
+	rt_raster_destroy(raster);
+	if (result == NULL) {
+		ereport(ERROR, (errmsg("RASTER_recv: Cannot serialize raster")));
+		PG_RETURN_NULL();
+	}
+
+	SET_VARSIZE(result, ((rt_pgraster*)result)->size);
+	PG_RETURN_POINTER(result);
+}
+
+/*
+ * Binary output is WKB.
+ * Used as the send function of the raster type.
+ */
+PG_FUNCTION_INFO_V1(RASTER_send);
+Datum RASTER_send(PG_FUNCTION_ARGS)
+{
+	POSTGIS_RT_DEBUG(3, "Starting");
+
+	PG_RETURN_POINTER(
+		DatumGetPointer(
+			DirectFunctionCall1(
+				RASTER_to_bytea,
+				PG_GETARG_DATUM(0)
+			)));
 }
 
 /**
@@ -175,4 +227,3 @@ Datum RASTER_noop(PG_FUNCTION_ARGS)
 	SET_VARSIZE(result, raster->size);
 	PG_RETURN_POINTER(result);
 }
-

--- a/raster/rt_pg/rtpg_inout.c
+++ b/raster/rt_pg/rtpg_inout.c
@@ -28,13 +28,16 @@
 
 #include <postgres.h>
 #include <fmgr.h>
+#include "lib/stringinfo.h"
 
 #include "rtpostgis.h"
 
 Datum RASTER_in(PG_FUNCTION_ARGS);
 Datum RASTER_out(PG_FUNCTION_ARGS);
+Datum RASTER_recv(PG_FUNCTION_ARGS);
+Datum RASTER_send(PG_FUNCTION_ARGS);
 
-Datum RASTER_to_bytea(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum RASTER_to_bytea(PG_FUNCTION_ARGS);
 
 Datum RASTER_noop(PG_FUNCTION_ARGS);
 
@@ -60,7 +63,7 @@ Datum RASTER_in(PG_FUNCTION_ARGS)
 	if (result == NULL)
 		PG_RETURN_NULL();
 
-	SET_VARSIZE(result, ((rt_pgraster*)result)->size);
+	SET_VARSIZE(result, ((rt_pgraster *) result)->size);
 	PG_RETURN_POINTER(result);
 }
 
@@ -101,6 +104,55 @@ Datum RASTER_out(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(pgraster, 0);
 
 	PG_RETURN_CSTRING(hexwkb);
+}
+
+/*
+ * Binary input is WKB.
+ * Used as the receive function of the raster type.
+ */
+PG_FUNCTION_INFO_V1(RASTER_recv);
+Datum RASTER_recv(PG_FUNCTION_ARGS)
+{
+	StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+	rt_raster raster = NULL;
+	void *result = NULL;
+
+	POSTGIS_RT_DEBUG(3, "Starting");
+
+	raster = rt_raster_from_wkb((uint8_t *) buf->data, buf->len);
+	if (raster == NULL) {
+		ereport(ERROR, (errmsg("recv error - invalid raster")));
+		PG_RETURN_NULL();
+	}
+
+	buf->cursor = buf->len;
+
+	result = rt_raster_serialize(raster);
+	rt_raster_destroy(raster);
+	if (result == NULL) {
+		ereport(ERROR, (errmsg("RASTER_recv: Cannot serialize raster")));
+		PG_RETURN_NULL();
+	}
+
+	SET_VARSIZE(result, ((rt_pgraster*)result)->size);
+	PG_RETURN_POINTER(result);
+}
+
+/*
+ * Binary output is WKB.
+ * Used as the send function of the raster type.
+ */
+PG_FUNCTION_INFO_V1(RASTER_send);
+Datum RASTER_send(PG_FUNCTION_ARGS)
+{
+	POSTGIS_RT_DEBUG(3, "Starting");
+
+	PG_RETURN_POINTER(
+		DatumGetPointer(
+			DirectFunctionCall1(
+				RASTER_to_bytea,
+				PG_GETARG_DATUM(0)
+			)));
 }
 
 /**
@@ -174,4 +226,3 @@ Datum RASTER_noop(PG_FUNCTION_ARGS)
 	SET_VARSIZE(result, raster->size);
 	PG_RETURN_POINTER(result);
 }
-

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -93,14 +93,39 @@ CREATE OR REPLACE FUNCTION raster_out(raster)
     AS 'MODULE_PATHNAME','RASTER_out'
     LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
 
+-- part of Raster type
+-- expects input to be WKB
+CREATE OR REPLACE FUNCTION raster_recv(internal)
+    RETURNS raster
+    AS 'MODULE_PATHNAME','RASTER_recv'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- part of Raster type
+-- expects output to be WKB
+CREATE OR REPLACE FUNCTION raster_send(raster)
+    RETURNS bytea
+    AS 'MODULE_PATHNAME','RASTER_send'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
 -- Availability: 2.0.0
 CREATE TYPE raster (
     alignment = double,
     internallength = variable,
     input = raster_in,
     output = raster_out,
+    receive = raster_recv,
+    send = raster_send,
     storage = extended
 );
+
+DO LANGUAGE 'plpgsql' $$
+BEGIN
+    ALTER TYPE raster SET (
+        receive = raster_recv,
+        send = raster_send
+    );
+END
+$$;
 
 ------------------------------------------------------------------------------
 -- FUNCTIONS

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -92,14 +92,39 @@ CREATE OR REPLACE FUNCTION raster_out(raster)
     AS 'MODULE_PATHNAME','RASTER_out'
     LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
 
+-- part of Raster type
+-- expects input to be WKB
+CREATE OR REPLACE FUNCTION raster_recv(internal)
+    RETURNS raster
+    AS 'MODULE_PATHNAME','RASTER_recv'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- part of Raster type
+-- expects output to be WKB
+CREATE OR REPLACE FUNCTION raster_send(raster)
+    RETURNS bytea
+    AS 'MODULE_PATHNAME','RASTER_send'
+    LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
 -- Availability: 2.0.0
 CREATE TYPE raster (
     alignment = double,
     internallength = variable,
     input = raster_in,
     output = raster_out,
+    receive = raster_recv,
+    send = raster_send,
     storage = extended
 );
+
+DO LANGUAGE 'plpgsql' $$
+BEGIN
+    ALTER TYPE raster SET (
+        receive = raster_recv,
+        send = raster_send
+    );
+END
+$$;
 
 ------------------------------------------------------------------------------
 -- FUNCTIONS

--- a/raster/test/regress/rt_bytea.sql
+++ b/raster/test/regress/rt_bytea.sql
@@ -175,5 +175,42 @@ WHERE
     encode(st_asbinary(rast), 'base64') != encode(rast::bytea, 'base64')
     ;
 
+-----------------------------------------------------------------------
+--- Test PostgreSQL binary send/receive hooks
+-----------------------------------------------------------------------
+
+SELECT
+	typreceive::regproc,
+	typsend::regproc
+FROM pg_type
+WHERE typname = 'raster';
+
+SELECT
+	id,
+    name
+FROM rt_bytea_test
+WHERE
+    encode(raster_send(rast), 'base64') != encode(rast::bytea, 'base64')
+    ;
+
+\! rm -f rt_bytea_binary.copy
+
+\copy (SELECT id, rast FROM rt_bytea_test ORDER BY id) TO 'rt_bytea_binary.copy' WITH (FORMAT binary)
+
+CREATE TEMP TABLE rt_bytea_binary_copy (
+        id numeric,
+        rast raster
+    );
+
+\copy rt_bytea_binary_copy FROM 'rt_bytea_binary.copy' WITH (FORMAT binary)
+
+SELECT
+	count(*) AS mismatched_rasters
+FROM rt_bytea_binary_copy copy_rasters
+JOIN rt_bytea_test source_rasters USING (id)
+WHERE copy_rasters.rast::bytea != source_rasters.rast::bytea;
+
+\! rm -f rt_bytea_binary.copy
+
 -- Cleanup
 DROP TABLE rt_bytea_test;

--- a/raster/test/regress/rt_bytea_expected
+++ b/raster/test/regress/rt_bytea_expected
@@ -1,1 +1,3 @@
 NOTICE:  SRID value -1 converted to the officially unknown SRID value 0
+raster_recv|raster_send
+0


### PR DESCRIPTION
## Summary

Adds PostgreSQL binary protocol hooks for the raster type:

- `raster_recv(internal)` parses binary WKB into serialized raster values.
- `raster_send(raster)` emits the existing raster WKB bytea representation.
- Fresh install and upgrade SQL wire the hooks into the `raster` type.
- `rt_bytea` regression verifies catalog hooks, direct send output, deterministic binary COPY round-trip receive, and upgrade behavior.

Ticket: https://trac.osgeo.org/postgis/ticket/3111.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `7e11db181467ad386d1887f39ba993511d07c09b`.
- The previous row-order review thread remains resolved and outdated.
- Replaced the regression's hardcoded `/tmp` binary copy file with a relative file so the test works under MSYS2/Windows PostgreSQL as well as Unix-like runners.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make install`
- `make -C raster/rt_pg -j32`
- `make -C raster/rt_pg rtpg_inout.o CC=clang`
- `sudo -n make -C raster/rt_pg install`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C extensions/postgis_raster install`
- `POSTGIS_REGRESS_DB=postgis_reg_3111_fresh PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --raster" TESTS="$(pwd)/raster/test/regress/rt_bytea"` (fresh and automatic-upgrade)
- `POSTGIS_REGRESS_DB=postgis_reg_3111_upgrade PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--upgrade --extension --verbose --raster" TESTS="$(pwd)/raster/test/regress/rt_bytea"`
- `make check-news`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
