### PR TITLE
topology: accept records in TopoGeo population functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,6 +71,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #5668, [topology] Allow TopoGeo population functions to accept
+          topology records (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1691,6 +1691,12 @@ Adds a point to an existing topology using a tolerance and possibly splitting an
 						<paramdef><type>geometry </type> <parameter>apoint</parameter></paramdef>
 						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
 					</funcprototype>
+					<funcprototype>
+						<funcdef>bigint <function>TopoGeo_AddPoint</function></funcdef>
+						<paramdef><type>topology.topology </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>geometry </type> <parameter>apoint</parameter></paramdef>
+						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
+					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
 
@@ -1705,6 +1711,7 @@ An existing edge may be split by the snapped point.
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="2.0.0">Availability: 2.0.0</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for passing a topology record.</para>
 			</refsection>
 
 
@@ -1735,6 +1742,13 @@ Adds a linestring to an existing topology using a tolerance and possibly splitti
 					<funcprototype>
 						<funcdef>SETOF bigint <function>TopoGeo_AddLineString</function></funcdef>
 						<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>geometry </type> <parameter>aline</parameter></paramdef>
+						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
+						<paramdef choice="opt"><type>int </type> <parameter>max_edges</parameter></paramdef>
+					</funcprototype>
+					<funcprototype>
+						<funcdef>SETOF bigint <function>TopoGeo_AddLineString</function></funcdef>
+						<paramdef><type>topology.topology </type> <parameter>atopology</parameter></paramdef>
 						<paramdef><type>geometry </type> <parameter>aline</parameter></paramdef>
 						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
 						<paramdef choice="opt"><type>int </type> <parameter>max_edges</parameter></paramdef>
@@ -1776,6 +1790,7 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
                 <para role="availability" conformance="2.0.0">Availability: 2.0.0</para>
                 <para role="enhanced" conformance="3.2.0">Enhanced: 3.2.0 added support for returning signed identifier.</para>
                 <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for limiting the number of new edges created in the topology.</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for passing a topology record.</para>
 			</refsection>
 
 
@@ -1807,6 +1822,12 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
 						<paramdef><type>geometry </type> <parameter>apoly</parameter></paramdef>
 						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
 					</funcprototype>
+					<funcprototype>
+						<funcdef>SETOF bigint <function>TopoGeo_AddPolygon</function></funcdef>
+						<paramdef><type>topology.topology </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>geometry </type> <parameter>apoly</parameter></paramdef>
+						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
+					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
 
@@ -1826,6 +1847,7 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="2.0.0">Availability: 2.0.0</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for passing a topology record.</para>
 			</refsection>
 
 
@@ -1857,6 +1879,12 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
 						<paramdef><type>geometry </type> <parameter>ageom</parameter></paramdef>
 						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
 					</funcprototype>
+					<funcprototype>
+						<funcdef>void <function>TopoGeo_LoadGeometry</function></funcdef>
+						<paramdef><type>topology.topology </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>geometry </type> <parameter>ageom</parameter></paramdef>
+						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
+					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
 
@@ -1876,6 +1904,7 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="3.5.0">Availability: 3.5.0</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for passing a topology record.</para>
 			</refsection>
 
 

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -21,6 +21,7 @@
 #include "lib/stringinfo.h"
 #include "access/htup_details.h" /* for heap_form_tuple() */
 #include "access/xact.h" /* for RegisterXactCallback */
+#include "executor/executor.h" /* for GetAttributeByName() */
 #include "funcapi.h" /* for FuncCallContext */
 #include "executor/spi.h" /* this is what you need to work with SPI */
 #include "inttypes.h" /* for PRId64 */
@@ -28,6 +29,7 @@
 
 #include "liblwgeom_internal.h" /* for gbox_clone */
 #include "topo/liblwgeom_topo.h"
+#include "topo/liblwgeom_topo_internal.h"
 
 /*#define POSTGIS_DEBUG_LEVEL 1*/
 #include "lwgeom_log.h"
@@ -95,6 +97,8 @@ struct LWT_BE_TOPOLOGY_T
   bool usesLargeIDs;
   Oid geometryOID;
 };
+
+static int cb_freeTopology(LWT_BE_TOPOLOGY *topo);
 
 /* utility funx */
 
