### PR TITLE
Add pg_upgrade coverage to Woodie CI

### DIFF
--- a/.woodpecker/regress.yml
+++ b/.woodpecker/regress.yml
@@ -131,3 +131,11 @@ steps:
       - <<: *steps-start-postgresql
       - <<: *steps-pg-install
       - <<: *steps-pg-test-all-upgrades
+
+  cluster-upgradecheck-pg14-to-pg18:
+    image: *test-image
+    depends_on: [ installcheck-pg14, installcheck-pg18 ]
+    commands:
+      - make -C build/pg14 install
+      - make -C build/pg18 install
+      - su postgres -c 'utils/check_cluster_upgrade.sh -i regress/hooks/cluster-upgrade-geography.sql /usr/lib/postgresql/14/bin/pg_config /usr/lib/postgresql/18/bin/pg_config'

--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #5995, Add pg_upgrade coverage to Woodie CI
+          (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/regress/hooks/cluster-upgrade-geography.sql
+++ b/regress/hooks/cluster-upgrade-geography.sql
@@ -1,0 +1,13 @@
+CREATE EXTENSION postgis;
+
+CREATE SCHEMA procsch;
+
+CREATE TABLE procsch."MyTab" (
+    "id" bigint,
+    "loc" public.geography(Point, 4283)
+);
+
+INSERT INTO procsch."MyTab"
+VALUES (1, 'SRID=4283;POINT(152.138672 -30.689888)'::geography);
+
+SELECT count(*) FROM procsch."MyTab";

--- a/utils/check_cluster_upgrade.sh
+++ b/utils/check_cluster_upgrade.sh
@@ -16,8 +16,15 @@ usage() {
 
 cleanup() {
   echo "-- Cleaning up --"
-  echo "Stopping postmaster on ${DATADIR} up"
-  ${BIN_OLD}/pg_ctl -D ${DATADIR} stop
+  if test -f "${DATADIR}/postmaster.pid"; then
+    if test -n "${BIN_NEW}"; then
+      echo "Stopping postmaster on ${DATADIR}"
+      ${BIN_NEW}/pg_ctl -D ${DATADIR} stop
+    else
+      echo "Stopping postmaster on ${DATADIR}"
+      ${BIN_OLD}/pg_ctl -D ${DATADIR} stop
+    fi
+  fi
   echo "Removing ${TMPDIR}"
   rm -rf ${TMPDIR}
 }
@@ -56,6 +63,11 @@ if test -z "$PG_CONFIG_NEW"; then
   exit 1
 fi
 
+if test "$(id -u)" = "0"; then
+  echo "This script must be run as an unprivileged PostgreSQL cluster owner, not root" >&2
+  exit 1
+fi
+
 if test "$PG_CONFIG_OLD" = "$PG_CONFIG_NEW"; then
   echo "Old and new pg_config paths need be different" >&2
   exit 1
@@ -63,6 +75,11 @@ fi
 
 BIN_OLD=$(${PG_CONFIG_OLD} --bindir)
 BIN_NEW=$(${PG_CONFIG_NEW} --bindir)
+
+INITDB_NEW_OPTS=
+if ${BIN_NEW}/initdb --help | grep -q -- "--no-data-checksums"; then
+  INITDB_NEW_OPTS=--no-data-checksums
+fi
 
 echo "Testing cluster upgrade"
 echo "FROM: $(${PG_CONFIG_OLD} --version)"
@@ -104,7 +121,7 @@ mv ${DATADIR} ${PGDATAOLD}
 export PGDATANEW=${DATADIR}
 
 echo "Creating TO cluster"
-${BIN_NEW}/initdb ${PGDATANEW} > ${LOGFILE} 2>&1 || {
+${BIN_NEW}/initdb ${INITDB_NEW_OPTS} ${PGDATANEW} > ${LOGFILE} 2>&1 || {
   cat ${LOGFILE} && exit 1
 }
 


### PR DESCRIPTION
## Summary
- add a Woodpecker regression step that runs `utils/check_cluster_upgrade.sh` from PostgreSQL 14 to PostgreSQL 18
- seed the upgrade with a geography table matching the case from https://trac.osgeo.org/postgis/ticket/5899
- make the upgrade helper handle newer `initdb --no-data-checksums` targets and stop the upgraded cluster during cleanup
- run the cluster-upgrade script under the unprivileged `postgres` account in CI, while leaving `make install` privileged
- reject accidental root execution in `utils/check_cluster_upgrade.sh` before reaching `initdb`

Trac ticket: https://trac.osgeo.org/postgis/ticket/5995

## Maintenance
- rebased on current `master` (`c94f62361`)
- resolved the `NEWS` conflict
- addressed the live Codex review thread about running `initdb` as root

## Validation
- `utils/check_cluster_upgrade.sh -i regress/hooks/cluster-upgrade-geography.sql /usr/lib/postgresql/14/bin/pg_config /usr/lib/postgresql/18/bin/pg_config`
- `sudo -n utils/check_cluster_upgrade.sh /usr/lib/postgresql/14/bin/pg_config /usr/lib/postgresql/18/bin/pg_config` rejects root with the new guard
- `sudo -n -u postgres id -u` returned `125`, and `sudo -n -u postgres sh -c ...` confirmed the workspace command context is non-root
- `sh -n utils/check_cluster_upgrade.sh`
- `./utils/check_news.sh .`
- `git diff --check`