### PR TITLE
Add record input support to AsTopoJSON

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,6 +71,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #5205, [topology] Allow AsTopoJSON to take a feature record
+          (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -4611,13 +4611,19 @@ SELECT topology.AsGML(topo,'') As rdgml
                         <paramdef><type>topogeometry </type> <parameter>tg</parameter></paramdef>
                         <paramdef><type>regclass </type> <parameter>edgeMapTable</parameter></paramdef>
 					</funcprototype>
+					<funcprototype>
+                        <funcdef>text <function>AsTopoJSON</function></funcdef>
+                        <paramdef><type>record </type> <parameter>feature</parameter></paramdef>
+                        <paramdef><type>text </type> <parameter>topogeom_column</parameter></paramdef>
+                        <paramdef><type>regclass </type> <parameter>edgeMapTable</parameter></paramdef>
+					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
 
 			<refsection>
                 <title>Description</title>
 
-                <para>Returns the TopoJSON representation of a topogeometry. If <varname>edgeMapTable</varname> is not null, it will be used as a lookup/storage mapping of edge identifiers to arc indices. This is to be able to allow for a compact "arcs" array in the final document.
+                <para>Returns the TopoJSON representation of a topogeometry. The record variant finds a <varname>topogeometry</varname> column in the input record and returns the same TopoJSON representation for that column. If <varname>topogeom_column</varname> is an empty string or omitted, the first <varname>topogeometry</varname> column is used. If <varname>edgeMapTable</varname> is not null, it will be used as a lookup/storage mapping of edge identifiers to arc indices. This is to be able to allow for a compact "arcs" array in the final document.
 </para>
 
 <para>
@@ -4640,6 +4646,7 @@ the actual arcs plus some headers. See the <link xlink:href="http://github.com/m
                 <!-- use this format if new function -->
                 <para role="availability" conformance="2.1.0">Availability: 2.1.0 </para>
                 <para role="enhanced" conformance="2.2.1">Enhanced: 2.2.1 added support for puntal inputs</para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 added support for record inputs</para>
 			</refsection>
 
 

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -17,6 +17,7 @@
 #include "utils/elog.h"
 #include "utils/memutils.h" /* for transaction contexts */
 #include "utils/array.h" /* for ArrayType */
+#include "utils/typcache.h" /* for lookup_rowtype_tupdesc */
 #include "catalog/pg_type.h" /* for INT4OID, TEXTOID */
 #include "lib/stringinfo.h"
 #include "access/htup_details.h" /* for heap_form_tuple() */
@@ -144,6 +145,144 @@ _lwtype_upper_name(int type, char *buf, size_t buflen)
     *ptr = toupper(*ptr);
     ++ptr;
   }
