### PR TITLE
topology: add pairwise ST_Union for TopoGeometry

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
+ - #4847, [topology] Add pairwise ST_Union for TopoGeometry
+          (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -4251,6 +4251,59 @@ UPDATE mylayer SET tg_overall = TopoGeom_addTopogeom(
         <para>
 <xref linkend="TopoGeom_addElement"/>,
 <xref linkend="clearTopoGeom"/>,
+<xref linkend="CreateTopoGeom"/>,
+<xref linkend="ST_Union_TopoGeometry"/>
+        </para>
+			</refsection>
+		</refentry>
+
+    <refentry xml:id="ST_Union_TopoGeometry">
+			<refnamediv>
+				<refname>ST_Union</refname>
+				<refpurpose>Returns the union of two TopoGeometry objects.</refpurpose>
+			</refnamediv>
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>topogeometry <function>ST_Union</function></funcdef>
+					<paramdef><type>topogeometry </type> <parameter>tg1</parameter></paramdef>
+                    <paramdef><type>topogeometry </type> <parameter>tg2</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+                <title>Description</title>
+
+                <para>
+Returns a new <xref linkend="topogeometry"/> containing the elements of
+both inputs. The input TopoGeometry objects are not changed.
+                </para>
+
+                <para>
+The returned TopoGeometry is created in the topology and layer of
+<varname>tg1</varname>. The inputs must be defined against the same
+topology and must satisfy the same layer compatibility constraints as
+<xref linkend="TopoGeom_addTopoGeom"/>.
+                </para>
+
+                <!-- use this format if new function -->
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+			</refsection>
+			<refsection>
+				<title>Examples</title>
+        <programlisting>
+SELECT topology.ST_Union(a.tg, b.tg)
+FROM mylayer a, mylayer b
+WHERE a.id = 1 AND b.id = 2;
+				</programlisting>
+			</refsection>
+
+			<!-- Optionally add a "See Also" section -->
+			<refsection>
+				<title>See Also</title>
+        <para>
+<xref linkend="TopoGeom_addTopoGeom"/>,
 <xref linkend="CreateTopoGeom"/>
         </para>
 			</refsection>

--- a/topology/sql/topogeometry/topogeom_edit.sql.in
+++ b/topology/sql/topogeometry/topogeom_edit.sql.in
@@ -145,12 +145,12 @@ BEGIN
 
   -- Check simple/hierarchical compatibility
   IF srcLayer.child_id IS NULL THEN
-    IF srcLayer.child_id IS NOT NULL THEN
-      RAISE EXCEPTION 'Cannot add components of hierarchical TopoGeometry to a non-hierarchical TopoGeometry';
+    IF tgtLayer.child_id IS NOT NULL THEN
+      RAISE EXCEPTION 'Cannot add components of non-hierarchical TopoGeometry to a hierarchical TopoGeometry';
     END IF;
   ELSIF tgtLayer.child_id IS NULL THEN
-      RAISE EXCEPTION 'Cannot add components of non-hierarchical TopoGeometry to a hierarchical TopoGeometry';
-  ELSIF tgtLayer.child_id != srcLayer.childId THEN
+      RAISE EXCEPTION 'Cannot add components of hierarchical TopoGeometry to a non-hierarchical TopoGeometry';
+  ELSIF tgtLayer.child_id != srcLayer.child_id THEN
       RAISE EXCEPTION 'Cannot add components of hierarchical TopoGeometry to a hierarchical TopoGeometry based on different layer';
   END IF;
 
@@ -215,6 +215,50 @@ SELECT array_agg(DISTINCT element_type) FROM inserted
 
 
   RETURN tgt;
+END
+$BODY$
+LANGUAGE 'plpgsql' VOLATILE STRICT;
+-- }
+
+-- {
+-- Return the union of two TopoGeometry objects without changing either input.
+--
+-- }{
+CREATE OR REPLACE FUNCTION topology.ST_Union(tg1 topology.TopoGeometry, tg2 topology.TopoGeometry)
+  RETURNS topology.TopoGeometry
+AS
+$BODY$
+DECLARE
+  topo topology.topology;
+  ret topology.TopoGeometry;
+  ret_elements topology.TopoElementArray;
+BEGIN
+  topo := topology.FindTopology(tg1);
+
+  IF topology_id(tg1) != topology_id(tg2) THEN
+    RAISE EXCEPTION 'TopoGeometry objects need be defined on the same topology';
+  END IF;
+
+  EXECUTE format($$
+    SELECT topology.TopoElementArray_agg(ARRAY[element_id, element_type]
+      ORDER BY element_type, element_id)
+    FROM %I.relation
+    WHERE topogeo_id = $1
+      AND layer_id = $2
+    $$,
+    topo.name
+  )
+  USING id(tg1), layer_id(tg1)
+  INTO ret_elements;
+
+  IF ret_elements IS NULL THEN
+    ret := topology.CreateTopoGeom(topo.name, type(tg1), layer_id(tg1));
+  ELSE
+    ret := topology.CreateTopoGeom(topo.name, type(tg1), layer_id(tg1),
+      ret_elements);
+  END IF;
+
+  RETURN topology.TopoGeom_addTopoGeom(ret, tg2);
 END
 $BODY$
 LANGUAGE 'plpgsql' VOLATILE STRICT;

--- a/topology/test/regress/topogeom_addtopogeom.sql
+++ b/topology/test/regress/topogeom_addtopogeom.sql
@@ -28,6 +28,15 @@ SELECT 'simple_collection_layer', AddTopoGeometryColumn('tt', 'tt', 'f_coll','g'
 CREATE TABLE tt.f_hier_puntal(id serial);
 SELECT 'hierarchical_puntual_layer', AddTopoGeometryColumn('tt', 'tt', 'f_hier_puntal','g','POINT', 1);
 
+INSERT INTO tt.f_puntal(g) VALUES
+  (toTopoGeom('POINT(1 1)'::geometry, 'tt', 1)),
+  (toTopoGeom('POINT(0 0)'::geometry, 'tt', 1)),
+  (topology.CreateTopoGeom('tt', 1, 1));
+
+INSERT INTO tt.f_hier_puntal(g)
+SELECT topology.CreateTopoGeom('tt', 1, 5, ARRAY[ARRAY[id(g), layer_id(g)]]::topology.TopoElementArray)
+FROM tt.f_puntal
+WHERE id IN (1, 2);
 
 -- point to point
 SELECT 'tg2tg.poi2poi', ST_AsText(TopoGeom_addTopoGeom(
@@ -65,6 +74,73 @@ SELECT 'tg2tg.pol2pol', ST_AsText(ST_Simplify(ST_Normalize(TopoGeom_addTopoGeom(
     toTopoGeom(ST_MakeEnvelope(0,0,10,10), 'tt', 4)
 )::geometry), 0));
 
+WITH unioned AS (
+  SELECT topology.ST_Union(a.g, b.g) AS g, a.g AS a, b.g AS b
+  FROM tt.f_puntal a, tt.f_puntal b
+  WHERE a.id = 1 AND b.id = 2
+)
+SELECT 'st_union.poi2poi',
+  ST_AsText(g),
+  id(g) NOT IN (id(a), id(b)),
+  GetTopoGeomElementArray(a),
+  GetTopoGeomElementArray(b)
+FROM unioned;
+
+WITH unioned AS (
+  SELECT topology.ST_Union(a.g, b.g) AS g, a.g AS a, b.g AS b
+  FROM tt.f_puntal a, tt.f_puntal b
+  WHERE a.id = 3 AND b.id = 1
+)
+SELECT 'st_union.empty_poi',
+  ST_AsText(g),
+  id(g) NOT IN (id(a), id(b)),
+  GetTopoGeomElementArray(a),
+  GetTopoGeomElementArray(b)
+FROM unioned;
+
+INSERT INTO tt.f_hier_puntal(g)
+SELECT topology.ST_Union(a.g, b.g)
+FROM tt.f_hier_puntal a, tt.f_hier_puntal b
+WHERE a.id = 1 AND b.id = 2;
+
+SELECT 'st_union.hier_poi2poi',
+  ST_AsText(u.g),
+  id(u.g) NOT IN (id(a.g), id(b.g)),
+  (SELECT topology.TopoElementArray_agg(ARRAY[element_id, element_type]
+    ORDER BY element_id, element_type)
+   FROM tt.relation
+   WHERE topogeo_id = id(u.g)
+     AND layer_id = layer_id(u.g)),
+  (SELECT topology.TopoElementArray_agg(ARRAY[element_id, element_type])
+   FROM tt.relation
+   WHERE topogeo_id = id(a.g)
+     AND layer_id = layer_id(a.g)),
+  (SELECT topology.TopoElementArray_agg(ARRAY[element_id, element_type])
+   FROM tt.relation
+   WHERE topogeo_id = id(b.g)
+     AND layer_id = layer_id(b.g))
+FROM tt.f_hier_puntal u, tt.f_hier_puntal a, tt.f_hier_puntal b
+WHERE u.id = 3 AND a.id = 1 AND b.id = 2;
+
+CREATE FUNCTION tt.try_st_union(a topology.TopoGeometry, b topology.TopoGeometry)
+RETURNS text
+AS $$
+BEGIN
+  PERFORM topology.ST_Union(a, b);
+  RETURN 'unexpected success';
+EXCEPTION WHEN OTHERS THEN
+  RETURN SQLERRM;
+END
+$$ LANGUAGE 'plpgsql' VOLATILE;
+
+SELECT 'st_union.hier_simple', tt.try_st_union(h.g, s.g)
+FROM tt.f_hier_puntal h, tt.f_puntal s
+WHERE h.id = 1 AND s.id = 1;
+
+SELECT 'st_union.simple_hier', tt.try_st_union(s.g, h.g)
+FROM tt.f_puntal s, tt.f_hier_puntal h
+WHERE s.id = 1 AND h.id = 1;
+
 -- TODO: point to point (hierarchical)
 -- TODO: point to mixed (hierarchical)
 -- TODO: line to line (hierarchical)
@@ -78,4 +154,5 @@ DROP TABLE tt.f_areal;
 DROP TABLE tt.f_lineal;
 DROP TABLE tt.f_hier_puntal;
 DROP TABLE tt.f_puntal;
+DROP FUNCTION tt.try_st_union(topology.TopoGeometry, topology.TopoGeometry);
 select NULL from droptopology('tt');

--- a/topology/test/regress/topogeom_addtopogeom_expected
+++ b/topology/test/regress/topogeom_addtopogeom_expected
@@ -9,3 +9,8 @@ tg2tg.lin2lin|MULTILINESTRING((0 0,2 0),(0 1,1 1,2 1))
 tg2tg.lin2mix|GEOMETRYCOLLECTION(LINESTRING(0 0,2 0),POINT(0 0))
 tg2tg.pol2pol|MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))
 tg2tg.pol2pol|GEOMETRYCOLLECTION(POLYGON((0 0,0 10,10 10,10 0,0 0)),POINT(0 0))
+st_union.poi2poi|MULTIPOINT((0 0),(1 1))|t|{{1,1}}|{{2,1}}
+st_union.empty_poi|MULTIPOINT((1 1))|t|{}|{{1,1}}
+st_union.hier_poi2poi|MULTIPOINT((0 0),(1 1))|t|{{1,1},{2,1}}|{{1,1}}|{{2,1}}
+st_union.hier_simple|Cannot add components of non-hierarchical TopoGeometry to a hierarchical TopoGeometry
+st_union.simple_hier|Cannot add components of hierarchical TopoGeometry to a non-hierarchical TopoGeometry


### PR DESCRIPTION
## Summary
- add `topology.ST_Union(TopoGeometry, TopoGeometry)` as a non-mutating pairwise TopoGeometry union
- implement it by copying the first input from its stored relation rows and folding in the second with `TopoGeom_addTopoGeom`
- handle empty first inputs through the normal empty TopoGeometry constructor
- document the new overload and cover non-mutating, empty, and hierarchical behavior in `topogeom_addtopogeom`

Closes https://trac.osgeo.org/postgis/ticket/4847

## Latest update
- rebased onto `postgis/postgis@a4ecc46176c3fc0ab3fa69cf117d408bc622e592`
- refreshed head to `4b4d02f0cb5b248897d7d435c25943881bd83d88`
- fixed the copy path so hierarchical `tg1` definitions are copied from stored relation rows instead of flattened primitive elements
- fixed the hierarchical compatibility field typo in `TopoGeom_addTopoGeom` (`child_id`)
- fixed simple/hierarchical compatibility checks before `TopoGeom_addTopoGeom` copies relation rows
- added regressions for empty `tg1`, hierarchical `tg1`/`tg2`, and incompatible simple/hierarchical unions

## Validation
- `make -C topology topology.sql`
- `make -C topology -j32`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_topology install`
- focused `topology/test/regress/topogeom_addtopogeom` fresh regression; fresh and automatic-upgrade checks passed
- focused `topology/test/regress/topogeom_addtopogeom` explicit upgrade regression; explicit upgrade check passed
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- topology/sql/topogeometry/topogeom_edit.sql.in topology/test/regress/topogeom_addtopogeom.sql topology/test/regress/topogeom_addtopogeom_expected doc/extras_topology.xml NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/341
