### PR TITLE
Add topology PointOnFace helper

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
+ - #4861, [topology] Add PointOnFace helper for topology faces
+          (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -3192,7 +3192,49 @@ SELECT ST_AsText(topology.ST_GetFaceGeometry('ma_topo', 1)) As facegeomwkt;
 			<!-- Optionally add a "See Also" section -->
 			<refsection>
 				<title>See Also</title>
-				<para><xref linkend="AddFace"/></para>
+				<para>
+<xref linkend="AddFace"/>,
+<xref linkend="PointOnFace"/>
+				</para>
+			</refsection>
+		</refentry>
+
+		<refentry xml:id="PointOnFace">
+			<refnamediv>
+				<refname>PointOnFace</refname>
+
+				<refpurpose>Returns a point found on the interior of the given topology face.</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>geometry <function>PointOnFace</function></funcdef>
+					<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
+					<paramdef><type>bigint </type> <parameter>aface</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+                <title>Description</title>
+
+                <para>
+Returns a point found on the interior of the given topology face.
+The function is equivalent to calling <xref linkend="ST_PointOnSurface"/>
+on the face geometry, but computes the point directly from the topology face.
+		</para>
+
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0 </para>
+			</refsection>
+
+			<refsection>
+				<title>See Also</title>
+				<para>
+<xref linkend="ST_GetFaceGeometry"/>,
+<xref linkend="GetFaceContainingPoint"/>,
+<xref linkend="ST_PointOnSurface"/>
+				</para>
 			</refsection>
 		</refentry>
 

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -134,6 +134,7 @@ topology.sql: \
 	sql/query/getedgebypoint.sql.in \
 	sql/query/getfacebypoint.sql.in \
 	sql/query/GetFaceContainingPoint.sql.in \
+	sql/query/PointOnFace.sql.in \
 	sql/query/getnodebypoint.sql.in \
 	sql/query/GetNodeEdges.sql.in \
 	sql/query/GetRingEdges.sql.in \

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -26,6 +26,7 @@
 #include "inttypes.h" /* for PRId64 */
 #include "../postgis_config.h"
 
+#include "liblwgeom.h"
 #include "liblwgeom_internal.h" /* for gbox_clone */
 #include "topo/liblwgeom_topo.h"
 
@@ -4203,6 +4204,82 @@ Datum ST_GetFaceGeometry(PG_FUNCTION_ARGS)
   SPI_finish();
 
   PG_RETURN_POINTER(geom);
+}
+
+/* PointOnFace(atopology, aface) */
+Datum PointOnFace(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(PointOnFace);
+Datum
+PointOnFace(PG_FUNCTION_ARGS)
+{
+	text *toponame_text;
+	char *toponame;
+	LWT_ELEMID face_id;
+	LWGEOM *face_geom;
+	LWGEOM *point_geom;
+	LWT_TOPOLOGY *topo;
+	GSERIALIZED *geom;
+	MemoryContext old_context, spi_context;
+
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+	{
+		lwpgerror("SQL/MM Spatial exception - null argument");
+		PG_RETURN_NULL();
+	}
+
+	toponame_text = PG_GETARG_TEXT_P(0);
+	toponame = text_to_cstring(toponame_text);
+	PG_FREE_IF_COPY(toponame_text, 0);
+
+	face_id = PG_GETARG_INT64(1);
+
+	old_context = CurrentMemoryContext;
+	if (SPI_OK_CONNECT != SPI_connect())
+	{
+		pfree(toponame);
+		lwpgerror("Could not connect to SPI");
+		PG_RETURN_NULL();
+	}
+
+	topo = lwt_LoadTopology(be_iface, toponame);
+	pfree(toponame);
+	if (!topo)
+	{
+		/* should never reach this point, as lwerror would raise an exception */
+		SPI_finish();
+		PG_RETURN_NULL();
+	}
+
+	POSTGIS_DEBUG(1, "Calling lwt_GetFaceGeometry");
+	face_geom = lwt_GetFaceGeometry(topo, face_id);
+	POSTGIS_DEBUG(1, "lwt_GetFaceGeometry returned");
+	lwt_FreeTopology(topo);
+
+	if (face_geom == NULL)
+	{
+		/* should never reach this point, as lwerror would raise an exception */
+		SPI_finish();
+		PG_RETURN_NULL();
+	}
+
+	point_geom = lwgeom_pointonsurface(face_geom);
+	if (point_geom == NULL)
+	{
+		/* should never reach this point, as lwerror would raise an exception */
+		SPI_finish();
+		PG_RETURN_NULL();
+	}
+
+	/* Serialize in upper memory context (outside of SPI) */
+	spi_context = MemoryContextSwitchTo(old_context);
+	geom = geometry_serialize(point_geom);
+	MemoryContextSwitchTo(spi_context);
+
+	/* No need to free LWGEOMs here because they will go away with the SPI context */
+
+	SPI_finish();
+
+	PG_RETURN_POINTER(geom);
 }
 
 typedef struct FACEEDGESSTATE

--- a/topology/sql/query/PointOnFace.sql.in
+++ b/topology/sql/query/PointOnFace.sql.in
@@ -1,0 +1,24 @@
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--
+-- PostGIS - Spatial Types for PostgreSQL
+-- http://postgis.net
+--
+-- Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+--
+-- This is free software; you can redistribute and/or modify it under
+-- the terms of the GNU General Public Licence. See the COPYING file.
+--
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+--{
+--
+-- PointOnFace(atopology, aface)
+--
+-- Returns a point found on the interior of the given face.
+--
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION topology.PointOnFace(atopology varchar, aface bigint)
+	RETURNS geometry AS
+	'MODULE_PATHNAME', 'PointOnFace'
+	LANGUAGE 'c' STABLE;
+--} PointOnFace

--- a/topology/test/regress/pointonface.sql
+++ b/topology/test/regress/pointonface.sql
@@ -1,0 +1,61 @@
+set client_min_messages to WARNING;
+
+SELECT topology.CreateTopology('tt') > 0;
+
+COPY tt.face(face_id, mbr) FROM STDIN;
+1	POLYGON((0 0,0 10,10 10,10 0,0 0))
+2	POLYGON((2 2,2 8,8 8,8 2,2 2))
+3	POLYGON((12 2,12 8,18 8,18 2,12 2))
+\.
+
+COPY tt.node(node_id, geom) FROM STDIN;
+1	POINT(2 2)
+2	POINT(0 0)
+3	POINT(12 2)
+\.
+
+COPY tt.edge_data(
+	edge_id, start_node, end_node,
+	abs_next_left_edge, abs_next_right_edge,
+	next_left_edge, next_right_edge,
+        left_face, right_face, geom) FROM STDIN;
+1	1	1	1	1	1	-1	1	2	LINESTRING(2 2, 2  8,  8  8,  8 2, 2 2)
+2	2	2	2	2	2	-2	0	1	LINESTRING(0 0, 0 10, 10 10, 10 0, 0 0)
+3	3	3	3	3	3	-3	0	3	LINESTRING(12 2, 12 8, 18 8, 18 2, 12 2)
+\.
+
+SELECT 'f' || face_id,
+  ST_AsText(topology.PointOnFace('tt', face_id)),
+  ST_Contains(
+    topology.ST_GetFaceGeometry('tt', face_id),
+    topology.PointOnFace('tt', face_id)
+  )
+FROM tt.face
+WHERE face_id > 0
+ORDER BY face_id;
+
+SELECT topology.PointOnFace('tt', 0);
+
+SELECT topology.PointOnFace(null, 1);
+SELECT topology.PointOnFace('tt', null);
+
+SELECT topology.PointOnFace('NonExistent', 1);
+SELECT topology.PointOnFace('', 1);
+
+SELECT topology.PointOnFace('tt', 666);
+
+COPY tt.face(face_id, mbr) FROM STDIN;
+4	POLYGON((0 0,2 2,2 2,0 0))
+\.
+COPY tt.edge_data(
+	edge_id, start_node, end_node,
+	abs_next_left_edge, abs_next_right_edge,
+	next_left_edge, next_right_edge,
+        left_face, right_face, geom) FROM STDIN;
+4	2	1	1	2	1	-2	4	4	LINESTRING(0 0, 2 2)
+\.
+SET client_min_messages TO NOTICE;
+SELECT ST_AsText(topology.PointOnFace('tt', 4));
+SET client_min_messages TO WARNING;
+
+SELECT topology.DropTopology('tt');

--- a/topology/test/regress/pointonface_expected
+++ b/topology/test/regress/pointonface_expected
@@ -1,0 +1,13 @@
+t
+f1|POINT(1 5)|t
+f2|POINT(5 5)|t
+f3|POINT(15 5)|t
+ERROR:  SQL/MM Spatial exception - universal face has no geometry
+ERROR:  SQL/MM Spatial exception - null argument
+ERROR:  SQL/MM Spatial exception - null argument
+ERROR:  SQL/MM Spatial exception - invalid topology name
+ERROR:  SQL/MM Spatial exception - invalid topology name
+ERROR:  SQL/MM Spatial exception - non-existent face.
+NOTICE:  Corrupted topology: face 4 could not be constructed only from edges knowing about it (like edge 4).
+POINT EMPTY
+Topology 'tt' dropped

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -38,6 +38,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/getnodebypoint.sql \
 	$(top_srcdir)/topology/test/regress/getnodeedges.sql \
 	$(top_srcdir)/topology/test/regress/getringedges.sql \
+	$(top_srcdir)/topology/test/regress/pointonface.sql \
 	$(top_srcdir)/topology/test/regress/gettopogeomelements.sql \
 	$(top_srcdir)/topology/test/regress/gettopogeomelements_large.sql \
 	$(top_srcdir)/topology/test/regress/gml.sql \

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -1379,6 +1379,7 @@ LANGUAGE 'plpgsql' VOLATILE STRICT;
 #include "sql/query/getedgebypoint.sql.in"
 #include "sql/query/getfacebypoint.sql.in"
 #include "sql/query/GetFaceContainingPoint.sql.in"
+#include "sql/query/PointOnFace.sql.in"
 #include "sql/query/FindVertexSegmentPairsBelowDistance.sql.in"
 
 --  Populating


### PR DESCRIPTION
## Summary

Adds `topology.PointOnFace(toponame, face_id)`, a topology helper that returns a point on the requested face.

The implementation loads the topology once, reuses the existing face-geometry construction path, and computes the point through the internal point-on-surface operation before returning the geometry. This keeps the same face error behavior as `topology.ST_GetFaceGeometry` while avoiding the SQL-level composition call.

Trac ticket: https://trac.osgeo.org/postgis/ticket/4861

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make install`
- `make -C doc check`
- `make -B -C doc comments`
- `./utils/check_news.sh .`
- `git diff --check`
- `git diff --cached --check`
- `git clang-format --diff upstream/master -- topology/postgis_topology.c`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/pointonface"`
- loaded `doc/topology_comments.sql` with `ON_ERROR_STOP=1` after creating `postgis` and `postgis_topology`

Note: one parallel validation attempt ran `sudo -n make install` while `make -B -C doc comments` was regenerating `doc/postgis-out.xml`; that install attempt failed with a transient XML parse error from the shared generated file. Rerunning `sudo -n make install` after comments completed passed cleanly.

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/333
