### PR TITLE
topology: add smallest type option to AsTopoJSON

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
+ - #5204, [topology] Allow AsTopoJSON to emit the smallest geometry type
+          (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -4611,6 +4611,12 @@ SELECT topology.AsGML(topo,'') As rdgml
                         <paramdef><type>topogeometry </type> <parameter>tg</parameter></paramdef>
                         <paramdef><type>regclass </type> <parameter>edgeMapTable</parameter></paramdef>
 					</funcprototype>
+					<funcprototype>
+                        <funcdef>text <function>AsTopoJSON</function></funcdef>
+                        <paramdef><type>topogeometry </type> <parameter>tg</parameter></paramdef>
+                        <paramdef><type>regclass </type> <parameter>edgeMapTable</parameter></paramdef>
+                        <paramdef><type>boolean </type> <parameter>useSmallestType</parameter></paramdef>
+					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
 
@@ -4622,6 +4628,10 @@ SELECT topology.AsGML(topo,'') As rdgml
 
 <para>
 The table, if given, is expected to have an "arc_id" field of type "serial" and an "edge_id" of type integer; the code will query the table for "edge_id" so it is recommended to add an index on that field.
+</para>
+
+<para>
+If <varname>useSmallestType</varname> is true, simple puntal, lineal, and areal TopoGeometries are output as Point, LineString, or Polygon when a Multi* representation is not required.
 </para>
 
 		<note>
@@ -4640,6 +4650,7 @@ the actual arcs plus some headers. See the <link xlink:href="http://github.com/m
                 <!-- use this format if new function -->
                 <para role="availability" conformance="2.1.0">Availability: 2.1.0 </para>
                 <para role="enhanced" conformance="2.2.1">Enhanced: 2.2.1 added support for puntal inputs</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added the <varname>useSmallestType</varname> parameter</para>
 			</refsection>
 
 

--- a/topology/sql/export/TopoJSON.sql.in
+++ b/topology/sql/export/TopoJSON.sql.in
@@ -20,17 +20,22 @@
 --
 -- API FUNCTION
 --
--- text AsTopoJSON(TopoGeometry, edgeMapTable)
+-- text AsTopoJSON(TopoGeometry, edgeMapTable, useSmallestType)
 --
 -- Format specification here:
 -- http://github.com/mbostock/topojson-specification/blob/master/README.md
 --
 -- Changed: 3.6.0 uses bigint for IDs
-CREATE OR REPLACE FUNCTION topology.AsTopoJSON(tg topology.TopoGeometry, edgeMapTable regclass)
+-- Changed: 3.7.0 added useSmallestType parameter
+CREATE OR REPLACE FUNCTION topology.AsTopoJSON(
+    tg topology.TopoGeometry,
+    edgeMapTable regclass,
+    useSmallestType boolean)
   RETURNS text AS
 $$
 DECLARE
   toponame text;
+  geom geometry;
   json text;
   sql text;
   rec RECORD;
@@ -61,7 +66,11 @@ BEGIN
 
   -- Puntal TopoGeometry, simply delegate to AsGeoJSON
   IF tg.type = 1 THEN
-    json := ST_AsGeoJSON(topology.Geometry(tg));
+    geom := topology.Geometry(tg);
+    IF useSmallestType AND ST_NumGeometries(geom) = 1 THEN
+      geom := ST_GeometryN(geom, 1);
+    END IF;
+    json := ST_AsGeoJSON(geom);
     return json;
   ELSIF tg.type = 2 THEN -- lineal
 
@@ -105,13 +114,21 @@ BEGIN
 
     END LOOP; -- }
 
-    json := '{ "type": "MultiLineString", "arcs": [' || array_to_string(comptxt,',') || ']}';
+    IF useSmallestType AND array_length(comptxt, 1) = 1 THEN
+      json := '{ "type": "LineString", "arcs": ' || comptxt[1] || '}';
+    ELSE
+      json := '{ "type": "MultiLineString", "arcs": [' || array_to_string(comptxt,',') || ']}';
+    END IF;
 
     return json;
 
   ELSIF tg.type = 3 THEN -- areal
 
-    json := '{ "type": "MultiPolygon", "arcs": [';
+    IF useSmallestType THEN
+      json := '{ "type": "Polygon", "arcs": ';
+    ELSE
+      json := '{ "type": "MultiPolygon", "arcs": [';
+    END IF;
 
     EXECUTE 'SHOW search_path' INTO old_search_path;
     EXECUTE 'SET search_path TO ' || quote_ident(toponame) || ',' || old_search_path;
@@ -315,7 +332,11 @@ FROM _edgepath
 
     DROP TABLE _postgis_topology_astopojson_tmp_edges;
 
-    json := json || array_to_string(comptxt, ',') || ']}';
+    IF useSmallestType AND array_length(comptxt, 1) = 1 THEN
+      json := json || comptxt[1] || '}';
+    ELSE
+      json := '{ "type": "MultiPolygon", "arcs": [' || array_to_string(comptxt, ',') || ']}';
+    END IF;
 
     EXECUTE 'SET search_path TO ' || old_search_path;
 
