### PR TITLE
Use table returns for topology edge listings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           GeometryCollections (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
           (Darafei Praliaskouski)
+ - #4862, [topology] Stop using custom return types for topology edge
+          listing functions (Darafei Praliaskouski)
 
 * Bug Fixes *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -58,11 +58,11 @@ number and an edge number.
 		  <refsection>
 			<title>Description</title>
 			<para>
-A composite type that consists of a sequence number
-and an edge number.
-This is the return type for <varname>ST_GetFaceEdges</varname>
-and <varname>GetNodeEdges</varname> functions.
-			</para>
+				A composite type that consists of a sequence number
+				and an edge number.
+				This legacy type was used by <varname>ST_GetFaceEdges</varname>,
+				<varname>GetRingEdges</varname>, and <varname>GetNodeEdges</varname>.
+				</para>
 			<orderedlist>
 			  <listitem>
 				<para><varname>sequence</varname> is an integer:  Refers to a topology defined in the topology.topology table which defines the topology schema and srid.</para>
@@ -3084,9 +3084,11 @@ ERROR:  Two or more faces found</programlisting>
 			<refsynopsisdiv>
 				<funcsynopsis>
 					<funcprototype>
-					<funcdef>getfaceedges_returntype <function>ST_GetFaceEdges</function></funcdef>
-					<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
-					<paramdef><type>bigint </type> <parameter>aface</parameter></paramdef>
+						<funcdef>record <function>ST_GetFaceEdges</function></funcdef>
+						<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>bigint </type> <parameter>aface</parameter></paramdef>
+						<paramdef><type>integer </type> <parameter>OUT sequence</parameter></paramdef>
+						<paramdef><type>bigint </type> <parameter>OUT edge</parameter></paramdef>
 					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
@@ -3209,10 +3211,12 @@ a given edge side.
 			<refsynopsisdiv>
 				<funcsynopsis>
 					<funcprototype>
-					<funcdef>getfaceedges_returntype <function>GetRingEdges</function></funcdef>
-					<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
-					<paramdef><type>bigint </type> <parameter>aring</parameter></paramdef>
-					<paramdef choice="opt"><type>integer </type> <parameter>max_edges=null</parameter></paramdef>
+						<funcdef>record <function>GetRingEdges</function></funcdef>
+						<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>bigint </type> <parameter>aring</parameter></paramdef>
+						<paramdef choice="opt"><type>integer </type> <parameter>max_edges=null</parameter></paramdef>
+						<paramdef><type>integer </type> <parameter>OUT sequence</parameter></paramdef>
+						<paramdef><type>bigint </type> <parameter>OUT edge</parameter></paramdef>
 					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
@@ -3271,9 +3275,11 @@ Returns an ordered set of edges incident to the given node.
 			<refsynopsisdiv>
 				<funcsynopsis>
 					<funcprototype>
-					<funcdef>getfaceedges_returntype <function>GetNodeEdges</function></funcdef>
-					<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
-					<paramdef><type>bigint </type> <parameter>anode</parameter></paramdef>
+						<funcdef>record <function>GetNodeEdges</function></funcdef>
+						<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>bigint </type> <parameter>anode</parameter></paramdef>
+						<paramdef><type>integer </type> <parameter>OUT sequence</parameter></paramdef>
+						<paramdef><type>bigint </type> <parameter>OUT edge</parameter></paramdef>
 					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
@@ -3306,9 +3312,8 @@ and is thus usable to build edge ring linking.
 			<refsection>
 				<title>See Also</title>
 				<para>
-<xref linkend="getfaceedges_returntype"/>,
-<xref linkend="GetRingEdges"/>,
-<xref linkend="ST_Azimuth"/>
+					<xref linkend="GetRingEdges"/>,
+					<xref linkend="ST_Azimuth"/>
 				</para>
 			</refsection>
 		</refentry>

--- a/doc/xsl/topology_comments.sql.xsl
+++ b/doc/xsl/topology_comments.sql.xsl
@@ -51,7 +51,7 @@ COMMENT ON DOMAIN topology.<xsl:value-of select="db:refnamediv/db:refname" /> IS
 	Do not output OUT params since they define output rather than act as input and do not put a comma after argument just before an OUT parameter -->
 		<xsl:for-each select="db:refsynopsisdiv/db:funcsynopsis/db:funcprototype">
 COMMENT ON <xsl:choose><xsl:when test="contains(db:paramdef/db:type,' set')">AGGREGATE</xsl:when><xsl:otherwise>FUNCTION</xsl:otherwise></xsl:choose><xsl:text></xsl:text> topology.<xsl:value-of select="db:funcdef/db:function" />(<xsl:for-each select="db:paramdef"><xsl:choose><xsl:when test="count(db:parameter) &gt; 0">
-<xsl:choose><xsl:when test="contains(db:parameter,'OUT')"></xsl:when><xsl:when test="contains(db:type,'topoelement set')">topoelement</xsl:when><xsl:otherwise><xsl:value-of select="db:type" /></xsl:otherwise></xsl:choose><xsl:if test="position()&lt;last() and not(contains(db:parameter,'OUT')) and not(contains(following-sibling::paramdef[1],'OUT'))"><xsl:text>, </xsl:text></xsl:if></xsl:when>
+<xsl:choose><xsl:when test="contains(db:parameter,'OUT')"></xsl:when><xsl:when test="contains(db:type,'topoelement set')">topoelement</xsl:when><xsl:otherwise><xsl:value-of select="db:type" /></xsl:otherwise></xsl:choose><xsl:if test="position()&lt;last() and not(contains(db:parameter,'OUT')) and not(contains(following-sibling::db:paramdef[1],'OUT'))"><xsl:text>, </xsl:text></xsl:if></xsl:when>
 </xsl:choose></xsl:for-each>) IS '<xsl:call-template name="listparams"><xsl:with-param name="func" select="." /></xsl:call-template> <xsl:value-of select='$comment' />';
 			</xsl:for-each>
 		</xsl:for-each>

--- a/doc/xsl/topology_gardentest.sql.xsl
+++ b/doc/xsl/topology_gardentest.sql.xsl
@@ -717,7 +717,7 @@ SELECT '<xsl:value-of select="$fnname" /><xsl:text> </xsl:text><xsl:value-of sel
 					</xsl:when>
 				</xsl:choose>
 				<!-- put a comma before an arg if it is not the first argument in a function and it is not an OUT parameter nor does it precede an OUT parameter -->
-				<xsl:if test="position()&lt;last() and not(contains(db:parameter,'OUT')) and not(contains(following-sibling::paramdef[1],'OUT'))"><xsl:text>, </xsl:text></xsl:if>
+				<xsl:if test="position()&lt;last() and not(contains(db:parameter,'OUT')) and not(contains(following-sibling::db:paramdef[1],'OUT'))"><xsl:text>, </xsl:text></xsl:if>
 			</xsl:for-each>
 		</xsl:for-each>
 	</xsl:template>

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -4226,16 +4226,11 @@ Datum ST_GetFaceEdges(PG_FUNCTION_ARGS)
   LWT_TOPOLOGY *topo;
   FuncCallContext *funcctx;
   MemoryContext oldcontext, newcontext;
-  TupleDesc tupdesc;
   HeapTuple tuple;
-  AttInMetadata *attinmeta;
   FACEEDGESSTATE *state;
-  char buf[64];
-  char *values[2];
   Datum result;
-
-  values[0] = buf;
-  values[1] = &(buf[32]);
+  Datum ret[2];
+  bool isnull[2] = {0, 0};
 
   if (SRF_IS_FIRSTCALL())
   {
@@ -4291,17 +4286,10 @@ Datum ST_GetFaceEdges(PG_FUNCTION_ARGS)
     funcctx->user_fctx = state;
 
     /*
-     * Build a tuple description for a
-     * getfaceedges_returntype tuple
+     * Get tuple description for return type
      */
-    tupdesc = RelationNameGetTupleDesc("topology.getfaceedges_returntype");
-
-    /*
-     * generate attribute metadata needed later to produce
-     * tuples from raw C strings
-     */
-    attinmeta = TupleDescGetAttInMetadata(tupdesc);
-    funcctx->attinmeta = attinmeta;
+    get_call_result_type(fcinfo, 0, &funcctx->tuple_desc);
+    BlessTupleDesc(funcctx->tuple_desc);
 
     POSTGIS_DEBUG(1, "lwt_GetFaceEdges calling SPI_finish");
 
@@ -4327,22 +4315,11 @@ Datum ST_GetFaceEdges(PG_FUNCTION_ARGS)
     SRF_RETURN_DONE(funcctx);
   }
 
-  if ( snprintf(values[0], 32, "%d", state->curr+1) >= 32 )
-  {
-    lwerror("Face edge sequence number does not fit 32 chars ?!: %d",
-            state->curr+1);
-  }
-  if ( snprintf(values[1], 32, "%" LWTFMT_ELEMID,
-                state->elems[state->curr]) >= 32 )
-  {
-    lwerror("Signed edge identifier does not fit 32 chars ?!: %"
-            LWTFMT_ELEMID, state->elems[state->curr]);
-  }
+  POSTGIS_DEBUGF(1, "ST_GetFaceEdges: cur:%d, edge:%" LWTFMT_ELEMID, state->curr, state->elems[state->curr]);
 
-  POSTGIS_DEBUGF(1, "ST_GetFaceEdges: cur:%d, val0:%s, val1:%s",
-                 state->curr, values[0], values[1]);
-
-  tuple = BuildTupleFromCStrings(funcctx->attinmeta, values);
+  ret[0] = Int32GetDatum(state->curr + 1);
+  ret[1] = Int64GetDatum(state->elems[state->curr]);
+  tuple = heap_form_tuple(funcctx->tuple_desc, ret, isnull);
   result = HeapTupleGetDatum(tuple);
   state->curr++;
 

--- a/topology/sql/query/GetNodeEdges.sql.in
+++ b/topology/sql/query/GetNodeEdges.sql.in
@@ -22,14 +22,13 @@
 -- Changed: 3.6.0 uses bigint for IDs
 -- Replaces getnodeedges(varchar, integer) deprecated in 3.6.0
 CREATE OR REPLACE FUNCTION topology.GetNodeEdges(atopology varchar, anode bigint)
-	RETURNS SETOF topology.GetFaceEdges_ReturnType
+	RETURNS TABLE(sequence integer, edge bigint)
 AS
 $BODY$
 DECLARE
   curedge bigint;
   nextedge bigint;
   rec RECORD;
-  retrec topology.GetFaceEdges_ReturnType;
   n int;
   sql text;
 BEGIN
@@ -73,9 +72,9 @@ BEGIN
     RAISE DEBUG 'Edge:% az:%', rec.edge_id, rec.az;
 #endif
     n := n + 1;
-    retrec.sequence := n;
-    retrec.edge := rec.edge_id;
-    RETURN NEXT retrec;
+    sequence := n;
+    edge := rec.edge_id;
+    RETURN NEXT;
   END LOOP; -- incident edges }
 
 END

