### PR TITLE
topology: add TopoGeometry overlap operator

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * New Features *
 
+ - #1290, [topology] Add bounding box overlap operator for TopoGeometry
+          (Darafei Praliaskouski)
  - #1124, #2935, #3033, #4658, #4659, [loader] Rework loader arguments:
           shp2pgsql can create UNLOGGED tables and choose the feature id column
           name, shp2pgsql --drop-table can emit DROP TABLE before prepare

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -4762,6 +4762,50 @@ UNION ALL SELECT ']}'::text as t;
         </refsection>
       </refentry>
 
+      <refentry xml:id="TG_Overlaps">
+        <refnamediv>
+          <refname>&amp;&amp;</refname>
+          <refname>Overlaps</refname>
+
+          <refpurpose>Returns true if the bounding boxes of two topogeometries overlap.</refpurpose>
+        </refnamediv>
+
+        <refsynopsisdiv>
+          <funcsynopsis>
+            <funcprototype>
+              <funcdef>boolean <function>Overlaps</function></funcdef>
+              <paramdef><type>topogeometry </type> <parameter>tg1</parameter></paramdef>
+              <paramdef><type>topogeometry </type> <parameter>tg2</parameter></paramdef>
+            </funcprototype>
+          </funcsynopsis>
+        </refsynopsisdiv>
+
+        <refsection>
+          <title>Description</title>
+
+          <para>
+Returns true if the bounding boxes of two topogeometries overlap.
+          </para>
+
+          <para>
+The <code>&amp;&amp;</code> operator calls this function. Bounds are computed from topology primitives without first converting the complete topogeometries to geometry. The operator is not index-assisted for TopoGeometry inputs.
+          </para>
+
+        <para role="availability" conformance="3.7.0">Availability: 3.7.0 </para>
+
+        <!-- Optionally mention 3d support -->
+        <para>&Z_support;</para>
+        </refsection>
+
+
+        <!-- Optionally add a "See Also" section -->
+        <refsection>
+          <title>See Also</title>
+
+          <para><xref linkend="TG_Intersects"/>, Geometry <xref linkend="geometry_overlaps"/></para>
+        </refsection>
+      </refentry>
+
       <refentry xml:id="TG_Intersects">
         <refnamediv>
           <refname>Intersects</refname>

--- a/topology/sql/predicates.sql.in
+++ b/topology/sql/predicates.sql.in
@@ -15,10 +15,165 @@
 --
 --  Overloaded spatial predicates for TopoGeometry inputs
 --
