### PR TITLE
Add ST_SetValues raster copy overloads

### DIFF
--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -5462,6 +5462,33 @@ UPDATE dummy_rast SET rast = ST_SetValue(rast, 1, ST_Point(3427927.75, 5793243.9
                         <paramdef><type>boolean </type> <parameter>keepnodata=FALSE</parameter></paramdef>
                     </funcprototype>
 
+                  <funcprototype>
+                        <funcdef>raster <function>ST_SetValues</function></funcdef>
+                        <paramdef><type>raster </type> <parameter>rast1</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>nband1</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>columnx</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>rowy</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>width</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>height</parameter></paramdef>
+                        <paramdef><type>raster </type> <parameter>rast2</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>nband2</parameter></paramdef>
+                        <paramdef><type>boolean </type> <parameter>keepdestnodata</parameter></paramdef>
+                        <paramdef><type>boolean </type> <parameter>keepsourcenodata</parameter></paramdef>
+                    </funcprototype>
+
+                  <funcprototype>
+                        <funcdef>raster <function>ST_SetValues</function></funcdef>
+                        <paramdef><type>raster </type> <parameter>rast1</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>columnx</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>rowy</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>width</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>height</parameter></paramdef>
+                        <paramdef><type>raster </type> <parameter>rast2</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>nband2</parameter></paramdef>
+                        <paramdef><type>boolean </type> <parameter>keepdestnodata</parameter></paramdef>
+                        <paramdef><type>boolean </type> <parameter>keepsourcenodata</parameter></paramdef>
+                    </funcprototype>
+
                 </funcsynopsis>
             </refsynopsisdiv>
 
@@ -5495,7 +5522,12 @@ UPDATE dummy_rast SET rast = ST_SetValue(rast, 1, ST_Point(3427927.75, 5793243.9
                     For Variant 5, an array of <xref linkend="geomval"/> is used to determine the specific pixels to be set.  If all the geometries in the array are of type POINT or MULTIPOINT, the function uses a shortcut where the longitude and latitude of each point is used to set a pixel directly.  Otherwise, the geometries are converted to rasters and then iterated through in one pass. See example Variant 5.
                 </para>
 
+                <para>
+                    For Variants 6 and 7, values are copied from the corresponding pixels of <varname>rast2</varname>.  The rasters must have the same SRID and alignment.  Only the portion of the requested destination window that overlaps <varname>rast1</varname> and <varname>rast2</varname> is copied.  If <varname>keepdestnodata</varname> is TRUE, NODATA pixels in the destination raster are not changed.  If <varname>keepsourcenodata</varname> is TRUE, NODATA pixels from the source raster are not copied.
+                </para>
+
                 <para role="availability" conformance="2.1.0">Availability: 2.1.0</para>
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0: Ability to copy values from another raster band.</para>
 
             </refsection>
 

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -5060,6 +5060,133 @@ CREATE OR REPLACE FUNCTION ST_SetValues(
 	AS 'MODULE_PATHNAME', 'RASTER_setPixelValuesGeomval'
 	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION ST_SetValues(
+	rast1 raster, nband1 integer,
+	x integer, y integer,
+	width integer, height integer,
+	rast2 raster, nband2 integer,
+	keepdestnodata boolean,
+	keepsourcenodata boolean
+)
+	RETURNS raster AS
+	$$
+	DECLARE
+		dest_x integer;
+		dest_y integer;
+		dest_x_end integer;
+		dest_y_end integer;
+		src_x integer;
+		src_y integer;
+		src_origin_x integer;
+		src_origin_y integer;
+		write_width integer;
+		write_height integer;
+		source_values double precision[][];
+		source_nodata double precision;
+	BEGIN
+		IF rast1 IS NULL THEN
+			RAISE NOTICE 'ST_SetValues: No destination raster provided. Returning NULL';
+			RETURN NULL;
+		END IF;
+
+		IF rast2 IS NULL THEN
+			RAISE NOTICE 'ST_SetValues: No source raster provided. Returning destination raster';
+			RETURN rast1;
+		END IF;
+
+		keepdestnodata := COALESCE(keepdestnodata, FALSE);
+		keepsourcenodata := COALESCE(keepsourcenodata, FALSE);
+
+		IF nband1 IS NULL OR nband1 < 1 THEN
+			RAISE NOTICE 'ST_SetValues: destination band out of range. Returning destination raster';
+			RETURN rast1;
+		END IF;
+
+		IF nband2 IS NULL OR nband2 < 1 THEN
+			RAISE NOTICE 'ST_SetValues: source band out of range. Returning destination raster';
+			RETURN rast1;
+		END IF;
+
+		IF @extschema@.ST_IsEmpty(rast1) OR @extschema@.ST_HasNoBand(rast1, nband1) THEN
+			RAISE NOTICE 'ST_SetValues: Empty or no band destination raster provided. Returning destination raster';
+			RETURN rast1;
+		END IF;
+
+		IF @extschema@.ST_IsEmpty(rast2) OR @extschema@.ST_HasNoBand(rast2, nband2) THEN
+			RAISE NOTICE 'ST_SetValues: Empty or no band source raster provided. Returning destination raster';
+			RETURN rast1;
+		END IF;
+
+		IF x IS NULL OR y IS NULL OR width IS NULL OR height IS NULL OR width <= 0 OR height <= 0 THEN
+			RAISE EXCEPTION 'Values for x, y, width, and height must be non-NULL, and width and height must be greater than zero';
+		END IF;
+
+		IF @extschema@.ST_SRID(rast1) != @extschema@.ST_SRID(rast2) THEN
+			RAISE EXCEPTION 'The two rasters do not have the same SRID';
+		END IF;
+
+		IF NOT @extschema@.ST_SameAlignment(rast1, rast2) THEN
+			RAISE EXCEPTION 'The two rasters do not have the same alignment';
+		END IF;
+
+		src_origin_x := @extschema@.ST_WorldToRasterCoordX(
+			rast1,
+			@extschema@.ST_RasterToWorldCoordX(rast2, 1, 1),
+			@extschema@.ST_RasterToWorldCoordY(rast2, 1, 1)
+		);
+		src_origin_y := @extschema@.ST_WorldToRasterCoordY(
+			rast1,
+			@extschema@.ST_RasterToWorldCoordX(rast2, 1, 1),
+			@extschema@.ST_RasterToWorldCoordY(rast2, 1, 1)
+		);
+
+		dest_x := GREATEST(x, 1, src_origin_x);
+		dest_y := GREATEST(y, 1, src_origin_y);
+		dest_x_end := LEAST(x + width - 1, @extschema@.ST_Width(rast1), src_origin_x + @extschema@.ST_Width(rast2) - 1);
+		dest_y_end := LEAST(y + height - 1, @extschema@.ST_Height(rast1), src_origin_y + @extschema@.ST_Height(rast2) - 1);
+
+		write_width := dest_x_end - dest_x + 1;
+		write_height := dest_y_end - dest_y + 1;
+
+		IF write_width < 1 OR write_height < 1 THEN
+			RETURN rast1;
+		END IF;
+
+		src_x := dest_x - src_origin_x + 1;
+		src_y := dest_y - src_origin_y + 1;
+		source_values := (@extschema@.ST_DumpValues(rast2, nband2, FALSE))[src_y:src_y + write_height - 1][src_x:src_x + write_width - 1];
+
+		IF keepsourcenodata THEN
+			source_nodata := @extschema@.ST_BandNoDataValue(rast2, nband2);
+			IF source_nodata IS NULL THEN
+				RAISE NOTICE 'ST_SetValues: keepsourcenodata was set to TRUE but source raster band does not have a nodata value. keepsourcenodata reset to FALSE';
+				keepsourcenodata := FALSE;
+			ELSIF @extschema@.ST_BandIsNoData(rast2, nband2) THEN
+				RETURN rast1;
+			END IF;
+		END IF;
+
+		IF keepsourcenodata THEN
+			RETURN @extschema@._ST_SetValues(rast1, nband1, dest_x, dest_y, source_values, NULL, TRUE, source_nodata, keepdestnodata);
+		END IF;
+
+		RETURN @extschema@._ST_SetValues(rast1, nband1, dest_x, dest_y, source_values, NULL, FALSE, NULL, keepdestnodata);
+	END;
+	$$
+	LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION ST_SetValues(
+	rast1 raster,
+	x integer, y integer,
+	width integer, height integer,
+	rast2 raster, nband2 integer,
+	keepdestnodata boolean,
+	keepsourcenodata boolean
+)
+	RETURNS raster
+	AS $$ SELECT @extschema@.ST_SetValues($1, 1, $2, $3, $4, $5, $6, $7, $8, $9) $$
+	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
 -----------------------------------------------------------------------
 -- ST_SetValue (set one or more pixels to a single value)
 -----------------------------------------------------------------------

--- a/raster/test/regress/rt_setvalues_raster.sql
+++ b/raster/test/regress/rt_setvalues_raster.sql
@@ -1,0 +1,130 @@
+SET client_min_messages TO warning;
+
+WITH dst AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(4, 4, 0, 0, 1, -1, 0, 0, 0),
+		1, '8BUI', 1, 0
+	) AS rast
+), src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 2, 1, -1, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, 0
+		),
+		1, 1, 1,
+		ARRAY[[10, 20], [30, 40]]::double precision[][]
+	) AS rast
+)
+SELECT 'copy_aligned',
+	ST_DumpValues(ST_SetValues(dst.rast, 1, 1, 1, 4, 4, src.rast, 1, false, false), 1, false)
+FROM dst, src;
+
+WITH dst AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(4, 4, 0, 0, 1, -1, 0, 0, 0),
+		1, '8BUI', 1, 0
+	) AS rast
+), src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 2, 1, -1, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, 0
+		),
+		1, 1, 1,
+		ARRAY[[10, 0], [30, 40]]::double precision[][]
+	) AS rast
+)
+SELECT 'skip_source_nodata',
+	ST_DumpValues(ST_SetValues(dst.rast, 1, 1, 1, 4, 4, src.rast, 1, false, true), 1, false)
+FROM dst, src;
+
+WITH dst AS (
+	SELECT ST_SetValue(
+		ST_AddBand(
+			ST_MakeEmptyRaster(4, 4, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 1, 0
+		),
+		1, 2, 2, 0
+	) AS rast
+), src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 2, 1, -1, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, 0
+		),
+		1, 1, 1,
+		ARRAY[[10, 20], [30, 40]]::double precision[][]
+	) AS rast
+)
+SELECT 'keep_dest_nodata',
+	ST_DumpValues(ST_SetValues(dst.rast, 1, 1, 1, 4, 4, src.rast, 1, true, false), 1, false)
+FROM dst, src;
+
+WITH dst AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0),
+		1, '8BUI', 1, 0
+	) AS rast
+), src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 1, -1, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, 0
+		),
+		1, 1, 1,
+		ARRAY[[99]]::double precision[][]
+	) AS rast
+)
+SELECT 'first_band_wrapper',
+	ST_DumpValues(ST_SetValues(dst.rast, 1, 1, 3, 3, src.rast, 1, false, false), 1, false)
+FROM dst, src;
+
+WITH r AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0),
+		1, '8BUI', 1, 0
+	) AS rast
+)
+SELECT 'null_scalar_fill',
+	ST_DumpValues(ST_SetValues(rast, 1, 1, 1, 2, 2, NULL), 1, false)
+FROM r;
+
+CREATE OR REPLACE FUNCTION _test_setvalues_raster_error(rast1 raster, rast2 raster)
+RETURNS text AS $$
+BEGIN
+	PERFORM ST_SetValues(rast1, 1, 1, 1, 2, 2, rast2, 1, false, false);
+	RETURN 'no error';
+EXCEPTION WHEN OTHERS THEN
+	RETURN SQLERRM;
+END;
+$$ LANGUAGE plpgsql;
+
+WITH dst AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(2, 2, 0, 0, 1, -1, 0, 0, 0),
+		1, '8BUI', 1, 0
+	) AS rast
+), src AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(2, 2, 0, 0, 1, -1, 0, 0, 4326),
+		1, '8BUI', 1, 0
+	) AS rast
+)
+SELECT 'srid_mismatch', _test_setvalues_raster_error(dst.rast, src.rast)
+FROM dst, src;
+
+WITH dst AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(2, 2, 0, 0, 1, -1, 0, 0, 0),
+		1, '8BUI', 1, 0
+	) AS rast
+), src AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(2, 2, 0.5, -0.5, 1, -1, 0, 0, 0),
+		1, '8BUI', 1, 0
+	) AS rast
+)
+SELECT 'alignment_mismatch', _test_setvalues_raster_error(dst.rast, src.rast)
+FROM dst, src;
+
+DROP FUNCTION _test_setvalues_raster_error(raster, raster);

