### PR TITLE
Add multiband ST_SetBandNoDataValue overload

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -131,6 +131,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * New Features *
 
+ - #2325, [raster] Allow ST_SetBandNoDataValue to set nodata values
+          for multiple bands in one call (Darafei Praliaskouski)
  - #1124, #2935, #3033, #4658, #4659, [loader] Rework loader arguments:
           shp2pgsql can create UNLOGGED tables and choose the feature id column
           name, shp2pgsql --drop-table can emit DROP TABLE before prepare

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -7215,7 +7215,7 @@ FROM baz</programlisting>
         <refentry xml:id="RT_ST_SetBandNoDataValue">
             <refnamediv>
                 <refname>ST_SetBandNoDataValue</refname>
-                <refpurpose>Sets the value for the given band that represents no data. Band 1 is assumed if no band is specified.  To mark a band as having no nodata value, set the nodata value = NULL.</refpurpose>
+                <refpurpose>Sets the value for the given band or bands that represents no data. Band 1 is assumed if no band is specified.  To mark a band as having no nodata value, set the nodata value = NULL.</refpurpose>
             </refnamediv>
 
             <refsynopsisdiv>
@@ -7234,13 +7234,21 @@ FROM baz</programlisting>
                     <paramdef choice="opt"><type>boolean </type> <parameter>forcechecking=false</parameter></paramdef>
                   </funcprototype>
 
+                  <funcprototype>
+                    <funcdef>raster <function>ST_SetBandNoDataValue</function></funcdef>
+                    <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                    <paramdef><type>integer[] </type> <parameter>bands</parameter></paramdef>
+                    <paramdef><type>double precision[] </type> <parameter>nodatavalues</parameter></paramdef>
+                    <paramdef choice="opt"><type>boolean </type> <parameter>forcechecking=false</parameter></paramdef>
+                  </funcprototype>
+
                 </funcsynopsis>
             </refsynopsisdiv>
 
             <refsection>
                 <title>Description</title>
 
-                <para>Sets the value that represents no data for the band.  Band 1 is assumed if not specified. This will affect results from <xref linkend="RT_ST_Polygon"/>, <xref linkend="RT_ST_DumpAsPolygons"/>, and the ST_PixelAs...() functions.</para>
+                <para>Sets the value that represents no data for the band or bands.  Band 1 is assumed if not specified.  When using the array variant, the <varname>bands</varname> and <varname>nodatavalues</varname> arrays must have the same length. This will affect results from <xref linkend="RT_ST_Polygon"/>, <xref linkend="RT_ST_DumpAsPolygons"/>, and the ST_PixelAs...() functions.</para>
                 </refsection>
 
                 <refsection>
@@ -7265,6 +7273,16 @@ UPDATE dummy_rast
                     <programlisting language="sql">
 UPDATE dummy_rast
     SET rast = ST_SetBandNoDataValue(rast, 1, NULL)
+WHERE rid = 2;
+
+-- change no data band values of bands 1,2,3 with one call
+UPDATE dummy_rast
+    SET rast = ST_SetBandNoDataValue(rast, ARRAY[1,2,3], ARRAY[254,99,108]::double precision[])
+WHERE rid = 2;
+
+-- wipe out the nodata value on bands 1,2,3
+UPDATE dummy_rast
+    SET rast = ST_SetBandNoDataValue(rast, ARRAY[1,2,3], ARRAY[NULL,NULL,NULL]::double precision[])
 WHERE rid = 2;
                     </programlisting>
 

--- a/raster/rt_pg/rtpg_band_properties.c
+++ b/raster/rt_pg/rtpg_band_properties.c
@@ -61,6 +61,7 @@ Datum RASTER_bandmetadata(PG_FUNCTION_ARGS);
 /* Set all the properties of a raster band */
 Datum RASTER_setBandIsNoData(PG_FUNCTION_ARGS);
 Datum RASTER_setBandNoDataValue(PG_FUNCTION_ARGS);
