### PR TITLE
topology: allow COPY into edge views

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -96,6 +96,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           shapefiles (Darafei Praliaskouski)
  - #2838, Emit valid X3D Coordinate nodes for 2D polygon output
           (Darafei Praliaskouski)
+ - #5119, [topology] Allow COPY into topology edge views
+          (Darafei Praliaskouski)
  - Fix WKB and TWKB parser resource exhaustion on malformed input
           (Darafei Praliaskouski)
  - #2850, Preserve pgsql2shp numeric precision and scale in DBF metadata

--- a/topology/sql/manage/CreateTopology.sql.in
+++ b/topology/sql/manage/CreateTopology.sql.in
@@ -200,16 +200,8 @@ BEGIN
       COMMENT ON COLUMN %1$I.edge.geom IS
       'The geometry of the edge';
 
-      -- edge standard view (insert rule)
-      CREATE RULE edge_insert_rule AS
-      ON INSERT TO %1$I.edge
-      DO INSTEAD INSERT into %1$I.edge_data
-      VALUES (
-        NEW.edge_id, NEW.start_node, NEW.end_node,
-        NEW.next_left_edge, abs(NEW.next_left_edge),
-        NEW.next_right_edge, abs(NEW.next_right_edge),
-        NEW.left_face, NEW.right_face, NEW.geom
-      );
+      -- edge standard view (insert trigger)
+      SELECT topology._install_edge_insert_trigger(%1$L);
 
       ------- Add support indices supporting edge linking foreign keys
       ------- See https://trac.osgeo.org/postgis/ticket/2083#comment:20

--- a/topology/sql/manage/ManageHelper.sql.in
+++ b/topology/sql/manage/ManageHelper.sql.in
@@ -86,24 +86,12 @@ RETURNS trigger
 AS
 $BODY$
 BEGIN
-  EXECUTE format(
-    'INSERT INTO %I.edge_data (
-      edge_id, start_node, end_node,
-      next_left_edge, abs_next_left_edge,
-      next_right_edge, abs_next_right_edge,
-      left_face, right_face, geom
-    ) VALUES ($1, $2, $3, $4, abs($4), $5, abs($5), $6, $7, $8)',
-    TG_TABLE_SCHEMA
-  )
-  USING
-    NEW.edge_id, NEW.start_node, NEW.end_node,
-    NEW.next_left_edge, NEW.next_right_edge,
-    NEW.left_face, NEW.right_face, NEW.geom;
-
-  RETURN NULL;
+  RAISE EXCEPTION
+    'topology._edge_insert() may only be used on registered topology edge views';
 END
 $BODY$
 LANGUAGE 'plpgsql' VOLATILE
+SET search_path = pg_catalog, pg_temp
 ;
 
 CREATE OR REPLACE FUNCTION topology._install_edge_insert_trigger(atopology name)
@@ -112,9 +100,21 @@ AS
 $BODY$
 DECLARE
   edge_view regclass;
+  edge_owner regrole;
 BEGIN
   edge_view := to_regclass(format('%I.edge', atopology));
 
