### PR TITLE
Analyze topology tables after ST_CreateTopoGeo

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,6 +58,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #2998, [topology] Refresh primitive-table statistics after
+          ST_CreateTopoGeo bulk population (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1398,10 +1398,11 @@ are up-to-date.
 </para>
 
 <para>
-PostGIS Topology population and editing functions do not automatically
-update the statistics because a updating stats after each and every
-change in a topology would be overkill, so it is the caller's duty
-to take care of that.
+PostGIS Topology editing functions do not automatically update the
+statistics because updating stats after each and every change in a
+topology would be overkill, so it is the caller's duty to take care of
+that.  The bulk <xref linkend="ST_CreateTopoGeo"/> constructor does run
+ANALYZE after populating a topology.
 </para>
 
 <note>

--- a/topology/sql/sqlmm.sql.in
+++ b/topology/sql/sqlmm.sql.in
@@ -595,6 +595,10 @@ BEGIN
     PERFORM topology.TopoGeo_addPoint(atopology, rec.geom);
   END LOOP;
 
+  EXECUTE format('ANALYZE %I.edge_data', atopology);
+  EXECUTE format('ANALYZE %I.node', atopology);
+  EXECUTE format('ANALYZE %I.face', atopology);
+
   RETURN 'Topology ' || atopology || ' populated';
 
 END
@@ -603,4 +607,3 @@ LANGUAGE 'plpgsql' VOLATILE;
 --} ST_CreateTopoGeo
 
 --=}  SQL/MM block
-

--- a/topology/test/regress/st_createtopogeo.sql
+++ b/topology/test/regress/st_createtopogeo.sql
@@ -35,6 +35,20 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
+CREATE function print_primitive_stats(lbl text)
+ RETURNS table(olbl text, relname name, stats_updated boolean)
+AS $$
+BEGIN
+  RETURN QUERY
+    SELECT lbl::text, c.relname, c.reltuples >= 0
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 't'
+      AND c.relname IN ('edge_data', 'node', 'face')
+    ORDER BY c.relname;
+END;
+$$ LANGUAGE 'plpgsql';
+
 -- Invalid geometries
 select null from ( select topology.CreateTopology('t', 4326) > 0 ) as ct;
 select topology.st_createtopogeo('t', null); -- Invalid geometry
@@ -57,6 +71,7 @@ SELECT g, topology.st_createtopogeo('t', g) FROM ( SELECT
 'SRID=4326;LINESTRING(0 0, 8 -40)'
 ::geometry as g ) as i ) as j;
 select * from print_elements_count('T2');
+select * from print_primitive_stats('T2');
 select null from ( select topology.DropTopology('t') ) as dt;
 
 -- Single polygon with no holes
@@ -247,3 +262,4 @@ select null from ( select topology.DropTopology('t') ) as dt;
 -- clean up
 DROP FUNCTION print_isolated_nodes(text);
 DROP FUNCTION print_elements_count(text);
+DROP FUNCTION print_primitive_stats(text);

--- a/topology/test/regress/st_createtopogeo_expected
+++ b/topology/test/regress/st_createtopogeo_expected
@@ -7,6 +7,9 @@ T1|POINT(0 0)
 T1|1 nodes|0 edges|0 faces
 T2|SRID=4326;LINESTRING(0 0,8 -40)
 T2|2 nodes|1 edges|0 faces
+T2|edge_data|t
+T2|face|t
+T2|node|t
 T3|SRID=4326;POLYGON((0 0,8 -40,70 34,0 0))
 T3|1 nodes|1 edges|1 faces
 T4|SRID=4326;POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,8 9,4 2,5 5))


### PR DESCRIPTION
## Summary

This is a bounded slice of https://trac.osgeo.org/postgis/ticket/2998.

`ST_CreateTopoGeo` bulk-populates a topology in one operation, then subsequent topology queries can immediately benefit from current primitive-table statistics. The broader ticket asks for a general automatic strategy during topology building; this PR only handles the safe bulk-constructor path and leaves row-by-row edit functions caller-managed.

Changes:

- run `ANALYZE` on the topology `edge_data`, `node`, and `face` tables after `ST_CreateTopoGeo` finishes populating them
- document that `ST_CreateTopoGeo` is the exception to caller-managed topology statistics
- add regression coverage proving primitive-table stats are populated
- add a NEWS entry

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo make install`
- `make -C topology -j8`
- `sudo -n make -C topology install`
- `make -C extensions/postgis_topology -j8`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/st_createtopogeo"`
- `make -C topology/test check RUNTESTFLAGS='--extension --verbose --schema=postgis_ci' TESTS="$(pwd)/topology/test/regress/st_createtopogeo"`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/328
