### PR TITLE
Check TopoGeo input SRIDs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
+ - #2994, [topology] Check SRID compatibility in TopoGeo_* loading functions
+          (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1702,6 +1702,9 @@ Adds a point to an existing topology and returns its identifier.
 The given point will snap to existing nodes or edges within given tolerance.
 An existing edge may be split by the snapped point.
                 </para>
+                <para>
+The input point SRID must match the SRID of the topology.
+                </para>
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="2.0.0">Availability: 2.0.0</para>
@@ -1759,6 +1762,9 @@ Existing edges and faces may be split by the line.  New nodes and faces may be a
 The returned edge identifiers may be either existing edges or newly
 created edges as needed to fully represent the input line as closely
 as possible.
+                </para>
+                <para>
+The input line SRID must match the SRID of the topology.
                 </para>
 
 <para>
@@ -1818,6 +1824,9 @@ Adds a polygon to an existing topology and returns a set of face identifiers for
 The boundary of the given polygon will snap to existing nodes or edges within given tolerance.
 Existing edges and faces may be split by the boundary of the new polygon.
                 </para>
+                <para>
+The input polygon SRID must match the SRID of the topology.
+                </para>
 
                 <note><para>
 Updating statistics about topologies being loaded via this function is
@@ -1867,6 +1876,9 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
 Loads a geometry into an existing topology.
 The given geometry will snap to existing nodes or edges within given tolerance.
 Existing edges and faces may be split as a consequence of the load.
+                </para>
+                <para>
+The input geometry SRID must match the SRID of the topology.
                 </para>
 
                 <note><para>

--- a/liblwgeom/topo/liblwgeom_topo.h
+++ b/liblwgeom/topo/liblwgeom_topo.h
@@ -962,6 +962,15 @@ LWT_TOPOLOGY *lwt_CreateTopology(LWT_BE_IFACE *iface, const char *name, int32_t 
 LWT_TOPOLOGY *lwt_LoadTopology(LWT_BE_IFACE *iface, const char *name);
 
 /**
+ * Return the SRID of a loaded topology.
+ *
+ * @param topo the topology to inspect
+ *
+ * @return topology SRID
+ */
+int32_t lwt_GetTopologySRID(const LWT_TOPOLOGY *topo);
+
+/**
  * Drop a topology and all its associated objects from the database
  *
  * @param topo the topology to drop

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -545,6 +545,12 @@ lwt_LoadTopology( LWT_BE_IFACE *iface, const char *name )
   return topo;
 }
 
+int32_t
+lwt_GetTopologySRID(const LWT_TOPOLOGY *topo)
+{
+	return topo->srid;
+}
+
 void
 lwt_FreeTopology( LWT_TOPOLOGY* topo )
 {

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -311,6 +311,18 @@ cb_topoHasZ(const LWT_BE_TOPOLOGY* topo)
   return topo->hasZ;
 }
 
+static void
+check_topology_srid(const GSERIALIZED *geom, const LWT_TOPOLOGY *topo)
+{
+	int geom_srid = gserialized_get_srid(geom);
+	int topo_srid = lwt_GetTopologySRID(topo);
+
+	if (geom_srid != topo_srid)
+	{
+		lwpgerror("Geometry SRID (%d) does not match topology SRID (%d)", geom_srid, topo_srid);
+	}
+}
+
 static double
 cb_topoGetPrecision(const LWT_BE_TOPOLOGY* topo)
 {
@@ -5214,6 +5226,7 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
     SPI_finish();
     PG_RETURN_NULL();
   }
+  check_topology_srid(geom, topo);
 
   POSTGIS_DEBUG(1, "Calling lwt_AddPoint");
   node_id = lwt_AddPoint(topo, pt, tol);
@@ -5290,14 +5303,6 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
         PG_RETURN_NULL();
       }
     }
-    /* Nothing to do if line is empty */
-    if ( lwline_is_empty(ln) )
-    {
-      lwgeom_free(lwgeom);
-      PG_FREE_IF_COPY(geom, 1);
-      PG_RETURN_NULL();
-    }
-
     tol = PG_GETARG_FLOAT8(2);
     if ( tol < -1 )
     {
@@ -5328,6 +5333,17 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
       /* should never reach this point, as lwerror would raise an exception */
       SPI_finish();
       PG_RETURN_NULL();
+    }
+    check_topology_srid(geom, topo);
+
+    /* Nothing to do if line is empty */
+    if (lwline_is_empty(ln))
+    {
+	    lwgeom_free(lwgeom);
+	    PG_FREE_IF_COPY(geom, 1);
+	    lwt_FreeTopology(topo);
+	    SPI_finish();
+	    PG_RETURN_NULL();
     }
 
     POSTGIS_DEBUG(1, "Calling lwt_AddLine");
@@ -5440,6 +5456,7 @@ Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS)
     SPI_finish();
     PG_RETURN_NULL();
   }
