### PR TITLE
utils: pass pg_restore options through postgis_restore

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -183,6 +183,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #2584, Allow postgis_restore to pass options through to pg_restore
+          (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and

--- a/NEWS
+++ b/NEWS
@@ -93,6 +93,10 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #2584, Allow postgis_restore to pass options through to pg_restore
+          (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -183,8 +187,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
- - #2584, Allow postgis_restore to pass options through to pg_restore
-          (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and

--- a/doc/administration.xml
+++ b/doc/administration.xml
@@ -291,6 +291,14 @@ string, and next time you'll need to drop the "next" suffix again:
 
 	  <programlisting language="bash">postgis_restore "/somepath/olddb.backup" | psql -h localhost -p 5432 -U postgres newdb 2&gt; errors.txt</programlisting>
 
+	  <para>
+		To pass additional options to the underlying
+		<application>pg_restore</application> calls, put them after a
+		<literal>--</literal> separator following the dump path.
+	  </para>
+
+	  <programlisting>postgis_restore "/somepath/olddb.backup" -- --schema-only | psql -h localhost -p 5432 -U postgres newdb 2&gt; errors.txt</programlisting>
+
 	</listitem>
 
 	</orderedlist>

--- a/doc/man/postgis_restore.1
+++ b/doc/man/postgis_restore.1
@@ -5,7 +5,7 @@ postgis_restore - restore a PostGIS database from an archive file created by pg_
 
 .SH "SYNTAX"
 .LP
-postgis_restore [\fI-v\fR] [\fI-L TOC\fR] [\fI-s schema\fR] \fIdumpfile\fR
+postgis_restore [\fI-v\fR] [\fI-L TOC\fR] [\fI-s schema\fR] \fIdumpfile\fR [\fI-- pg_restore-arg ...\fR]
 
 .SH "DESCRIPTION"
 .LP
@@ -26,6 +26,8 @@ those created with \fIpg_dump -Fc\fR.
 Usage information is printed when the script is invoked with no
 arguments.
 
+Arguments after \fI--\fR are passed through to \fIpg_restore\fR.
+
 .SH "EXAMPLES"
 .LP
 
@@ -44,6 +46,10 @@ PostGIS-enable the new database:
 Restore your data:
 
 	postgis_restore.pl olddb.dump | psql newdb
+
+Restore schema objects only by passing an option through to \fIpg_restore\fR:
+
+	postgis_restore.pl olddb.dump -- --schema-only | psql newdb
 
 .SH "AUTHORS"
 .LP

--- a/utils/Makefile.in
+++ b/utils/Makefile.in
@@ -126,7 +126,10 @@ check: check-unit
 create_upgrade_replaced_function_errors_check:
 	srcdir=$(srcdir) PERL=$(PERL) $(SHELL) $(srcdir)/check_create_upgrade_replaced_function_errors.sh
 
-check-unit: postgis_restore-check create_upgrade_replaced_function_errors_check
+check-unit: postgis_restore-check create_upgrade_replaced_function_errors_check test-postgis-restore
+
+test-postgis-restore:
+	$(SHELL) $(srcdir)/test_postgis_restore.sh $(srcdir)/postgis_restore.pl.in
 
 installdir:
 	@mkdir -p $(DESTDIR)$(bindir)

--- a/utils/postgis_restore.pl.in
+++ b/utils/postgis_restore.pl.in
@@ -36,7 +36,7 @@ use strict;
 my $me = $0;
 
 my $usage = qq{
-Usage:	$me [-v] [-L TOC] [-s schema] <dumpfile>
+Usage:	$me [-v] [-L TOC] [-s schema] <dumpfile> [-- pg_restore-arg ...]
         Restore a custom dump (pg_dump -Fc) of a PostGIS-enabled database.
         First dump the old database: pg_dump -Fc MYDB > MYDB.dmp
         Then create a new database: createdb NEWDB
@@ -50,6 +50,7 @@ Usage:	$me [-v] [-L TOC] [-s schema] <dumpfile>
         The -v switch writes detailed report on stderr.
         Use -L to provide a TOC rather than extracting it from the dump.
         Use -s if you installed PostGIS in a custom schema.
+        Use -- after the dump file to pass the following arguments to pg_restore.
 
 };
 
@@ -84,7 +85,12 @@ while (@ARGV && $ARGV[0] =~ /^-/) {
 
 die $usage if (@ARGV < 1);
 
-my $dumpfile = $ARGV[0];
+my $dumpfile = shift(@ARGV);
+my @pg_restore_args;
+if ( @ARGV ) {
+  die $usage if shift(@ARGV) ne '--';
+  @pg_restore_args = @ARGV;
+}
 my $manifest = $dumpfile;
 $manifest =~ s/\/$//; # strip trailing slash
 $manifest .= ".lst";
@@ -123,7 +129,7 @@ if(!defined($POSTGIS_TOC)) {
   print STDERR "  Writing manifest of things to read from dump file...\n"
     if $DEBUG;
 
-  open( DUMP, "pg_restore -f - -l $dumpfile |" ) || die "$me:\tCannot open dump file '$dumpfile'\n";
+  open( DUMP, "-|", "pg_restore", "-f", "-", "-l", $dumpfile ) || die "$me:\tCannot open dump file '$dumpfile'\n";
 } else {
   open( DUMP, '<' . $POSTGIS_TOC) || die "$me:\tCannot open TOC file '$POSTGIS_TOC'\n";
 }
@@ -145,7 +151,7 @@ while( my $l = <DUMP> ) {
 
 	if ( not defined ($POSTGIS_SCHEMA) )
 	{
-		if ( $l =~ / TABLE DATA ([^ ]*) spatial_ref_sys / )
+		if ( $l =~ / TABLE (?:DATA )?([^ ]*) spatial_ref_sys / )
 		{
 			$POSTGIS_SCHEMA = $1;
 			print STDERR "  Setting postgis schema to $POSTGIS_SCHEMA, as found in the dump\n"
@@ -170,11 +176,10 @@ close(DUMP) || die "$me: pg_restore returned an error\n";
 #
 print STDERR "  Writing ASCII to stdout...\n"
   if $DEBUG;
-open( INPUT, "pg_restore -f - -L $manifest $dumpfile |") || die "$me:\tCan't run pg_restore\n";
+open( INPUT, "-|", "pg_restore", @pg_restore_args, "-f", "-", "-L", $manifest, $dumpfile ) || die "$me:\tCan't run pg_restore\n";
 
-if ( defined $POSTGIS_SCHEMA ) {
-  print STDOUT "SET search_path = \"" . $POSTGIS_SCHEMA . "\";\n";
-}
+my $postgis_schema = defined $POSTGIS_SCHEMA ? $POSTGIS_SCHEMA : "public";
+print STDOUT "SET search_path = \"" . $postgis_schema . "\";\n";
 
 #
 # Disable topology metadata tables triggers to allow for population
@@ -349,9 +354,7 @@ while( my $l = <INPUT> ) {
 
 }
 
-if ( defined $POSTGIS_SCHEMA ) {
-  print STDOUT "SET search_path = \"" . $POSTGIS_SCHEMA . "\";\n";
-}
+print STDOUT "SET search_path = \"" . $postgis_schema . "\";\n";
 
 if ( $hasTopology ) {
 

--- a/utils/postgis_restore.pl.in
+++ b/utils/postgis_restore.pl.in
@@ -353,6 +353,7 @@ while( my $l = <INPUT> ) {
   print STDOUT $l;
 
 }
+close(INPUT) || die "$me: pg_restore returned an error\n";
 
 print STDOUT "SET search_path = \"" . $postgis_schema . "\";\n";
 

--- a/utils/test_postgis_restore.sh
+++ b/utils/test_postgis_restore.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -eu
+
+if test "$#" -ne 1; then
+  echo "usage: $0 POSTGIS_RESTORE" >&2
+  exit 2
+fi
+
+restore=$1
+tmpdir=$(mktemp -d "${TMPDIR:-.}/postgis_restore.XXXXXX")
+trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+mkdir "$tmpdir/bin"
+
+cat > "$tmpdir/bin/pg_dump" <<'EOF'
+#!/bin/sh
+echo 'pg_dump (PostgreSQL) test'
+EOF
+
+cat > "$tmpdir/bin/pg_restore" <<'EOF'
+#!/bin/sh
+if test "${1-}" = '--version'; then
+  echo 'pg_restore (PostgreSQL) test'
+  exit 0
+fi
+
+for arg in "$@"; do
+  if test "$arg" = '-l'; then
+    exit 0
+  fi
+done
+
+echo 'CREATE TABLE restore_failure_test (id integer);'
+exit 1
+EOF
+chmod +x "$tmpdir/bin/pg_dump" "$tmpdir/bin/pg_restore"
+touch "$tmpdir/dump"
+
+set +e
+sed \
+  -e 's/@SRID_MAXIMUM@/999999/g' \
+  -e 's/@SRID_USER_MAXIMUM@/999999/g' \
+  "$restore" | PATH="$tmpdir/bin:$PATH" perl - "$tmpdir/dump" > "$tmpdir/out" 2> "$tmpdir/err"
+status=$?
+set -e
+
+if test "$status" -eq 0; then
+  echo 'postgis_restore succeeded after pg_restore failed' >&2
+  exit 1
+fi
+
+grep -F 'pg_restore returned an error' "$tmpdir/err" >/dev/null
+if grep -F 'DROP TABLE _pgis_restore_spatial_ref_sys;' "$tmpdir/out" >/dev/null; then
+  echo 'postgis_restore emitted trailing SQL after pg_restore failed' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This updates `postgis_restore.pl` so callers can pass additional options to the underlying `pg_restore` restore call after a `--` separator:

```sh
postgis_restore.pl olddb.dump -- --schema-only | psql newdb
```

The existing positional dumpfile interface is preserved. The restore invocation now uses Perl list-form `open`, so forwarded arguments and dump paths are not re-tokenized through the shell.

The internal TOC scan remains unfiltered and runs without the forwarded restore options. That keeps PostGIS schema detection stable for options such as `--schema-only`, where `pg_restore -l --schema-only` can hide the `TABLE DATA ... spatial_ref_sys` entry. The schema detector also accepts the `TABLE ... spatial_ref_sys` TOC entry, so custom PostGIS schemas are still detected when only schema objects are visible.

Trac: https://trac.osgeo.org/postgis/ticket/2584

## Validation

- `make -C utils postgis_restore.pl`
- `perl -c utils/postgis_restore.pl`
- `make check-news`
- `make -C doc check`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
- Smoke-tested a custom-format dump with PostGIS installed in schema `postgis_custom`:
  - `postgis_restore.pl dump -- --schema-only` emitted `SET search_path = "postgis_custom";`
  - schema-only output included the dumped table definition
  - schema-only output did not include `COPY` data rows
