### PR TITLE
Add ST_Convolution raster wrapper

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -131,6 +131,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * New Features *
 
+ - #2601, [raster] Add ST_Convolution wrapper for 1x1 and 3x3
+          weighted raster map algebra masks (Darafei Praliaskouski)
  - #1124, #2935, #3033, #4658, #4659, [loader] Rework loader arguments:
           shp2pgsql can create UNLOGGED tables and choose the feature id column
           name, shp2pgsql --drop-table can emit DROP TABLE before prepare

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -10389,11 +10389,8 @@ SELECT ST_Value(
     ),
     2, 2
 )
-FROM src;
- st_value
-----------
-       25
-                    </programlisting>
+FROM src;</programlisting>
+                    <screen>25</screen>
                 </refsection>
 
                 <refsection>

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -10334,6 +10334,77 @@ WHERE t1.rid = 1
 
             </refentry>
 
+            <refentry xml:id="RT_ST_Convolution">
+                <refnamediv>
+                    <refname>ST_Convolution</refname>
+                    <refpurpose>Return a raster computed by applying a weighted convolution matrix to the first band.</refpurpose>
+                </refnamediv>
+
+                <refsynopsisdiv>
+                    <funcsynopsis>
+                        <funcprototype>
+                            <funcdef>raster <function>ST_Convolution</function></funcdef>
+                            <paramdef><type>raster</type> <parameter>rast</parameter></paramdef>
+                            <paramdef><type>double precision[][]</type> <parameter>matrix</parameter></paramdef>
+                            <paramdef choice="opt"><type>text</type> <parameter>pixeltype=32BF</parameter></paramdef>
+                        </funcprototype>
+                    </funcsynopsis>
+                </refsynopsisdiv>
+
+                <refsection>
+                    <title>Description</title>
+                    <para>
+                        Applies <varname>matrix</varname> as a weighted mask over the first band of <varname>rast</varname> and returns the summed result as a new raster. This is a convenience wrapper around <xref linkend="RT_ST_MapAlgebra"/> using <xref linkend="RT_ST_Sum4ma"/> as the callback and <varname>weighted</varname> set to true. The output band uses <varname>pixeltype</varname>, which defaults to <literal>32BF</literal> to avoid clipping or rounding integer source rasters.
+                    </para>
+                    <para>
+                        The matrix must currently be 1x1 or 3x3.
+                    </para>
+
+                    <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                </refsection>
+
+                <refsection>
+                    <title>Examples</title>
+                    <programlisting>WITH src AS (
+    SELECT ST_SetValues(
+        ST_AddBand(
+            ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0),
+            1, '32BF', 0, NULL
+        ),
+        1, 1, 1, ARRAY[
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9]
+        ]::double precision[][]
+    ) AS rast
+)
+SELECT ST_Value(
+    ST_Convolution(
+        rast,
+        ARRAY[
+            [0, 1, 0],
+            [1, 1, 1],
+            [0, 1, 0]
+        ]::double precision[][]
+    ),
+    2, 2
+)
+FROM src;
+ st_value
+----------
+       25
+                    </programlisting>
+                </refsection>
+
+                <refsection>
+                    <title>See Also</title>
+                    <para>
+                        <xref linkend="RT_ST_MapAlgebra"/>,
+                        <xref linkend="RT_ST_Sum4ma"/>
+                    </para>
+                </refsection>
+            </refentry>
+
             <refentry xml:id="RT_ST_MapAlgebra_expr">
                 <refnamediv>
                     <refname>ST_MapAlgebra (expression version)</refname>

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -2966,6 +2966,44 @@ CREATE OR REPLACE FUNCTION st_sum4ma(value double precision[][][], pos integer[]
 	END;
 	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION st_convolution(
+	rast raster,
+	matrix double precision[][],
+	pixeltype text DEFAULT '32BF'
+)
+	RETURNS raster
+	AS $$
+	DECLARE
+		width integer;
+		height integer;
+	BEGIN
+		IF rast IS NULL OR matrix IS NULL THEN
+			RETURN NULL;
+		END IF;
+
+		IF array_ndims(matrix) != 2 THEN
+			RAISE EXCEPTION 'Convolution matrix must be a two-dimensional array';
+		END IF;
+
+		height := array_length(matrix, 1);
+		width := array_length(matrix, 2);
+
+		IF NOT (width = 1 AND height = 1) AND NOT (width = 3 AND height = 3) THEN
+			RAISE EXCEPTION 'Convolution matrix must be 1x1 or 3x3';
+		END IF;
+
+		RETURN @extschema@.ST_MapAlgebra(
+			rast,
+			1,
+			'@extschema@.st_sum4ma(double precision[][][], integer[][], text[])'::regprocedure,
+			matrix,
+			true,
+			pixeltype
+		);
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION st_mean4ma(value double precision[][][], pos integer[][], VARIADIC userargs text[] DEFAULT NULL)
 	RETURNS double precision
 	AS $$

--- a/raster/test/regress/rt_mapalgebra_mask.sql
+++ b/raster/test/regress/rt_mapalgebra_mask.sql
@@ -120,5 +120,149 @@ FROM (SELECT rid, st_dumpvalues(st_mapalgebra(rast,1,'raster_nmapalgebra_test(do
     from raster_nmapalgebra_mask_in) AS f
 ORDER BY rid, (dv).nband;
 
+SET client_min_messages TO warning;
+
+WITH src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0),
+			1, '32BF', 0, NULL
+		),
+		1, 1, 1, ARRAY[
+			[1, 2, 3],
+			[4, 5, 6],
+			[7, 8, 9]
+		]::double precision[][]
+	) AS rast
+), kernel AS (
+	SELECT ARRAY[
+		[0, 1, 0],
+		[1, 1, 1],
+		[0, 1, 0]
+	]::double precision[][] AS matrix
+)
+SELECT 'st_convolution_equiv',
+	ST_AsBinary(ST_Convolution(rast, matrix)) =
+	ST_AsBinary(ST_MapAlgebra(
+		rast,
+		1,
+		'st_sum4ma(double precision[][][], integer[][], text[])'::regprocedure,
+		matrix,
+		true
+	))
+FROM src, kernel;
+
+WITH src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0),
+			1, '32BF', 0, NULL
+		),
+		1, 1, 1, ARRAY[
+			[1, 2, 3],
+			[4, 5, 6],
+			[7, 8, 9]
+		]::double precision[][]
+	) AS rast
+)
+SELECT 'st_convolution_center',
+	ST_Value(
+		ST_Convolution(
+			rast,
+			ARRAY[
+				[0, 1, 0],
+				[1, 1, 1],
+				[0, 1, 0]
+			]::double precision[][]
+		),
+		2, 2
+	)
+FROM src;
+
+WITH src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, NULL
+		),
+		1, 1, 1, ARRAY[
+			[250, 250, 250],
+			[250, 250, 250],
+			[250, 250, 250]
+		]::double precision[][]
+	) AS rast
+)
+SELECT 'st_convolution_default_pixeltype',
+	ST_BandPixelType(
+		ST_Convolution(
+			rast,
+			ARRAY[
+				[1, 1, 1],
+				[1, 1, 1],
+				[1, 1, 1]
+			]::double precision[][]
+		)
+	)
+FROM src;
+
+WITH src AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0),
+		1, '32BF', 10, NULL
+	) AS rast
+)
+SELECT 'st_convolution_explicit_pixeltype',
+	ST_BandPixelType(
+		ST_Convolution(
+			rast,
+			ARRAY[[1]]::double precision[][],
+			'64BF'
+		)
+	)
+FROM src;
+
+WITH src AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0),
+		1, '8BUI', 10, NULL
+	) AS rast
+)
+SELECT 'st_convolution_null_pixeltype',
+	ST_BandPixelType(
+		ST_Convolution(
+			rast,
+			ARRAY[[1]]::double precision[][],
+			NULL
+		)
+	)
+FROM src;
+
+WITH src AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0),
+		1, '32BF', 1, NULL
+	) AS rast
+)
+SELECT 'st_convolution_rejects_5x5';
+
+WITH src AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0),
+		1, '32BF', 1, NULL
+	) AS rast
+)
+SELECT
+	ST_Convolution(
+		rast,
+		ARRAY[
+			[1, 1, 1, 1, 1],
+			[1, 1, 1, 1, 1],
+			[1, 1, 1, 1, 1],
+			[1, 1, 1, 1, 1],
+			[1, 1, 1, 1, 1]
+		]::double precision[][]
+	)
+FROM src;
+
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test(double precision[], int[], text[]);
 DROP TABLE IF EXISTS raster_nmapalgebra_mask_in;