@@ -297,6 +301,101 @@ cb_loadTopologyByName(const LWT_BE_DATA* be, const char *name)
   SPI_freetuptable(SPI_tuptable);
 
   return topo;
+}
+
+static LWT_TOPOLOGY *
+lwt_LoadTopologyByRecord(HeapTupleHeader rec)
+{
+	Datum dat;
+	bool isnull;
+	LWT_BE_TOPOLOGY *be_topo;
+	LWT_TOPOLOGY *topo;
+
+	be_topo = palloc0(sizeof(LWT_BE_TOPOLOGY));
+	be_topo->be_data = &be_data;
+
+	dat = GetAttributeByName(rec, "name", &isnull);
+	if (isnull)
+	{
+		pfree(be_topo);
+		lwpgerror("Topology record has null name");
+		return NULL;
+	}
+	be_topo->name = TextDatumGetCString(dat);
+
+	dat = GetAttributeByName(rec, "id", &isnull);
+	if (isnull)
+	{
+		char *toponame = pstrdup(be_topo->name);
+		cb_freeTopology(be_topo);
+		lwpgerror("Topology record \"%s\" has null identifier", toponame);
+		pfree(toponame);
+		return NULL;
+	}
+	be_topo->id = DatumGetInt32(dat);
+
+	dat = GetAttributeByName(rec, "srid", &isnull);
+	if (isnull)
+	{
+		char *toponame = pstrdup(be_topo->name);
+		cb_freeTopology(be_topo);
+		lwpgerror("Topology record \"%s\" has null SRID", toponame);
+		pfree(toponame);
+		return NULL;
+	}
+	be_topo->srid = DatumGetInt32(dat);
+	if (be_topo->srid < 0)
+	{
+		lwnotice(
+		    "Topology SRID value %d converted to "
+		    "the officially unknown SRID value %d",
+		    be_topo->srid,
+		    SRID_UNKNOWN);
+		be_topo->srid = SRID_UNKNOWN;
+	}
+
+	dat = GetAttributeByName(rec, "precision", &isnull);
+	if (isnull)
+	{
+		lwnotice("Topology record \"%s\" has null precision, taking as 0", be_topo->name);
+		be_topo->precision = 0;
+	}
+	else
+	{
+		be_topo->precision = DatumGetFloat8(dat);
+	}
+
+	dat = GetAttributeByName(rec, "hasz", &isnull);
+	if (!isnull)
+	{
+		be_topo->hasZ = DatumGetBool(dat);
+	}
+
+	dat = GetAttributeByName(rec, "useslargeids", &isnull);
+	if (!isnull)
+	{
+		be_topo->usesLargeIDs = DatumGetBool(dat);
+	}
+
+	postgis_initialize_cache();
+	be_topo->geometryOID = postgis_oid(GEOMETRYOID);
+
+	topo = lwalloc(sizeof(LWT_TOPOLOGY));
+	topo->be_iface = be_iface;
+	topo->be_topo = be_topo;
+	topo->srid = be_topo->srid;
+	topo->hasZ = be_topo->hasZ;
+	topo->precision = be_topo->precision;
+
+	POSTGIS_DEBUGF(1,
+		       "lwt_LoadTopologyByRecord: topo '%s' has "
+		       "id %d, srid %d, precision %g",
+		       be_topo->name,
+		       be_topo->id,
+		       be_topo->srid,
+		       be_topo->precision);
+
+	return topo;
 }
 
 static int
@@ -5147,10 +5246,8 @@ Datum GetFaceByPoint(PG_FUNCTION_ARGS)
   PG_RETURN_INT64(node_id);
 }
 
-/*  TopoGeo_AddPoint(atopology, point, tolerance) */
-Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(TopoGeo_AddPoint);
-Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
+static Datum
+TopoGeo_AddPoint_impl(FunctionCallInfo fcinfo, bool topology_record)
 {
   text* toponame_text;
   char* toponame;
@@ -5166,10 +5263,6 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
     lwpgerror("SQL/MM Spatial exception - null argument");
     PG_RETURN_NULL();
   }
-
-  toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text_to_cstring(toponame_text);
-  PG_FREE_IF_COPY(toponame_text, 0);
 
   geom = PG_GETARG_GSERIALIZED_P(1);
   lwgeom = lwgeom_from_gserialized(geom);