+  IF edge_view IS NULL
+  THEN
+    RAISE EXCEPTION 'Topology edge view %.edge does not exist', atopology;
+  END IF;
+
+  SELECT relowner
+  FROM pg_catalog.pg_class
+  WHERE oid = edge_view
+  INTO edge_owner;
+
+  -- Old upgrade scripts could have attached the local helper to the extension.
   IF EXISTS (
     SELECT 1
     FROM pg_catalog.pg_rewrite
@@ -125,6 +125,7 @@ BEGIN
     EXECUTE format('DROP RULE edge_insert_rule ON %I.edge', atopology);
   END IF;
 
+  -- CREATE FUNCTION inside ALTER EXTENSION UPDATE may attach the helper again.
   IF EXISTS (
     SELECT 1
     FROM pg_catalog.pg_trigger
@@ -135,11 +136,96 @@ BEGIN
     EXECUTE format('DROP TRIGGER edge_insert ON %I.edge', atopology);
   END IF;
 
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_depend dep
+    JOIN pg_catalog.pg_extension ext
+      ON ext.oid = dep.refobjid
+    JOIN pg_catalog.pg_proc proc
+      ON proc.oid = dep.objid
+    JOIN pg_catalog.pg_namespace nsp
+      ON nsp.oid = proc.pronamespace
+    WHERE dep.classid = 'pg_catalog.pg_proc'::regclass
+      AND dep.deptype = 'e'
+      AND ext.extname = 'postgis_topology'
+      AND nsp.nspname = atopology
+      AND proc.proname = '_edge_insert'
+      AND proc.pronargs = 0
+  )
+  THEN
+    EXECUTE format('ALTER EXTENSION postgis_topology DROP FUNCTION %I._edge_insert()', atopology);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_proc proc
+    JOIN pg_catalog.pg_namespace nsp ON nsp.oid = proc.pronamespace
+    WHERE nsp.nspname = atopology
+      AND proc.proname = '_edge_insert'
+      AND proc.pronargs = 0
+  )
+  THEN
+    EXECUTE format('DROP FUNCTION %I._edge_insert()', atopology);
+  END IF;
+
+  EXECUTE format(
+    'CREATE OR REPLACE ' ||
+    'FUNCTION %1$I._edge_insert()
+     RETURNS trigger
+     AS %2$L
+     LANG' || 'UAGE ''plpgsql'' VOLATILE
+     SECURITY DEFINER
+     SET search_path = pg_catalog, pg_temp',
+    atopology,
+    format(
+      'BEGIN
+        INSERT INTO %I.edge_data (
+          edge_id, start_node, end_node,
+          next_left_edge, abs_next_left_edge,
+          next_right_edge, abs_next_right_edge,
+          left_face, right_face, geom
+        ) VALUES (
+          NEW.edge_id, NEW.start_node, NEW.end_node,
+          NEW.next_left_edge, abs(NEW.next_left_edge),
+          NEW.next_right_edge, abs(NEW.next_right_edge),
+          NEW.left_face, NEW.right_face, NEW.geom
+        )
+      ' || chr(59) || '
+
+        RETURN NEW
+      ' || chr(59) || '
+      END',
+      atopology
+    )
+  );
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_depend dep
+    JOIN pg_catalog.pg_extension ext
+      ON ext.oid = dep.refobjid
+    JOIN pg_catalog.pg_proc proc
+      ON proc.oid = dep.objid
+    JOIN pg_catalog.pg_namespace nsp
+      ON nsp.oid = proc.pronamespace
+    WHERE dep.classid = 'pg_catalog.pg_proc'::regclass
+      AND dep.deptype = 'e'
+      AND ext.extname = 'postgis_topology'
+      AND nsp.nspname = atopology
+      AND proc.proname = '_edge_insert'
+      AND proc.pronargs = 0
+  )
+  THEN
+    EXECUTE format('ALTER EXTENSION postgis_topology DROP FUNCTION %I._edge_insert()', atopology);
+  END IF;
+  EXECUTE format('ALTER FUNCTION %I._edge_insert() OWNER TO %s', atopology, edge_owner);
+  EXECUTE format('REVOKE ALL ON FUNCTION %I._edge_insert() FROM PUBLIC', atopology);
+
   EXECUTE format(
     'CREATE TRIGGER edge_insert
      INSTEAD OF INSERT ON %I.edge
      FOR EACH ROW
-     EXECUTE FUNCTION topology._edge_insert()',
+     EXECUTE FUNCTION %I._edge_insert()',
+    atopology,
     atopology
   );
 END

--- a/topology/sql/manage/ManageHelper.sql.in
+++ b/topology/sql/manage/ManageHelper.sql.in
@@ -81,3 +81,68 @@ SET search_path = pg_catalog, pg_temp
 LANGUAGE 'plpgsql' VOLATILE STRICT
 ;
 
