### PR TITLE
topology: add ST_ValidateTopoGeo

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
+ - #1224, [topology] Add SQL/MM ST_ValidateTopoGeo entrypoint
+          (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -993,7 +993,48 @@ face without edges |   1 |
 			<!-- Optionally add a "See Also" section -->
 			<refsection>
 				<title>See Also</title>
-				<para><xref linkend="validatetopology_returntype"/></para>
+				<para><xref linkend="ST_ValidateTopoGeo"/>, <xref linkend="validatetopology_returntype"/></para>
+			</refsection>
+		</refentry>
+
+		<refentry xml:id="ST_ValidateTopoGeo">
+			<refnamediv>
+				<refname>ST_ValidateTopoGeo</refname>
+
+				<refpurpose>Returns a set of validatetopology_returntype objects detailing issues with topology.</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>setof validatetopology_returntype <function>ST_ValidateTopoGeo</function></funcdef>
+					<paramdef><type>varchar </type> <parameter>toponame</parameter></paramdef>
+					<paramdef choice="opt"><type>geometry</type> <parameter>bbox</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+				<title>Description</title>
+
+				<para>SQL/MM standard entrypoint for topology validation. This function returns the same result as <xref linkend="ValidateTopology"/>, optionally limiting the check to the area specified by the <varname>bbox</varname> parameter.</para>
+
+				<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+				<para>&sqlmm_compliant; SQL-MM 3 Topo-Geo and Topo-Net 3: Routine Details: X.3.18</para>
+			</refsection>
+
+			<refsection>
+				<title>Examples</title>
+				<programlisting>SELECT * FROM topology.ST_ValidateTopoGeo('ma_topo');
+      error        | id1 | id2
+-------------------+-----+-----
+face without edges |   1 |
+				</programlisting>
+			</refsection>
+
+			<refsection>
+				<title>See Also</title>
+				<para><xref linkend="ValidateTopology"/>, <xref linkend="validatetopology_returntype"/></para>
 			</refsection>
 		</refentry>
 

--- a/topology/sql/manage/ValidateTopology.sql.in
+++ b/topology/sql/manage/ValidateTopology.sql.in
@@ -1127,3 +1127,17 @@ $$
 LANGUAGE 'plpgsql' VOLATILE; -- NOTE: we need VOLATILE to use SHOW
 --} ValidateTopology(toponame, bbox)
 
+--{
+--  ST_ValidateTopoGeo(toponame, [bbox])
+--
+--  SQL/MM standard entrypoint for topology validation.
+--
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION topology.ST_ValidateTopoGeo(toponame varchar, bbox geometry DEFAULT NULL)
+  RETURNS setof topology.ValidateTopology_ReturnType
+AS
+$$
+  SELECT * FROM topology.ValidateTopology(toponame, bbox);
+$$
+LANGUAGE 'sql' VOLATILE;
+--} ST_ValidateTopoGeo(toponame, bbox)

--- a/topology/test/regress/validatetopology.sql
+++ b/topology/test/regress/validatetopology.sql
@@ -204,6 +204,8 @@ DELETE FROM t5548.edge;
 DELETE FROM t5548.node;
 SELECT '#5548.1', * FROM topology.ValidateTopology('t5548',
   ST_MakeEnvelope(2,2,4,4));
+SELECT '#1224', * FROM topology.ST_ValidateTopoGeo('t5548',
+  ST_MakeEnvelope(2,2,4,4));
 ROLLBACK;
 
 -- See https://trac.osgeo.org/postgis/ticket/5766
@@ -242,4 +244,3 @@ VALUES
 ( 4,1,4,-1,-2,1,2,'LINESTRING(17.42207545158684 69.11091383590066,17.42207570266477 69.11091383235974,17.422075702665087 69.11091383235977)' );
 SELECT '#6065', 'invalidities', * FROM topology.ValidateTopology('t6065');
 ROLLBACK;
-

--- a/topology/test/regress/validatetopology_expected
+++ b/topology/test/regress/validatetopology_expected
@@ -40,6 +40,7 @@
 #5403.0|1
 #5548.0|1
 #5548.1|face without edges|1|
+#1224|face without edges|1|
 #5766.1|no bbox|("face has wrong mbr",0,)
 #5766.1|overlapping bbox|("face has wrong mbr",0,)
 #5766.1|disjoint bbox|

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -180,7 +180,8 @@
 --    Also updates the Relation table
 --
 --   ST_ValidateTopoGeo
---    Unimplemented (probably a wrapper around ValidateTopology)
+--    Complete
+--    Implemented as a wrapper around ValidateTopology
 --
 --
 


### PR DESCRIPTION
## Summary

- adds `topology.ST_ValidateTopoGeo(toponame, bbox)` as the SQL/MM entrypoint for topology validation
- documents the function and marks the topology TODO as implemented
- covers bbox pass-through using the existing `ValidateTopology` regression case

Ticket: https://trac.osgeo.org/postgis/ticket/1224

## Validation

- `make -C topology topology.sql topology_upgrade.sql uninstall_topology.sql`
- `make -C topology -j1`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/validatetopology"`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- topology/sql/manage/ValidateTopology.sql.in topology/topology.sql.in doc/extras_topology.xml topology/test/regress/validatetopology.sql topology/test/regress/validatetopology_expected NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/342