--- a/raster/test/regress/rt_setvalues_raster_expected
+++ b/raster/test/regress/rt_setvalues_raster_expected
@@ -1,0 +1,7 @@
+copy_aligned|{{1,1,1,1},{1,10,20,1},{1,30,40,1},{1,1,1,1}}
+skip_source_nodata|{{1,1,1,1},{1,10,1,1},{1,30,40,1},{1,1,1,1}}
+keep_dest_nodata|{{1,1,1,1},{1,0,20,1},{1,30,40,1},{1,1,1,1}}
+first_band_wrapper|{{1,1,1},{1,99,1},{1,1,1}}
+null_scalar_fill|{{0,0,1},{0,0,1},{1,1,1}}
+srid_mismatch|The two rasters do not have the same SRID
+alignment_mismatch|The two rasters do not have the same alignment

--- a/raster/test/regress/tests.mk.in
+++ b/raster/test/regress/tests.mk.in
@@ -64,6 +64,7 @@ RASTER_TEST_BANDPROPS = \
 	$(top_srcdir)/raster/test/regress/rt_pixelaspoints \
 	$(top_srcdir)/raster/test/regress/rt_pixelascentroids \
 	$(top_srcdir)/raster/test/regress/rt_setvalues_array \
+	$(top_srcdir)/raster/test/regress/rt_setvalues_raster \
 	$(top_srcdir)/raster/test/regress/rt_summarystats \
 	$(top_srcdir)/raster/test/regress/rt_count \
 	$(top_srcdir)/raster/test/regress/rt_histogram \