+CREATE OR REPLACE FUNCTION topology._edge_insert()
+RETURNS trigger
+AS
+$BODY$
+BEGIN
+  EXECUTE format(
+    'INSERT INTO %I.edge_data (
+      edge_id, start_node, end_node,
+      next_left_edge, abs_next_left_edge,
+      next_right_edge, abs_next_right_edge,
+      left_face, right_face, geom
+    ) VALUES ($1, $2, $3, $4, abs($4), $5, abs($5), $6, $7, $8)',
+    TG_TABLE_SCHEMA
+  )
+  USING
+    NEW.edge_id, NEW.start_node, NEW.end_node,
+    NEW.next_left_edge, NEW.next_right_edge,
+    NEW.left_face, NEW.right_face, NEW.geom;
+
+  RETURN NULL;
+END
+$BODY$
+LANGUAGE 'plpgsql' VOLATILE
+;
+
+CREATE OR REPLACE FUNCTION topology._install_edge_insert_trigger(atopology name)
+RETURNS void
+AS
+$BODY$
+DECLARE
+  edge_view regclass;
+BEGIN
+  edge_view := to_regclass(format('%I.edge', atopology));
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_rewrite
+    WHERE ev_class = edge_view
+      AND rulename = 'edge_insert_rule'
+  )
+  THEN
+    EXECUTE format('DROP RULE edge_insert_rule ON %I.edge', atopology);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_trigger
+    WHERE tgrelid = edge_view
+      AND tgname = 'edge_insert'
+  )
+  THEN
+    EXECUTE format('DROP TRIGGER edge_insert ON %I.edge', atopology);
+  END IF;
+
+  EXECUTE format(
+    'CREATE TRIGGER edge_insert
+     INSTEAD OF INSERT ON %I.edge
+     FOR EACH ROW
+     EXECUTE FUNCTION topology._edge_insert()',
+    atopology
+  );
+END
+$BODY$
+LANGUAGE 'plpgsql' VOLATILE STRICT
+;

--- a/topology/sql/manage/RenameTopology.sql.in
+++ b/topology/sql/manage/RenameTopology.sql.in
@@ -35,6 +35,8 @@ BEGIN
   );
   EXECUTE sql;
 
+  PERFORM topology._install_edge_insert_trigger(new_name::name);
+
   RETURN new_name;
 END
 $BODY$

--- a/topology/sql/manage/UpgradeTopology.sql.in
+++ b/topology/sql/manage/UpgradeTopology.sql.in
@@ -152,16 +152,8 @@ BEGIN
 		COMMENT ON COLUMN %1$I.edge.geom IS
 		'The geometry of the edge';
 
-		-- edge standard view (insert rule)
-		CREATE RULE edge_insert_rule AS
-		ON INSERT TO %1$I.edge
-		DO INSTEAD INSERT into %1$I.edge_data
-		VALUES (
-			NEW.edge_id, NEW.start_node, NEW.end_node,
-			NEW.next_left_edge, abs(NEW.next_left_edge),
-			NEW.next_right_edge, abs(NEW.next_right_edge),
-			NEW.left_face, NEW.right_face, NEW.geom
-		);
+		-- edge standard view (insert trigger)
+		SELECT topology._install_edge_insert_trigger(%1$L);
 
 		-- Upgrade the node table
 	  ALTER TABLE %1$I.node
@@ -205,4 +197,3 @@ BEGIN
   EXECUTE sql;
 END;
 $BODY$ LANGUAGE 'plpgsql' VOLATILE;
-

--- a/topology/test/regress/copytopology.sql
+++ b/topology/test/regress/copytopology.sql
@@ -47,6 +47,14 @@ SELECT tableoid::regclass AS sequence_name, last_value,  is_called  from "CITY_d
 SELECT tableoid::regclass AS sequence_name, last_value,  is_called  from "CITY_data_UP_down".topogeo_s_2;
 SELECT tableoid::regclass AS sequence_name, last_value,  is_called  from "CITY_data_UP_down".topogeo_s_3;
 
