### PR TITLE
pgsql2shp: prompt for required passwords

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -101,6 +101,10 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #398, pgsql2shp prompts for a password when required
+          (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -181,8 +185,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
  - #2045, pgsql2shp query dumps no longer require temporary table
           privileges (Darafei Praliaskouski)
- - #398, pgsql2shp prompts for a password when required
-          (Darafei Praliaskouski)
  - #1577, [loader] Report unsupported .zip archive input before trying
           to open shapefile sidecar files (Darafei Praliaskouski)
  - #3158, Move geometry and geography typmod bit helpers out of the

--- a/NEWS
+++ b/NEWS
@@ -181,6 +181,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
  - #2045, pgsql2shp query dumps no longer require temporary table
           privileges (Darafei Praliaskouski)
+ - #398, pgsql2shp prompts for a password when required
+          (Darafei Praliaskouski)
  - #1577, [loader] Report unsupported .zip archive input before trying
           to open shapefile sidecar files (Darafei Praliaskouski)
  - #3158, Move geometry and geography typmod bit helpers out of the

--- a/doc/man/pgsql2shp.1
+++ b/doc/man/pgsql2shp.1
@@ -39,7 +39,8 @@ The database host to connect to.
 The port to connect to on the database host.
 .TP 
 \fB\-P\fR <\fIpassword\fR>
-The password to use when connecting to the database.
+The password to use when connecting to the database. If omitted, pgsql2shp
+prompts when a password is required and stdin is a terminal.
 .TP 
 \fB\-u\fR <\fIuser\fR>
 The username to use when connecting to the database.

--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -2172,7 +2172,9 @@ pgsql2shp [<options>] <database> <query>
 		  <term><option>-P &lt;password&gt;</option></term>
 
 		  <listitem>
-			<para>The password to use when connecting to the database.</para>
+			<para>The password to use when connecting to the database. If
+			omitted, pgsql2shp prompts when a password is required and stdin is
+			a terminal.</para>
 		  </listitem>
 		</varlistentry>
 

--- a/loader/README.pgsql2shp
+++ b/loader/README.pgsql2shp
@@ -40,7 +40,9 @@ OPTIONS
               The port to connect to on the database host.
 
        -P <password>
-              The password to use when connecting to the database.
+              The password to use when connecting to the database. If omitted,
+              pgsql2shp prompts when a password is required and stdin is a
+              terminal.
 
        -u <user>
               The username to use when connecting to the database.

--- a/loader/cunit/cu_pgsql2shp.c
+++ b/loader/cunit/cu_pgsql2shp.c
@@ -13,9 +13,13 @@
 #include "cu_tester.h"
 #include "../pgsql2shp-core.h"
 
+#include <stdlib.h>
+#include <string.h>
+
 /* Test functions */
 void test_ShpDumperCreate(void);
 void test_ShpDumperDestroy(void);
+void test_ShpDumperConnectionStringPasswordEscaping(void);
 
 SHPDUMPERCONFIG *dumper_config;
 SHPDUMPERSTATE *dumper_state;
@@ -33,10 +37,11 @@ CU_pSuite register_pgsql2shp_suite(void)
 		return NULL;
 	}
 