--- a/topology/sql/query/GetRingEdges.sql.in
+++ b/topology/sql/query/GetRingEdges.sql.in
@@ -40,7 +40,7 @@
 -- Changed: 3.6.0 uses bigint for IDs
 -- Replaces getringedges(varchar, integer, integer) deprecated in 3.6.0
 CREATE OR REPLACE FUNCTION topology.GetRingEdges(atopology varchar, anedge bigint, maxedges int DEFAULT null)
-	RETURNS SETOF topology.GetFaceEdges_ReturnType AS
+	RETURNS TABLE(sequence integer, edge bigint) AS
 	'MODULE_PATHNAME', 'GetRingEdges'
 LANGUAGE 'c' STABLE;
 --} GetRingEdges

--- a/topology/sql/sqlmm.sql.in
+++ b/topology/sql/sqlmm.sql.in
@@ -44,7 +44,7 @@ CREATE TYPE topology.GetFaceEdges_ReturnType AS (
 -- Changed: 3.6.0 uses bigint for IDs
 -- Replaces st_getfaceedges(varchar, integer) deprecated in 3.6.0
 CREATE OR REPLACE FUNCTION topology.ST_GetFaceEdges(toponame varchar, face_id bigint)
-  RETURNS SETOF topology.GetFaceEdges_ReturnType AS
+  RETURNS TABLE(sequence integer, edge bigint) AS
 	'MODULE_PATHNAME', 'ST_GetFaceEdges'
   LANGUAGE 'c' STABLE;
 --} ST_GetFaceEdges
