### PR TITLE
raster: expand ST_Rescale extent for fractional dimensions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -115,6 +115,9 @@ These are only changes since 3.7.0alpha1.
 
 PostGIS 3.7.0dev
 2026/xx/xx
+
+* Bug Fixes *
+
  - #2800, [raster] Make ST_Rescale expand output to cover input extent (Darafei Praliaskouski)
 PostGIS 3.7.0alpha1
 2026/07/05

--- a/NEWS
+++ b/NEWS
@@ -295,6 +295,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #6080, Avoid out-of-bounds hex WKB lookup for high-bit input bytes
           (Darafei Praliaskouski)
  - #4828, geometry_columns handles NOT VALID SRID checks without errors (Darafei Praliaskouski)
+ - #2800, [raster] Make ST_Rescale expand output to cover input extent (Darafei Praliaskouski)
  - #6048, [raster] ST_Clip no longer crashes when clipping sparse band
           selections (Darafei Praliaskouski)
  - GH-894, [raster] Fix Float16 import, mixed nodata warping,

--- a/NEWS
+++ b/NEWS
@@ -115,6 +115,9 @@ These are only changes since 3.7.0alpha1.
 
 PostGIS 3.7.0dev
 2026/xx/xx
+ - #2800, [raster] Make ST_Rescale expand output to cover input extent (Darafei Praliaskouski)
+PostGIS 3.7.0alpha1
+2026/07/05
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.
 To take advantage of all features postgis extension features, GEOS 3.15+ is needed.
@@ -295,7 +298,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #6080, Avoid out-of-bounds hex WKB lookup for high-bit input bytes
           (Darafei Praliaskouski)
  - #4828, geometry_columns handles NOT VALID SRID checks without errors (Darafei Praliaskouski)
- - #2800, [raster] Make ST_Rescale expand output to cover input extent (Darafei Praliaskouski)
  - #6048, [raster] ST_Clip no longer crashes when clipping sparse band
           selections (Darafei Praliaskouski)
  - GH-894, [raster] Fix Float16 import, mixed nodata warping,

--- a/raster/rt_core/rt_warp.c
+++ b/raster/rt_core/rt_warp.c
@@ -101,6 +101,31 @@ _rti_warp_arg_init() {
 	return arg;
 }
 