-	if (
-	    (NULL == CU_add_test(pSuite, "test_ShpDumperCreate()", test_ShpDumperCreate)) ||
-	    (NULL == CU_add_test(pSuite, "test_ShpDumperDestroy()", test_ShpDumperDestroy))
-	)
+	if ((NULL == CU_add_test(pSuite, "test_ShpDumperCreate()", test_ShpDumperCreate)) ||
+	    (NULL == CU_add_test(pSuite, "test_ShpDumperDestroy()", test_ShpDumperDestroy)) ||
+	    (NULL == CU_add_test(pSuite,
+				 "test_ShpDumperConnectionStringPasswordEscaping()",
+				 test_ShpDumperConnectionStringPasswordEscaping)))
 	{
 		CU_cleanup_registry();
 		return NULL;
@@ -74,4 +79,22 @@ void test_ShpDumperCreate(void)
 void test_ShpDumperDestroy(void)
 {
 	ShpDumperDestroy(dumper_state);
+}
+
+void
+test_ShpDumperConnectionStringPasswordEscaping(void)
+{
+	SHPDUMPERCONFIG config;
+	char *connstring;
+
+	set_dumper_config_defaults(&config);
+	config.conn->database = "postgis";
+	config.conn->password = "pa'ss\\word";
+
+	connstring = ShpDumperGetConnectionStringFromConn(config.conn);
+	CU_ASSERT_PTR_NOT_NULL(connstring);
+	CU_ASSERT_PTR_NOT_NULL(strstr(connstring, " password='pa\\'ss\\\\word'"));
+
+	free(connstring);
+	free(config.conn);
 }

--- a/loader/pgsql2shp-cli.c
+++ b/loader/pgsql2shp-cli.c
@@ -40,7 +40,9 @@ usage(int status)
 	printf(_("  -h <host>  Allows you to specify connection to a database on a\n"
 	         "     machine other than the default.\n" ));
 	printf(_("  -p <port>  Allows you to specify a database port other than the default.\n" ));
-	printf(_("  -P <password>  Connect to the database with the specified password.\n" ));
+	printf(
+	    _("  -P <password>  Connect to the database with the specified password.\n"
+	      "     If omitted, pgsql2shp prompts when a password is required and stdin is a terminal.\n"));
 	printf(_("  -u <user>  Connect to the database as the specified user.\n" ));
 	printf(_("  -g <geometry_column> Specify the geometry column to be exported.\n" ));
 	printf(_("  -b Use a binary cursor.\n" ));

--- a/loader/pgsql2shp-core.c
+++ b/loader/pgsql2shp-core.c
@@ -34,10 +34,6 @@
 #include <unistd.h>
 #endif
 
-#if HAVE_TERMIOS_H
-#include <termios.h>
-#endif
-
 #ifdef __CYGWIN__
 #include <sys/param.h>
 #endif
@@ -45,6 +41,10 @@
 #include "../liblwgeom/stringbuffer.h"
 #include "../liblwgeom/liblwgeom.h" /* for LWGEOM struct and funx */
 #include "../liblwgeom/lwgeom_log.h" /* for LWDEBUG macros */
+
+#if HAVE_TERMIOS_H
+#include <termios.h>
+#endif
 
 /* Maximum DBF field width (according to ARCGIS) */
 #define MAX_DBF_FIELD_SIZE 254
@@ -84,13 +84,13 @@ core_asprintf(const char* format, ...)
 {
 	va_list ap;
 	char *value;
-    int err;
+	int err;
 	va_start(ap, format);
-    err = vasprintf(&value, format, ap);
-    if (err < 0)
-    	exit(-1);
-    va_end(ap);
-    return value;
+	err = vasprintf(&value, format, ap);
+	if (err < 0)
+		exit(-1);
+	va_end(ap);
+	return value;
 }
 
 static int
@@ -1388,7 +1388,7 @@ ShpDumperPromptPassword(void)
 	}
 #endif
 
-	fprintf(stderr, "Password: ");
+	fprintf(stderr, _("Password: "));
 	fflush(stderr);
 
 	if (!fgets(password, sizeof(password), stdin))

--- a/loader/pgsql2shp-core.c
+++ b/loader/pgsql2shp-core.c
@@ -34,6 +34,10 @@
 #include <unistd.h>
 #endif
 
+#if HAVE_TERMIOS_H
+#include <termios.h>
+#endif
+
 #ifdef __CYGWIN__
 #include <sys/param.h>
 #endif
