### PR TITLE
topology: add UpdateTopologySRID

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
+ - #5863, [topology] Add UpdateTopologySRID to relabel topology primitive
+          geometry columns (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -465,6 +465,50 @@ SELECT topology.RenameTopoGeometryColumn('public.parcels', 'topogeom', 'tgeom');
 				<para><xref linkend="DropTopoGeometryColumn"/></para>
 			</refsection>
 		</refentry>
+		<refentry xml:id="UpdateTopologySRID">
+			<refnamediv>
+				<refname>UpdateTopologySRID</refname>
+				<refpurpose>Updates the SRID of a topology and its primitive geometry columns</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+						<funcdef>text <function>UpdateTopologySRID</function></funcdef>
+						<paramdef><type>name </type> <parameter>toponame</parameter></paramdef>
+						<paramdef><type>integer </type> <parameter>srid</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+                <title>Description</title>
+
+                <para>
+Updates the spatial reference identifier recorded in <varname>topology.topology</varname> and relabels the geometry columns in the topology <varname>face</varname>, <varname>node</varname>, and <varname>edge_data</varname> primitive tables. Returns a status message. This changes the SRID metadata with <xref linkend="ST_SetSRID"/>; it does not transform coordinates.
+		</para>
+
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+			</refsection>
+
+			<refsection>
+				<title>Examples</title>
+				<para>Relabel a topology from an unknown or incorrect SRID to WGS 84.</para>
+				<programlisting>SELECT topology.UpdateTopologySRID('ma_topo', 4326);</programlisting>
+			</refsection>
+
+			<refsection>
+				<title>See Also</title>
+
+				<para>
+                    <xref linkend="CreateTopology"/>,
+                    <xref linkend="GetTopologySRID"/>,
+                    <xref linkend="ST_SetSRID"/>,
+                    <xref linkend="ST_Transform"/>,
+                    <xref linkend="UpdateGeometrySRID"/>
+                </para>
+			</refsection>
+		</refentry>
 		<refentry xml:id="RenameTopology">
 			<refnamediv>
 				<refname>RenameTopology</refname>

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -150,6 +150,7 @@ topology.sql: \
 	sql/manage/RenameTopology.sql.in \
 	sql/manage/TopologySummary.sql.in \
 	sql/manage/UpgradeTopology.sql.in \
+	sql/manage/UpdateTopologySRID.sql.in \
 	sql/manage/ValidateTopologyRelation.sql.in \
 	sql/manage/ValidateTopologyPrecision.sql.in \
 	sql/manage/ValidateTopology.sql.in \

--- a/topology/sql/manage/UpdateTopologySRID.sql.in
+++ b/topology/sql/manage/UpdateTopologySRID.sql.in
@@ -1,0 +1,200 @@
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--
+-- PostGIS - Spatial Types for PostgreSQL
+-- http://postgis.net
+--
+-- Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+--
+-- This is free software; you can redistribute and/or modify it under
+-- the terms of the GNU General Public Licence. See the COPYING file.
+--
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+--{
+-- UpdateTopologySRID(toponame, srid)
+--
+-- Relabels topology primitive geometries and the topology metadata SRID.
+--
+-- Availability: 3.7.0
+--
+CREATE OR REPLACE FUNCTION topology.UpdateTopologySRID(atopology name, srid integer)
+RETURNS text
+AS
+$BODY$
+DECLARE
+  rec RECORD;
+  topo topology.topology;
+  new_srid integer := srid;
+  unknown_srid integer;
+  zsuffix text := '';
+  sql text;
+  edge_owner name;
+  edge_grants text[];
+  edge_column_grants text[];
+BEGIN
+  topo := topology.FindTopology(atopology);
+  IF topo.id IS NULL THEN
+    RAISE EXCEPTION 'Could not find topology "%"', atopology;
+  END IF;
+
+  IF topo.hasz THEN
+    zsuffix := 'z';
+  END IF;
+
+  IF new_srid > 0 THEN
+    SELECT srs.srid
+    FROM spatial_ref_sys srs
+    WHERE srs.srid = new_srid
+    INTO rec;
+
+    IF rec.srid IS NULL THEN
+      RAISE EXCEPTION 'invalid SRID: % not found in spatial_ref_sys', new_srid;
+    END IF;
+  ELSE
+    unknown_srid := ST_SRID('POINT EMPTY'::geometry);
+    IF new_srid != unknown_srid THEN
+      new_srid := unknown_srid;
+      RAISE NOTICE 'SRID value % converted to the officially unknown SRID value %', srid, new_srid;
+    END IF;
+  END IF;
+
+  SELECT pg_get_userbyid(c.relowner)
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = topo.name
+    AND c.relname = 'edge'
+  INTO edge_owner;
+
+  SELECT coalesce(array_agg(stmt ORDER BY stmt), ARRAY[]::text[])
+  FROM (
+    SELECT format(
+      'GRANT %s ON %I.edge TO %s%s',
+      string_agg(privilege_type, ', ' ORDER BY privilege_type),
+      topo.name,
+      CASE WHEN grantee = 0 THEN 'PUBLIC' ELSE format('%I', grantee_role.rolname) END,
+      CASE WHEN is_grantable THEN ' WITH GRANT OPTION' ELSE '' END
+    ) AS stmt
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    CROSS JOIN LATERAL aclexplode(c.relacl) acl
+    LEFT JOIN pg_roles grantee_role ON grantee_role.oid = acl.grantee
+    WHERE n.nspname = topo.name
+      AND c.relname = 'edge'
+      AND acl.grantee <> c.relowner
+    GROUP BY grantee, grantee_role.rolname, is_grantable
+  ) grants
+  INTO edge_grants;
+
+  SELECT coalesce(array_agg(stmt ORDER BY stmt), ARRAY[]::text[])
+  FROM (
+    SELECT format(
+      'GRANT %s (%I) ON %I.edge TO %s%s',
+      string_agg(privilege_type, ', ' ORDER BY privilege_type),
+      a.attname,
+      topo.name,
+      CASE WHEN grantee = 0 THEN 'PUBLIC' ELSE format('%I', grantee_role.rolname) END,
+      CASE WHEN is_grantable THEN ' WITH GRANT OPTION' ELSE '' END
+    ) AS stmt
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid
+    CROSS JOIN LATERAL aclexplode(a.attacl) acl
+    LEFT JOIN pg_roles grantee_role ON grantee_role.oid = acl.grantee
+    WHERE n.nspname = topo.name
+      AND c.relname = 'edge'
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+      AND acl.grantee <> c.relowner
+    GROUP BY a.attnum, a.attname, grantee, grantee_role.rolname, is_grantable
+  ) grants
+  INTO edge_column_grants;
+
+  sql := format(
+    $$
+      -- PostgreSQL blocks ALTER COLUMN TYPE while the edge view rule
+      -- depends on edge_data.geom. Drop without CASCADE so external
+      -- dependents stop the change, then restore owner and grants below.
+      DROP VIEW %1$I.edge;
+
+      ALTER TABLE %1$I.face
+        ALTER COLUMN mbr TYPE geometry(polygon, %2$L)
+        USING ST_SetSRID(mbr, %2$L);
+
+      ALTER TABLE %1$I.node
+        ALTER COLUMN geom TYPE geometry(point%3$s, %2$L)
+        USING ST_SetSRID(geom, %2$L);
+
+      ALTER TABLE %1$I.edge_data
+        ALTER COLUMN geom TYPE geometry(linestring%3$s, %2$L)
+        USING ST_SetSRID(geom, %2$L);
+
+      CREATE VIEW %1$I.edge AS
+      SELECT
+        edge_id, start_node, end_node, next_left_edge,
+        next_right_edge, left_face, right_face, geom
+      FROM %1$I.edge_data;
+
+      COMMENT ON VIEW %1$I.edge IS
+      'Contains edge topology primitives';
+      COMMENT ON COLUMN %1$I.edge.edge_id IS
+      'Unique identifier of the edge';
+      COMMENT ON COLUMN %1$I.edge.start_node IS
+      'Unique identifier of the node at the start of the edge';
+      COMMENT ON COLUMN %1$I.edge.end_node IS
+      'Unique identifier of the node at the end of the edge';
+      COMMENT ON COLUMN %1$I.edge.next_left_edge IS
+      'Unique identifier of the next edge of the face on the left (when looking in the direction from START_NODE to END_NODE), moving counterclockwise around the face boundary';
+      COMMENT ON COLUMN %1$I.edge.next_right_edge IS
+      'Unique identifier of the next edge of the face on the right (when looking in the direction from START_NODE to END_NODE), moving counterclockwise around the face boundary';
+      COMMENT ON COLUMN %1$I.edge.left_face IS
+      'Unique identifier of the face on the left side of the edge when looking in the direction from START_NODE to END_NODE';
+      COMMENT ON COLUMN %1$I.edge.right_face IS
+      'Unique identifier of the face on the right side of the edge when looking in the direction from START_NODE to END_NODE';
+      COMMENT ON COLUMN %1$I.edge.geom IS
+      'The geometry of the edge';
+
+      CREATE RULE edge_insert_rule AS
+      ON INSERT TO %1$I.edge
+      DO INSTEAD INSERT into %1$I.edge_data
+      VALUES (
+        NEW.edge_id, NEW.start_node, NEW.end_node,
+        NEW.next_left_edge, abs(NEW.next_left_edge),
+        NEW.next_right_edge, abs(NEW.next_right_edge),
+        NEW.left_face, NEW.right_face, NEW.geom
+      );
+
+      UPDATE topology.topology
+      SET srid = %2$L
+      WHERE id = %4$L;
+    $$,
+    topo.name,
+    new_srid,
+    zsuffix,
+    topo.id
+  );
+
+  EXECUTE sql;
+
+  IF edge_owner IS NOT NULL THEN
+    EXECUTE format('ALTER VIEW %I.edge OWNER TO %I', topo.name, edge_owner);
+  END IF;
+
+  FOREACH sql IN ARRAY edge_grants
+  LOOP
+    EXECUTE sql;
+  END LOOP;
+
+  FOREACH sql IN ARRAY edge_column_grants
+  LOOP
+    EXECUTE sql;
+  END LOOP;
+
+  RETURN format(
+    'Topology %L SRID changed to %s',
+    topo.name,
+    new_srid
+  );
+END
+$BODY$
+LANGUAGE 'plpgsql' VOLATILE STRICT;
+--} UpdateTopologySRID

--- a/topology/test/regress/updatetopologysrid.sql
+++ b/topology/test/regress/updatetopologysrid.sql
@@ -1,0 +1,84 @@
+set client_min_messages to WARNING;
+
+DROP SCHEMA IF EXISTS t5863_feat CASCADE;
+DROP SCHEMA IF EXISTS t5863 CASCADE;
+DROP SCHEMA IF EXISTS t5863_unknown CASCADE;
+DROP SCHEMA IF EXISTS t5863z CASCADE;
+DROP ROLE IF EXISTS t5863_reader;
+DROP ROLE IF EXISTS t5863_column_reader;
+DELETE FROM topology.topology WHERE name = 't5863';
+DELETE FROM topology.topology WHERE name = 't5863_unknown';
+DELETE FROM topology.topology WHERE name = 't5863z';
+
+CREATE ROLE t5863_reader;
+CREATE ROLE t5863_column_reader;
+
+SELECT 'create', topology.CreateTopology('t5863', 4326) > 0;
+SELECT 'node1', topology.ST_AddIsoNode('t5863', 0, 'SRID=4326;POINT(0 0)'::geometry);
+SELECT 'node2', topology.ST_AddIsoNode('t5863', 0, 'SRID=4326;POINT(1 1)'::geometry);
+SELECT 'edge', topology.ST_AddIsoEdge('t5863', 1, 2, 'SRID=4326;LINESTRING(0 0, 1 1)'::geometry);
+UPDATE t5863.face SET mbr = ST_MakeEnvelope(0, 0, 1, 1, 4326) WHERE face_id = 0;
+GRANT SELECT ON t5863.edge TO t5863_reader;
+GRANT SELECT (geom) ON t5863.edge TO t5863_column_reader;
+
+CREATE SCHEMA t5863_feat;
+CREATE TABLE t5863_feat.lines(id integer);
+SELECT 'layer', topology.AddTopoGeometryColumn('t5863', 't5863_feat', 'lines', 'tg', 'LINE');
+INSERT INTO t5863_feat.lines(id, tg)
+VALUES (1, topology.CreateTopoGeom('t5863', 2, 1, '{{1,2}}'::topology.TopoElementArray));
+
+SELECT 'before-topology',
+  topology.GetTopologySRID('t5863'),
+  (SELECT ST_Srid(tg) FROM t5863_feat.lines WHERE id = 1);
+SELECT 'before-primitives',
+  (SELECT DISTINCT ST_SRID(geom) FROM t5863.node),
+  (SELECT DISTINCT ST_SRID(geom) FROM t5863.edge_data),
+  (SELECT DISTINCT ST_SRID(mbr) FROM t5863.face WHERE mbr IS NOT NULL);
+SELECT 'before-typmods',
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863.node'::regclass AND attname = 'geom'),
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863.edge_data'::regclass AND attname = 'geom'),
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863.face'::regclass AND attname = 'mbr');
+
+SELECT 'update', topology.UpdateTopologySRID('t5863', 3857);
+
+SELECT 'after-topology',
+  topology.GetTopologySRID('t5863'),
+  (SELECT ST_Srid(tg) FROM t5863_feat.lines WHERE id = 1);
+SELECT 'after-primitives',
+  (SELECT DISTINCT ST_SRID(geom) FROM t5863.node),
+  (SELECT DISTINCT ST_SRID(geom) FROM t5863.edge_data),
+  (SELECT DISTINCT ST_SRID(mbr) FROM t5863.face WHERE mbr IS NOT NULL);
+SELECT 'after-typmods',
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863.node'::regclass AND attname = 'geom'),
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863.edge_data'::regclass AND attname = 'geom'),
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863.face'::regclass AND attname = 'mbr');
+SELECT 'edge-grant',
+  has_table_privilege('t5863_reader', 't5863.edge', 'SELECT');
+SELECT 'edge-column-grant',
+  has_table_privilege('t5863_column_reader', 't5863.edge', 'SELECT'),
+  has_column_privilege('t5863_column_reader', 't5863.edge', 'geom', 'SELECT');
+
+INSERT INTO t5863.edge(edge_id, start_node, end_node, next_left_edge, next_right_edge, left_face, right_face, geom)
+VALUES (2, 2, 1, -2, 2, 0, 0, 'SRID=3857;LINESTRING(1 1, 0 0)'::geometry);
+SELECT 'view-insert', edge_id, ST_SRID(geom), abs_next_left_edge, abs_next_right_edge
+FROM t5863.edge_data
+WHERE edge_id = 2;
+
+SELECT 'create-z', topology.CreateTopology('t5863z', 4326, 0, true) > 0;
+SELECT 'update-z', topology.UpdateTopologySRID('t5863z', 3857);
+SELECT 'z-typmods',
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863z.node'::regclass AND attname = 'geom'),
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863z.edge_data'::regclass AND attname = 'geom'),
+  (SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid = 't5863z.face'::regclass AND attname = 'mbr');
+
+SELECT 'create-unknown', topology.CreateTopology('t5863_unknown', 4326) > 0;
+SELECT 'invalid-srid', topology.UpdateTopologySRID('t5863_unknown', 999000);
+SELECT 'unknown-srid', topology.UpdateTopologySRID('t5863_unknown', 0);
+SELECT 'after-unknown-srid', topology.GetTopologySRID('t5863_unknown');
+
+SELECT topology.DropTopology('t5863_unknown');
+SELECT topology.DropTopology('t5863z');
+SELECT topology.DropTopology('t5863');
+DROP SCHEMA t5863_feat CASCADE;
+DROP ROLE t5863_column_reader;
+DROP ROLE t5863_reader;

--- a/topology/test/regress/updatetopologysrid_expected
+++ b/topology/test/regress/updatetopologysrid_expected
@@ -1,0 +1,25 @@
+create|t
+node1|1
+node2|2
+edge|1
+layer|1
+before-topology|4326|4326
+before-primitives|4326|4326|4326
+before-typmods|geometry(Point,4326)|geometry(LineString,4326)|geometry(Polygon,4326)
+update|Topology 't5863' SRID changed to 3857
+after-topology|3857|3857
+after-primitives|3857|3857|3857
+after-typmods|geometry(Point,3857)|geometry(LineString,3857)|geometry(Polygon,3857)
+edge-grant|t
+edge-column-grant|f|t
+view-insert|2|3857|2|2
+create-z|t
+update-z|Topology 't5863z' SRID changed to 3857
+z-typmods|geometry(PointZ,3857)|geometry(LineStringZ,3857)|geometry(Polygon,3857)
+create-unknown|t
+ERROR:  invalid SRID: 999000 not found in spatial_ref_sys
+unknown-srid|Topology 't5863_unknown' SRID changed to 0
+after-unknown-srid|0
+Topology 't5863_unknown' dropped
+Topology 't5863z' dropped
+Topology 't5863' dropped

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -92,6 +92,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/topologysummary.sql \
 	$(top_srcdir)/topology/test/regress/totaltopologysize.sql \
 	$(top_srcdir)/topology/test/regress/totopogeom.sql \
+	$(top_srcdir)/topology/test/regress/updatetopologysrid.sql \
 	$(top_srcdir)/topology/test/regress/upgradetopology.sql \
 	$(top_srcdir)/topology/test/regress/validatetopologyprecision.sql \
 	$(top_srcdir)/topology/test/regress/validatetopologyrelation.sql \

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -51,6 +51,10 @@
 --    Delete a topology removing reference from the
 --    topology.topology table
 --
+-- FUNCTION UpdateTopologySRID(name, srid)
+--    Update the spatial reference identifier of a topology and relabel
+--    geometries in the topology primitive tables.
+--
 -- FUNCTION GetTopologyId(name)
 -- FUNCTION GetTopologySRID(name)
 -- FUNCTION GetTopologyName(id)
@@ -1427,6 +1431,7 @@ LANGUAGE 'plpgsql' VOLATILE STRICT;
 #include "sql/manage/MakeTopologyPrecise.sql.in"
 #include "sql/manage/TotalTopologySize.sql.in"
 #include "sql/manage/UpgradeTopology.sql.in"
+#include "sql/manage/UpdateTopologySRID.sql.in"
 
 -- Cleanup functions
 #include "sql/cleanup/RemoveUnusedPrimitives.sql.in"


### PR DESCRIPTION
## Summary

Adds `topology.UpdateTopologySRID(toponame, srid)` for https://trac.osgeo.org/postgis/ticket/5863.

The function relabels a topology SRID in `topology.topology` and retags the primitive geometry columns in `face`, `node`, and `edge_data` using `ST_SetSRID`, without transforming coordinates. It preserves 3D topology typmods.

PostgreSQL does not allow the `edge_data.geom` typmod change while the standard `edge` view rule depends on that column, so the function recreates the standard `edge` view and insert rule without `CASCADE`. It restores the view owner, relation-level grants, and column-level grants after recreation, and the regression test checks grant survival.

The regression avoids assumptions about global `topology.topology_id_seq` values so it can run inside the shared topology regression database. It also covers invalid positive SRIDs and normalization of non-positive SRIDs to the official unknown SRID value.

## Validation

- `./utils/check_news.sh .`
- `make -C topology all`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/updatetopologysrid"`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose --after-create-db-script ../../regress/hooks/standard-conforming-strings-off.sql' TESTS="$(pwd)/topology/test/regress/updatetopologysrid"`
- `make -C doc check`
- `git diff --check upstream/master..HEAD`
- `git diff --check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/337