+Datum RASTER_setBandNoDataValues(PG_FUNCTION_ARGS);
 Datum RASTER_setBandPath(PG_FUNCTION_ARGS);
 Datum RASTER_setBandIndex(PG_FUNCTION_ARGS);
 
@@ -792,6 +793,45 @@ Datum RASTER_bandmetadata(PG_FUNCTION_ARGS)
 	}
 }
 
+static void
+rtpg_set_band_nodata_value(rt_raster raster, int32_t bandindex, bool nodata_is_null, double nodata, bool forcechecking)
+{
+	rt_band band = NULL;
+
+	if (bandindex < 1)
+	{
+		elog(NOTICE, "Invalid band index (must use 1-based). Nodata value not set. Returning original raster");
+		return;
+	}
+
+	/* Fetch requested band */
+	band = rt_raster_get_band(raster, bandindex - 1);
+	if (!band)
+	{
+		elog(
+		    NOTICE,
+		    "Could not find raster band of index %d when setting pixel value. Nodata value not set. Returning original raster",
+		    bandindex);
+		return;
+	}
+
+	if (nodata_is_null)
+	{
+		/* Set the hasnodata flag to FALSE */
+		rt_band_set_hasnodata_flag(band, FALSE);
+		POSTGIS_RT_DEBUGF(3, "Raster band %d does not have a nodata value", bandindex);
+	}
+	else
+	{
+		/* Set the band's nodata value */
+		rt_band_set_nodata(band, nodata, NULL);
+
+		/* Recheck all pixels if requested */
+		if (forcechecking)
+			rt_band_check_is_nodata(band);
+	}
+}
+
 /**
  * Set the nodata value of the specified band of raster.
  */
@@ -801,11 +841,9 @@ Datum RASTER_setBandNoDataValue(PG_FUNCTION_ARGS)
 	rt_pgraster *pgraster = NULL;
 	rt_pgraster *pgrtn = NULL;
 	rt_raster raster = NULL;
-	rt_band band = NULL;
-	double nodata;
+	double nodata = 0;
 	int32_t bandindex;
 	bool forcechecking = FALSE;
-	bool skipset = FALSE;
 
 	/* Deserialize raster */
 	if (PG_ARGISNULL(0))
@@ -817,10 +855,6 @@ Datum RASTER_setBandNoDataValue(PG_FUNCTION_ARGS)
 		bandindex = -1;
 	else
 		bandindex = PG_GETARG_INT32(1);