@@ -1333,7 +1337,12 @@ ShpDumperGetConnectionStringFromConn(SHPCONNECTIONCONFIG *conn)
 		stringbuffer_aprintf(&cs, " user=%s", conn->username);
 
 	if (conn->password)
-		stringbuffer_aprintf(&cs, " password='%s'", conn->password);
+	{
+		char *password = escape_connection_string(conn->password);
+		stringbuffer_aprintf(&cs, " password='%s'", password);
+		if (password != conn->password)
+			free(password);
+	}
 
 	if (conn->database)
 		stringbuffer_aprintf(&cs, " dbname=%s", conn->database);
@@ -1344,6 +1353,71 @@ ShpDumperGetConnectionStringFromConn(SHPCONNECTIONCONFIG *conn)
 	return cs.str_start;
 }
 
+static PGconn *
+ShpDumperConnectWithConn(SHPCONNECTIONCONFIG *conn)
+{
+	PGconn *pgconn;
+	char *connstring = ShpDumperGetConnectionStringFromConn(conn);
+	pgconn = PQconnectdb(connstring);
+	free(connstring);
+	return pgconn;
+}
+
+static char *
+ShpDumperPromptPassword(void)
+{
+	char password[1024];
+	size_t length;
+
+#if HAVE_TERMIOS_H
+	struct termios old_termios;
+	struct termios new_termios;
+	int has_termios = (tcgetattr(fileno(stdin), &old_termios) == 0);
+#endif
+
+	if (!isatty(fileno(stdin)))
+		return NULL;
+
+#if HAVE_TERMIOS_H
+	if (has_termios)
+	{
+		new_termios = old_termios;
+		new_termios.c_lflag &= ~ECHO;
+		if (tcsetattr(fileno(stdin), TCSAFLUSH, &new_termios) != 0)
+			has_termios = 0;
+	}
+#endif
+
+	fprintf(stderr, "Password: ");
+	fflush(stderr);
+
+	if (!fgets(password, sizeof(password), stdin))
+	{
+#if HAVE_TERMIOS_H
+		if (has_termios)
+		{
+			(void)tcsetattr(fileno(stdin), TCSAFLUSH, &old_termios);
+			fprintf(stderr, "\n");
+		}
+#endif
+		return NULL;
+	}
+
+#if HAVE_TERMIOS_H
+	if (has_termios)
+	{
+		(void)tcsetattr(fileno(stdin), TCSAFLUSH, &old_termios);
+		fprintf(stderr, "\n");
+	}
+#endif
+
+	length = strlen(password);
+	while (length > 0 && (password[length - 1] == '\n' || password[length - 1] == '\r'))
+		password[--length] = '\0';
+
+	return strdup(password);
+}
+
 /* Connect to the database and identify the version of PostGIS (and any other
 capabilities required) */
 int
@@ -1352,15 +1426,27 @@ ShpDumperConnectDatabase(SHPDUMPERSTATE *state)
 	PGresult *res;
 	char *tmpvalue;
 
-	/* Generate the PostgreSQL connection string */
-	char *connstring = ShpDumperGetConnectionStringFromConn(state->config->conn);
-
 	/* Connect to the database */
-	state->conn = PQconnectdb(connstring);
+	state->conn = ShpDumperConnectWithConn(state->config->conn);
+	if (PQstatus(state->conn) == CONNECTION_BAD)
+	{
+		if (!state->config->conn->password && PQconnectionNeedsPassword(state->conn))
+		{
+			char *password = ShpDumperPromptPassword();
+			if (password)
+			{
+				SHPCONNECTIONCONFIG retry_conn = *state->config->conn;
+				retry_conn.password = password;
+				PQfinish(state->conn);
+				state->conn = ShpDumperConnectWithConn(&retry_conn);
+				free(password);
+			}
+		}
+	}
+
 	if (PQstatus(state->conn) == CONNECTION_BAD)
 	{
 		snprintf(state->message, SHPDUMPERMSGLEN, "%s", PQerrorMessage(state->conn));
-		free(connstring);
 		return SHPDUMPERERR;
 	}
 
