### PR TITLE
topology: improve noded line insertion tolerance

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -88,6 +88,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - #5722, [topology] Use component-scale tolerance when adding
+          noded TopoGeo_AddLineString edges (Sandro Santilli)
  - #2807, [raster] Preserve missing NODATA values in ST_MapAlgebra outputs
           (Darafei Praliaskouski)
  - #2832, [raster] Avoid padding single-tile raster2pgsql overviews

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -5192,7 +5192,8 @@ _lwt_minToleranceDouble( double d )
 }
 
 /* Return the smallest delta that can perturb
- * the given point
+ * the given point.
+ */
 static inline double
 _lwt_minTolerancePoint2d( const POINT2D* p )
 {
@@ -5200,7 +5201,22 @@ _lwt_minTolerancePoint2d( const POINT2D* p )
   if ( max < FP_ABS(p->y) ) max = FP_ABS(p->y);
   return _lwt_minToleranceDouble(max);
 }
-*/
+
+/* Return the smallest delta that can perturb
+ * the given segment.
+ */
+static inline double
+_lwt_minToleranceSegment2d(const POINT2D *p1, const POINT2D *p2)
+{
+	double max = FP_ABS(p1->x);
+	if (max < FP_ABS(p1->y))
+		max = FP_ABS(p1->y);
+	if (max < FP_ABS(p2->x))
+		max = FP_ABS(p2->x);
+	if (max < FP_ABS(p2->y))
+		max = FP_ABS(p2->y);
+	return _lwt_minToleranceDouble(max);
+}
 
 /* Return the smallest delta that can perturb
  * the maximum absolute value of a geometry ordinate
@@ -7093,8 +7109,14 @@ lwt_AddPoint(LWT_TOPOLOGY* topo, LWPOINT* point, double tol)
  *
  */
 static LWT_ELEMID
-_lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
-                  int handleFaceSplit, int *forward, int *numNewEdges )
+_lwt_AddLineEdge(LWT_TOPOLOGY *topo,
+		 LWLINE *edge,
+		 double tol,
+		 double startEndpointTol,
+		 double endEndpointTol,
+		 int handleFaceSplit,
+		 int *forward,
+		 int *numNewEdges)
 {
   LWCOLLECTION *col;
   LWPOINT *start_point, *end_point;
@@ -7118,9 +7140,7 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
     lwnotice("Empty component of noded line");
     return 0; /* must be empty */
   }
-  nid[0] = _lwt_AddPoint( topo, start_point,
-                          _lwt_minTolerance(lwpoint_as_lwgeom(start_point)),
-                          handleFaceSplit, &mm, &pointSplitEdges );
+  nid[0] = _lwt_AddPoint(topo, start_point, startEndpointTol, handleFaceSplit, &mm, &pointSplitEdges);
   lwpoint_free(start_point); /* too late if lwt_AddPoint calls lwerror */
   if ( nid[0] == -1 ) return -1; /* lwerror should have been called */
   if ( numNewEdges ) *numNewEdges += pointSplitEdges;
@@ -7135,9 +7155,7 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
             "after successfully getting first point !?");
     return -1;
   }
-  nid[1] = _lwt_AddPoint( topo, end_point,
-                          _lwt_minTolerance(lwpoint_as_lwgeom(end_point)),
-                          handleFaceSplit, &mm, &pointSplitEdges );
+  nid[1] = _lwt_AddPoint(topo, end_point, endEndpointTol, handleFaceSplit, &mm, &pointSplitEdges);
   lwpoint_free(end_point); /* too late if lwt_AddPoint calls lwerror */
   if ( nid[1] == -1 ) return -1; /* lwerror should have been called */
   if ( numNewEdges ) *numNewEdges += pointSplitEdges;
@@ -7682,8 +7700,34 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     }
 #endif
 
+    const LWLINE *edge_line = lwgeom_as_lwline(g);
+    double start_endpoint_tol = _lwt_minTolerance(g);
+    double end_endpoint_tol = start_endpoint_tol;
+    if (edge_line && edge_line->points->npoints > 0)
+    {
+	    uint32_t npoints = edge_line->points->npoints;
+	    const POINT2D *start = getPoint2d_cp(edge_line->points, 0);
+	    const POINT2D *end = getPoint2d_cp(edge_line->points, npoints - 1);
+	    if (npoints > 1)
+	    {
+		    const POINT2D *after_start = getPoint2d_cp(edge_line->points, 1);
+		    const POINT2D *before_end = getPoint2d_cp(edge_line->points, npoints - 2);
+		    start_endpoint_tol = _lwt_minToleranceSegment2d(start, after_start);
+		    end_endpoint_tol = _lwt_minToleranceSegment2d(before_end, end);
+		    if (p2d_same(start, end) && start_endpoint_tol != end_endpoint_tol)
+		    {
+			    start_endpoint_tol = end_endpoint_tol = FP_MAX(start_endpoint_tol, end_endpoint_tol);
+		    }
+	    }
+	    else
+	    {
+		    start_endpoint_tol = _lwt_minTolerancePoint2d(start);
+		    end_endpoint_tol = _lwt_minTolerancePoint2d(end);
+	    }
+    }
     forward = -1; /* will be set to either 0 or 1 if the edge already existed */
