### PR TITLE
doc: clarify repeated ring point validity

### DIFF
--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -1090,6 +1090,13 @@ SELECT
         </para></listitem>
         </orderedlist>
 
+      <para>
+        Consecutive repeated points in a polygon boundary ring are treated as
+        redundant vertices, and do not make the polygon invalid. Repeated points
+        that cause the boundary to self-intersect, self-touch, or collapse
+        still violate the validity rules.
+      </para>
+
 	  <informaltable frame="none">
 		<tgroup cols="1">
 		  <tbody>


### PR DESCRIPTION
## Summary
- clarify that consecutive repeated points in polygon boundary rings are treated as redundant vertices and do not make polygons invalid
- distinguish that from repeated points that create self-intersection, self-touching, or collapse

Trac: https://trac.osgeo.org/postgis/ticket/3425

## Testing
- `psql -X -v ON_ERROR_STOP=1 -d postgres -Atc "CREATE EXTENSION IF NOT EXISTS postgis; SELECT 'consecutive_polygon', ST_IsValid('POLYGON((0 0, 1 0, 1 0, 1 1, 0 0))'::geometry), ST_IsValidReason('POLYGON((0 0, 1 0, 1 0, 1 1, 0 0))'::geometry); SELECT 'repeated_nonconsecutive_polygon', ST_IsValid('POLYGON((0 0, 1 0, 0 0, 1 1, 0 0))'::geometry), ST_IsValidReason('POLYGON((0 0, 1 0, 0 0, 1 1, 0 0))'::geometry);"`
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check`
- `git diff --check`
