### PR TITLE
Improve raster MapAlgebra callback arity handling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,7 +55,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 * Enhancements *
 
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
-          and size callback call data to actual arguments (Darafei Praliaskouski)
+          and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Enhancements *
 
+ - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
+          and size callback call data to actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -10276,7 +10276,7 @@ CREATE OR REPLACE FUNCTION sample_callbackfunc(value double precision[][][], pos
                                     </programlisting>
 
                                 <para>
-                                    The <varname>callbackfunc</varname> must have three arguments: a 3-dimension double precision array, a 2-dimension integer array and a variadic 1-dimension text array. The first argument <varname>value</varname> is the set of values (as double precision) from all input rasters. The three dimensions (where indexes are 1-based) are: raster #, row y, column x. The second argument <varname>position</varname> is the set of pixel positions from the output raster and input rasters. The outer dimension (where indexes are 0-based) is the raster #.  The position at outer dimension index 0 is the output raster's pixel position.  For each outer dimension, there are two elements in the inner dimension for X and Y.  The third argument <varname>userargs</varname> is for passing through any user-specified arguments.
+                                    The <varname>callbackfunc</varname> must have two or three arguments: a 3-dimension double precision array, a 2-dimension integer array and, optionally, a variadic 1-dimension text array. The first argument <varname>value</varname> is the set of values (as double precision) from all input rasters. The three dimensions (where indexes are 1-based) are: raster #, row y, column x. The second argument <varname>position</varname> is the set of pixel positions from the output raster and input rasters. The outer dimension (where indexes are 0-based) is the raster #.  The position at outer dimension index 0 is the output raster's pixel position.  For each outer dimension, there are two elements in the inner dimension for X and Y.  The optional third argument <varname>userargs</varname> is for passing through any user-specified arguments.
                                 </para>
 
                                 <para>
@@ -10364,7 +10364,7 @@ CREATE OR REPLACE FUNCTION sample_callbackfunc(value double precision[][][], pos
                             <term><varname>userargs</varname></term>
                             <listitem>
                                 <para>
-                                    The third argument to the <varname>callbackfunc</varname> is a <type>variadic text</type> array. All trailing text arguments are passed through to the specified <varname>callbackfunc</varname>, and are contained in the <varname>userargs</varname> argument.
+                                    If the <varname>callbackfunc</varname> declares a third argument, that argument is a <type>variadic text</type> array. All trailing text arguments are passed through to the specified <varname>callbackfunc</varname>, and are contained in the <varname>userargs</varname> argument.
                                 </para>
                             </listitem>
                         </varlistentry>
@@ -10373,12 +10373,6 @@ CREATE OR REPLACE FUNCTION sample_callbackfunc(value double precision[][][], pos
                     <note>
                         <para>
                             For more information about the VARIADIC keyword, please refer to the PostgreSQL documentation and the "SQL Functions with Variable Numbers of Arguments" section of <link xlink:href="http://www.postgresql.org/docs/current/static/xfunc-sql.html">Query Language (SQL) Functions</link>.
-                        </para>
-                    </note>
-
-                    <note>
-                        <para>
-                            The <type>text[]</type> argument to the <varname>callbackfunc</varname> is required, regardless of whether you choose to pass any arguments to the callback function for processing or not.
                         </para>
                     </note>
 

--- a/raster/rt_pg/rtpg_mapalgebra.c
+++ b/raster/rt_pg/rtpg_mapalgebra.c
@@ -91,7 +91,7 @@ typedef struct {
 	/* copied from LOCAL_FCINFO in fmgr.h */
 	union {
 		FunctionCallInfoBaseData fcinfo;
-		char fcinfo_data[SizeForFunctionCallInfo(FUNC_MAX_ARGS)]; /* Could be optimized */
+		char fcinfo_data[SizeForFunctionCallInfo(3)];
 	} ufc_info_data;
 	FunctionCallInfo ufc_info;
 } rtpg_nmapalgebra_callback_arg;
@@ -803,7 +803,8 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 			noerr = 1;
 		}
 		/* function should have correct # of args */
-		else if (arg->callback.ufl_info.fn_nargs != 3) {
+		else if (arg->callback.ufl_info.fn_nargs < 2 || arg->callback.ufl_info.fn_nargs > 3)
+		{
 			noerr = 2;
 		}
 
@@ -842,7 +843,9 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 					elog(ERROR, "RASTER_nMapAlgebra: Function provided must return scalar (double precision, float, int, smallint)");
 					break;
 				case 2:
-					elog(ERROR, "RASTER_nMapAlgebra: Function provided must have three input parameters");
+					elog(
+					    ERROR,
+					    "RASTER_nMapAlgebra: Function provided must have two or three input parameters");
 					break;
 				case 1:
 					elog(ERROR, "RASTER_nMapAlgebra: Function provided must return double precision, not resultset");
@@ -864,20 +867,27 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 
 		arg->callback.ufc_info->args[0].isnull = FALSE;
 		arg->callback.ufc_info->args[1].isnull = FALSE;
-		arg->callback.ufc_info->args[2].isnull = FALSE;
-		/* userargs (7) */
-		if (!PG_ARGISNULL(9))
-			arg->callback.ufc_info->args[2].value = PG_GETARG_DATUM(9);
-		else {
-      if (arg->callback.ufl_info.fn_strict) {
-				/* build and assign an empty TEXT array */
-				/* TODO: manually free the empty array? */
-				arg->callback.ufc_info->args[2].value = PointerGetDatum(construct_empty_array(TEXTOID));
-				arg->callback.ufc_info->args[2].isnull = FALSE;
-      }
-			else {
-				arg->callback.ufc_info->args[2].value = (Datum)NULL;
-				arg->callback.ufc_info->args[2].isnull = TRUE;
+		if (arg->callback.ufl_info.fn_nargs == 3)
+		{
+			arg->callback.ufc_info->args[2].isnull = FALSE;
+			/* userargs (7) */
+			if (!PG_ARGISNULL(9))
+				arg->callback.ufc_info->args[2].value = PG_GETARG_DATUM(9);
+			else
+			{
+				if (arg->callback.ufl_info.fn_strict)
+				{
+					/* build and assign an empty TEXT array */
+					/* TODO: manually free the empty array? */
+					arg->callback.ufc_info->args[2].value =
+					    PointerGetDatum(construct_empty_array(TEXTOID));
+					arg->callback.ufc_info->args[2].isnull = FALSE;
+				}
+				else
+				{
+					arg->callback.ufc_info->args[2].value = (Datum)NULL;
+					arg->callback.ufc_info->args[2].isnull = TRUE;
+				}
 			}
 		}
 	}
@@ -5280,7 +5290,7 @@ Datum RASTER_mapAlgebraFct(PG_FUNCTION_ARGS)
     int ret = -1;
     Oid oid;
     FmgrInfo cbinfo;
-    LOCAL_FCINFO(cbdata, FUNC_MAX_ARGS); /* Could be optimized */
+    LOCAL_FCINFO(cbdata, 3);
 
     Datum tmpnewval;
     char * strFromText = NULL;
@@ -5521,11 +5531,12 @@ Datum RASTER_mapAlgebraFct(PG_FUNCTION_ARGS)
     }
 
     /* prep function call data */
-    InitFunctionCallInfoData(*cbdata, &cbinfo, 2, InvalidOid, NULL, NULL);
+    InitFunctionCallInfoData(*cbdata, &cbinfo, cbinfo.fn_nargs, InvalidOid, NULL, NULL);
 
     cbdata->args[0].isnull = FALSE;
     cbdata->args[1].isnull = FALSE;
-    cbdata->args[2].isnull = FALSE;
+    if (cbinfo.fn_nargs == 3)
+	    cbdata->args[2].isnull = FALSE;
 
     /* check that the function isn't strict if the args are null. */
     if (PG_ARGISNULL(4)) {
@@ -5706,7 +5717,7 @@ Datum RASTER_mapAlgebraFctNgb(PG_FUNCTION_ARGS)
     int ret = -1;
     Oid oid;
     FmgrInfo cbinfo;
-    LOCAL_FCINFO(cbdata, FUNC_MAX_ARGS); /* Could be optimized */
+    LOCAL_FCINFO(cbdata, 3);
     Datum tmpnewval;
     ArrayType * neighborDatum;
     char * strFromText = NULL;
@@ -5953,7 +5964,7 @@ Datum RASTER_mapAlgebraFctNgb(PG_FUNCTION_ARGS)
     }
 
     /* prep function call data */
-    InitFunctionCallInfoData(*cbdata, &cbinfo, 3, InvalidOid, NULL, NULL);
+    InitFunctionCallInfoData(*cbdata, &cbinfo, cbinfo.fn_nargs, InvalidOid, NULL, NULL);
     cbdata->args[0].isnull = FALSE;
     cbdata->args[1].isnull = FALSE;
     cbdata->args[2].isnull = FALSE;
@@ -6332,7 +6343,7 @@ Datum RASTER_mapAlgebra2(PG_FUNCTION_ARGS)
 
 	Oid ufc_noid = InvalidOid;
 	FmgrInfo ufl_info;
-	LOCAL_FCINFO(ufc_info, FUNC_MAX_ARGS); /* Could be optimized */
+	LOCAL_FCINFO(ufc_info, 4);
 
 	int ufc_nullcount = 0;
 

--- a/raster/test/regress/rt_mapalgebra.sql
+++ b/raster/test/regress/rt_mapalgebra.sql
@@ -34,6 +34,15 @@ CREATE OR REPLACE FUNCTION raster_nmapalgebra_test(
 	END;
 	$$ LANGUAGE 'plpgsql' IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION raster_nmapalgebra_test_no_userargs(
+	value double precision[][][],
+	pos int[][]
+)
+	RETURNS double precision
+	AS $$
+		SELECT $1[1][1][1] + $2[0][1] + $2[0][2];
+	$$ LANGUAGE 'sql' IMMUTABLE STRICT;
+
 SET client_min_messages TO notice;
 
 SELECT
@@ -59,6 +68,18 @@ SELECT
 	) = 255
 FROM raster_nmapalgebra_in
 WHERE rid IN (2,3,4);
+
+SELECT
+	rid,
+	ST_Value(
+		ST_MapAlgebra(
+			ARRAY[ROW(rast, 1)]::rastbandarg[],
+			'raster_nmapalgebra_test_no_userargs(double precision[], int[])'::regprocedure
+		),
+		1, 1, 1
+	) = 3
+FROM raster_nmapalgebra_in
+WHERE rid = 2;
 
 SELECT
 	rid,
@@ -594,5 +615,6 @@ FROM raster_nmapalgebra_in
 WHERE rid IN (2);
 
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test(double precision[], int[], text[]);
+DROP FUNCTION IF EXISTS raster_nmapalgebra_test_no_userargs(double precision[], int[]);
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test_bad_return(double precision[], int[], text[]);
 DROP TABLE IF EXISTS raster_nmapalgebra_in;

--- a/raster/test/regress/rt_mapalgebra_expected
+++ b/raster/test/regress/rt_mapalgebra_expected
@@ -43,6 +43,7 @@ NOTICE:  userargs = <NULL>
 2|t
 3|t
 4|t
+2|t
 NOTICE:  value = {{{20}}}
 NOTICE:  pos = [0:1][1:2]={{1,1},{1,1}}
 NOTICE:  userargs = {3.14}


### PR DESCRIPTION
## Summary
- allow n-raster `ST_MapAlgebra` callbacks to omit the optional `userargs` argument and use a two-argument `value, position` signature
- size raster MapAlgebra callback `FunctionCallInfo` storage to the supported callback arities instead of `FUNC_MAX_ARGS`
- document the optional callback `userargs` argument and add regression coverage for a strict two-argument callback

Trac tickets:
- https://trac.osgeo.org/postgis/ticket/2804
- https://trac.osgeo.org/postgis/ticket/4315

## Validation
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- first `make -C raster/rt_pg -j32` exposed a generated `postgis_revision.h` race in the fresh worktree; rerun after the header existed passed
- `make -C raster/rt_pg -j32`
- `make -j32`
- `sudo make install`
- private PostgreSQL 18 cluster at `/tmp/postgis-4315-socket`, port `55438`
- `make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose" TESTS="rt_mapalgebra"`
- `make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose" TESTS="rt_mapalgebra rt_mapalgebrafct rt_mapalgebrafct_2raster rt_mapalgebrafctngb rt_mapalgebrafctngb_userfunc"`
- `make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --schema=postgis_ci" TESTS="rt_mapalgebra"`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check`