@@ -603,4 +603,3 @@ LANGUAGE 'plpgsql' VOLATILE;
 --} ST_CreateTopoGeo
 
 --=}  SQL/MM block
-

--- a/topology/test/regress/getnodeedges.sql
+++ b/topology/test/regress/getnodeedges.sql
@@ -2,6 +2,8 @@ set client_min_messages to ERROR;
 
 \i :top_builddir/topology/test/load_topology.sql
 
+SELECT pg_get_function_result('topology.GetNodeEdges(varchar, bigint)'::regprocedure);
+
 SELECT 'N'||node_id, (topology.GetNodeEdges('city_data', node_id)).*
 	FROM city_data.node ORDER BY node_id, sequence;
 

--- a/topology/test/regress/getnodeedges_expected
+++ b/topology/test/regress/getnodeedges_expected
@@ -1,3 +1,4 @@
+TABLE(sequence integer, edge bigint)
 N1|1|1
 N1|2|-1
 N2|1|3

--- a/topology/test/regress/getringedges.sql
+++ b/topology/test/regress/getringedges.sql
@@ -2,6 +2,8 @@ set client_min_messages to ERROR;
 
 \i :top_builddir/topology/test/load_topology.sql
 
+SELECT pg_get_function_result('topology.GetRingEdges(varchar, bigint, int)'::regprocedure);
+
 -- Test bogus calls
 SELECT 'non-existent-topo', topology.GetRingEdges('non-existent', 1);
 SELECT 'non-existent-edge', topology.GetRingEdges('city_data', 10000000);

