### PR TITLE
Clarify raster2pgsql append index behavior

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #4385, [raster] Clarify raster2pgsql -I behavior with append loads
+          (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/doc/man/raster2pgsql.1
+++ b/doc/man/raster2pgsql.1
@@ -88,7 +88,9 @@ overviews are stored in the database and are not affected by \-R.
 Wrap PostgreSQL identifiers in quotes.
 .TP
 \fB\-I\fR
-Create a GiST spatial index on the raster column.
+Create a GiST spatial index on the raster column at the end of this
+raster2pgsql run. With repeated \-a append runs, use \-I only on the final run
+or create the index manually after loading.
 .TP
 \fB\-\-create\-index\fR
 Create a GiST spatial index on the raster column.

--- a/doc/using_raster_dataman.xml
+++ b/doc/using_raster_dataman.xml
@@ -319,7 +319,10 @@ Available GDAL raster formats:
                   <term><option>-I</option></term>
                   <listitem>
                     <para>
-                      Create a GiST index on the raster column.
+                      Create a GiST index on the raster column at the end of this
+                      raster2pgsql run.  With repeated <option>-a</option> append
+                      runs, use <option>-I</option> only on the final run or create
+                      the index manually after loading.
                     </para>
                   </listitem>
                 </varlistentry>

--- a/raster/loader/raster2pgsql.c
+++ b/raster/loader/raster2pgsql.c
@@ -409,8 +409,9 @@ usage() {
 		"  -q  Wrap PostgreSQL identifiers in quotes.\n"
 	));
 	printf(_(
-		"  -I  Create a GIST spatial index on the raster column. The ANALYZE\n"
-		"      command will automatically be issued for the created index.\n"
+		"  -I  Create a GIST spatial index on the raster column at the end of\n"
+		"      this raster2pgsql run. With repeated -a append runs, use -I only\n"
+		"      on the final run or create the index manually after loading.\n"
 	));
 	printf(
 	    _("  --add-constraints  Set the standard set of constraints on the\n"


### PR DESCRIPTION
## Summary
- clarify that `raster2pgsql -I` creates the GiST raster index once at the end of the current loader run
- document that repeated `-a` append batches should use `-I` only on the final append run, or create the index manually after loading
- keep `-a -I` legal because the final-append workflow is valid

Trac ticket: https://trac.osgeo.org/postgis/ticket/4385

## Validation
- initial PR validation: `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`, `make -j32`, `make -C raster/loader -j32`, loader help/append smokes, `make -C doc check`, `./utils/check_news.sh .`, `git diff --check`
- latest rebase validation on `b02221a45`: `make -C raster/loader -j32`
- latest rebase validation on `b02221a45`: `./raster/loader/raster2pgsql '-?'` help smoke
- latest rebase validation on `b02221a45`: `./raster/loader/raster2pgsql -a -I raster/test/regress/loader/testraster.tif loadedrast` produced one `CREATE INDEX` and only normal processing/info stderr
- latest rebase validation on `b02221a45`: `make -C doc check`
- latest rebase validation on `b02221a45`: `make check-news`
- latest rebase validation on `b02221a45`: `git diff --check`