--- a/raster/test/regress/rt_mapalgebra_mask.sql
+++ b/raster/test/regress/rt_mapalgebra_mask.sql
@@ -237,23 +237,13 @@ SELECT 'st_convolution_null_pixeltype',
 	)
 FROM src;
 
-WITH src AS (
-	SELECT ST_AddBand(
-		ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0),
-		1, '32BF', 1, NULL
-	) AS rast
-)
-SELECT 'st_convolution_rejects_5x5';
-
-WITH src AS (
-	SELECT ST_AddBand(
-		ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0),
-		1, '32BF', 1, NULL
-	) AS rast
-)
-SELECT
-	ST_Convolution(
-		rast,
+DO $$
+BEGIN
+	PERFORM ST_Convolution(
+		ST_AddBand(
+			ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0),
+			1, '32BF', 1, NULL
+		),
 		ARRAY[
 			[1, 1, 1, 1, 1],
 			[1, 1, 1, 1, 1],
@@ -261,8 +251,17 @@ SELECT
 			[1, 1, 1, 1, 1],
 			[1, 1, 1, 1, 1]
 		]::double precision[][]
-	)
-FROM src;
+	);
+	RAISE EXCEPTION 'ST_Convolution accepted a 5x5 matrix';
+EXCEPTION
+	WHEN OTHERS THEN
+		IF SQLERRM <> 'Convolution matrix must be 1x1 or 3x3' THEN
+			RAISE;
+		END IF;
+END;
+$$;
+
+SELECT 'st_convolution_rejects_5x5', true;
 
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test(double precision[], int[], text[]);
 DROP TABLE IF EXISTS raster_nmapalgebra_mask_in;