+}
+
+PG_FUNCTION_INFO_V1(AsTopoJSONRow);
+Datum
+AsTopoJSONRow(PG_FUNCTION_ARGS)
+{
+	Datum composite;
+	HeapTupleHeader td;
+	Oid tupType;
+	int32 tupTypmod;
+	TupleDesc tupdesc;
+	HeapTupleData tmptup;
+	HeapTuple tuple;
+	char *topogeom_column = NULL;
+	Oid topogeom_oid;
+	int topogeom_attnum = -1;
+	Datum topogeom;
+	Datum values[2];
+	Oid argtypes[2];
+	char nulls[3] = {' ', ' ', '\0'};
+	bool isnull;
+	int spi_result;
+	int i;
+	MemoryContext oldcontext = CurrentMemoryContext;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	composite = PG_GETARG_DATUM(0);
+	if (!PG_ARGISNULL(1))
+	{
+		topogeom_column = text_to_cstring(PG_GETARG_TEXT_PP(1));
+		if (!topogeom_column[0])
+			topogeom_column = NULL;
+	}
+
+	if (SPI_connect() != SPI_OK_CONNECT)
+		elog(ERROR, "could not connect to SPI manager");
+
+	spi_result = SPI_execute("SELECT 'topology.TopoGeometry'::regtype::oid", true, 1);
+	if (spi_result != SPI_OK_SELECT || SPI_processed != 1)
+		elog(ERROR, "could not resolve topology.TopoGeometry type");
+
+	topogeom_oid = DatumGetObjectId(SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull));
+	if (isnull)
+		elog(ERROR, "could not resolve topology.TopoGeometry type");
+
+	td = DatumGetHeapTupleHeader(composite);
+	tupType = HeapTupleHeaderGetTypeId(td);
+	tupTypmod = HeapTupleHeaderGetTypMod(td);
+	tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
+
+	tmptup.t_len = HeapTupleHeaderGetDatumLength(td);
+	tmptup.t_data = td;
+	tuple = &tmptup;
+
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+		char *attname;
+
+		if (att->attisdropped)
+			continue;
+
+		attname = NameStr(att->attname);
+		if (topogeom_column)
+		{
+			if (strcmp(attname, topogeom_column) != 0)
+				continue;
+
+			if (att->atttypid != topogeom_oid)
+			{
+				ReleaseTupleDesc(tupdesc);
+				SPI_finish();
+				ereport(
+				    ERROR,
+				    (errmsg("column \"%s\" is not of type topology.TopoGeometry", topogeom_column)));
+			}
+
+			topogeom_attnum = i + 1;
+			break;
+		}
+
+		if (att->atttypid == topogeom_oid)
+		{
+			topogeom_attnum = i + 1;
+			break;
+		}
+	}
+
+	if (topogeom_attnum < 0)
+	{
+		ReleaseTupleDesc(tupdesc);
+		SPI_finish();
+		if (topogeom_column)
+			ereport(ERROR, (errmsg("topology.TopoGeometry column \"%s\" does not exist", topogeom_column)));
+		ereport(ERROR, (errmsg("record contains no topology.TopoGeometry column")));
+	}
+
+	topogeom = heap_getattr(tuple, topogeom_attnum, tupdesc, &isnull);
+	ReleaseTupleDesc(tupdesc);
+
+	if (isnull)
+	{
+		SPI_finish();
+		PG_RETURN_NULL();
+	}
+
+	values[0] = topogeom;
+	argtypes[0] = topogeom_oid;
+	argtypes[1] = REGCLASSOID;
+	if (PG_ARGISNULL(2))
+		nulls[1] = 'n';
+	else
+		values[1] = PG_GETARG_OID(2);
+
+	spi_result = SPI_execute_with_args("SELECT topology.AsTopoJSON($1, $2)", 2, argtypes, values, nulls, true, 1);
+	if (spi_result != SPI_OK_SELECT || SPI_processed != 1)
+	{
+		SPI_finish();
+		elog(ERROR, "unexpected return (%d) from topology.AsTopoJSON", spi_result);
+	}
+
+	topogeom = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
+	if (isnull)
+	{
+		SPI_finish();
+		PG_RETURN_NULL();
+	}
+	else
+	{
+		char *json = TextDatumGetCString(topogeom);
+		text *result;
+		MemoryContextSwitchTo(oldcontext);
+		result = cstring_to_text(json);
+		SPI_finish();
+		PG_RETURN_TEXT_P(result);
+	}
 }
 
 /* Return an lwalloc'ed geometrical representation of the box */

--- a/topology/sql/export/TopoJSON.sql.in
+++ b/topology/sql/export/TopoJSON.sql.in
@@ -330,3 +330,20 @@ END
 $$ LANGUAGE 'plpgsql' VOLATILE; -- writes into visited table
 -- } AsTopoJSON(TopoGeometry, visited_table)
 
+--{
+--
+-- API FUNCTION
+--
+-- text AsTopoJSON(record, topogeom_column, edgeMapTable)
+--
+-- Similar to ST_AsGeoJSON(record), but delegates the selected TopoGeometry
+-- column to topology.AsTopoJSON(topogeometry, regclass).
+--
+CREATE OR REPLACE FUNCTION topology.AsTopoJSON(
+    r record,
+    topogeom_column text DEFAULT '',
+    edgeMapTable regclass DEFAULT NULL)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'AsTopoJSONRow'
+  LANGUAGE 'c' VOLATILE;
+-- } AsTopoJSON(record, topogeom_column, edgeMapTable)

--- a/topology/test/regress/topojson.sql
+++ b/topology/test/regress/topojson.sql
@@ -17,6 +17,24 @@ SELECT 'L1-vanilla', feature_name, topology.AsTopoJSON(feature, NULL)
  WHERE feature_name IN ('R3', 'R4', 'R1', 'R2' )
  ORDER BY feature_name;
 
+SELECT 'L1-record-auto', feature_name, topology.AsTopoJSON(features.city_streets.*)
+ FROM features.city_streets
+ WHERE feature_name IN ('R3')
+ ORDER BY feature_name;
+
+SELECT 'L1-record-explicit', feature_name, topology.AsTopoJSON(features.city_streets.*, 'feature')
+ FROM features.city_streets
+ WHERE feature_name IN ('R3')
+ ORDER BY feature_name;
+
+SELECT 'L1-record-subquery-auto', feature_name, topology.AsTopoJSON(q)
+ FROM (
+  SELECT feature_name, feature
+  FROM features.city_streets
+  WHERE feature_name IN ('R3')
+ ) q
+ ORDER BY feature_name;
+
 --- Lineal hierarchical
 SELECT 'L2-vanilla', feature_name, topology.AsTopoJSON(feature, NULL)
  FROM features.big_streets
