### PR TITLE
Add ST_Extent aggregate for TopoGeometry

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,6 +58,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #5314, [topology] Add ST_Extent aggregate for TopoGeometry
+          (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -4376,6 +4376,40 @@ Refer to <xref linkend="toTopoGeom"/>.
 			</refsection>
 		</refentry>
 
+		<refentry xml:id="TG_ST_Extent">
+			<refnamediv>
+				<refname>ST_Extent</refname>
+				<refpurpose>Returns the bounding box of a set of topogeometries.</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>box2d <function>ST_Extent</function></funcdef>
+					<paramdef><type>topogeometry </type> <parameter>tg</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+				<title>Description</title>
+
+				<para>An aggregate function that returns a <xref linkend="box2d_type"/> bounding box containing a set of TopoGeometry values. The aggregate reads the topology primitive extents instead of converting each TopoGeometry value to a geometry.</para>
+				<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+			</refsection>
+
+			<refsection>
+				<title>Examples</title>
+
+				<programlisting>SELECT topology.ST_Extent(topo) FROM parcels;</programlisting>
+			</refsection>
+
+			<refsection>
+				<title>See Also</title>
+				<para><xref linkend="ST_Extent"/>, <xref linkend="GetTopoGeomElements"/>, <xref linkend="topogeometry"/></para>
+			</refsection>
+		</refentry>
+
     <refentry xml:id="TG_ST_SRID">
 	  <refnamediv>
 		<refname>ST_SRID</refname>

--- a/topology/sql/topogeometry/extent.sql.in
+++ b/topology/sql/topogeometry/extent.sql.in
@@ -1,0 +1,137 @@
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--
+-- PostGIS - Spatial Types for PostgreSQL
+-- http://postgis.net
+--
+-- Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+--
+-- This is free software; you can redistribute and/or modify it under
+-- the terms of the GNU General Public Licence. See the COPYING file.
+--
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+-- {
+-- Aggregate state function for ST_Extent() over topogeometry objects.
+--
+-- Availability: 3.7.0
+--
+-- }{
+CREATE OR REPLACE FUNCTION topology._ST_Extent(state box3d, tg topology.TopoGeometry)
+	RETURNS box3d
+AS
+$$
+DECLARE
+	toponame name;
+	layer_info RECORD;
+	child_layer_id integer;
+	extent box3d;
+	sql text;
+BEGIN
+	IF tg IS NULL THEN
+		RETURN state;
+	END IF;
+
+	SELECT name FROM topology.topology
+	WHERE id = topology_id(tg)
+	INTO toponame;
+
+	IF toponame IS NULL THEN
+		RAISE EXCEPTION 'Invalid TopoGeometry (unexistent topology id %)', topology_id(tg);
+	END IF;
+
+	SELECT * FROM topology.layer
+	WHERE topology_id = topology_id(tg)
+	AND layer_id = layer_id(tg)
+	INTO layer_info;
+
+	IF layer_info IS NULL THEN
+		RAISE EXCEPTION 'Could not find TopoGeometry layer % in topology %',
+			layer_id(tg), topology_id(tg);
+	END IF;
+
+	IF layer_info.level > 0 THEN
+		child_layer_id := layer_info.child_id;
+
+		SELECT * FROM topology.layer
+		WHERE topology_id = topology_id(tg)
+		AND layer_id = child_layer_id
+		INTO layer_info;
+
+		IF layer_info IS NULL THEN
+			RAISE EXCEPTION 'Invalid layer % in topology % (unexistent child layer %)',
+				layer_id(tg), topology_id(tg), child_layer_id;
+		END IF;
+
+		sql := format(
+			$q$
+			SELECT topology.ST_Extent(child.%1$I)::box3d
+			FROM %2$I.%3$I child, %4$I.relation rel
+			WHERE rel.topogeo_id = id($1)
+			AND rel.layer_id = layer_id($1)
+			AND id(child.%1$I) = rel.element_id
+			AND layer_id(child.%1$I) = rel.element_type
+			$q$,
+			layer_info.feature_column,
+			layer_info.schema_name,
+			layer_info.table_name,
+			toponame
+		);
+	ELSE
+		sql := format(
+			$q$
+			WITH component_geoms AS (
+				SELECT n.geom
+				FROM %1$I.relation rel
+				JOIN %1$I.node n ON n.node_id = rel.element_id
+				WHERE rel.topogeo_id = id($1)
+				AND rel.layer_id = layer_id($1)
+				AND rel.element_type = 1
+				UNION ALL
+				SELECT e.geom
+				FROM %1$I.relation rel
+				JOIN %1$I.edge_data e ON e.edge_id = abs(rel.element_id)
+				WHERE rel.topogeo_id = id($1)
+				AND rel.layer_id = layer_id($1)
+				AND rel.element_type = 2
+				UNION ALL
+				SELECT f.mbr
+				FROM %1$I.relation rel
+				JOIN %1$I.face f ON f.face_id = rel.element_id
+				WHERE rel.topogeo_id = id($1)
+				AND rel.layer_id = layer_id($1)
+				AND rel.element_type = 3
+			)
+			SELECT ST_Extent(geom)::box3d
+			FROM component_geoms
+			$q$,
+			toponame
+		);
+	END IF;
+
+	EXECUTE sql USING tg INTO extent;
+
+	IF extent IS NULL THEN
+		RETURN state;
+	END IF;
+
+	IF state IS NULL THEN
+		RETURN extent;
+	END IF;
+
+	RETURN ST_CombineBBox(state, extent);
+END
+$$
+LANGUAGE 'plpgsql' VOLATILE;
+-- }
+
+-- {
+-- ST_Extent(TopoGeometry)
+--
+-- Availability: 3.7.0
+--
+CREATE AGGREGATE topology.ST_Extent(topology.TopoGeometry) (
+	sfunc = topology._ST_Extent,
+	stype = box3d,
+	finalfunc = box2d
+	);
+-- }

--- a/topology/test/regress/topogeometry_extent.sql
+++ b/topology/test/regress/topogeometry_extent.sql
@@ -1,0 +1,47 @@
+set client_min_messages to WARNING;
+
+\i :top_builddir/topology/test/load_topology.sql
+\i :regdir/../topology/test/load_features.sql
+\i :regdir/../topology/test/more_features.sql
+\i :regdir/../topology/test/hierarchy.sql
+
+SELECT 'traffic_signs',
+	topology.ST_Extent(feature)::text
+FROM features.traffic_signs;
+
+SELECT 'city_streets',
+	topology.ST_Extent(feature)::text
+FROM features.city_streets;
+
+SELECT 'land_parcels',
+	topology.ST_Extent(feature)::text
+FROM features.land_parcels;
+
+SELECT 'big_signs',
+	topology.ST_Extent(feature)::text
+FROM features.big_signs;
+
+SELECT 'big_streets',
+	topology.ST_Extent(feature)::text
+FROM features.big_streets;
+
+SELECT 'big_parcels',
+	topology.ST_Extent(feature)::text
+FROM features.big_parcels;
+
+SELECT 'empty_set',
+	topology.ST_Extent(feature) IS NULL
+FROM features.big_parcels
+WHERE false;
+
+SELECT 'empty_topogeom',
+	topology.ST_Extent(
+		topology.CreateTopoGeom(
+			'city_data',
+			3,
+			(SELECT layer_id FROM topology.layer WHERE table_name = 'land_parcels')
+		)
+	) IS NULL;
+
+SELECT topology.DropTopology('city_data');
+DROP SCHEMA features CASCADE;

--- a/topology/test/regress/topogeometry_extent_expected
+++ b/topology/test/regress/topogeometry_extent_expected
@@ -1,0 +1,9 @@
+traffic_signs|BOX(8 14,57 37)
+city_streets|BOX(9 6,62 42)
+land_parcels|BOX(3 6,47 40)
+big_signs|BOX(21 14,35 14)
+big_streets|BOX(9 14,62 42)
+big_parcels|BOX(9 6,47 40)
+empty_set|t
+empty_topogeom|t
+Topology 'city_data' dropped

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -85,6 +85,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/topogeo_loadgeometry.sql \
 	$(top_srcdir)/topology/test/regress/topogeom_addtopogeom.sql \
 	$(top_srcdir)/topology/test/regress/topogeom_edit.sql \
+	$(top_srcdir)/topology/test/regress/topogeometry_extent.sql \
 	$(top_srcdir)/topology/test/regress/topogeometry_srid.sql \
 	$(top_srcdir)/topology/test/regress/topogeometry_type.sql \
 	$(top_srcdir)/topology/test/regress/topojson.sql \
@@ -101,4 +102,3 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/verifylargeids.sql \
 	$(top_srcdir)/topology/test/regress/fix_topogeometry_columns.sql \
 	$(top_srcdir)/topology/test/regress/findvertexsegmentpairsbelowdistance.sql
-

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -1391,6 +1391,7 @@ LANGUAGE 'plpgsql' VOLATILE STRICT;
 --  TopoGeometry
 #include "sql/topogeometry/type.sql.in"
 #include "sql/topogeometry/srid.sql.in"
+#include "sql/topogeometry/extent.sql.in"
 #include "sql/topogeometry/cleartopogeom.sql.in"
 #include "sql/topogeometry/simplify.sql.in"
 #include "sql/topogeometry/totopogeom.sql.in"


### PR DESCRIPTION
Closes #5314.

Trac ticket: https://trac.osgeo.org/postgis/ticket/5314

This adds `topology.ST_Extent(topology.TopoGeometry)` as a topology aggregate. The transition function reads primitive extents from topology relation/node/edge/face tables, and recurses through child feature tables for hierarchical TopoGeometry layers, instead of materializing each input TopoGeometry as a geometry first.

The aggregate definition avoids an unconditional `DROP AGGREGATE`, leaving extension upgrades to the generated aggregate replacement path. The regression suite covers populated primitive and hierarchical layers, an empty aggregate input set, and a real empty TopoGeometry created with the three-argument `CreateTopoGeom` overload.

Validation run locally:

- `make -C topology topology.sql topology_upgrade.sql`
- `make -C topology -j16`
- `sudo -n make -C topology install`
- `make -C extensions/postgis_topology -j16`
- `sudo -n make -C extensions/postgis_topology install`
- focused topology regression for `topogeometry_extent`, normal and automatic upgrade: `Run tests: 2 Failed: 0`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/326