@@ -5204,10 +5297,20 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   {
     int pre = be_data.topoLoadFailMessageFlavor;
     be_data.topoLoadFailMessageFlavor = 1;
-    topo = lwt_LoadTopology(be_iface, toponame);
+    if (topology_record)
+    {
+	    topo = lwt_LoadTopologyByRecord(PG_GETARG_HEAPTUPLEHEADER(0));
+    }
+    else
+    {
+	    toponame_text = PG_GETARG_TEXT_P(0);
+	    toponame = text_to_cstring(toponame_text);
+	    PG_FREE_IF_COPY(toponame_text, 0);
+	    topo = lwt_LoadTopology(be_iface, toponame);
+	    pfree(toponame);
+    }
     be_data.topoLoadFailMessageFlavor = pre;
   }
-  pfree(toponame);
   if ( ! topo )
   {
     /* should never reach this point, as lwerror would raise an exception */
@@ -5233,10 +5336,25 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   PG_RETURN_INT64(node_id);
 }
 
-/*  TopoGeo_AddLinestring(atopology, point, tolerance) */
-Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(TopoGeo_AddLinestring);
-Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
+/*  TopoGeo_AddPoint(atopology, point, tolerance) */
+Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPoint);
+Datum
+TopoGeo_AddPoint(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPoint_impl(fcinfo, false);
+}
+
+Datum TopoGeo_AddPointTopology(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPointTopology);
+Datum
+TopoGeo_AddPointTopology(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPoint_impl(fcinfo, true);
+}
+
+static Datum
+TopoGeo_AddLinestring_impl(FunctionCallInfo fcinfo, bool topology_record)
 {
   text* toponame_text;
   char* toponame;
@@ -5270,10 +5388,6 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     {
       max_new_edges = PG_GETARG_INT32(3);
     }
-
-    toponame_text = PG_GETARG_TEXT_P(0);
-    toponame = text_to_cstring(toponame_text);
-    PG_FREE_IF_COPY(toponame_text, 0);
 
     geom = PG_GETARG_GSERIALIZED_P(1);
     lwgeom = lwgeom_from_gserialized(geom);
@@ -5318,11 +5432,21 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     {
       int pre = be_data.topoLoadFailMessageFlavor;
       be_data.topoLoadFailMessageFlavor = 1;
-      topo = lwt_LoadTopology(be_iface, toponame);
+      if (topology_record)
+      {
+	      topo = lwt_LoadTopologyByRecord(PG_GETARG_HEAPTUPLEHEADER(0));
+      }
+      else
+      {
+	      toponame_text = PG_GETARG_TEXT_P(0);
+	      toponame = text_to_cstring(toponame_text);
+	      PG_FREE_IF_COPY(toponame_text, 0);
+	      topo = lwt_LoadTopology(be_iface, toponame);
+	      pfree(toponame);
+      }
       be_data.topoLoadFailMessageFlavor = pre;
     }
-    oldcontext = MemoryContextSwitchTo( newcontext );
-    pfree(toponame);
+    oldcontext = MemoryContextSwitchTo(newcontext);
     if ( ! topo )
     {
       /* should never reach this point, as lwerror would raise an exception */
@@ -5381,6 +5505,23 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
   result = Int64GetDatum((int64)id);
 
   SRF_RETURN_NEXT(funcctx, result);
+}
+
+/*  TopoGeo_AddLinestring(atopology, point, tolerance) */
+Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddLinestring);
+Datum
+TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddLinestring_impl(fcinfo, false);
+}
+
+Datum TopoGeo_AddLinestringTopology(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddLinestringTopology);
+Datum
+TopoGeo_AddLinestringTopology(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddLinestring_impl(fcinfo, true);
 }
 
 /*  _TopoGeo_AddLinestringNoFace(atopology, point, tolerance) */
@@ -5457,10 +5598,8 @@ Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS)
   PG_RETURN_VOID();
 }
 
-/*  TopoGeo_AddPolygon(atopology, poly, tolerance) */
-Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(TopoGeo_AddPolygon);
-Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
+static Datum
+TopoGeo_AddPolygon_impl(FunctionCallInfo fcinfo, bool topology_record)
 {
   text* toponame_text;
   char* toponame;
@@ -5488,10 +5627,6 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
       lwpgerror("SQL/MM Spatial exception - null argument");
       PG_RETURN_NULL();
     }