-	if (bandindex < 1) {
-		elog(NOTICE, "Invalid band index (must use 1-based). Nodata value not set. Returning original raster");
-		skipset = TRUE;
-	}
 
 	raster = rt_raster_deserialize(pgraster, FALSE);
 	if (!raster) {
@@ -829,37 +863,133 @@ Datum RASTER_setBandNoDataValue(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 	}
 
-	if (!skipset) {
-		/* Fetch requested band */
-		band = rt_raster_get_band(raster, bandindex - 1);
-		if (!band) {
-			elog(NOTICE, "Could not find raster band of index %d when setting pixel value. Nodata value not set. Returning original raster", bandindex);
+	if (!PG_ARGISNULL(3))
+		forcechecking = PG_GETARG_BOOL(3);
+
+	if (!PG_ARGISNULL(2))
+		nodata = PG_GETARG_FLOAT8(2);
+
+	rtpg_set_band_nodata_value(raster, bandindex, PG_ARGISNULL(2), nodata, forcechecking);
+
+	pgrtn = rt_raster_serialize(raster);
+	rt_raster_destroy(raster);
+	PG_FREE_IF_COPY(pgraster, 0);
+	if (!pgrtn)
+		PG_RETURN_NULL();
+
+	SET_VARSIZE(pgrtn, pgrtn->size);
+	PG_RETURN_POINTER(pgrtn);
+}
+
+/**
+ * Set nodata values for the specified bands of raster.
+ */
+PG_FUNCTION_INFO_V1(RASTER_setBandNoDataValues);
+Datum
+RASTER_setBandNoDataValues(PG_FUNCTION_ARGS)
+{
+	rt_pgraster *pgraster = NULL;
+	rt_pgraster *pgrtn = NULL;
+	rt_raster raster = NULL;
+	ArrayType *band_array = NULL;
+	ArrayType *nodata_array = NULL;
+	Datum *band_values = NULL;
+	Datum *nodata_values = NULL;
+	bool *band_nulls = NULL;
+	bool *nodata_nulls = NULL;
+	int band_count = 0;
+	int nodata_count = 0;
+	int i = 0;
+	bool forcechecking = FALSE;
+
+	/* Deserialize raster */
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+	pgraster = (rt_pgraster *)PG_DETOAST_DATUM(PG_GETARG_DATUM(0));
+
+	if (PG_ARGISNULL(1) || PG_ARGISNULL(2))
+	{
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "RASTER_setBandNoDataValues: band and nodatavalue arrays cannot be NULL");
+		PG_RETURN_NULL();
+	}
+
+	band_array = PG_GETARG_ARRAYTYPE_P(1);
+	nodata_array = PG_GETARG_ARRAYTYPE_P(2);
+
+	if (ARR_ELEMTYPE(band_array) != INT4OID)
+	{
+		PG_FREE_IF_COPY(nodata_array, 2);
+		PG_FREE_IF_COPY(band_array, 1);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "RASTER_setBandNoDataValues: Invalid data type for band number(s)");
+		PG_RETURN_NULL();
+	}
+
+	if (ARR_ELEMTYPE(nodata_array) != FLOAT8OID)
+	{
+		PG_FREE_IF_COPY(nodata_array, 2);
+		PG_FREE_IF_COPY(band_array, 1);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "RASTER_setBandNoDataValues: Invalid data type for nodata value(s)");
+		PG_RETURN_NULL();
+	}
+
+	deconstruct_array(band_array, INT4OID, 4, true, 'i', &band_values, &band_nulls, &band_count);
+	deconstruct_array(nodata_array,
+			  FLOAT8OID,
+			  sizeof(float8),
+			  FLOAT8PASSBYVAL,
+			  'd',
+			  &nodata_values,
+			  &nodata_nulls,
+			  &nodata_count);
+
+	if (band_count != nodata_count)
+	{
+		PG_FREE_IF_COPY(nodata_array, 2);
+		PG_FREE_IF_COPY(band_array, 1);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "RASTER_setBandNoDataValues: band and nodatavalue arrays must have the same length");
+		PG_RETURN_NULL();
+	}
+
+	raster = rt_raster_deserialize(pgraster, FALSE);
+	if (!raster)
+	{
+		PG_FREE_IF_COPY(nodata_array, 2);
+		PG_FREE_IF_COPY(band_array, 1);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "RASTER_setBandNoDataValues: Could not deserialize raster");
+		PG_RETURN_NULL();
+	}
+
+	if (!PG_ARGISNULL(3))
+		forcechecking = PG_GETARG_BOOL(3);
+
+	for (i = 0; i < band_count; i++)
+	{
+		int32_t bandindex = -1;
+		double nodata = 0;
+
+		if (band_nulls[i])
+		{
+			elog(NOTICE,
+			     "Invalid band index (must use 1-based). Nodata value not set. Returning original raster");
+			continue;
 		}
-		else {
-			if (!PG_ARGISNULL(3))
-				forcechecking = PG_GETARG_BOOL(3);
 
-			if (PG_ARGISNULL(2)) {
-				/* Set the hasnodata flag to FALSE */
-				rt_band_set_hasnodata_flag(band, FALSE);
-				POSTGIS_RT_DEBUGF(3, "Raster band %d does not have a nodata value", bandindex);
-			}
-			else {
-				/* Get the nodata value */
-				nodata = PG_GETARG_FLOAT8(2);
+		bandindex = DatumGetInt32(band_values[i]);
+		if (!nodata_nulls[i])
+			nodata = DatumGetFloat8(nodata_values[i]);
 
-				/* Set the band's nodata value */
-				rt_band_set_nodata(band, nodata, NULL);
-
-				/* Recheck all pixels if requested */
-				if (forcechecking)
-					rt_band_check_is_nodata(band);
-			}
-		}
+		rtpg_set_band_nodata_value(raster, bandindex, nodata_nulls[i], nodata, forcechecking);
 	}
 
 	pgrtn = rt_raster_serialize(raster);
 	rt_raster_destroy(raster);