### PR DESCRIPTION
## Summary

- add `ST_SetValues` overloads that copy values from another raster band into the overlapping destination window
- require explicit source band and nodata flags on the raster-copy overloads so existing scalar `NULL` calls remain unambiguous
- reject raster-copy calls with mismatched SRID or alignment before grid-slice coordinate math
- document the overloads and add focused raster regression coverage

Ticket: https://trac.osgeo.org/postgis/ticket/2058.

## Maintenance Notes

- Rebased onto current `master` (`4e470f1534795ae4a4c52ad5ad35b8744af9d708`).
- Current head: `84eab1cf347313a6433cea8b08caf215149177fd`.
- The stale ambiguity review thread was resolved after confirming the explicit-argument overload shape and focused regression coverage still pass on current `master`.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make install`
- `make -C doc check`
- `make -C doc comments`
- `make -C raster/rt_pg -j32`
- `sudo -n make -C raster/rt_pg install`
- `sudo -n make -C extensions/postgis_raster install`
- `POSTGIS_REGRESS_DB=postgis_reg_2058_fresh make -C raster/test/regress check RUNTESTFLAGS='--extension --verbose --raster --nodrop' TESTS="$(pwd)/raster/test/regress/rt_setvalues_array $(pwd)/raster/test/regress/rt_setvalues_raster"`
- `POSTGIS_REGRESS_DB=postgis_reg_2058_upgrade make -C raster/test/regress check RUNTESTFLAGS='--upgrade --extension --verbose --raster --nodrop' TESTS="$(pwd)/raster/test/regress/rt_setvalues_array $(pwd)/raster/test/regress/rt_setvalues_raster"`
- `make check-news`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