+--   OPERATOR &&(TopoGeometry, TopoGeometry)
+--   FUNCTION overlaps(TopoGeometry, TopoGeometry)
 --   FUNCTION intersects(TopoGeometry, TopoGeometry)
 --   FUNCTION equals(TopoGeometry, TopoGeometry)
 --
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+--{
+-- _bbox(TopoGeometry)
+--
+CREATE OR REPLACE FUNCTION topology._bbox(tg topology.TopoGeometry)
+  RETURNS geometry
+AS
+$$
+DECLARE
+  topology_info RECORD;
+  layer_info RECORD;
+  child_layer_info RECORD;
+  geom geometry;
+  query text;
+BEGIN
+  SELECT id, name, srid FROM topology.topology
+    INTO topology_info
+    WHERE id = tg.topology_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No topology with id "%" in topology.topology', tg.topology_id;
+  END IF;
+
+  SELECT * FROM topology.layer
+    WHERE topology_id = tg.topology_id
+    AND layer_id = tg.layer_id
+    INTO layer_info;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Could not find TopoGeometry layer % in topology %', tg.layer_id, tg.topology_id;
+  END IF;
+
+  IF layer_info.level > 0 THEN
+    SELECT * FROM topology.layer
+      WHERE topology_id = tg.topology_id
+      AND layer_id = layer_info.child_id
+      INTO child_layer_info;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Invalid layer % in topology % (unexistent child layer %)', tg.layer_id, tg.topology_id, layer_info.child_id;
+    END IF;
+
+    query := format(
+      'SELECT ST_SetSRID(ST_Extent(topology._bbox(%1$I))::geometry, $1)
+       FROM %2$I.%3$I f, %4$I.relation pr
+       WHERE pr.topogeo_id = $2
+       AND pr.layer_id = $3
+       AND id(f.%1$I) = pr.element_id
+       AND layer_id(f.%1$I) = pr.element_type',
+      child_layer_info.feature_column,
+      child_layer_info.schema_name,
+      child_layer_info.table_name,
+      topology_info.name
+    );
+    EXECUTE query INTO geom USING topology_info.srid, tg.id, tg.layer_id;
+
+  ELSIF tg.type = 1 THEN
+    query := format(
+      'SELECT ST_SetSRID(ST_Extent(n.geom)::geometry, $1)
+       FROM %1$I.node n, %1$I.relation r
+       WHERE r.topogeo_id = $2
+       AND r.layer_id = $3
+       AND r.element_type = 1
+       AND r.element_id = n.node_id',
+      topology_info.name
+    );
+    EXECUTE query INTO geom USING topology_info.srid, tg.id, tg.layer_id;
+
+  ELSIF tg.type = 2 THEN
+    query := format(
+      'SELECT ST_SetSRID(ST_Extent(e.geom)::geometry, $1)
+       FROM %1$I.edge e, %1$I.relation r
+       WHERE r.topogeo_id = $2
+       AND r.layer_id = $3
+       AND r.element_type = 2
+       AND abs(r.element_id) = e.edge_id',
+      topology_info.name
+    );
+    EXECUTE query INTO geom USING topology_info.srid, tg.id, tg.layer_id;
+
+  ELSIF tg.type = 3 THEN
+    query := format(
+      'SELECT ST_SetSRID(ST_Extent(f.mbr)::geometry, $1)
+       FROM %1$I.face f, %1$I.relation r
+       WHERE r.topogeo_id = $2
+       AND r.layer_id = $3
+       AND r.element_type = 3
+       AND r.element_id = f.face_id',
+      topology_info.name
+    );
+    EXECUTE query INTO geom USING topology_info.srid, tg.id, tg.layer_id;
+
+  ELSIF tg.type = 4 THEN
+    query := format(
+      'WITH components AS (
+         SELECT n.geom
+         FROM %1$I.node n, %1$I.relation r
+         WHERE r.topogeo_id = $2
+         AND r.layer_id = $3
+         AND r.element_type = 1
+         AND r.element_id = n.node_id
+         UNION ALL
+         SELECT e.geom
+         FROM %1$I.edge e, %1$I.relation r
+         WHERE r.topogeo_id = $2
+         AND r.layer_id = $3
+         AND r.element_type = 2
+         AND abs(r.element_id) = e.edge_id
+         UNION ALL
+         SELECT f.mbr
+         FROM %1$I.face f, %1$I.relation r
+         WHERE r.topogeo_id = $2
+         AND r.layer_id = $3
+         AND r.element_type = 3
+         AND r.element_id = f.face_id
+       )
+       SELECT ST_SetSRID(ST_Extent(geom)::geometry, $1)
+       FROM components',
+      topology_info.name
+    );
+    EXECUTE query INTO geom USING topology_info.srid, tg.id, tg.layer_id;
+
+  ELSE
+    RAISE EXCEPTION 'Invalid TopoGeometries (unknown type %)', tg.type;
+  END IF;
+
+  RETURN geom;
+END
+$$
+LANGUAGE 'plpgsql' VOLATILE STRICT;
+--} _bbox(TopoGeometry)
+
+--{
+-- overlaps(TopoGeometry, TopoGeometry)
+--
+CREATE OR REPLACE FUNCTION topology.overlaps(tg1 topology.TopoGeometry, tg2 topology.TopoGeometry)
+  RETURNS bool
+AS
+$$
+  SELECT COALESCE(topology._bbox($1) && topology._bbox($2), false);
+$$
+LANGUAGE 'sql' VOLATILE STRICT;
+--} overlaps(TopoGeometry, TopoGeometry)
+
+--{
+-- &&(TopoGeometry, TopoGeometry)
+--
+-- Availability: 3.7.0
+--
+CREATE OPERATOR topology.&& (
+  LEFTARG = topology.TopoGeometry,
+  RIGHTARG = topology.TopoGeometry,
+  PROCEDURE = topology.overlaps,
+  COMMUTATOR = OPERATOR(topology.&&)
+);
+--} &&(TopoGeometry, TopoGeometry)
 
 --{
 -- intersects(TopoGeometry, TopoGeometry)
@@ -510,4 +665,3 @@ END
 $$
 LANGUAGE 'plpgsql' STABLE STRICT;
 --} equals(TopoGeometry, TopoGeometry)
