### PR TITLE
Add parallel raster aggregate support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -95,6 +95,10 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #3836, [raster] Add parallel aggregation support to ST_CountAgg and
+          ST_SummaryStatsAgg (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -185,8 +189,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
- - #3836, [raster] Add parallel aggregation support to ST_CountAgg and
-          ST_SummaryStatsAgg (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and

--- a/NEWS
+++ b/NEWS
@@ -185,6 +185,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #3836, [raster] Add parallel aggregation support to ST_CountAgg and
+          ST_SummaryStatsAgg (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and

--- a/raster/rt_pg/rtpg_statistics.c
+++ b/raster/rt_pg/rtpg_statistics.c
@@ -576,6 +576,25 @@ rtpg_summarystats_arg_init(void) {
 	return arg;
 }
 
+static rtpg_summarystats_arg
+rtpg_summarystats_arg_copy(rtpg_summarystats_arg src)
+{
+	rtpg_summarystats_arg dst = rtpg_summarystats_arg_init();
+
+	memcpy(dst->stats, src->stats, sizeof(struct rt_bandstats_t));
+	dst->stats->values = NULL;
+
+	dst->cK = src->cK;
+	dst->cM = src->cM;
+	dst->cQ = src->cQ;
+
+	dst->band_index = src->band_index;
+	dst->exclude_nodata_value = src->exclude_nodata_value;
+	dst->sample = src->sample;
+
+	return dst;
+}
+
 static void
 rtpg_summarystats_arg_merge(rtpg_summarystats_arg dst, rtpg_summarystats_arg src)
 {
@@ -976,7 +995,7 @@ RASTER_summaryStats_combinefn(PG_FUNCTION_ARGS)
 		state2 = (rtpg_summarystats_arg)PG_GETARG_POINTER(1);
 
 	if (state1 == NULL && state2 != NULL)
-		state1 = state2;
+		state1 = rtpg_summarystats_arg_copy(state2);
 	else if (state1 != NULL && state2 != NULL)
 	{
 		rtpg_summarystats_arg_merge(state1, state2);

--- a/raster/rt_pg/rtpg_statistics.c
+++ b/raster/rt_pg/rtpg_statistics.c
@@ -11,6 +11,7 @@
  * Copyright (C) 2009-2011 Pierre Racine <pierre.racine@sbf.ulaval.ca>
  * Copyright (C) 2009-2011 Mateusz Loskot <mateusz@loskot.net>
  * Copyright (C) 2008-2009 Sandro Santilli <strk@kbt.io>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -51,6 +52,9 @@ Datum RASTER_summaryStatsCoverage(PG_FUNCTION_ARGS);
 
 Datum RASTER_summaryStats_transfn(PG_FUNCTION_ARGS);
 Datum RASTER_summaryStats_finalfn(PG_FUNCTION_ARGS);
+Datum RASTER_summaryStats_combinefn(PG_FUNCTION_ARGS);
+Datum RASTER_summaryStats_serialfn(PG_FUNCTION_ARGS);
+Datum RASTER_summaryStats_deserialfn(PG_FUNCTION_ARGS);
 
 /* get histogram */
 Datum RASTER_histogram(PG_FUNCTION_ARGS);
@@ -504,6 +508,22 @@ struct rtpg_summarystats_arg_t {
 	double sample; /* value between 0 and 1 */
 };
 
+typedef struct rtpg_summarystats_serialized_t {
+	double sample;
+	uint64_t count;
+	double min;
+	double max;
+	double sum;
+	double mean;
+	double stddev;
+	uint64_t cK;
+	double cM;
+	double cQ;
+	int32_t band_index;
+	bool exclude_nodata_value;
+	double arg_sample;
+} rtpg_summarystats_serialized;
+
 static void
 rtpg_summarystats_arg_destroy(rtpg_summarystats_arg arg) {
 	if (arg->stats != NULL)
@@ -554,6 +574,135 @@ rtpg_summarystats_arg_init(void) {
 	arg->sample = 1;
 
 	return arg;
+}
+
+static rtpg_summarystats_arg
+rtpg_summarystats_arg_copy(rtpg_summarystats_arg src)
+{
+	rtpg_summarystats_arg dst = rtpg_summarystats_arg_init();
+
+	memcpy(dst->stats, src->stats, sizeof(struct rt_bandstats_t));
+	dst->stats->values = NULL;
+
+	dst->cK = src->cK;
+	dst->cM = src->cM;
+	dst->cQ = src->cQ;
+
+	dst->band_index = src->band_index;
+	dst->exclude_nodata_value = src->exclude_nodata_value;
+	dst->sample = src->sample;
+
+	return dst;
+}
+
+static void
+rtpg_summarystats_arg_merge(rtpg_summarystats_arg dst, rtpg_summarystats_arg src)
+{
+	uint64_t dst_count = dst->cK;
+	uint64_t src_count = src->cK;
+
+	if (dst->band_index != src->band_index || dst->exclude_nodata_value != src->exclude_nodata_value ||
+	    !FLT_EQ(dst->sample, src->sample))
+		elog(ERROR, "RASTER_summaryStats_combinefn: Cannot combine states with different aggregate parameters");
+
+	if (src->stats->count < 1)
+		return;
+
+	if (dst->stats->count < 1)
+	{
+		memcpy(dst->stats, src->stats, sizeof(struct rt_bandstats_t));
+		dst->stats->values = NULL;
+		dst->cK = src->cK;
+		dst->cM = src->cM;
+		dst->cQ = src->cQ;
+		dst->band_index = src->band_index;
+		dst->exclude_nodata_value = src->exclude_nodata_value;
+		dst->sample = src->sample;
+		return;
+	}
+
+	dst->stats->count += src->stats->count;
+	dst->stats->sum += src->stats->sum;
+
+	if (src->stats->min < dst->stats->min)
+		dst->stats->min = src->stats->min;
+	if (src->stats->max > dst->stats->max)
+		dst->stats->max = src->stats->max;
+
+	if (dst_count > 0 && src_count > 0)
+	{
+		double delta = src->cM - dst->cM;
+		uint64_t count = dst_count + src_count;
+
+		dst->cQ += src->cQ + (delta * delta * dst_count * src_count) / count;
+		dst->cM += delta * src_count / count;
+		dst->cK = count;
+	}
+	else if (src_count > 0)
+	{
+		dst->cK = src->cK;
+		dst->cM = src->cM;
+		dst->cQ = src->cQ;
+	}
+
+	dst->stats->stddev = -1;
+	dst->stats->mean = 0;
+}
+
+static bytea *
+rtpg_summarystats_arg_serialize(rtpg_summarystats_arg state)
+{
+	bytea *result;
+	rtpg_summarystats_serialized serialized;
+
+	serialized.sample = state->stats->sample;
+	serialized.count = state->stats->count;
+	serialized.min = state->stats->min;
+	serialized.max = state->stats->max;
+	serialized.sum = state->stats->sum;
+	serialized.mean = state->stats->mean;
+	serialized.stddev = state->stats->stddev;
+	serialized.cK = state->cK;
+	serialized.cM = state->cM;
+	serialized.cQ = state->cQ;
+	serialized.band_index = state->band_index;
+	serialized.exclude_nodata_value = state->exclude_nodata_value;
+	serialized.arg_sample = state->sample;
+
+	result = (bytea *)palloc(VARHDRSZ + sizeof(rtpg_summarystats_serialized));
+	SET_VARSIZE(result, VARHDRSZ + sizeof(rtpg_summarystats_serialized));
+	memcpy(VARDATA(result), &serialized, sizeof(rtpg_summarystats_serialized));
+
+	return result;
+}
+
+static rtpg_summarystats_arg
+rtpg_summarystats_arg_deserialize(bytea *serialized_bytea)
+{
+	rtpg_summarystats_arg state;
+	rtpg_summarystats_serialized serialized;
+
+	if (VARSIZE(serialized_bytea) != VARHDRSZ + sizeof(rtpg_summarystats_serialized))
+		elog(ERROR, "RASTER_summaryStats_deserialfn: Invalid serialized state size");
+
+	memcpy(&serialized, VARDATA(serialized_bytea), sizeof(rtpg_summarystats_serialized));
+
+	state = rtpg_summarystats_arg_init();
+	state->stats->sample = serialized.sample;
+	state->stats->count = serialized.count;
+	state->stats->min = serialized.min;
+	state->stats->max = serialized.max;
+	state->stats->sum = serialized.sum;
+	state->stats->mean = serialized.mean;
+	state->stats->stddev = serialized.stddev;
+	state->cK = serialized.cK;
+	state->cM = serialized.cM;
+	state->cQ = serialized.cQ;
+	state->band_index = serialized.band_index;
+	state->exclude_nodata_value = serialized.exclude_nodata_value;
+	state->sample = serialized.arg_sample;
+
+	return state;
 }
 
 PG_FUNCTION_INFO_V1(RASTER_summaryStats_transfn);
@@ -820,6 +969,90 @@ Datum RASTER_summaryStats_transfn(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(state);
 }
 
+PG_FUNCTION_INFO_V1(RASTER_summaryStats_combinefn);
+Datum
+RASTER_summaryStats_combinefn(PG_FUNCTION_ARGS)
+{
+	MemoryContext aggcontext;
+	MemoryContext oldcontext;
+	rtpg_summarystats_arg state1 = NULL;
+	rtpg_summarystats_arg state2 = NULL;
+
+	if (!AggCheckCallContext(fcinfo, &aggcontext))
+	{
+		elog(ERROR, "RASTER_summaryStats_combinefn: Cannot be called in a non-aggregate context");
+		PG_RETURN_NULL();
+	}
+
+	if (PG_ARGISNULL(0) && PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+
+	oldcontext = MemoryContextSwitchTo(aggcontext);
+
+	if (!PG_ARGISNULL(0))
+		state1 = (rtpg_summarystats_arg)PG_GETARG_POINTER(0);
+	if (!PG_ARGISNULL(1))
+		state2 = (rtpg_summarystats_arg)PG_GETARG_POINTER(1);
+
+	if (state1 == NULL && state2 != NULL)
+		state1 = rtpg_summarystats_arg_copy(state2);
+	else if (state1 != NULL && state2 != NULL)
+		rtpg_summarystats_arg_merge(state1, state2);
+
+	MemoryContextSwitchTo(oldcontext);
+
+	PG_RETURN_POINTER(state1);
+}
+
+PG_FUNCTION_INFO_V1(RASTER_summaryStats_serialfn);
+Datum
+RASTER_summaryStats_serialfn(PG_FUNCTION_ARGS)
+{
+	rtpg_summarystats_arg state = NULL;
+
+	if (!AggCheckCallContext(fcinfo, NULL))
+	{
+		elog(ERROR, "RASTER_summaryStats_serialfn: Cannot be called in a non-aggregate context");
+		PG_RETURN_NULL();
+	}
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	state = (rtpg_summarystats_arg)PG_GETARG_POINTER(0);
+
+	PG_RETURN_BYTEA_P(rtpg_summarystats_arg_serialize(state));
+}
+
+PG_FUNCTION_INFO_V1(RASTER_summaryStats_deserialfn);
+Datum
+RASTER_summaryStats_deserialfn(PG_FUNCTION_ARGS)
+{
+	MemoryContext aggcontext;
+	MemoryContext oldcontext;
+	bytea *serialized_bytea;
+	rtpg_summarystats_arg state;
+
+	if (!AggCheckCallContext(fcinfo, &aggcontext))
+	{
+		elog(ERROR, "RASTER_summaryStats_deserialfn: Cannot be called in a non-aggregate context");
+		PG_RETURN_NULL();
+	}
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	oldcontext = MemoryContextSwitchTo(aggcontext);
+
+	serialized_bytea = PG_GETARG_BYTEA_P(0);
+	state = rtpg_summarystats_arg_deserialize(serialized_bytea);
+	PG_FREE_IF_COPY(serialized_bytea, 0);
+
+	MemoryContextSwitchTo(oldcontext);
+
+	PG_RETURN_POINTER(state);
+}
+
 PG_FUNCTION_INFO_V1(RASTER_summaryStats_finalfn);
 Datum RASTER_summaryStats_finalfn(PG_FUNCTION_ARGS)
 {
@@ -855,7 +1088,8 @@ Datum RASTER_summaryStats_finalfn(PG_FUNCTION_ARGS)
 		state->stats->mean = state->stats->sum / state->stats->count;
 		/* sample deviation */
 		if (state->stats->sample > 0 && state->stats->sample < 1)
-			state->stats->stddev = sqrt(state->cQ / (state->stats->count - 1));
+			state->stats->stddev =
+			    state->stats->count > 1 ? sqrt(state->cQ / (state->stats->count - 1)) : -1;
 		/* standard deviation */
 		else
 			state->stats->stddev = sqrt(state->cQ / state->stats->count);
@@ -2077,4 +2311,3 @@ Datum RASTER_valueCountCoverage(PG_FUNCTION_ARGS) {
 		SRF_RETURN_DONE(funcctx);
 	}
 }
-

--- a/raster/rt_pg/rtpg_statistics.c
+++ b/raster/rt_pg/rtpg_statistics.c
@@ -995,7 +995,10 @@ RASTER_summaryStats_combinefn(PG_FUNCTION_ARGS)
 		state2 = (rtpg_summarystats_arg)PG_GETARG_POINTER(1);
 
 	if (state1 == NULL && state2 != NULL)
+	{
 		state1 = rtpg_summarystats_arg_copy(state2);
+		rtpg_summarystats_arg_destroy(state2);
+	}
 	else if (state1 != NULL && state2 != NULL)
 	{
 		rtpg_summarystats_arg_merge(state1, state2);

--- a/raster/rt_pg/rtpg_statistics.c
+++ b/raster/rt_pg/rtpg_statistics.c
@@ -576,25 +576,6 @@ rtpg_summarystats_arg_init(void) {
 	return arg;
 }
 
-static rtpg_summarystats_arg
-rtpg_summarystats_arg_copy(rtpg_summarystats_arg src)
-{
-	rtpg_summarystats_arg dst = rtpg_summarystats_arg_init();
-
-	memcpy(dst->stats, src->stats, sizeof(struct rt_bandstats_t));
-	dst->stats->values = NULL;
-
-	dst->cK = src->cK;
-	dst->cM = src->cM;
-	dst->cQ = src->cQ;
-
-	dst->band_index = src->band_index;
-	dst->exclude_nodata_value = src->exclude_nodata_value;
-	dst->sample = src->sample;
-
-	return dst;
-}
-
 static void
 rtpg_summarystats_arg_merge(rtpg_summarystats_arg dst, rtpg_summarystats_arg src)
 {
@@ -995,9 +976,12 @@ RASTER_summaryStats_combinefn(PG_FUNCTION_ARGS)
 		state2 = (rtpg_summarystats_arg)PG_GETARG_POINTER(1);
 
 	if (state1 == NULL && state2 != NULL)
-		state1 = rtpg_summarystats_arg_copy(state2);
+		state1 = state2;
 	else if (state1 != NULL && state2 != NULL)
+	{
 		rtpg_summarystats_arg_merge(state1, state2);
+		rtpg_summarystats_arg_destroy(state2);
+	}
 
 	MemoryContextSwitchTo(oldcontext);
 

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -550,6 +550,21 @@ CREATE OR REPLACE FUNCTION _st_summarystats_finalfn(internal)
 	AS 'MODULE_PATHNAME', 'RASTER_summaryStats_finalfn'
 	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION _st_summarystats_combinefn(internal, internal)
+	RETURNS internal
+	AS 'MODULE_PATHNAME', 'RASTER_summaryStats_combinefn'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _st_summarystats_serialfn(internal)
+	RETURNS bytea
+	AS 'MODULE_PATHNAME', 'RASTER_summaryStats_serialfn'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _st_summarystats_deserialfn(bytea, internal)
+	RETURNS internal
+	AS 'MODULE_PATHNAME', 'RASTER_summaryStats_deserialfn'
+	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION _st_summarystats_transfn(
 	internal,
 	raster, integer,
@@ -565,6 +580,9 @@ CREATE AGGREGATE st_summarystatsagg(raster, integer, boolean, double precision) 
 	SFUNC = _st_summarystats_transfn,
 	STYPE = internal,
 	parallel = safe,
+	COMBINEFUNC = _st_summarystats_combinefn,
+	SERIALFUNC = _st_summarystats_serialfn,
+	DESERIALFUNC = _st_summarystats_deserialfn,
 	FINALFUNC = _st_summarystats_finalfn
 );
 
@@ -582,6 +600,9 @@ CREATE AGGREGATE st_summarystatsagg(raster, boolean, double precision) (
 	SFUNC = _st_summarystats_transfn,
 	STYPE = internal,
 	parallel = safe,
+	COMBINEFUNC = _st_summarystats_combinefn,
+	SERIALFUNC = _st_summarystats_serialfn,
+	DESERIALFUNC = _st_summarystats_deserialfn,
 	FINALFUNC = _st_summarystats_finalfn
 );
 
@@ -599,7 +620,9 @@ CREATE AGGREGATE st_summarystatsagg(raster, int, boolean) (
 	SFUNC = _st_summarystats_transfn,
 	STYPE = internal,
 	parallel = safe,
-#
+	COMBINEFUNC = _st_summarystats_combinefn,
+	SERIALFUNC = _st_summarystats_serialfn,
+	DESERIALFUNC = _st_summarystats_deserialfn,
 	FINALFUNC = _st_summarystats_finalfn
 );
 
@@ -678,6 +701,34 @@ CREATE OR REPLACE FUNCTION _st_countagg_finalfn(agg agg_count)
 	END;
 	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION _st_countagg_combinefn(
+	agg1 agg_count,
+	agg2 agg_count
+)
+	RETURNS agg_count
+	AS $$
+	DECLARE
+		rtn_agg agg_count;
+	BEGIN
+		IF agg1 IS NULL THEN
+			RETURN agg2;
+		END IF;
+		IF agg2 IS NULL THEN
+			RETURN agg1;
+		END IF;
+
+		IF agg1.nband IS DISTINCT FROM agg2.nband OR
+		   agg1.exclude_nodata_value IS DISTINCT FROM agg2.exclude_nodata_value OR
+		   agg1.sample_percent IS DISTINCT FROM agg2.sample_percent THEN
+			RAISE EXCEPTION 'Cannot combine ST_CountAgg states with different aggregate parameters';
+		END IF;
+
+		rtn_agg := agg1;
+		rtn_agg.count := agg1.count + agg2.count;
+		RETURN rtn_agg;
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION __st_countagg_transfn(
 	agg agg_count,
 	rast raster,
@@ -687,7 +738,7 @@ CREATE OR REPLACE FUNCTION __st_countagg_transfn(
 	RETURNS agg_count
 	AS $$
 	DECLARE
-		_count bigint;
+		_count bigint := 0;
 		rtn_agg agg_count;
 	BEGIN
 
@@ -759,6 +810,7 @@ CREATE AGGREGATE st_countagg(raster, integer, boolean, double precision) (
 	SFUNC = _st_countagg_transfn,
 	STYPE = agg_count,
 	parallel = safe,
+	COMBINEFUNC = _st_countagg_combinefn,
 	FINALFUNC = _st_countagg_finalfn
 );
 
@@ -787,6 +839,7 @@ CREATE AGGREGATE st_countagg(raster, integer, boolean) (
 	SFUNC = _st_countagg_transfn,
 	STYPE = agg_count,
 	parallel = safe,
+	COMBINEFUNC = _st_countagg_combinefn,
 	FINALFUNC = _st_countagg_finalfn
 );
 
@@ -816,6 +869,7 @@ CREATE AGGREGATE st_countagg(raster, boolean) (
 	SFUNC = _st_countagg_transfn,
 	STYPE = agg_count,
 	parallel = safe,
+	COMBINEFUNC = _st_countagg_combinefn,
 	FINALFUNC = _st_countagg_finalfn
 );
 

--- a/raster/test/regress/rt_parallel_agg.sql
+++ b/raster/test/regress/rt_parallel_agg.sql
@@ -51,19 +51,14 @@ SELECT
 FROM generate_series(1, 2000) AS id;
 
 ALTER TABLE raster_parallel_agg_test SET (parallel_workers = 4);
-ANALYZE raster_parallel_agg_test;
+ANALYZE raster_parallel_agg_test (id);
 
 SELECT 'countagg_catalog',
 	count(*) FILTER (WHERE a.aggcombinefn <> 0::oid),
 	count(*)
 FROM pg_proc p
 JOIN pg_aggregate a ON a.aggfnoid = p.oid
-WHERE p.pronamespace = (
-		SELECT extnamespace
-		FROM pg_extension
-		WHERE extname = 'postgis_raster'
-	)
-	AND p.proname = 'st_countagg';
+WHERE p.proname = 'st_countagg';
 
 SELECT 'summarystatsagg_catalog',
 	count(*) FILTER (
@@ -74,12 +69,7 @@ SELECT 'summarystatsagg_catalog',
 	count(*)
 FROM pg_proc p
 JOIN pg_aggregate a ON a.aggfnoid = p.oid
-WHERE p.pronamespace = (
-		SELECT extnamespace
-		FROM pg_extension
-		WHERE extname = 'postgis_raster'
-	)
-	AND p.proname = 'st_summarystatsagg';
+WHERE p.proname = 'st_summarystatsagg';
 
 CALL p_force_parallel_mode('off');
 

--- a/raster/test/regress/rt_parallel_agg.sql
+++ b/raster/test/regress/rt_parallel_agg.sql
@@ -1,0 +1,139 @@
+CREATE OR REPLACE PROCEDURE p_force_parallel_mode(param_state text) LANGUAGE plpgsql AS
+$$
+BEGIN
+	IF (_postgis_pgsql_version())::integer < 160 THEN
+		IF param_state = 'on' THEN
+			SET force_parallel_mode = on;
+		ELSE
+			SET force_parallel_mode = off;
+		END IF;
+	ELSE
+		IF param_state = 'on' THEN
+			SET debug_parallel_query = on;
+		ELSE
+			SET debug_parallel_query = off;
+		END IF;
+	END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION qnodes(q text) RETURNS text
+LANGUAGE plpgsql AS
+$$
+DECLARE
+	exp text;
+	mat text[];
+	ret text[];
+BEGIN
+	FOR exp IN EXECUTE 'EXPLAIN (COSTS OFF) ' || q LOOP
+		mat := regexp_matches(exp, ' *(?:-> *)?(Finalize Aggregate|Gather|Partial Aggregate|Parallel Seq Scan)');
+		IF mat IS NOT NULL THEN
+			ret := array_append(ret, mat[1]);
+		END IF;
+	END LOOP;
+	RETURN array_to_string(ret, ',');
+END;
+$$;
+
+CREATE TABLE raster_parallel_agg_test AS
+SELECT
+	id,
+	ST_SetValue(
+		ST_SetValue(
+			ST_AddBand(
+				ST_MakeEmptyRaster(10, 10, 0, 10, 1, -1, 0, 0, 0),
+				1, '64BF', id::double precision, 0
+			),
+			1, 1, 1, -10
+		),
+		1, 5, 5, id::double precision + 0.5
+	) AS rast
+FROM generate_series(1, 2000) AS id;
+
+ALTER TABLE raster_parallel_agg_test SET (parallel_workers = 4);
+ANALYZE raster_parallel_agg_test;
+
+SELECT 'countagg_catalog',
+	count(*) FILTER (WHERE a.aggcombinefn <> 0::oid),
+	count(*)
+FROM pg_proc p
+JOIN pg_aggregate a ON a.aggfnoid = p.oid
+WHERE p.pronamespace = (
+		SELECT extnamespace
+		FROM pg_extension
+		WHERE extname = 'postgis_raster'
+	)
+	AND p.proname = 'st_countagg';
+
+SELECT 'summarystatsagg_catalog',
+	count(*) FILTER (
+		WHERE a.aggcombinefn <> 0::oid
+			AND a.aggserialfn <> 0::oid
+			AND a.aggdeserialfn <> 0::oid
+	),
+	count(*)
+FROM pg_proc p
+JOIN pg_aggregate a ON a.aggfnoid = p.oid
+WHERE p.pronamespace = (
+		SELECT extnamespace
+		FROM pg_extension
+		WHERE extname = 'postgis_raster'
+	)
+	AND p.proname = 'st_summarystatsagg';
+
+CALL p_force_parallel_mode('off');
+
+CREATE TEMP TABLE raster_parallel_agg_serial AS
+SELECT
+	ST_CountAgg(rast, 1, TRUE, 1) AS count_full,
+	ST_CountAgg(rast, 1, TRUE) AS count_default_sample,
+	ST_CountAgg(rast, TRUE) AS count_default_band,
+	ST_SummaryStatsAgg(rast, 1, TRUE, 1) AS stats_full,
+	ST_SummaryStatsAgg(rast, TRUE, 1) AS stats_default_band,
+	ST_SummaryStatsAgg(rast, 1, TRUE) AS stats_default_sample
+FROM raster_parallel_agg_test;
+
+CALL p_force_parallel_mode('on');
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET max_parallel_workers_per_gather = 4;
+
+SELECT 'countagg_plan',
+	qnodes('SELECT ST_CountAgg(rast, 1, TRUE, 1) FROM raster_parallel_agg_test');
+
+SELECT 'summarystatsagg_plan',
+	qnodes('SELECT ST_SummaryStatsAgg(rast, 1, TRUE, 1) FROM raster_parallel_agg_test');
+
+WITH parallel_result AS (
+	SELECT
+		ST_CountAgg(rast, 1, TRUE, 1) AS count_full,
+		ST_CountAgg(rast, 1, TRUE) AS count_default_sample,
+		ST_CountAgg(rast, TRUE) AS count_default_band,
+		ST_SummaryStatsAgg(rast, 1, TRUE, 1) AS stats_full,
+		ST_SummaryStatsAgg(rast, TRUE, 1) AS stats_default_band,
+		ST_SummaryStatsAgg(rast, 1, TRUE) AS stats_default_sample
+	FROM raster_parallel_agg_test
+)
+SELECT 'parallel_results',
+	p.count_full = s.count_full,
+	p.count_default_sample = s.count_default_sample,
+	p.count_default_band = s.count_default_band,
+	(p.stats_full).count = (s.stats_full).count,
+	round((p.stats_full).sum::numeric, 3) = round((s.stats_full).sum::numeric, 3),
+	round((p.stats_full).mean::numeric, 3) = round((s.stats_full).mean::numeric, 3),
+	round((p.stats_full).stddev::numeric, 3) = round((s.stats_full).stddev::numeric, 3),
+	(p.stats_default_band).count = (s.stats_default_band).count,
+	(p.stats_default_sample).count = (s.stats_default_sample).count
+FROM parallel_result p, raster_parallel_agg_serial s;
+
+RESET max_parallel_workers_per_gather;
+RESET min_parallel_table_scan_size;
+RESET parallel_tuple_cost;
+RESET parallel_setup_cost;
+CALL p_force_parallel_mode('off');
+
+DROP TABLE raster_parallel_agg_serial;
+DROP TABLE raster_parallel_agg_test;
+DROP FUNCTION qnodes(text);
+DROP PROCEDURE p_force_parallel_mode(text);

--- a/raster/test/regress/rt_parallel_agg.sql
+++ b/raster/test/regress/rt_parallel_agg.sql
@@ -71,6 +71,25 @@ FROM pg_proc p
 JOIN pg_aggregate a ON a.aggfnoid = p.oid
 WHERE p.proname = 'st_summarystatsagg';
 
+CREATE FUNCTION countagg_rejects_null_parameter_mismatch() RETURNS boolean
+LANGUAGE plpgsql AS
+$$
+BEGIN
+	PERFORM _st_countagg_combinefn(
+		ROW(1, NULL, TRUE, 1)::agg_count,
+		ROW(2, 1, TRUE, 1)::agg_count
+	);
+	RETURN FALSE;
+EXCEPTION WHEN OTHERS THEN
+	RETURN SQLERRM = 'Cannot combine ST_CountAgg states with different aggregate parameters';
+END;
+$$;
+
+SELECT 'countagg_null_parameter_mismatch',
+	countagg_rejects_null_parameter_mismatch();
+
+DROP FUNCTION countagg_rejects_null_parameter_mismatch();
+
 CALL p_force_parallel_mode('off');
 
 CREATE TEMP TABLE raster_parallel_agg_serial AS

--- a/raster/test/regress/rt_parallel_agg_expected
+++ b/raster/test/regress/rt_parallel_agg_expected
@@ -1,0 +1,5 @@
+countagg_catalog|3|3
+summarystatsagg_catalog|3|3
+countagg_plan|Finalize Aggregate,Gather,Partial Aggregate,Parallel Seq Scan
+summarystatsagg_plan|Finalize Aggregate,Gather,Partial Aggregate,Parallel Seq Scan
+parallel_results|t|t|t|t|t|t|t|t|t

--- a/raster/test/regress/rt_parallel_agg_expected
+++ b/raster/test/regress/rt_parallel_agg_expected
@@ -1,5 +1,6 @@
 countagg_catalog|3|3
 summarystatsagg_catalog|3|3
+countagg_null_parameter_mismatch|t
 countagg_plan|Finalize Aggregate,Gather,Partial Aggregate,Parallel Seq Scan
 summarystatsagg_plan|Finalize Aggregate,Gather,Partial Aggregate,Parallel Seq Scan
 parallel_results|t|t|t|t|t|t|t|t|t

--- a/raster/test/regress/tests.mk.in
+++ b/raster/test/regress/tests.mk.in
@@ -66,6 +66,7 @@ RASTER_TEST_BANDPROPS = \
 	$(top_srcdir)/raster/test/regress/rt_setvalues_array \
 	$(top_srcdir)/raster/test/regress/rt_summarystats \
 	$(top_srcdir)/raster/test/regress/rt_count \
+	$(top_srcdir)/raster/test/regress/rt_parallel_agg \
 	$(top_srcdir)/raster/test/regress/rt_histogram \
 	$(top_srcdir)/raster/test/regress/rt_quantile \
 	$(top_srcdir)/raster/test/regress/rt_valuecount \


### PR DESCRIPTION
## Summary
- add combine functions for raster `ST_CountAgg` and `ST_SummaryStatsAgg`
- add serialize/deserialize support for the internal `ST_SummaryStatsAgg` aggregate state
- preserve Welford variance state while merging partial aggregates
- copy or merge discarded `ST_SummaryStatsAgg` partial states into aggregate-context-owned state, then release the discarded second state
- add focused parallel-plan regression coverage that works with non-public extension schemas

Trac ticket: https://trac.osgeo.org/postgis/ticket/3836

## Validation
- rebased over current `upstream/master` at `4e470f153`
- `./config.status --file=regress/dumper/tests.mk`
- `./config.status --file=raster/test/regress/tests.mk`
- `make postgis_revision.h`
- `make -C raster -j32`
- `make -C extensions/postgis_raster -j32`
- `sudo -n make -C raster install`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/raster/test/regress/rt_parallel_agg"`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --schema=postgis_ci" TESTS="$(pwd)/raster/test/regress/rt_parallel_agg"`
- `make check-news`
- `git clang-format --diff upstream/master -- raster/rt_pg/rtpg_statistics.c raster/rt_pg/rtpostgis.sql.in raster/test/regress/rt_parallel_agg.sql raster/test/regress/rt_parallel_agg_expected raster/test/regress/tests.mk.in NEWS`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