--- a/raster/test/regress/rt_mapalgebra_mask_expected
+++ b/raster/test/regress/rt_mapalgebra_mask_expected
@@ -593,3 +593,10 @@ NOTICE:  userargs = <NULL>
 2|(1,"{{255,255},{255,255}}")
 3|(1,"{{255,255},{255,255}}")
 4|(1,"{{255,255},{255,255}}")
+st_convolution_equiv|t
+st_convolution_center|25
+st_convolution_default_pixeltype|32BF
+st_convolution_explicit_pixeltype|64BF
+st_convolution_null_pixeltype|8BUI
+st_convolution_rejects_5x5
+ERROR:  Convolution matrix must be 1x1 or 3x3

--- a/raster/test/regress/rt_mapalgebra_mask_expected
+++ b/raster/test/regress/rt_mapalgebra_mask_expected
@@ -598,5 +598,4 @@ st_convolution_center|25
 st_convolution_default_pixeltype|32BF
 st_convolution_explicit_pixeltype|64BF
 st_convolution_null_pixeltype|8BUI
-st_convolution_rejects_5x5
-ERROR:  Convolution matrix must be 1x1 or 3x3
+st_convolution_rejects_5x5|t


### PR DESCRIPTION
## Summary

Adds `ST_Convolution(raster, double precision[][])` as requested in Trac:

- wraps weighted masked `ST_MapAlgebra` on band 1
- uses `ST_Sum4ma` as the callback
- documents the new raster function
- extends the raster map-algebra mask regression with equivalence, center-value, pixel-type, NULL-pixeltype, and 5x5 rejection coverage

Ticket: https://trac.osgeo.org/postgis/ticket/2601.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `51b5c6a6336d7a691d79223b3238a89e14e0c195`.
- Addressed and resolved the stale review threads about default output pixel type, unsupported larger kernels, unreachable `IS NULL` rejection coverage, and NULL `pixeltype` handling.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make install`
- `make -C doc check`
- `make -C raster/rt_pg -j32`
- `sudo -n make -C raster/rt_pg install`
- `sudo -n make -C extensions/postgis_raster install`
- `POSTGIS_REGRESS_DB=postgis_reg_2601_fresh make -C raster/test/regress check RUNTESTFLAGS='--extension --verbose --raster --nodrop' TESTS="$(pwd)/raster/test/regress/rt_mapalgebra_mask"`
- `POSTGIS_REGRESS_DB=postgis_reg_2601_upgrade make -C raster/test/regress check RUNTESTFLAGS='--upgrade --extension --verbose --raster --nodrop' TESTS="$(pwd)/raster/test/regress/rt_mapalgebra_mask"`
- `make check-news`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