+  check_topology_srid(geom, topo);
 
   POSTGIS_DEBUG(1, "Calling lwt_AddLineNoFace");
   /* return discarded as we assume lwerror would raise an exception earlier
@@ -5537,6 +5554,7 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
       SPI_finish();
       PG_RETURN_NULL();
     }
+    check_topology_srid(geom, topo);
 
     POSTGIS_DEBUG(1, "Calling lwt_AddPolygon");
     elems = lwt_AddPolygon(topo, pol, tol, &nelems);
@@ -5881,6 +5899,7 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
     SPI_finish();
     PG_RETURN_NULL();
   }
+  check_topology_srid(geom, topo);
 
   /* Nothing to do if the input is empty */
   if (gserialized_is_empty(geom) != LW_TRUE)

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -59,6 +59,8 @@ SELECT 'invalid', TopoGeo_addLineString('city_data', 'SRID=4326;MULTILINESTRING(
 SELECT 'invalid', TopoGeo_addLineString('city_data', 'SRID=4326;POINT(36 26)');
 SELECT 'invalid', TopoGeo_addLineString('invalid', 'SRID=4326;LINESTRING(36 26, 0 0)');
 SELECT 'empty', TopoGeo_addLineString('city_data', 'SRID=4326;LINESTRING EMPTY');
+SELECT 'empty_srid_mismatch', TopoGeo_addLineString('city_data', 'LINESTRING EMPTY');
+SELECT 'srid_mismatch', TopoGeo_addLineString('city_data', 'LINESTRING(36 26, 38 30)');
 
 -- Isolated edge in universal face
 SELECT 'iso_uni', TopoGeo_addLineString('city_data', 'SRID=4326;LINESTRING(36 26, 38 30)');

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -4,6 +4,8 @@ ERROR:  Invalid geometry type (MULTILINESTRING) passed to TopoGeo_AddLinestring,
 ERROR:  Invalid geometry type (POINT) passed to TopoGeo_AddLinestring, expected LINESTRING
 ERROR:  No topology with name "invalid" in topology.topology
 empty|
+ERROR:  Geometry SRID (0) does not match topology SRID (4326)
+ERROR:  Geometry SRID (0) does not match topology SRID (4326)
 iso_uni|27
 iso_uni|N||POINT(36 26)
 iso_uni|N||POINT(38 30)

--- a/topology/test/regress/topogeo_addpoint.sql
+++ b/topology/test/regress/topogeo_addpoint.sql
@@ -11,6 +11,7 @@ SELECT 'invalid', TopoGeo_addPoint('invalid', 'POINT(36 26)');
 SELECT 'invalid', TopoGeo_addPoint(null::varchar, null::geometry, null::float8);
 SELECT 'invalid', TopoGeo_addPoint(null::varchar, 'POINT(36 36)'::geometry, null::float8);
 SELECT 'invalid', TopoGeo_addPoint('city_data', null::geometry, null::float8);
+SELECT 'srid_mismatch', TopoGeo_addPoint('city_data', 'SRID=4326;POINT(36 26)');
 
 -- Save max node id
 select 'node'::text as what, max(node_id) INTO city_data.limits FROM city_data.node;

--- a/topology/test/regress/topogeo_addpoint_expected
+++ b/topology/test/regress/topogeo_addpoint_expected
@@ -4,6 +4,7 @@ ERROR:  No topology with name "invalid" in topology.topology
 ERROR:  SQL/MM Spatial exception - null argument
 ERROR:  SQL/MM Spatial exception - null argument
 ERROR:  SQL/MM Spatial exception - null argument
+ERROR:  Geometry SRID (4326) does not match topology SRID (0)
 iso_uni|23
 iso_f3|24
 iso_ex|23

--- a/topology/test/regress/topogeo_addpolygon.sql
+++ b/topology/test/regress/topogeo_addpolygon.sql
@@ -73,6 +73,7 @@ SELECT 'invalid', TopoGeo_addPolygon('city_data', 'MULTILINESTRING((36 26, 38 30
 SELECT 'invalid', TopoGeo_addPolygon('city_data', 'POINT(36 26)');
 SELECT 'invalid', TopoGeo_addPolygon('invalid', 'POLYGON((36 26, 40 24, 40 30, 36 26))');
 SELECT 'empty', TopoGeo_addPolygon('city_data', 'POLYGON EMPTY');
+SELECT 'srid_mismatch', TopoGeo_addPolygon('city_data', 'SRID=4326;POLYGON((36 26, 40 24, 40 30, 36 26))');
 
 -- Isolated face in universal face
 SELECT 'iso_uni', TopoGeo_addPolygon('city_data', 'POLYGON((36 26, 38 30, 43 26, 36 26))');

--- a/topology/test/regress/topogeo_addpolygon_expected
+++ b/topology/test/regress/topogeo_addpolygon_expected
@@ -4,6 +4,7 @@ max|face|9
 ERROR:  Invalid geometry type (MULTILINESTRING) passed to TopoGeo_AddPolygon, expected POLYGON
 ERROR:  Invalid geometry type (POINT) passed to TopoGeo_AddPolygon, expected POLYGON
 ERROR:  No topology with name "invalid" in topology.topology
+ERROR:  Geometry SRID (4326) does not match topology SRID (0)
 iso_uni|10
 iso_uni|N|23||POINT(36 26)
 iso_uni|E|27|sn23|en23

--- a/topology/test/regress/topogeo_loadgeometry.sql
+++ b/topology/test/regress/topogeo_loadgeometry.sql
@@ -18,6 +18,10 @@ $$ LANGUAGE 'sql';
 -- Null call
 SELECT 'null', topology.TopoGeo_LoadGeometry('t', NULL::geometry);
 
+-- SRID compatibility, including empty inputs
+SELECT 'srid_mismatch', topology.TopoGeo_LoadGeometry('t', 'SRID=4326;POINT(0 0)'::geometry);
+SELECT 'srid_mismatch_empty', topology.TopoGeo_LoadGeometry('t', 'SRID=4326;POINT EMPTY'::geometry);
+
 -- Empty
 SELECT 'empty', topology.TopoGeo_LoadGeometry('t', 'POINT EMPTY'::geometry);
 

--- a/topology/test/regress/topogeo_loadgeometry_expected
+++ b/topology/test/regress/topogeo_loadgeometry_expected
@@ -1,5 +1,7 @@
 ERROR:  SQL/MM Spatial exception - invalid topology name
 ERROR:  SQL/MM Spatial exception - null argument
+ERROR:  Geometry SRID (4326) does not match topology SRID (0)
+ERROR:  Geometry SRID (4326) does not match topology SRID (0)
 empty|
 point1|1 nodes|0 edges|0 faces
 mpoint1|2 nodes|0 edges|0 faces


### PR DESCRIPTION
## Summary

- rejects mismatched input SRIDs in `TopoGeo_AddPoint`, `TopoGeo_AddLineString`, `_TopoGeo_AddLineStringNoFace`, `TopoGeo_AddPolygon`, and `TopoGeo_LoadGeometry`
- adds a liblwgeom topology SRID accessor used by the PostgreSQL topology wrappers
- documents the SRID requirement and adds focused regression coverage for both SRID mismatch directions
- checks `TopoGeo_AddLineString` SRIDs before returning on empty lines, so empty mismatched inputs are rejected consistently with the other TopoGeo loading paths

Ticket: https://trac.osgeo.org/postgis/ticket/2994

## Tests

- `make -C liblwgeom -j32`
- `make -C postgis -j32`
- `make -C topology -j32`
- `make -C extensions/postgis -j1`
- `make -C extensions/postgis_topology -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring"`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git clang-format --diff upstream/master -- liblwgeom/topo/liblwgeom_topo.h liblwgeom/topo/lwgeom_topo.c topology/postgis_topology.c topology/test/regress/topogeo_addpoint_expected topology/test/regress/topogeo_addlinestring.sql topology/test/regress/topogeo_addlinestring_expected topology/test/regress/topogeo_addpolygon_expected topology/test/regress/topogeo_loadgeometry_expected doc/extras_topology.xml NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/332