@@ -328,5 +349,9 @@ FROM _edgepath
 
 END
 $$ LANGUAGE 'plpgsql' VOLATILE; -- writes into visited table
--- } AsTopoJSON(TopoGeometry, visited_table)
 
+CREATE OR REPLACE FUNCTION topology.AsTopoJSON(tg topology.TopoGeometry, edgeMapTable regclass)
+  RETURNS text AS
+$$ SELECT topology.AsTopoJSON($1, $2, false); $$
+LANGUAGE 'sql' VOLATILE; -- writes into visited table
+-- } AsTopoJSON(TopoGeometry, visited_table)

--- a/topology/test/regress/topojson.sql
+++ b/topology/test/regress/topojson.sql
@@ -23,6 +23,12 @@ SELECT 'L2-vanilla', feature_name, topology.AsTopoJSON(feature, NULL)
  WHERE feature_name IN ('R4', 'R1R2' )
  ORDER BY feature_name;
 
+--- Lineal smallest type
+SELECT 'L-smallest', feature_name, topology.AsTopoJSON(feature, NULL, true)
+ FROM features.big_streets
+ WHERE feature_name IN ('R4', 'R1R2' )
+ ORDER BY feature_name;
+
 --- Areal non-hierarchical
 SELECT 'A1-vanilla', feature_name, topology.AsTopoJSON(feature, NULL)
  FROM features.land_parcels
@@ -33,6 +39,17 @@ SELECT 'A1-vanilla', feature_name, topology.AsTopoJSON(feature, NULL)
 SELECT 'A2-vanilla', feature_name, topology.AsTopoJSON(feature, NULL)
  FROM features.big_parcels
  WHERE feature_name IN ('P1P2', 'P3P4')
