### PR TITLE
topology: add DropTopoGeometryTable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
+ - #1185, [topology] Add DropTopoGeometryTable
+          (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -549,7 +549,53 @@ Rename a topology from <varname>topo_stage</varname> to <varname>topo_prod</varn
 			<!-- Optionally add a "See Also" section -->
 			<refsection>
 				<title>See Also</title>
-				<para><xref linkend="AddTopoGeometryColumn"/></para>
+				<para><xref linkend="AddTopoGeometryColumn"/>, <xref linkend="DropTopoGeometryTable"/></para>
+			</refsection>
+		</refentry>
+
+		<refentry xml:id="DropTopoGeometryTable">
+			<refnamediv>
+				<refname>DropTopoGeometryTable</refname>
+
+				<refpurpose>Drops a table and unregisters all associated topogeometry columns from topology.layer.</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>text <function>DropTopoGeometryTable</function></funcdef>
+					<paramdef><type>varchar </type> <parameter>schema_name</parameter></paramdef>
+					<paramdef><type>varchar </type> <parameter>table_name</parameter></paramdef>
+					</funcprototype>
+
+					<funcprototype>
+					<funcdef>text <function>DropTopoGeometryTable</function></funcdef>
+					<paramdef><type>varchar </type> <parameter>table_name</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+                <title>Description</title>
+
+                <para>Drops the table named <varname>table_name</varname> in schema <varname>schema_name</varname>, unregistering every associated topogeometry column from the <varname>topology.layer</varname> table and removing related records from the topology relation table.</para>
+
+                <para>If the schema is omitted, the current schema is used.</para>
+
+                <!-- use this format if new function -->
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+			</refsection>
+
+
+			<refsection>
+				<title>Examples</title>
+				<programlisting>SELECT topology.DropTopoGeometryTable('public', 'parcel_topo');</programlisting>
+			</refsection>
+
+			<!-- Optionally add a "See Also" section -->
+			<refsection>
+				<title>See Also</title>
+				<para><xref linkend="DropTopoGeometryColumn"/>, <xref linkend="AddTopoGeometryColumn"/></para>
 			</refsection>
 		</refentry>
 

--- a/topology/test/regress/droptopogeometrytable.sql
+++ b/topology/test/regress/droptopogeometrytable.sql
@@ -1,0 +1,60 @@
+set client_min_messages to ERROR;
+
+SELECT NULL FROM topology.CreateTopology('t1185');
+
+CREATE TABLE t1185f(id int);
+SELECT 'point_layer', topology.AddTopoGeometryColumn('t1185', 'public', 't1185f', 'g_point', 'POINT');
+SELECT 'line_layer', topology.AddTopoGeometryColumn('t1185', 'public', 't1185f', 'g_line', 'LINE');
+
+INSERT INTO t1185f(id, g_point, g_line)
+VALUES (
+  1,
+  topology.toTopoGeom('POINT(0 0)'::geometry, 't1185', 1),
+  topology.toTopoGeom('LINESTRING(0 0, 1 0)'::geometry, 't1185', 2)
+);
+
+CREATE TABLE t1185_parent(id int);
+SELECT 'parent_layer', topology.AddTopoGeometryColumn('t1185', 'public', 't1185_parent', 'g_parent', 'POINT', 1);
+
+CREATE OR REPLACE FUNCTION t1185_try_drop_topogeometry_table()
+RETURNS text AS
+$$
+BEGIN
+  PERFORM topology.DropTopoGeometryTable('public', 't1185f');
+  RETURN 'dropped';
+EXCEPTION WHEN OTHERS THEN
+  RETURN SQLERRM;
+END
+$$
+LANGUAGE 'plpgsql';
+
+SELECT 'parent-block',
+  t1185_try_drop_topogeometry_table() =
+    'Cannot drop public.t1185f because layer 1 is referenced by hierarchical layer 3 (public.t1185_parent.g_parent)';
+
+SELECT 'parent-still-registered', count(*) = 3
+FROM topology.layer
+WHERE topology_id = id(topology.findTopology('t1185'));
+
+SELECT '#1185.drop-parent-column', topology.DropTopoGeometryColumn('public', 't1185_parent', 'g_parent');
+
+SELECT 'before',
+  count(*) = 2 AS layers,
+  (SELECT count(*) > 0 FROM t1185.relation) AS relations
+FROM topology.layer
+WHERE schema_name = 'public'
+AND table_name = 't1185f';
+
+SELECT '#1185.drop', topology.DropTopoGeometryTable('public', 't1185f');
+
+SELECT 'after',
+  to_regclass('public.t1185f') IS NULL AS table_dropped,
+  count(*) = 0 AS layers_dropped,
+  (SELECT count(*) = 0 FROM t1185.relation) AS relations_dropped
+FROM topology.layer
+WHERE schema_name = 'public'
+AND table_name = 't1185f';
+
+SELECT NULL FROM topology.DropTopology('t1185');
+DROP TABLE t1185_parent;
+DROP FUNCTION t1185_try_drop_topogeometry_table();

--- a/topology/test/regress/droptopogeometrytable_expected
+++ b/topology/test/regress/droptopogeometrytable_expected
@@ -1,0 +1,9 @@
+point_layer|1
+line_layer|2
+parent_layer|3
+parent-block|t
+parent-still-registered|t
+#1185.drop-parent-column|Layer 3 (public.t1185_parent.g_parent) dropped
+before|t|t
+#1185.drop|public.t1185f dropped.
+after|t|t|t

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -28,6 +28,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/createtopogeom.sql \
 	$(top_srcdir)/topology/test/regress/createtopology.sql \
 	$(top_srcdir)/topology/test/regress/droptopogeometrycolumn.sql \
+	$(top_srcdir)/topology/test/regress/droptopogeometrytable.sql \
 	$(top_srcdir)/topology/test/regress/droptopology.sql \
 	$(top_srcdir)/topology/test/regress/findlayer.sql \
 	$(top_srcdir)/topology/test/regress/findtopology.sql \
@@ -101,4 +102,3 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/verifylargeids.sql \
 	$(top_srcdir)/topology/test/regress/fix_topogeometry_columns.sql \
 	$(top_srcdir)/topology/test/regress/findvertexsegmentpairsbelowdistance.sql
-

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -641,6 +641,84 @@ LANGUAGE 'plpgsql' VOLATILE;
 --
 --} DropTopoGeometryColumn
 