-

--- a/topology/test/predicates.sql.in
+++ b/topology/test/predicates.sql.in
@@ -14,6 +14,72 @@
 
 BEGIN;
 
+SELECT 'TOPOGEOMETRY BBOX OVERLAPS' as operation;
+
+SELECT 'point/point',
+  bool_and(
+    (a.@COLUMN@ && b.@COLUMN@) =
+    (topology.Geometry(a.@COLUMN@) && topology.Geometry(b.@COLUMN@))
+  )
+FROM features.traffic_signs a, features.traffic_signs b
+WHERE a.fid < b.fid;
+
+SELECT 'point/line',
+  bool_and(
+    (a.@COLUMN@ && b.@COLUMN@) =
+    (topology.Geometry(a.@COLUMN@) && topology.Geometry(b.@COLUMN@))
+  )
+FROM features.traffic_signs a, features.city_streets b;
+
+SELECT 'line/polygon',
+  bool_and(
+    (a.@COLUMN@ && b.@COLUMN@) =
+    (topology.Geometry(a.@COLUMN@) && topology.Geometry(b.@COLUMN@))
+  )
+FROM features.city_streets a, features.land_parcels b;
+
+SELECT 'polygon/hierarchical polygon',
+  bool_and(
+    (a.@COLUMN@ && b.@COLUMN@) =
+    (topology.Geometry(a.@COLUMN@) && topology.Geometry(b.@COLUMN@))
+  )
+FROM features.land_parcels a, features.big_parcels b;
+
+SELECT 'empty/point', empty_feature && feature
+FROM features.traffic_signs,
+  topology.CreateTopoGeom(
+    'city_data',
+    1,
+    (
+      SELECT layer_id FROM topology.layer
+      WHERE topology_id = (
+        SELECT id FROM topology.topology WHERE name = 'city_data'
+      )
+      AND schema_name = 'features'
+      AND table_name = 'traffic_signs'
+      AND feature_column = '@COLUMN@'
+    )
+  ) AS empty_feature
+WHERE feature_name = 'S1';
+
+SELECT 'new point/existing point', new_feature && @COLUMN@
+FROM features.traffic_signs,
+  topology.CreateTopoGeom(
+    'city_data',
+    1,
+    (
+      SELECT layer_id FROM topology.layer
+      WHERE topology_id = (
+        SELECT id FROM topology.topology WHERE name = 'city_data'
+      )
+      AND schema_name = 'features'
+      AND table_name = 'traffic_signs'
+      AND feature_column = '@COLUMN@'
+    ),
+    '{{14,1}}'
+  ) AS new_feature
+WHERE feature_name = 'S1';
+
 #if DO_POINT_POINT_INTERSECTS
 
 -- Detect intersections between traffic_signs
@@ -127,4 +193,3 @@ SELECT a.feature_name, b.feature_name
 	ORDER BY a.feature_name;
 
 END;
-

--- a/topology/test/regress/legacy_predicate_expected
+++ b/topology/test/regress/legacy_predicate_expected
@@ -1,3 +1,10 @@
+TOPOGEOMETRY BBOX OVERLAPS
+point/point|t
+point/line|t
+line/polygon|t
+polygon/hierarchical polygon|t
+empty/point|f
+new point/existing point|t
 POINT/POINT INTERSECTS
 S1|N1N6N14
 S3|N1N6N14