+ ORDER BY feature_name;
+
+--- Areal smallest type
+SELECT 'A-smallest', feature_name, topology.AsTopoJSON(feature, NULL, true)
+ FROM features.land_parcels
+ WHERE feature_name IN ('P4', 'P5')
+ ORDER BY feature_name;
+
+SELECT 'A-smallest', feature_name, topology.AsTopoJSON(feature, NULL, true)
+ FROM features.big_parcels
+ WHERE feature_name IN ('P3P4')
  ORDER BY feature_name;
 
 -- Now again with edge mapping {
@@ -51,6 +68,13 @@ SELECT 'L2-edgemap', feature_name, topology.AsTopoJSON(feature, 'edgemap')
  WHERE feature_name IN ('R4', 'R1R2' )
  ORDER BY feature_name;
 
+--- Lineal smallest type
+TRUNCATE edgemap; SELECT NULLIF(setval('edgemap_arc_id_seq', 1, false), 1);
+SELECT 'L-edgemap-smallest', feature_name, topology.AsTopoJSON(feature, 'edgemap', true)
+ FROM features.big_streets
+ WHERE feature_name IN ('R4', 'R1R2' )
+ ORDER BY feature_name;
+
 --- Areal non-hierarchical
 TRUNCATE edgemap; SELECT NULLIF(setval('edgemap_arc_id_seq', 1, false), 1);
 SELECT 'A1-edgemap', feature_name, topology.AsTopoJSON(feature, 'edgemap')
@@ -63,6 +87,18 @@ TRUNCATE edgemap; SELECT NULLIF(setval('edgemap_arc_id_seq', 1, false), 1);
 SELECT 'A2-edgemap', feature_name, topology.AsTopoJSON(feature, 'edgemap')
  FROM features.big_parcels
  WHERE feature_name IN ('P1P2', 'P3P4')
+ ORDER BY feature_name;
+
+--- Areal smallest type
+TRUNCATE edgemap; SELECT NULLIF(setval('edgemap_arc_id_seq', 1, false), 1);
+SELECT 'A-edgemap-smallest', feature_name, topology.AsTopoJSON(feature, 'edgemap', true)
+ FROM features.land_parcels
+ WHERE feature_name IN ('P4', 'P5')
+ ORDER BY feature_name;
+
+SELECT 'A-edgemap-smallest', feature_name, topology.AsTopoJSON(feature, 'edgemap', true)
+ FROM features.big_parcels
+ WHERE feature_name IN ('P3P4')
  ORDER BY feature_name;
 
 DROP TABLE edgemap;
@@ -93,6 +129,11 @@ SELECT 'A3-vanilla', feature_name, topology.AsTopoJSON(feature, null)
  ORDER BY feature_name;
 
 SELECT 'P1-vanilla', feature_name, topology.AsTopoJSON(feature, null)
+ FROM features.traffic_signs
+ WHERE feature_name IN ('S2')
+ ORDER BY feature_name;
+
+SELECT 'P-smallest', feature_name, topology.AsTopoJSON(feature, null, true)
  FROM features.traffic_signs
  WHERE feature_name IN ('S2')
  ORDER BY feature_name;

--- a/topology/test/regress/topojson_expected
+++ b/topology/test/regress/topojson_expected
@@ -8,6 +8,8 @@ L1-vanilla|R3|{ "type": "MultiLineString", "arcs": [[25]]}
 L1-vanilla|R4|{ "type": "MultiLineString", "arcs": [[3]]}
 L2-vanilla|R1R2|{ "type": "MultiLineString", "arcs": [[9,-11],[4,-6]]}
 L2-vanilla|R4|{ "type": "MultiLineString", "arcs": [[3]]}
+L-smallest|R1R2|{ "type": "MultiLineString", "arcs": [[9,-11],[4,-6]]}
+L-smallest|R4|{ "type": "LineString", "arcs": [3]}
 A1-vanilla|P1|{ "type": "MultiPolygon", "arcs": [[[21,20,5,-19,-20,-12]]]}
 A1-vanilla|P2|{ "type": "MultiPolygon", "arcs": [[[19,18,6,-17,-18,-13]]]}
 A1-vanilla|P3|{ "type": "MultiPolygon", "arcs": [[[17,16,7,-15,-16,-14]]]}
@@ -15,12 +17,17 @@ A1-vanilla|P4|{ "type": "MultiPolygon", "arcs": [[[-2]]]}
 A1-vanilla|P5|{ "type": "MultiPolygon", "arcs": [[[-1],[25]]]}
 A2-vanilla|P1P2|{ "type": "MultiPolygon", "arcs": [[[21,20,5,6,-17,-18,-13,-12]]]}
 A2-vanilla|P3P4|{ "type": "MultiPolygon", "arcs": [[[-2]],[[17,16,7,-15,-16,-14]]]}
+A-smallest|P4|{ "type": "Polygon", "arcs": [[-2]]}
+A-smallest|P5|{ "type": "Polygon", "arcs": [[-1],[25]]}
+A-smallest|P3P4|{ "type": "MultiPolygon", "arcs": [[[-2]],[[17,16,7,-15,-16,-14]]]}
 L1-edgemap|R1|{ "type": "MultiLineString", "arcs": [[0,-2]]}
 L1-edgemap|R2|{ "type": "MultiLineString", "arcs": [[2,-4]]}
 L1-edgemap|R3|{ "type": "MultiLineString", "arcs": [[4]]}
 L1-edgemap|R4|{ "type": "MultiLineString", "arcs": [[5]]}
 L2-edgemap|R1R2|{ "type": "MultiLineString", "arcs": [[0,-2],[2,-4]]}
 L2-edgemap|R4|{ "type": "MultiLineString", "arcs": [[4]]}
+L-edgemap-smallest|R1R2|{ "type": "MultiLineString", "arcs": [[0,-2],[2,-4]]}
+L-edgemap-smallest|R4|{ "type": "LineString", "arcs": [4]}
 A1-edgemap|P1|{ "type": "MultiPolygon", "arcs": [[[5,4,3,-3,-2,-1]]]}
 A1-edgemap|P2|{ "type": "MultiPolygon", "arcs": [[[1,2,9,-9,-8,-7]]]}
 A1-edgemap|P3|{ "type": "MultiPolygon", "arcs": [[[7,8,13,-13,-12,-11]]]}
@@ -28,10 +35,14 @@ A1-edgemap|P4|{ "type": "MultiPolygon", "arcs": [[[-15]]]}
 A1-edgemap|P5|{ "type": "MultiPolygon", "arcs": [[[-16],[16]]]}
 A2-edgemap|P1P2|{ "type": "MultiPolygon", "arcs": [[[7,6,5,4,-4,-3,-2,-1]]]}
 A2-edgemap|P3P4|{ "type": "MultiPolygon", "arcs": [[[-9]],[[2,3,12,-12,-11,-10]]]}
+A-edgemap-smallest|P4|{ "type": "Polygon", "arcs": [[-1]]}
+A-edgemap-smallest|P5|{ "type": "Polygon", "arcs": [[-2],[2]]}
+A-edgemap-smallest|P3P4|{ "type": "MultiPolygon", "arcs": [[[-1]],[[8,7,6,-6,-5,-4]]]}
 E32
 E33
 E34
 E35
 A3-vanilla|P6|{ "type": "MultiPolygon", "arcs": [[[-33],[30,25],[1]],[[-34],[34]]]}
 P1-vanilla|S2|{"type":"MultiPoint","coordinates":[[35,14]]}
+P-smallest|S2|{"type":"Point","coordinates":[35,14]}
 Topology 'city_data' dropped


### PR DESCRIPTION
## Summary

- add an explicit `useSmallestType` option to `topology.AsTopoJSON`
- preserve the existing two-argument API as a compatibility wrapper
- cover point, line, polygon, still-multi, and `edgeMapTable` TopoJSON output in regression tests

Trac: https://trac.osgeo.org/postgis/ticket/5204

## Validation

- `./config.status --file=regress/dumper/tests.mk:regress/dumper/tests.mk.in`
- `make -j32`
- `make -C extensions/postgis_topology -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGPASSWORD=postgres PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topojson.sql"`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGPASSWORD=postgres PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/topology/test/regress/topojson.sql"`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/339