@@ -42,6 +60,15 @@ CREATE TEMP TABLE edgemap (arc_id bigserial, edge_id bigint unique);
 SELECT 'L1-edgemap', feature_name, topology.AsTopoJSON(feature, 'edgemap')
  FROM features.city_streets
  WHERE feature_name IN ('R3', 'R4', 'R1', 'R2' )
+ ORDER BY feature_name;
+
+TRUNCATE edgemap; SELECT NULLIF(setval('edgemap_arc_id_seq', 1, false), 1);
+SELECT 'L1-record-edgemap', feature_name, topology.AsTopoJSON(q, 'feature', 'edgemap')
+ FROM (
+  SELECT feature_name, feature
+  FROM features.city_streets
+  WHERE feature_name IN ('R3')
+ ) q
  ORDER BY feature_name;
 
 --- Lineal hierarchical

--- a/topology/test/regress/topojson_expected
+++ b/topology/test/regress/topojson_expected
@@ -6,6 +6,9 @@ L1-vanilla|R1|{ "type": "MultiLineString", "arcs": [[9,-11]]}
 L1-vanilla|R2|{ "type": "MultiLineString", "arcs": [[4,-6]]}
 L1-vanilla|R3|{ "type": "MultiLineString", "arcs": [[25]]}
 L1-vanilla|R4|{ "type": "MultiLineString", "arcs": [[3]]}
+L1-record-auto|R3|{ "type": "MultiLineString", "arcs": [[25]]}
+L1-record-explicit|R3|{ "type": "MultiLineString", "arcs": [[25]]}
+L1-record-subquery-auto|R3|{ "type": "MultiLineString", "arcs": [[25]]}
 L2-vanilla|R1R2|{ "type": "MultiLineString", "arcs": [[9,-11],[4,-6]]}
 L2-vanilla|R4|{ "type": "MultiLineString", "arcs": [[3]]}
 A1-vanilla|P1|{ "type": "MultiPolygon", "arcs": [[[21,20,5,-19,-20,-12]]]}
@@ -19,6 +22,7 @@ L1-edgemap|R1|{ "type": "MultiLineString", "arcs": [[0,-2]]}
 L1-edgemap|R2|{ "type": "MultiLineString", "arcs": [[2,-4]]}
 L1-edgemap|R3|{ "type": "MultiLineString", "arcs": [[4]]}
 L1-edgemap|R4|{ "type": "MultiLineString", "arcs": [[5]]}
+L1-record-edgemap|R3|{ "type": "MultiLineString", "arcs": [[0]]}
 L2-edgemap|R1R2|{ "type": "MultiLineString", "arcs": [[0,-2],[2,-4]]}
 L2-edgemap|R4|{ "type": "MultiLineString", "arcs": [[4]]}
 A1-edgemap|P1|{ "type": "MultiPolygon", "arcs": [[[5,4,3,-3,-2,-1]]]}


### PR DESCRIPTION
## Summary
- add a C-backed `topology.AsTopoJSON(record, text, regclass)` overload
- auto-detect the first `topology.TopoGeometry` column or use an explicit column name
- keep the existing TopoJSON geometry-fragment output and delegate to the existing TopoGeometry exporter
- document the record input and add regression coverage for table rows, anonymous subquery records, and edge maps
- include PostgreSQL typcache declarations for `lookup_rowtype_tupdesc`, fixing older/stricter build failures and possible tuple-descriptor pointer truncation

## Ticket
https://trac.osgeo.org/postgis/ticket/5205

## Validation
- initial PR validation: `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`, `make -j32`, staged install, full topology test run, `git clang-format`, doc checks, NEWS checks
- latest rebase validation on `f909d1011`: `make -C topology -j32`
- latest rebase validation on `f909d1011`: `sudo -n make install`
- latest rebase validation on `f909d1011`: `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres PGPASSWORD=postgres make -C topology/test check-regress RUNTESTFLAGS="--extension --verbose" TESTS="regress/topojson"` passed fresh and upgrade
- latest rebase validation on `f909d1011`: `make -C doc check`
- latest rebase validation on `f909d1011`: `make check-news`
- latest rebase validation on `f909d1011`: `git diff --check`
- standards-conforming string validation on `f909d1011`: `make -j32`, `sudo -n make install`, and focused `topology/test` `topojson` regression with `regress/hooks/standard-conforming-strings-off.sql` passed fresh and upgrade; log has no `nonstandard use of escape` warnings

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/329