+-- See https://trac.osgeo.org/postgis/ticket/5119
+COPY "CITY_data_UP_down".edge (edge_id, start_node, end_node, next_left_edge, next_right_edge, left_face, right_face, geom) FROM stdin;
+1001	1	2	1001	-1001	0	0	SRID=4326;LINESTRING(1 1,2 2)
+\.
+SELECT '#5119', edge_id, abs_next_left_edge, abs_next_right_edge, ST_AsText(geom)
+FROM "CITY_data_UP_down".edge_data
+WHERE edge_id = 1001;
+
 -- See https://trac.osgeo.org/postgis/ticket/5298
 BEGIN;
 UPDATE city_data.relation SEt layer_id = 1 WHERE layer_id = 1;

--- a/topology/test/regress/copytopology.sql
+++ b/topology/test/regress/copytopology.sql
@@ -54,6 +54,146 @@ COPY "CITY_data_UP_down".edge (edge_id, start_node, end_node, next_left_edge, ne
 SELECT '#5119', edge_id, abs_next_left_edge, abs_next_right_edge, ST_AsText(geom)
 FROM "CITY_data_UP_down".edge_data
 WHERE edge_id = 1001;
+INSERT INTO "CITY_data_UP_down".edge (
+  edge_id, start_node, end_node,
+  next_left_edge, next_right_edge,
+  left_face, right_face, geom
+) VALUES (
+  1002, 1, 2,
+  1002, -1002,
+  0, 0, 'SRID=4326;LINESTRING(2 2,3 3)'::geometry
+)
+RETURNING '#5119-returning', edge_id, ST_AsText(geom);
+
+BEGIN;
+CREATE SCHEMA fake_5119;
+CREATE TABLE fake_5119.edge_data (
+  edge_id integer,
+  start_node integer,
+  end_node integer,
+  next_left_edge integer,
+  abs_next_left_edge integer,
+  next_right_edge integer,
+  abs_next_right_edge integer,
+  left_face integer,
+  right_face integer,
+  geom geometry
+);
+CREATE VIEW fake_5119.edge AS
+SELECT
+  NULL::integer AS edge_id,
+  NULL::integer AS start_node,
+  NULL::integer AS end_node,
+  NULL::integer AS next_left_edge,
+  NULL::integer AS next_right_edge,
+  NULL::integer AS left_face,
+  NULL::integer AS right_face,
+  NULL::geometry AS geom
+WHERE false;
+CREATE TRIGGER edge_insert
+  INSTEAD OF INSERT ON fake_5119.edge
+  FOR EACH ROW
+  EXECUTE FUNCTION topology._edge_insert();
+CREATE FUNCTION fake_5119.try_edge_insert()
+RETURNS text
+AS $$
+BEGIN
+  INSERT INTO fake_5119.edge (
+    edge_id, start_node, end_node,
+    next_left_edge, next_right_edge,
+    left_face, right_face, geom
+  ) VALUES (
+    1, 1, 1,
+    1, -1,
+    0, 0, 'LINESTRING(0 0,1 1)'::geometry
+  );
+  RETURN 'unexpected success';
+EXCEPTION WHEN OTHERS THEN
+  RETURN SQLERRM;
+END
+$$ LANGUAGE 'plpgsql' VOLATILE;
+SELECT '#5119-fake', fake_5119.try_edge_insert();
+SELECT '#5119-fake-edge-data', count(*) FROM fake_5119.edge_data;
+ROLLBACK;
+
+DO $$
+DECLARE
+	can_switch_role boolean;
+	trigger_user name;
+	audit_rows bigint;
+BEGIN
+	SELECT rolsuper INTO can_switch_role
+	FROM pg_roles
+	WHERE rolname = current_user;
+
+	IF NOT can_switch_role THEN
+		RETURN;
+	END IF;
+
+	DROP SCHEMA IF EXISTS t5119_priv CASCADE;
+	DROP ROLE IF EXISTS t5119_viewer;
+	DROP ROLE IF EXISTS t5119_owner;
+	CREATE ROLE t5119_owner;
+	CREATE ROLE t5119_viewer;
+	GRANT t5119_owner TO CURRENT_USER;
+	GRANT t5119_viewer TO CURRENT_USER;
+	EXECUTE format('GRANT CREATE ON DATABASE %I TO t5119_owner', current_database());
+	GRANT USAGE, SELECT ON SEQUENCE topology.topology_id_seq TO t5119_owner;
+	GRANT INSERT, SELECT ON topology.topology TO t5119_owner;
+
+	EXECUTE 'SET LOCAL ROLE t5119_owner';
+	PERFORM topology.CreateTopology('t5119_priv', 4326);
+	INSERT INTO t5119_priv.node(node_id, geom)
+	VALUES
+		(1, 'SRID=4326;POINT(0 0)'::geometry),
+		(2, 'SRID=4326;POINT(1 1)'::geometry);
+	CREATE TABLE t5119_priv.trigger_audit(username name);
+	CREATE FUNCTION t5119_priv.audit_edge_insert()
+	RETURNS trigger
+	AS $audit$
+	BEGIN
+		INSERT INTO t5119_priv.trigger_audit(username) VALUES (current_user);
+		RETURN NEW;
+	END
+	$audit$
+	LANGUAGE 'plpgsql' VOLATILE;
+	CREATE TRIGGER audit_edge_insert
+		AFTER INSERT ON t5119_priv.edge_data
+		FOR EACH ROW
+		EXECUTE FUNCTION t5119_priv.audit_edge_insert();
+	GRANT USAGE ON SCHEMA t5119_priv TO t5119_viewer;
+	GRANT INSERT ON t5119_priv.edge TO t5119_viewer;
+	EXECUTE 'RESET ROLE';
+
+	EXECUTE 'SET LOCAL ROLE t5119_viewer';
+	INSERT INTO t5119_priv.edge (
+		edge_id, start_node, end_node,
+		next_left_edge, next_right_edge,
+		left_face, right_face, geom
+	) VALUES (
+		1, 1, 2,
+		1, -1,
+		0, 0, 'SRID=4326;LINESTRING(0 0,1 1)'::geometry
+	);
+	EXECUTE 'RESET ROLE';
+
+	SELECT count(*), min(username) INTO audit_rows, trigger_user
+	FROM t5119_priv.trigger_audit;
+	IF audit_rows != 1 OR trigger_user IS DISTINCT FROM 't5119_owner' THEN
+		RAISE EXCEPTION 'edge_data trigger ran as %, expected t5119_owner (rows=%)', trigger_user, audit_rows;
+	END IF;
+
+	PERFORM topology.DropTopology('t5119_priv');
+	REVOKE INSERT, SELECT ON topology.topology FROM t5119_owner;
+	REVOKE USAGE, SELECT ON SEQUENCE topology.topology_id_seq FROM t5119_owner;
+	EXECUTE format('REVOKE CREATE ON DATABASE %I FROM t5119_owner', current_database());
+	REVOKE t5119_owner FROM CURRENT_USER;
+	REVOKE t5119_viewer FROM CURRENT_USER;
+	DROP ROLE t5119_viewer;
+	DROP ROLE t5119_owner;
+END
+$$;
+SELECT '#5119-security', 'ok';
 
 -- See https://trac.osgeo.org/postgis/ticket/5298
 BEGIN;

--- a/topology/test/regress/copytopology_expected
+++ b/topology/test/regress/copytopology_expected
@@ -19,6 +19,10 @@ layers|6
 "CITY_data_UP_down".topogeo_s_2|8|t
 "CITY_data_UP_down".topogeo_s_3|8|t
 #5119|1001|1001|1001|LINESTRING(1 1,2 2)
+#5119-returning|1002|LINESTRING(2 2,3 3)
+#5119-fake|topology._edge_insert() may only be used on registered topology edge views
+#5119-fake-edge-data|0
+#5119-security|ok
 #5298|t
 #2184.1|t
 #2184.2|1

--- a/topology/test/regress/copytopology_expected
+++ b/topology/test/regress/copytopology_expected
@@ -18,6 +18,7 @@ layers|6
 "CITY_data_UP_down".topogeo_s_1|9|t
 "CITY_data_UP_down".topogeo_s_2|8|t
 "CITY_data_UP_down".topogeo_s_3|8|t
+#5119|1001|1001|1001|LINESTRING(1 1,2 2)
 #5298|t
 #2184.1|t
 #2184.2|1

--- a/topology/test/regress/renametopology.sql
+++ b/topology/test/regress/renametopology.sql
@@ -1,6 +1,20 @@
 BEGIN;
 SELECT NULL FROM topology.CreateTopology('topo');
 SELECT 't1', topology.RenameTopology('topo', 'topo with space');
+INSERT INTO "topo with space".node(node_id, geom)
+VALUES
+	(1, 'POINT(0 0)'::geometry),
+	(2, 'POINT(1 1)'::geometry);
+INSERT INTO "topo with space".edge (
+	edge_id, start_node, end_node,
+	next_left_edge, next_right_edge,
+	left_face, right_face, geom
+) VALUES (
+	1, 1, 2,
+	1, -1,
+	0, 0, 'LINESTRING(0 0,1 1)'::geometry
+);
+SELECT 't-edge', count(*) FROM "topo with space".edge_data;
 SELECT 't2', topology.RenameTopology('topo with space', 'topo with MixedCase');
 SELECT 't2', topology.RenameTopology('topo with MixedCase', 'topo');
 ROLLBACK;

--- a/topology/test/regress/renametopology_expected
+++ b/topology/test/regress/renametopology_expected
@@ -1,3 +1,4 @@
 t1|topo with space
+t-edge|1
 t2|topo with MixedCase
 t2|topo

--- a/topology/topology_after_upgrade.sql.in
+++ b/topology/topology_after_upgrade.sql.in
@@ -32,3 +32,16 @@ BEGIN
   END LOOP;
 END;
 $BODY$ LANGUAGE 'plpgsql';
+
+DO $BODY$
+DECLARE
+  rec RECORD;
+BEGIN
+  FOR rec IN
+    SELECT name
+    FROM topology.topology
+  LOOP
+    PERFORM topology._install_edge_insert_trigger(rec.name);
+  END LOOP;
+END;
+$BODY$ LANGUAGE 'plpgsql';


### PR DESCRIPTION
## Summary
- replace topology edge view INSERT rules with INSTEAD OF INSERT triggers so `COPY FROM` can write through the standard edge view
- install a per-topology `_edge_insert()` trigger helper owned by that topology schema owner, preserving view-only INSERT grants without firing `edge_data` triggers as the `postgis_topology` extension owner
- keep the shared `topology._edge_insert()` as a rejecting compatibility guard for stray/manual trigger attachments outside registered topology edge views
- retrofit registered topology schemas during `postgis_topology` extension upgrade, including old extension-owned local helper cleanup
- rebuild the generated edge insert trigger when `RenameTopology` changes the schema name
- cover `COPY`, `INSERT ... RETURNING`, fake-view trigger rejection, topology rename, and the low-privilege view-only security boundary in the topology regression suite

Trac: https://trac.osgeo.org/postgis/ticket/5119

## Validation
- `make -C topology topology.sql topology_upgrade.sql uninstall_topology.sql`
- `make -C extensions/postgis_topology -j1`
- `make -C topology -j32`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- focused topology regression set covering `copytopology`, `renametopology`, `findlayer`, `findtopology`, `maketopologyprecise`, `populate_topology_layer`, `renametopogeometrycolumn`, and `topology_error_location`; fresh and automatic-upgrade runs passed
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- topology/sql/manage/ManageHelper.sql.in topology/sql/manage/RenameTopology.sql.in topology/test/regress/copytopology.sql topology/test/regress/renametopology.sql topology/test/regress/renametopology_expected`
- `git diff --check`

Current head: `26310e468276531b9143f8d38b5d027ffcfba862`.

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/345