+	PG_FREE_IF_COPY(nodata_array, 2);
+	PG_FREE_IF_COPY(band_array, 1);
 	PG_FREE_IF_COPY(pgraster, 0);
 	if (!pgrtn)
 		PG_RETURN_NULL();

--- a/raster/rt_pg/rtpg_band_properties.c
+++ b/raster/rt_pg/rtpg_band_properties.c
@@ -970,22 +970,44 @@ RASTER_setBandNoDataValues(PG_FUNCTION_ARGS)
 	for (i = 0; i < band_count; i++)
 	{
 		int32_t bandindex = -1;
-		double nodata = 0;
 
 		if (band_nulls[i])
 		{
 			elog(NOTICE,
 			     "Invalid band index (must use 1-based). Nodata value not set. Returning original raster");
-			continue;
+			goto serialize;
 		}
 
 		bandindex = DatumGetInt32(band_values[i]);
+		if (bandindex < 1)
+		{
+			elog(NOTICE,
+			     "Invalid band index (must use 1-based). Nodata value not set. Returning original raster");
+			goto serialize;
+		}
+
+		if (!rt_raster_get_band(raster, bandindex - 1))
+		{
+			elog(
+			    NOTICE,
+			    "Could not find raster band of index %d when setting pixel value. Nodata value not set. Returning original raster",
+			    bandindex);
+			goto serialize;
+		}
+	}
+
+	for (i = 0; i < band_count; i++)
+	{
+		int32_t bandindex = DatumGetInt32(band_values[i]);
+		double nodata = 0;
+
 		if (!nodata_nulls[i])
 			nodata = DatumGetFloat8(nodata_values[i]);
 
 		rtpg_set_band_nodata_value(raster, bandindex, nodata_nulls[i], nodata, forcechecking);
 	}
 