-    id = _lwt_AddLineEdge( topo, lwgeom_as_lwline(g), tol, handleFaceSplit, &forward, &edgeNewEdges );
+    id = _lwt_AddLineEdge(
+	topo, lwgeom_as_lwline(g), tol, start_endpoint_tol, end_endpoint_tol, handleFaceSplit, &forward, &edgeNewEdges);
     num_new_edges += edgeNewEdges;
     /* if forward is still == -1 this was NOT an existing edge ? */
     if ( forward == -1 )

--- a/topology/test/regress/topogeo_addlinestring_robust.sql
+++ b/topology/test/regress/topogeo_addlinestring_robust.sql
@@ -181,4 +181,38 @@ SELECT * FROM runTest('#5711',
   0
 ) WHERE true ;
 
+-- See https://trac.osgeo.org/postgis/ticket/5722
+SELECT * FROM runTest('#5722',
+  ARRAY[
+    'LINESTRING(
+      -11.968112622212203 0.651457829865329,
+        8.13909499443551  0.334122751124234,
+      -11.964143711257549 0.31568377154268)'
+  ],
+  'LINESTRING(
+    -0.65145782986533 -11.968112622212203,
+    -0.159231454672685  8.13973141470126)',
+  0
+) WHERE true ;
+
+SELECT NULL FROM topology.CreateTopology('closed_polygon_tol');
+SELECT 'closed-node', topology.ST_AddIsoNode('closed_polygon_tol', 0, 'POINT(0.001 0)');
+SELECT 'closed-addpolygon', count(*) > 0
+FROM topology.TopoGeo_AddPolygon(
+  'closed_polygon_tol',
+  'POLYGON((0 0, 1000000000000 0, 1 1, 0 0))',
+  0
+);
+SELECT 'closed-valid', count(*)
+FROM topology.ValidateTopology('closed_polygon_tol');
+SELECT 'closed-faces', count(*)
+FROM closed_polygon_tol.face
+WHERE face_id > 0;
+SELECT 'closed-edges',
+  count(*),
+  bool_and(ST_IsClosed(geom) = (start_node = end_node))
+FROM closed_polygon_tol.edge
+WHERE edge_id > 0;
+SELECT topology.DropTopology('closed_polygon_tol');
+
 DROP FUNCTION runTest(text, geometry[], geometry, float8, bool);

--- a/topology/test/regress/topogeo_addlinestring_robust_expected
+++ b/topology/test/regress/topogeo_addlinestring_robust_expected
@@ -1,2 +1,9 @@
 #5699|-checking-
 #5711|-checking-
+#5722|-checking-
+closed-node|1
+closed-addpolygon|t
+closed-valid|0
+closed-faces|1
+closed-edges|2|t
+Topology 'closed_polygon_tol' dropped


### PR DESCRIPTION
## Summary

This adapts Sandro Santilli's topology robustness fix for https://trac.osgeo.org/postgis/ticket/5722 from https://git.osgeo.org/gitea/postgis/postgis/pulls/202 onto current master.

`TopoGeo_AddLineString` can receive GEOS-noded line components whose intersection endpoints are microscopically displaced from existing edges. When adding those final components as topology edges, the endpoint-node insertion now uses tolerance derived from each endpoint's adjacent local segment, while the final edge insertion keeps the caller/topology tolerance. This lets the endpoint snap consistently with the noding result without widening snapping from unrelated distant vertices in the same component.

Closed components with identical start/end coordinates now share the same endpoint tolerance, so mixed-scale rings get one consistent snapping decision for the repeated endpoint.

## Validation

- `./utils/check_news.sh .`
- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C topology -j32`
- `make -C extensions/postgis -j1`
- `make -C extensions/postgis_topology -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring_robust"`
- `make -C doc check`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git clang-format --diff upstream/master -- liblwgeom/topo/lwgeom_topo.c topology/test/regress/topogeo_addlinestring_robust.sql topology/test/regress/topogeo_addlinestring_robust_expected NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/335