-
-    toponame_text = PG_GETARG_TEXT_P(0);
-    toponame = text_to_cstring(toponame_text);
-    PG_FREE_IF_COPY(toponame_text, 0);
 
     geom = PG_GETARG_GSERIALIZED_P(1);
     lwgeom = lwgeom_from_gserialized(geom);
@@ -5526,11 +5661,21 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
     {
       int pre = be_data.topoLoadFailMessageFlavor;
       be_data.topoLoadFailMessageFlavor = 1;
-      topo = lwt_LoadTopology(be_iface, toponame);
+      if (topology_record)
+      {
+	      topo = lwt_LoadTopologyByRecord(PG_GETARG_HEAPTUPLEHEADER(0));
+      }
+      else
+      {
+	      toponame_text = PG_GETARG_TEXT_P(0);
+	      toponame = text_to_cstring(toponame_text);
+	      PG_FREE_IF_COPY(toponame_text, 0);
+	      topo = lwt_LoadTopology(be_iface, toponame);
+	      pfree(toponame);
+      }
       be_data.topoLoadFailMessageFlavor = pre;
     }
-    oldcontext = MemoryContextSwitchTo( newcontext );
-    pfree(toponame);
+    oldcontext = MemoryContextSwitchTo(newcontext);
     if ( ! topo )
     {
       /* should never reach this point, as lwerror would raise an exception */
@@ -5588,6 +5733,23 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
   result = Int64GetDatum((int64)id);
 
   SRF_RETURN_NEXT(funcctx, result);
+}
+
+/*  TopoGeo_AddPolygon(atopology, poly, tolerance) */
+Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPolygon);
+Datum
+TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPolygon_impl(fcinfo, false);
+}
+
+Datum TopoGeo_AddPolygonTopology(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_AddPolygonTopology);
+Datum
+TopoGeo_AddPolygonTopology(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_AddPolygon_impl(fcinfo, true);
 }
 
 /*  GetRingEdges(atopology, anedge, maxedges default null) */
@@ -5835,10 +5997,8 @@ Datum RegisterMissingFaces(PG_FUNCTION_ARGS)
   PG_RETURN_NULL();
 }
 
-/*  TopoGeo_LoadGeometry(atopology, geom, tolerance) */
-Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(TopoGeo_LoadGeometry);
-Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
+static Datum
+TopoGeo_LoadGeometry_impl(FunctionCallInfo fcinfo, bool topology_record)
 {
   text* toponame_text;
   char* toponame;
@@ -5852,10 +6012,6 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
     lwpgerror("SQL/MM Spatial exception - null argument");
     PG_RETURN_NULL();
   }
-
-  toponame_text = PG_GETARG_TEXT_P(0);
-  toponame = text_to_cstring(toponame_text);
-  PG_FREE_IF_COPY(toponame_text, 0);
 
   geom = PG_GETARG_GSERIALIZED_P(1);
 
@@ -5873,8 +6029,18 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
     PG_RETURN_NULL();
   }
 