+serialize:
 	pgrtn = rt_raster_serialize(raster);
 	rt_raster_destroy(raster);
 	PG_FREE_IF_COPY(nodata_array, 2);

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -4946,6 +4946,12 @@ CREATE OR REPLACE FUNCTION st_setbandnodatavalue(rast raster, band integer, noda
     AS 'MODULE_PATHNAME','RASTER_setBandNoDataValue'
     LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
 
+-- This function can not be STRICT, because nodatavalue can contain NULL values indicating that no nodata value should be set
+CREATE OR REPLACE FUNCTION st_setbandnodatavalue(rast raster, bands integer[], nodatavalues float8[], forceChecking boolean DEFAULT FALSE)
+    RETURNS raster
+    AS 'MODULE_PATHNAME','RASTER_setBandNoDataValues'
+    LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
+
 -- This function can not be STRICT, because nodatavalue can be NULL indicating that no nodata value should be set
 CREATE OR REPLACE FUNCTION st_setbandnodatavalue(rast raster, nodatavalue float8)
     RETURNS raster

--- a/raster/test/regress/rt_set_band_properties.sql
+++ b/raster/test/regress/rt_set_band_properties.sql
@@ -243,4 +243,39 @@ SELECT
  FROM rt_band_properties_test
 WHERE (b1nodatavalue+1) != st_bandnodatavalue(st_setbandnodatavalue(rast, 1, b1nodatavalue+1),1);
 
+SELECT
+    id,
+    st_bandnodatavalue(rast, 1) AS band1,
+    st_bandnodatavalue(rast, 2) AS band2
+FROM (
+    SELECT
+        id,
+        st_setbandnodatavalue(rast, ARRAY[1, 2], ARRAY[11, 12]::double precision[]) AS rast
+    FROM rt_band_properties_test
+    WHERE id = 1
+) AS foo;
+
+SELECT
+    id,
+    st_bandnodatavalue(rast, 1) AS band1,
+    st_bandnodatavalue(rast, 2) IS NULL AS band2_is_null
+FROM (
+    SELECT
+        id,
+        st_setbandnodatavalue(rast, ARRAY[1, 2], ARRAY[14, NULL]::double precision[]) AS rast
+    FROM rt_band_properties_test
+    WHERE id = 1
+) AS foo;
+
+SELECT
+    id,
+    st_bandnodatavalue(st_setbandnodatavalue(rast, 14), 1) AS band1,
+    st_bandnodatavalue(st_setbandnodatavalue(rast, 14), 2) AS band2
+FROM rt_band_properties_test
+WHERE id = 1;
+
+SELECT st_setbandnodatavalue(rast, ARRAY[1, 2], ARRAY[10]::double precision[]) IS NULL
+FROM rt_band_properties_test
+WHERE id = 1;
+
 DROP TABLE rt_band_properties_test;

--- a/raster/test/regress/rt_set_band_properties.sql
+++ b/raster/test/regress/rt_set_band_properties.sql
@@ -274,6 +274,16 @@ SELECT
 FROM rt_band_properties_test
 WHERE id = 1;
 
+SELECT
+    id,
+    st_bandnodatavalue(rast, 1) AS band1_before,
+    st_bandnodatavalue(
+        st_setbandnodatavalue(rast, ARRAY[1, 999], ARRAY[15, 16]::double precision[]),
+        1
+    ) AS band1_after_invalid
+FROM rt_band_properties_test
+WHERE id = 1;
+
 SELECT st_setbandnodatavalue(rast, ARRAY[1, 2], ARRAY[10]::double precision[]) IS NULL
 FROM rt_band_properties_test
 WHERE id = 1;

--- a/raster/test/regress/rt_set_band_properties_expected
+++ b/raster/test/regress/rt_set_band_properties_expected
@@ -1,0 +1,4 @@
+1|11|12
+1|14|t
+1|14|
+ERROR:  RASTER_setBandNoDataValues: band and nodatavalue arrays must have the same length

--- a/raster/test/regress/rt_set_band_properties_expected
+++ b/raster/test/regress/rt_set_band_properties_expected
@@ -1,4 +1,6 @@
 1|11|12
 1|14|t
 1|14|
+NOTICE:  Could not find raster band of index 999 when setting pixel value. Nodata value not set. Returning original raster
+1|3|3
 ERROR:  RASTER_setBandNoDataValues: band and nodatavalue arrays must have the same length


### PR DESCRIPTION
## Summary

- add a multiband `ST_SetBandNoDataValue(raster, integer[], double precision[], boolean)` overload
- keep the existing `ST_SetBandNoDataValue(raster, double precision)` shortcut as a band-1 operation
- prevalidate all requested bands before applying array updates so invalid later bands leave the original raster unchanged
- document the array overload and add regression coverage for multiband setting, NULL clearing, shortcut compatibility, invalid-band all-or-original behavior, and mismatched array lengths

Trac ticket: https://trac.osgeo.org/postgis/ticket/2325

## Rebase

- rebased on current `upstream/master` at `4e470f153`
- current head: `992ec3d20b9a32b00117a080e4d8a24d24a90f3c`
- the Trac discussion keeps the existing no-band shortcut semantics out of this ticket; that behavior was split to postgis/postgis#2328

## Validation

- `./config.status --file=regress/dumper/tests.mk`
- `./config.status --file=raster/test/regress/tests.mk`
- `make postgis_revision.h`
- `make -C raster/rt_pg -j32`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C raster/rt_pg install`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/raster/test/regress/rt_set_band_properties"`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --schema=postgis_ci" TESTS="$(pwd)/raster/test/regress/rt_set_band_properties"`
- `make -C doc check`
- `make check-news`
- `git clang-format --diff upstream/master -- raster/rt_pg/rtpg_band_properties.c raster/rt_pg/rtpostgis.sql.in raster/test/regress/rt_set_band_properties.sql raster/test/regress/rt_set_band_properties_expected doc/reference_raster.xml NEWS`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