+--{
+--  DropTopoGeometryTable(schema, table)
+--
+--  Drop a table with TopoGeometry columns, unregistering its associated
+--  layers and cleaning topology relation records.
+--
+-- Availability: 3.7.0
+--
+CREATE OR REPLACE FUNCTION topology.DropTopoGeometryTable(schema varchar, tbl varchar)
+  RETURNS text
+AS
+$BODY$
+DECLARE
+  rec RECORD;
+  dependent_layer RECORD;
+  real_schema name;
+  sql TEXT;
+BEGIN
+  IF schema = '' THEN
+    real_schema := current_schema();
+  ELSE
+    real_schema := schema;
+  END IF;
+
+  SELECT parent_layer.topology_id, parent_layer.layer_id, parent_layer.schema_name,
+    parent_layer.table_name, parent_layer.feature_column, child_layer.layer_id AS child_layer_id
+  INTO dependent_layer
+  FROM topology.layer child_layer
+  JOIN topology.layer parent_layer
+    ON parent_layer.topology_id = child_layer.topology_id
+    AND parent_layer.child_id = child_layer.layer_id
+  WHERE child_layer.schema_name = real_schema
+    AND child_layer.table_name = tbl
+    AND NOT (
+      parent_layer.schema_name = real_schema
+      AND parent_layer.table_name = tbl
+    )
+  ORDER BY parent_layer.topology_id, parent_layer.layer_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RAISE EXCEPTION
+      'Cannot drop %.% because layer % is referenced by hierarchical layer % (%.%.%)',
+      real_schema, tbl, dependent_layer.child_layer_id, dependent_layer.layer_id,
+      dependent_layer.schema_name, dependent_layer.table_name,
+      dependent_layer.feature_column;
+  END IF;
+
+  FOR rec IN
+    SELECT feature_column
+    FROM topology.layer
+    WHERE schema_name = real_schema
+    AND table_name = tbl
+    ORDER BY layer_id DESC
+  LOOP
+    PERFORM topology.DropTopoGeometryColumn(real_schema::varchar, tbl, rec.feature_column::varchar);
+  END LOOP;
+
+  sql := format('DROP TABLE IF EXISTS %I.%I RESTRICT', real_schema, tbl);
+  EXECUTE sql;
+
+  RETURN format('%I.%I dropped.', real_schema, tbl);
+END;
+$BODY$
+LANGUAGE 'plpgsql' VOLATILE STRICT;
+
+--
+-- DropTopoGeometryTable(table)
+--
+CREATE OR REPLACE FUNCTION topology.DropTopoGeometryTable(tbl varchar)
+  RETURNS text
+AS
+$$
+  SELECT topology.DropTopoGeometryTable('', $1);
+$$ LANGUAGE 'sql' VOLATILE STRICT;
+--
+--} DropTopoGeometryTable
+
 --
 -- CreateTopoGeom(topology_name, topogeom_type, layer_id, elements, tg_id)
 --


### PR DESCRIPTION
## Summary

- adds `topology.DropTopoGeometryTable(schema, table)` and a current-schema wrapper
- cleans each registered TopoGeometry column through `DropTopoGeometryColumn` before dropping the table
- rejects drops that would leave an outside hierarchical parent layer pointing at a removed child layer
- documents the function and adds regression coverage for multi-column relation/layer cleanup

Ticket: https://trac.osgeo.org/postgis/ticket/1185

## Validation

- `make -C topology topology.sql topology_upgrade.sql uninstall_topology.sql`
- `make -C topology -j32`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_topology install`
- focused `topology/test/regress/droptopogeometrytable.sql` fresh and automatic upgrade regression: `Run tests: 2 Failed: 0`
- focused `topology/test/regress/droptopogeometrytable.sql` explicit upgrade regression: `Run tests: 2 Failed: 0`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- topology/topology.sql.in topology/test/regress/droptopogeometrytable.sql topology/test/regress/droptopogeometrytable_expected topology/test/tests.mk doc/extras_topology.xml NEWS`

Current head: `6f4b032398081f7953b8d08ace1ac5edbce68db6`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/340