-  topo = lwt_LoadTopology(be_iface, toponame);
-  pfree(toponame);
+  if (topology_record)
+  {
+	  topo = lwt_LoadTopologyByRecord(PG_GETARG_HEAPTUPLEHEADER(0));
+  }
+  else
+  {
+	  toponame_text = PG_GETARG_TEXT_P(0);
+	  toponame = text_to_cstring(toponame_text);
+	  PG_FREE_IF_COPY(toponame_text, 0);
+	  topo = lwt_LoadTopology(be_iface, toponame);
+	  pfree(toponame);
+  }
   if ( ! topo )
   {
     /* should never reach this point, as lwerror would raise an exception */
@@ -5900,6 +6066,23 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
   SPI_finish();
 
   PG_RETURN_VOID();
+}
+
+/*  TopoGeo_LoadGeometry(atopology, geom, tolerance) */
+Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_LoadGeometry);
+Datum
+TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_LoadGeometry_impl(fcinfo, false);
+}
+
+Datum TopoGeo_LoadGeometryTopology(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(TopoGeo_LoadGeometryTopology);
+Datum
+TopoGeo_LoadGeometryTopology(PG_FUNCTION_ARGS)
+{
+	return TopoGeo_LoadGeometry_impl(fcinfo, true);
 }
 
 /*  TopoGeo_LoadGeometry(atopology, geom, tolerance) */

--- a/topology/sql/populate.sql.in
+++ b/topology/sql/populate.sql.in
@@ -733,6 +733,11 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPoint(atopology varchar, apoint g
 	RETURNS bigint AS
 	'MODULE_PATHNAME', 'TopoGeo_AddPoint'
   LANGUAGE 'c' VOLATILE;
+
+CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPoint(atopology topology.topology, apoint geometry, tolerance float8 DEFAULT -1)
+	RETURNS bigint AS
+	'MODULE_PATHNAME', 'TopoGeo_AddPointTopology'
+  LANGUAGE 'c' VOLATILE;
 --} TopoGeo_AddPoint
 
 --{
@@ -746,6 +751,11 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPoint(atopology varchar, apoint g
 CREATE OR REPLACE FUNCTION topology.TopoGeo_AddLinestring(atopology varchar, aline geometry, tolerance float8 DEFAULT -1, max_edges int DEFAULT -1)
 	RETURNS SETOF bigint AS
 	'MODULE_PATHNAME', 'TopoGeo_AddLinestring'
+  LANGUAGE 'c' VOLATILE;
+
+CREATE OR REPLACE FUNCTION topology.TopoGeo_AddLinestring(atopology topology.topology, aline geometry, tolerance float8 DEFAULT -1, max_edges int DEFAULT -1)
+	RETURNS SETOF bigint AS
+	'MODULE_PATHNAME', 'TopoGeo_AddLinestringTopology'
   LANGUAGE 'c' VOLATILE;
 --} TopoGeo_addLinestring
 
@@ -761,6 +771,11 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPolygon(atopology varchar, apoly 
 	RETURNS SETOF bigint AS
 	'MODULE_PATHNAME', 'TopoGeo_AddPolygon'
   LANGUAGE 'c' VOLATILE;
+
+CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPolygon(atopology topology.topology, apoly geometry, tolerance float8 DEFAULT -1)
+	RETURNS SETOF bigint AS
+	'MODULE_PATHNAME', 'TopoGeo_AddPolygonTopology'
+  LANGUAGE 'c' VOLATILE;
 --} TopoGeo_AddPolygon
 
 --{
@@ -774,6 +789,11 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddPolygon(atopology varchar, apoly 
 CREATE OR REPLACE FUNCTION topology.TopoGeo_LoadGeometry(atopology varchar, ageom geometry, tolerance float8 DEFAULT -1)
 	RETURNS void AS
 	'MODULE_PATHNAME', 'TopoGeo_LoadGeometry'
+  LANGUAGE 'c' VOLATILE;
+
+CREATE OR REPLACE FUNCTION topology.TopoGeo_LoadGeometry(atopology topology.topology, ageom geometry, tolerance float8 DEFAULT -1)
+	RETURNS void AS
+	'MODULE_PATHNAME', 'TopoGeo_LoadGeometryTopology'
   LANGUAGE 'c' VOLATILE;
 --} TopoGeo_LoadGeometry
 

--- a/topology/test/regress/topogeo_record_population.sql
+++ b/topology/test/regress/topogeo_record_population.sql
@@ -1,0 +1,66 @@
+\set VERBOSITY terse
+set client_min_messages to ERROR;
+
+SELECT NULL FROM topology.CreateTopology('t5668_record', 0);
+
+CREATE TEMP TABLE t5668_saved_topology AS
+SELECT id, name, srid, precision, hasz, useslargeids
+FROM topology.topology
+WHERE name = 't5668_record';
+
+CREATE FUNCTION pg_temp.t5668_addpoint_result(t topology.topology)
+RETURNS text AS $$
+BEGIN
+  PERFORM topology.TopoGeo_AddPoint(t, 'POINT(0 0)'::geometry);
+  RETURN 'unexpected success';
+EXCEPTION WHEN OTHERS THEN
+  RETURN SQLERRM;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT 'null id',
+       pg_temp.t5668_addpoint_result((NULL, 't5668_record', 0, 0, false, false)::topology.topology);
+
+SELECT 'null srid',
+       pg_temp.t5668_addpoint_result((0, 't5668_record', NULL, 0, false, false)::topology.topology);
+
+DELETE FROM topology.topology
+WHERE name = 't5668_record';
+
+WITH topo AS (
+  SELECT (id, name, srid, precision, hasz, useslargeids)::topology.topology AS t
+  FROM t5668_saved_topology
+)
+SELECT 'point', topology.TopoGeo_AddPoint(t, 'POINT(0 0)'::geometry)
+FROM topo;
+
+WITH topo AS (
+  SELECT (id, name, srid, precision, hasz, useslargeids)::topology.topology AS t
+  FROM t5668_saved_topology
+)
+SELECT 'line', array_agg(edge_id ORDER BY edge_id)
+FROM topo, topology.TopoGeo_AddLineString(t, 'LINESTRING(1 0, 2 0)'::geometry) AS edge_id;
+
+WITH topo AS (
+  SELECT (id, name, srid, precision, hasz, useslargeids)::topology.topology AS t
+  FROM t5668_saved_topology
+)
+SELECT 'polygon', array_agg(face_id ORDER BY face_id)
+FROM topo, topology.TopoGeo_AddPolygon(t, 'POLYGON((10 10, 11 10, 11 11, 10 11, 10 10))'::geometry) AS face_id;
+
+WITH topo AS (
+  SELECT (id, name, srid, precision, hasz, useslargeids)::topology.topology AS t
+  FROM t5668_saved_topology
+)
+SELECT 'load', topology.TopoGeo_LoadGeometry(t, 'GEOMETRYCOLLECTION(POINT(20 20), LINESTRING(20 20, 21 20))'::geometry)
+FROM topo;
+
+SELECT 'counts',
+       (SELECT count(*) FROM t5668_record.node),
+       (SELECT count(*) FROM t5668_record.edge_data),
+       (SELECT count(*) FROM t5668_record.face WHERE face_id > 0);
+
+INSERT INTO topology.topology
+SELECT * FROM t5668_saved_topology;
+
+SELECT NULL FROM topology.DropTopology('t5668_record');

--- a/topology/test/regress/topogeo_record_population_expected
+++ b/topology/test/regress/topogeo_record_population_expected
@@ -1,0 +1,7 @@
+null id|Topology record "t5668_record" has null identifier
+null srid|Topology record "t5668_record" has null SRID
+point|1
+line|{1}
+polygon|{1}
+load|
+counts|6|3|1

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -82,6 +82,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/topogeo_addpoint_merge_edges.sql \
 	$(top_srcdir)/topology/test/regress/topogeo_addpoint.sql \
 	$(top_srcdir)/topology/test/regress/topogeo_addpolygon.sql \
+	$(top_srcdir)/topology/test/regress/topogeo_record_population.sql \
 	$(top_srcdir)/topology/test/regress/topogeo_loadgeometry.sql \
 	$(top_srcdir)/topology/test/regress/topogeom_addtopogeom.sql \
 	$(top_srcdir)/topology/test/regress/topogeom_edit.sql \
@@ -101,4 +102,3 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/verifylargeids.sql \
 	$(top_srcdir)/topology/test/regress/fix_topogeometry_columns.sql \
 	$(top_srcdir)/topology/test/regress/findvertexsegmentpairsbelowdistance.sql
-


### PR DESCRIPTION
## Summary

This adds record-taking overloads for the topology population functions so callers can reuse a `topology.topology` row returned by `FindTopology(...)` instead of re-querying `topology.topology` by name for every population call.

Covered functions:

- `TopoGeo_AddPoint(topology.topology, geometry, float8)`
- `TopoGeo_AddLineString(topology.topology, geometry, float8, int)`
- `TopoGeo_AddPolygon(topology.topology, geometry, float8)`
- `TopoGeo_LoadGeometry(topology.topology, geometry, float8)`

Review follow-up:

- initializes the PostGIS OID cache before record overloads cache `GEOMETRYOID`

Trac: https://trac.osgeo.org/postgis/ticket/5668

## Validation

- `make -C topology -j32`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_topology install`
- focused `topology/test/regress/topogeo_record_population.sql` fresh and automatic upgrade regression: `Run tests: 2 Failed: 0`
- focused `topology/test/regress/topogeo_record_population.sql` explicit upgrade regression: `Run tests: 2 Failed: 0`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- topology/postgis_topology.c topology/sql/populate.sql.in topology/test/regress/topogeo_record_population.sql topology/test/regress/topogeo_record_population_expected doc/extras_topology.xml NEWS`

Current head: `61578a955e50a147ba85d8f69fdacc7985d55215`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/336
