### PR TITLE
topology: limit Polygonize by extent

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,6 +71,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #917, [topology] Allow Polygonize to be limited by a rectangular extent
+          (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -3375,13 +3375,19 @@ them is below the given tolerance.
 					<funcdef>text <function>Polygonize</function></funcdef>
 					<paramdef><type>varchar </type> <parameter>toponame</parameter></paramdef>
 					</funcprototype>
+					<funcprototype>
+					<funcdef>text <function>Polygonize</function></funcdef>
+					<paramdef><type>varchar </type> <parameter>toponame</parameter></paramdef>
+					<paramdef><type>geometry </type> <parameter>bbox</parameter></paramdef>
+					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
 
 			<refsection>
                 <title>Description</title>
 
-                <para>Registers all faces that can be built out a topology edge primitives.</para>
+                <para>Registers all faces that can be built out of topology edge primitives. When the optional <parameter>bbox</parameter> parameter is passed, only edge primitives whose bounding boxes intersect the given rectangle are considered, and only faces covered by that rectangle are registered.</para>
+                <para>The <parameter>bbox</parameter> value, when provided, must be a rectangular polygon.</para>
                 <para>The target topology is assumed to contain no self-intersecting edges.</para>
                 <note><para>Already known faces are recognized, so it is safe to call Polygonize multiple times on the same topology.</para></note>
 		<note><para>
@@ -3391,6 +3397,7 @@ This function does not use nor set the next_left_edge and next_right_edge fields
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="2.0.0">Availability: 2.0.0</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added the ability to limit polygonization to faces covered by a rectangular bounding box.</para>
 			</refsection>
 
 			<!-- Optionally add a "See Also" section -->

--- a/topology/README
+++ b/topology/README
@@ -217,7 +217,9 @@ given Face on the left or right side. This reduces the number
 of SQL queries to 1, but makes it hard to detect any
 inconsistency in the underlying topology.
 Also, the polygonize() function does not use *any* of the
-metadata information in the Edge table, so replacing it
+metadata information in the Edge table. The SQL wrapper can
+restrict polygonization to faces covered by a rectangular
+bounding box, but replacing it
 with a more topology-aware function could speed it up.
 
 ==ValidateTopology() performance
@@ -234,4 +236,3 @@ be slower then overloading the predicates.
 In addition to the constraints defined in SQL/MM specification,
 this implementation adds constraints to enforce Node and Edge
 geometry types to be 'POINT' and 'LINESTRING' respectively.
-

--- a/topology/sql/polygonize.sql.in
+++ b/topology/sql/polygonize.sql.in
@@ -17,11 +17,10 @@
 --{
 --
 -- int Polygonize(toponame)
---
--- TODO: allow restricting polygonization to a bounding box
+-- int Polygonize(toponame, bbox)
 --
 -- }{
-CREATE OR REPLACE FUNCTION topology.polygonize(toponame varchar)
+CREATE OR REPLACE FUNCTION topology.polygonize(toponame varchar, bbox geometry)
   RETURNS text
 AS
 $$
@@ -30,12 +29,34 @@ DECLARE
   rec RECORD;
   faces int;
 BEGIN
+  IF bbox IS NOT NULL
+  THEN
+    IF ST_IsEmpty(bbox)
+      OR ST_GeometryType(bbox) != 'ST_Polygon'
+      OR NOT ST_Equals(bbox, ST_Envelope(bbox))
+    THEN
+      RAISE EXCEPTION 'Polygonize extent must be a rectangular polygon'
+        USING ERRCODE = '22023';
+    END IF;
+  END IF;
 
-  sql := 'SELECT (st_dump(st_polygonize(geom))).geom from '
-         || quote_ident(toponame) || '.edge_data';
+  sql := 'SELECT geom FROM (SELECT (st_dump(st_polygonize(geom))).geom FROM '
+         || '(SELECT geom FROM ' || quote_ident(toponame) || '.edge_data';
+
+  IF bbox IS NOT NULL
+  THEN
+    sql := sql || ' WHERE geom && $1';
+  END IF;
+
+  sql := sql || ') edges) faces';
+
+  IF bbox IS NOT NULL
+  THEN
+    sql := sql || ' WHERE ST_CoveredBy(geom, $1)';
+  END IF;
 
   faces = 0;
-  FOR rec in EXECUTE sql LOOP
+  FOR rec in EXECUTE sql USING bbox LOOP
     BEGIN
       PERFORM topology.AddFace(toponame, rec.geom);
       faces = faces + 1;
@@ -48,4 +69,14 @@ BEGIN
 END
 $$
 LANGUAGE 'plpgsql';
+--} Polygonize(toponame, bbox)
+
+--{
+CREATE OR REPLACE FUNCTION topology.polygonize(toponame varchar)
+  RETURNS text
+AS
+$$
+  SELECT topology.polygonize($1, NULL::geometry);
+$$
+LANGUAGE 'sql';
 --} Polygonize(toponame)

--- a/topology/test/regress/polygonize.sql
+++ b/topology/test/regress/polygonize.sql
@@ -26,3 +26,51 @@ SELECT edge_id, left_face, right_face from tt.edge ORDER by edge_id;
 
 SELECT topology.DropTopology('tt');
 
+SELECT topology.CreateTopology('tt_bbox') > 0;
+
+SELECT 'b1', topology.addEdge('tt_bbox', 'LINESTRING(0 0, 10 0)');
+SELECT 'b2', topology.addEdge('tt_bbox', 'LINESTRING(10 0, 10 10)');
+SELECT 'b3', topology.addEdge('tt_bbox', 'LINESTRING(10 10, 0 10)');
+SELECT 'b4', topology.addEdge('tt_bbox', 'LINESTRING(0 10, 0 0)');
+SELECT 'b5', topology.addEdge('tt_bbox', 'LINESTRING(100 0, 110 0)');
+SELECT 'b6', topology.addEdge('tt_bbox', 'LINESTRING(110 0, 110 10)');
+SELECT 'b7', topology.addEdge('tt_bbox', 'LINESTRING(110 10, 100 10)');
+SELECT 'b8', topology.addEdge('tt_bbox', 'LINESTRING(100 10, 100 0)');
+
+SELECT topology.polygonize('tt_bbox', 'POLYGON((-1 -1, 11 -1, 11 11, -1 11, -1 -1))');
+SELECT face_id, Box2d(mbr) from tt_bbox.face ORDER by face_id;
+SELECT edge_id, left_face, right_face from tt_bbox.edge ORDER by edge_id;
+
+SELECT topology.polygonize('tt_bbox', 'POLYGON((-1 -1, 11 -1, 11 11, -1 11, -1 -1))');
+SELECT face_id, Box2d(mbr) from tt_bbox.face ORDER by face_id;
+SELECT edge_id, left_face, right_face from tt_bbox.edge ORDER by edge_id;
+
+SELECT topology.CreateTopology('tt_bbox_leak') > 0;
+
+SELECT 'l1', topology.addEdge('tt_bbox_leak', 'LINESTRING(0 5, 5 10)');
+SELECT 'l2', topology.addEdge('tt_bbox_leak', 'LINESTRING(5 10, 10 5)');
+SELECT 'l3', topology.addEdge('tt_bbox_leak', 'LINESTRING(10 5, 5 0)');
+SELECT 'l4', topology.addEdge('tt_bbox_leak', 'LINESTRING(5 0, 0 5)');
+SELECT 'l5', topology.addEdge('tt_bbox_leak', 'LINESTRING(1 5, 2 5)');
+
+SELECT topology.polygonize('tt_bbox_leak', 'POLYGON((4 -1, 6 -1, 6 11, 4 11, 4 -1))');
+SELECT face_id, Box2d(mbr) from tt_bbox_leak.face ORDER by face_id;
+SELECT edge_id, left_face, right_face from tt_bbox_leak.edge ORDER by edge_id;
+
+SELECT topology.polygonize('tt_bbox_leak');
+SELECT face_id, Box2d(mbr) from tt_bbox_leak.face ORDER by face_id;
+SELECT edge_id, left_face, right_face from tt_bbox_leak.edge ORDER by edge_id;
+
+SELECT topology.DropTopology('tt_bbox_leak');
+
+SET client_min_messages TO NOTICE;
+DO $$
+BEGIN
+  PERFORM topology.polygonize('tt_bbox', 'POLYGON((0 0, 1 0, 0 1, 0 0))');
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'non-rectangle bbox: % %', SQLSTATE, SQLERRM;
+END
+$$;
+SET client_min_messages TO ERROR;
+
+SELECT topology.DropTopology('tt_bbox');

--- a/topology/test/regress/polygonize_expected
+++ b/topology/test/regress/polygonize_expected
@@ -45,3 +45,58 @@ e11|11
 10|4|2
 11|2|4
 Topology 'tt' dropped
+t
+b1|1
+b2|2
+b3|3
+b4|4
+b5|5
+b6|6
+b7|7
+b8|8
+1 faces registered
+0|
+1|BOX(0 0,10 10)
+1|1|0
+2|1|0
+3|1|0
+4|1|0
+5|0|0
+6|0|0
+7|0|0
+8|0|0
+1 faces registered
+0|
+1|BOX(0 0,10 10)
+1|1|0
+2|1|0
+3|1|0
+4|1|0
+5|0|0
+6|0|0
+7|0|0
+8|0|0
+t
+l1|1
+l2|2
+l3|3
+l4|4
+l5|5
+0 faces registered
+0|
+1|0|0
+2|0|0
+3|0|0
+4|0|0
+5|0|0
+1 faces registered
+0|
+1|BOX(0 0,10 10)
+1|0|1
+2|0|1
+3|0|1
+4|0|1
+5|1|1
+Topology 'tt_bbox_leak' dropped
+NOTICE:  non-rectangle bbox: 22023 Polygonize extent must be a rectangular polygon
+Topology 'tt_bbox' dropped


### PR DESCRIPTION
## Summary
- add `topology.polygonize(toponame, bbox)` to restrict polygonization to a rectangular extent
- consider only edges intersecting the rectangle, but register only faces covered by it so `AddFace` cannot mutate primitives outside the requested extent
- keep the existing one-argument function as a wrapper
- document the overload and cover limited/idempotent/non-rectangular/out-of-extent face cases

Closes https://trac.osgeo.org/postgis/ticket/917

## Latest update
- rebased onto `postgis/postgis@a4ecc46176c3fc0ab3fa69cf117d408bc622e592`
- refreshed head to `53542f2029e926128315221969337dbc1cc3284a`
- verified the bounded face-registration path with the `tt_bbox_leak` regression, where a narrow bbox crosses the outer face boundary but must not assign a dangling edge outside the requested extent
- kept the bounded-idempotence regression isolated from an unbounded polygonize call

## Tests
- `make -C topology topology.sql`
- `make -C topology -j32`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `dropdb --if-exists postgis_reg; make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="/home/kom/proj/ai_pr/postgis-ticket-917-polygonize-bbox/topology/test/regress/polygonize"`
- `dropdb --if-exists postgis_reg; make -C topology/test check RUNTESTFLAGS='--extension --verbose --before-test-script /home/kom/proj/ai_pr/postgis-ticket-917-polygonize-bbox/regress/hooks/standard-conforming-strings-off.sql' TESTS="/home/kom/proj/ai_pr/postgis-ticket-917-polygonize-bbox/topology/test/regress/polygonize"`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD && git diff --check`
- `git clang-format --diff upstream/master -- topology/sql/polygonize.sql.in topology/test/regress/polygonize.sql topology/test/regress/polygonize_expected doc/extras_topology.xml topology/README NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/331