@@ -1370,7 +1456,6 @@ ShpDumperConnectDatabase(SHPDUMPERSTATE *state)
 	{
 		snprintf(state->message, SHPDUMPERMSGLEN, "%s", PQresultErrorMessage(res));
 		PQclear(res);
-		free(connstring);
 		return SHPDUMPERERR;
 	}
 
@@ -1382,7 +1467,6 @@ ShpDumperConnectDatabase(SHPDUMPERSTATE *state)
 	{
 		snprintf(state->message, SHPDUMPERMSGLEN, "%s", PQresultErrorMessage(res));
 		PQclear(res);
-		free(connstring);
 		return SHPDUMPERERR;
 	}
 
@@ -1397,7 +1481,6 @@ ShpDumperConnectDatabase(SHPDUMPERSTATE *state)
 	{
 		snprintf(state->message, SHPDUMPERMSGLEN, _("Error looking up geometry oid: %s"), PQresultErrorMessage(res));
 		PQclear(res);
-		free(connstring);
 		return SHPDUMPERERR;
 	}
 
@@ -1410,7 +1493,6 @@ ShpDumperConnectDatabase(SHPDUMPERSTATE *state)
 	{
 		snprintf(state->message, SHPDUMPERMSGLEN, _("Geometry type unknown (have you enabled postgis?)"));
 		PQclear(res);
-		free(connstring);
 		return SHPDUMPERERR;
 	}
 
@@ -1422,7 +1504,6 @@ ShpDumperConnectDatabase(SHPDUMPERSTATE *state)
 	{
 		snprintf(state->message, SHPDUMPERMSGLEN, _("Error looking up geography oid: %s"), PQresultErrorMessage(res));
 		PQclear(res);
-		free(connstring);
 		return SHPDUMPERERR;
 	}
 
@@ -1434,8 +1515,6 @@ ShpDumperConnectDatabase(SHPDUMPERSTATE *state)
 	}
 
 	PQclear(res);
-
-	free(connstring);
 
 	return SHPDUMPEROK;
 }

--- a/loader/pgsql2shp-core.c
+++ b/loader/pgsql2shp-core.c
@@ -1388,7 +1388,7 @@ ShpDumperPromptPassword(void)
 	}
 #endif
 
-	fprintf(stderr, _("Password: "));
+	fprintf(stderr, "%s", _("Password: "));
 	fflush(stderr);
 
 	if (!fgets(password, sizeof(password), stdin))

--- a/postgis_config.h.in
+++ b/postgis_config.h.in
@@ -17,6 +17,9 @@
 /* Define if the GNU gettext() function is already present or preinstalled. */
 #undef HAVE_GETTEXT
 
+/* termios.h header */
+#undef HAVE_TERMIOS_H
+
 /* Define if the build is big endian */
 #undef WORDS_BIGENDIAN
 


### PR DESCRIPTION
## Summary
- let libpq try the initial pgsql2shp connection without an explicit password, preserving `.pgpass` and other libpq credential sources
- prompt once when libpq reports that a password is required and stdin is a terminal
- escape passwords embedded in generated conninfo strings

Trac ticket: https://trac.osgeo.org/postgis/ticket/398

## Validation
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C loader -j32`
- `make -C loader/cunit cu_tester`
- `./loader/cunit/cu_tester`
- `make -C doc check`
- `make check-news`
- `git clang-format --diff upstream/master -- loader/pgsql2shp-core.c loader/pgsql2shp-cli.c loader/cunit/cu_pgsql2shp.c`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- configured header check: `postgis_config.h` contains `#define HAVE_TERMIOS_H 1`
- local PostgreSQL 18 SCRAM smoke: no-tty failure did not prompt, `.pgpass` succeeded, explicit `-P` with quote/backslash succeeded, and a pty-driven prompt succeeded