--- a/utils/create_uninstall.pl
+++ b/utils/create_uninstall.pl
@@ -218,7 +218,7 @@ foreach my $opc (@opcs)
 print "-- Drop all operators.\n";
 foreach my $op (@ops)
 {
-	if ($op =~ /create operator ([^(]+)\s*\(.*LEFTARG\s*=\s*(\w+),\s*RIGHTARG\s*=\s*(\w+).*/ism )
+	if ($op =~ /create operator ([^(]+)\s*\(.*LEFTARG\s*=\s*([\w\.]+),\s*RIGHTARG\s*=\s*([\w\.]+).*/ism )
 	{
 		print "DROP OPERATOR IF EXISTS $1 ($2,$3);\n";
 	}

--- a/utils/create_unpackaged.pl
+++ b/utils/create_unpackaged.pl
@@ -263,7 +263,7 @@ foreach my $opc (@opcs)
 print "-- Register all operators.\n";
 foreach my $op (@ops)
 {
-	if ($op =~ /create operator ([^(]+)\s*\(.*LEFTARG\s*=\s*(\w+),\s*RIGHTARG\s*=\s*(\w+).*/ism )
+	if ($op =~ /create operator ([^(]+)\s*\(.*LEFTARG\s*=\s*([\w\.]+),\s*RIGHTARG\s*=\s*([\w\.]+).*/ism )
 	{
 		add_if_not_exists("OPERATOR $1 ($2,$3)");
 	}

--- a/utils/create_upgrade.pl
+++ b/utils/create_upgrade.pl
@@ -704,6 +704,13 @@ EOF
     if (/^create operator\s+(\S+)\s*\(/i)
     {
         my $opname = $1;
+        my $opbasename = $opname;
+        my $opnamespace = '';
+        if ( $opname =~ /^(.+)\.([^.]+)$/ )
+        {
+            $opnamespace = $1;
+            $opbasename = $2;
+        }
         my $opleft = 'unknown';
         my $opright = 'unknown';
         my $def = $_;
@@ -718,8 +725,10 @@ EOF
             }
 
             $def .= $_;
-            $opleft = $1 if (/leftarg\s*=\s*(\w+)\s*,/i);
-            $opright = $1 if (/rightarg\s*=\s*(\w+)\s*,/i);
+            $opleft = lc($1) if (/leftarg\s*=\s*([\w\.]+)\s*,/i);
+            $opright = lc($1) if (/rightarg\s*=\s*([\w\.]+)\s*,/i);
+            $opleft =~ s/^.*\.//;
+            $opright =~ s/^.*\.//;
 
             # Support changing restrict selectivity at later versions
             if (/\s+(RESTRICT|JOIN)\s*=\s*([^,\n]+)/)
@@ -734,6 +743,11 @@ EOF
             last if /\);/;
         }
         my $opsig = $opleft . " " . $opname . " " . $opright;
+        my $namespace_check = "";
+        if ( $opnamespace )
+        {
+            $namespace_check = "AND o.oprnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = '$opnamespace')";
+        }
 
         my $last_updated = parse_last_updated($comment);
         if ( !$last_updated )
@@ -755,9 +769,10 @@ BEGIN
             o.oprleft = tl.oid AND
             o.oprright = tr.oid AND
             o.oprcode != 0 AND
-            o.oprname = '$opname' AND
+            o.oprname = '$opbasename' AND
             tl.typname = '$opleft' AND
             tr.typname = '$opright'
+            $namespace_check
     )
     THEN
 $def
@@ -1067,4 +1082,3 @@ BEGIN
 END
 $$
 LANGUAGE 'plpgsql';
-


### PR DESCRIPTION
## Summary
- add a TopoGeometry bounding-box helper and expose it through `topology.overlaps(topogeometry, topogeometry)`
- add the `&&` operator for TopoGeometry bounding-box overlap without promising index support
- teach topology SQL packaging helpers to parse schema-qualified operator signatures for upgrade, uninstall, and unpackaged extension scripts
- cover the operator in the existing topology predicate regression against the geometry-cast `&&` behavior
- mark the TopoGeometry bbox reader and overlap wrapper `VOLATILE`, so same-statement `CreateTopoGeom` relation rows are visible to `&&`
- keep the same-statement predicate regression in the generated SQL template so clean CI builds include it

Trac: https://trac.osgeo.org/postgis/ticket/1290

## Validation
- `make -C topology/test topo_predicates.sql`
- `make -C topology topology.sql topology_upgrade.sql uninstall_topology.sql`
- `make -C extensions/postgis_topology all`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_topology install`
- focused `topology/test/regress/legacy_predicate.sql` fresh regression; fresh and automatic upgrade checks passed
- focused `topology/test/regress/legacy_predicate.sql` explicit upgrade regression; explicit upgrade check passed
- focused `legacy_predicate` run while attempting the standard-conforming-strings-off hook also passed; this local test runner reported `Unknown option: before-create-script`, so the hook itself was not applied by this target
- `make -C doc check`
- `./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- topology/sql/predicates.sql.in topology/test/predicates.sql.in topology/test/regress/legacy_predicate_expected utils/create_uninstall.pl utils/create_unpackaged.pl utils/create_upgrade.pl doc/extras_topology.xml NEWS`
- `git diff --check`

Current head: `41c955dcd3e13c8d7f0e71f8d6bcc004b93ded7c`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/344