+/*
+ * Use ceiling semantics so fractional output dimensions cover the source
+ * extent, but keep nearly integral dimensions rounded for compatibility.
+ */
+static int
+_rti_warp_ceil_dimension(double extent_size, double scale)
+{
+	double pixels;
+	double rounded;
+
+	if (FLT_EQ(scale, 0.0))
+	{
+		rterror("rt_raster_gdal_warp: Scale cannot be zero");
+		return 0;
+	}
+
+	pixels = fabs(extent_size) / scale;
+	rounded = floor(pixels + 0.5);
+
+	if (FLT_EQ(pixels, rounded))
+		return (int)fmax(rounded, 1);
+
+	return (int)fmax(ceil(pixels), 1);
+}
+
 static void
 _rti_warp_arg_destroy(_rti_warp_arg arg) {
 	int i = 0;
@@ -560,9 +585,9 @@ rt_raster rt_raster_gdal_warp(
 
 	/* dimensions not defined, compute from extent */
 	if (!_dim[0])
-		_dim[0] = (int) fmax((fabs(extent.MaxX - extent.MinX) + (_scale[0] / 2.)) / _scale[0], 1);
+		_dim[0] = _rti_warp_ceil_dimension(extent.MaxX - extent.MinX, _scale[0]);
 	if (!_dim[1])
-		_dim[1] = (int) fmax((fabs(extent.MaxY - extent.MinY) + (_scale[1] / 2.)) / _scale[1], 1);
+		_dim[1] = _rti_warp_ceil_dimension(extent.MaxY - extent.MinY, _scale[1]);
 
 	/* temporary raster */
 	rast = rt_raster_new(_dim[0], _dim[1]);

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -8780,7 +8780,7 @@ BEGIN
       --RAISE DEBUG 'sfx/sfy: %, %', sfx, sfy;
       --RAISE DEBUG 'tile extent %', te;
       sql := 'SELECT count(*),  @extschema@.ST_Clip(  @extschema@.ST_Union(  @extschema@.ST_SnapToGrid(  @extschema@.ST_Rescale(  @extschema@.ST_Clip(' || quote_ident(col)
-          || ',  @extschema@.ST_Expand($3, greatest($1,$2))),$1, $2, $6), $4, $5, $1, $2)),  @extschema@.ST_Intersection($3,  @extschema@.ST_Expand($7, greatest(abs($1), abs($2)) / 2.0))) g FROM ' || tab::text
+          || ',  @extschema@.ST_Expand($3, greatest($1,$2))),$1, $2, $6), $4, $5, $1, $2)),  @extschema@.ST_Intersection($3,  @extschema@.ST_Expand($7, abs($1) / 2.0, abs($2) / 2.0))) g FROM ' || tab::text
           || ' WHERE  @extschema@.ST_Intersects(' || quote_ident(col) || ', $3)';
       --RAISE DEBUG 'SQL: %', sql;
       FOR rec IN EXECUTE sql USING sfx, sfy, te, ipx, ipy, algo, ext LOOP

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -8780,10 +8780,10 @@ BEGIN
       --RAISE DEBUG 'sfx/sfy: %, %', sfx, sfy;
       --RAISE DEBUG 'tile extent %', te;
       sql := 'SELECT count(*),  @extschema@.ST_Clip(  @extschema@.ST_Union(  @extschema@.ST_SnapToGrid(  @extschema@.ST_Rescale(  @extschema@.ST_Clip(' || quote_ident(col)
-          || ',  @extschema@.ST_Expand($3, greatest($1,$2))),$1, $2, $6), $4, $5, $1, $2)), $3) g FROM ' || tab::text
+          || ',  @extschema@.ST_Expand($3, greatest($1,$2))),$1, $2, $6), $4, $5, $1, $2)),  @extschema@.ST_Intersection($3,  @extschema@.ST_Expand($7, greatest(abs($1), abs($2)) / 2.0))) g FROM ' || tab::text
           || ' WHERE  @extschema@.ST_Intersects(' || quote_ident(col) || ', $3)';
       --RAISE DEBUG 'SQL: %', sql;
-      FOR rec IN EXECUTE sql USING sfx, sfy, te, ipx, ipy, algo LOOP
+      FOR rec IN EXECUTE sql USING sfx, sfy, te, ipx, ipy, algo, ext LOOP
         --RAISE DEBUG '% source tiles intersect target tile %,% with extent %', rec.count, tx, ty, te::@extschema@.box2d;
         IF rec.g IS NULL THEN
           RAISE WARNING 'No source tiles cover target tile %,% with extent %',

--- a/raster/test/regress/rt_gdalwarp.sql
+++ b/raster/test/regress/rt_gdalwarp.sql
@@ -888,6 +888,30 @@ SELECT
 	ST_Metadata(ST_Resize(rast, 0.5, 0.5)) AS resize
 FROM foo;
 
+-- ticket #2800: ST_Rescale should expand, not shrink, to cover the input extent
+WITH src AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(256, 256, -180, 90, 0.00719999999999928, -0.00719999999999928, 0, 0, 4326),
+		1, '8BUI', 1, 0
+	) AS rast
+), rescaled AS (
+	SELECT rast, ST_Rescale(rast, 0.6, 0.6) AS rescale
+	FROM src
+), meta AS (
+	SELECT ST_Metadata(rescale) AS meta,
+		ST_Covers(ST_Envelope(rescale), ST_Envelope(rast)) AS covers_input
+	FROM rescaled
+)
+SELECT '#2800',
+	covers_input,
+	(meta).width,
+	(meta).height,
+	round((meta).scalex::numeric, 3) AS scalex,
+	round((meta).scaley::numeric, 3) AS scaley,
+	round((meta).upperleftx::numeric, 3) AS upperleftx,
+	round((meta).upperlefty::numeric, 3) AS upperlefty
+FROM meta;
+
 -- Mixed nodata/no-nodata bands keep declared nodata without treating no-nodata NaN as invalid
 WITH src AS (
 	SELECT ST_SetValue(

--- a/raster/test/regress/rt_gdalwarp_expected
+++ b/raster/test/regress/rt_gdalwarp_expected
@@ -107,5 +107,6 @@ NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL War
 NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL Warp API
 NOTICE:  Raster has default geotransform. Adjusting metadata for use of GDAL Warp API
 (0,0,5,5,2,-2,0,0,0,1)|(0,0,5,5,2,-2,0,0,0,1)
+#2800|t|4|4|0.600|0.600|-180.000|87.600
 t|t|f|NaN|t
 t|t


### PR DESCRIPTION
## What

Make raster warp dimension calculation use ceiling semantics when the requested
scale does not divide the source extent evenly. This lets `ST_Rescale` expand to
cover the input extent instead of shrinking inside it.

`ST_CreateOverview`/`ST_Retile` now crop overview tiles to the source coverage
extent expanded by half a target pixel, so the expanded intermediate rescale
rasters do not bloat overview constraints.

Adds regression coverage for the fractional scale case from
https://trac.osgeo.org/postgis/ticket/2800.

Trac ticket: https://trac.osgeo.org/postgis/ticket/2800

## Testing

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C raster -j32`
- `make -C extensions/postgis_raster -j32`
- `sudo -n make -C raster install`
- `sudo -n make -C extensions/postgis_raster install`
- `make postgis_revision.h`
- `make -C raster -j32`
- `make -C extensions/postgis_raster -j32`
- `sudo -n make -C raster install`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/raster/test/regress/rt_gdalwarp $(pwd)/raster/test/regress/rt_createoverview"`
- `git clang-format --diff upstream/master -- raster/rt_core/rt_warp.c`
- `make check-news`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