--- a/topology/test/regress/getringedges_expected
+++ b/topology/test/regress/getringedges_expected
@@ -1,3 +1,4 @@
+TABLE(sequence integer, edge bigint)
 ERROR:  No topology with name "non-existent" in topology.topology
 ERROR:  No edge with id 10000000 in Topology "city_data"
 ERROR:  No edge with id 10000000 in Topology "city_data"

--- a/topology/test/regress/st_getfaceedges.sql
+++ b/topology/test/regress/st_getfaceedges.sql
@@ -1,5 +1,7 @@
 set client_min_messages to ERROR;
 
+SELECT pg_get_function_result('topology.ST_GetFaceEdges(varchar, bigint)'::regprocedure);
+
 SELECT topology.CreateTopology('tt') > 0;
 
 SELECT topology.ST_GetFaceEdges(null, null);

--- a/topology/test/regress/st_getfaceedges_expected
+++ b/topology/test/regress/st_getfaceedges_expected
@@ -1,3 +1,4 @@
+TABLE(sequence integer, edge bigint)
 t
 ERROR:  SQL/MM Spatial exception - null argument
 ERROR:  SQL/MM Spatial exception - null argument

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -109,7 +109,7 @@
 --    TODO: implement
 --
 -- TYPE GetFaceEdges_ReturnType
---    Complex type used to return tuples from ST_GetFaceEdges
+--    Legacy complex type formerly used by ST_GetFaceEdges
 --
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 --
@@ -1405,7 +1405,6 @@ LANGUAGE 'plpgsql' VOLATILE STRICT;
 --  SQL/MM block
 #include "sql/sqlmm.sql.in"
 
--- The following files needs getfaceedges_returntype, defined in sqlmm.sql
 #include "sql/query/GetRingEdges.sql.in"
 #include "sql/query/GetNodeEdges.sql.in"
 

--- a/topology/topology_before_upgrade.sql.in
+++ b/topology/topology_before_upgrade.sql.in
@@ -46,3 +46,8 @@ SELECT _postgis_topology_upgrade_domain_type('topoelement','integer[]','bigint[]
 SELECT _postgis_topology_upgrade_domain_type('topoelementarray','integer[][]','bigint[][]','3.6.0');
 SELECT _postgis_add_column_to_table('topology.topology', 'useslargeids', 'BOOLEAN', true, 'false','3.6.0');
 
+-- 3.7.0
+-- Return type changed from topology.GetFaceEdges_ReturnType to OUT parameters.
+SELECT _postgis_drop_function_by_signature('topology.ST_GetFaceEdges(varchar, bigint)', '3.7.0');
+SELECT _postgis_drop_function_by_signature('topology.GetRingEdges(varchar, bigint, int)', '3.7.0');
+SELECT _postgis_drop_function_by_signature('topology.GetNodeEdges(varchar, bigint)', '3.7.0');


### PR DESCRIPTION
## Summary

This updates the topology edge-listing functions to return `TABLE(sequence integer, edge bigint)` instead of `SETOF topology.GetFaceEdges_ReturnType`:

- `topology.ST_GetFaceEdges(varchar, bigint)`
- `topology.GetRingEdges(varchar, bigint, int)`
- `topology.GetNodeEdges(varchar, bigint)`

The legacy `topology.GetFaceEdges_ReturnType` type is left in place for compatibility, but these functions no longer depend on it. Upgrade pre-drop hooks are added so extension/script upgrades can recreate the same-argument functions with the new result shape.

The branch also fixes topology garden SQL generation for these OUT-parameter docs by using the DocBook namespace when checking the next `paramdef`, preventing trailing commas in generated garden calls.

This is a partial slice of https://trac.osgeo.org/postgis/ticket/4862 because topology still has other custom return types, including `ValidateTopology_ReturnType`.

References #4862.

## Tests

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo -n make install`
- `make garden`
- `make -C doc check-xml`
- `make -C doc comments`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- topology/postgis_topology.c`
- `rg -n "ST_GetFaceEdges\\([^\\n]*, \\)|GetRingEdges\\([^\\n]*, \\)|GetNodeEdges\\([^\\n]*, \\)" doc/topology_gardentest_37.sql || true`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/st_getfaceedges $(pwd)/topology/test/regress/getringedges $(pwd)/topology/test/regress/getnodeedges"`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose --schema=postgis_ci" TESTS="$(pwd)/topology/test/regress/st_getfaceedges $(pwd)/topology/test/regress/getringedges $(pwd)/topology/test/regress/getnodeedges"`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/327
