### PR TITLE
Add cleanup for orphaned TopoGeometries

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           both loaders accept long aliases for existing options, and
           --if-not-exists makes creation actions idempotent
           (Darafei Praliaskouski)
+ - #1844, [topology] Add DropOrphanedTopoGeometries cleanup helper
+          (Darafei Praliaskouski)
  - #4208, Add single-geometry variants of ST_MaxDistance and ST_LongestLine
           (Darafei Praliaskouski)
  - [topology] FindVertexSegmentPairsBelowDistance function (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -720,6 +720,37 @@ FROM topology.layer;
 			<!-- Optionally add a "See Also" section -->
 		</refentry>
 
+		<refentry xml:id="DropOrphanedTopoGeometries">
+			<refnamediv>
+				<refname>DropOrphanedTopoGeometries</refname>
+
+				<refpurpose>Drops TopoGeometry relation rows no longer reachable from their layer tables.</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>bigint <function>DropOrphanedTopoGeometries</function></funcdef>
+					<paramdef><type>text </type> <parameter>topology_name</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+				<title>Description</title>
+
+				<para>Deletes rows from the topology <varname>relation</varname> table when their <varname>topogeo_id</varname> is not found in the registered TopoGeometry column for the layer. Such orphaned rows can be left behind by direct <command>DELETE</command> or <command>UPDATE</command> operations on the layer table.</para>
+				<para>The return value is the number of distinct TopoGeometry objects dropped. Layers with missing, detached, or otherwise invalid layer tables are skipped.</para>
+
+				<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+			</refsection>
+
+			<refsection>
+				<title>See Also</title>
+				<para><xref linkend="TopologySummary"/>, <xref linkend="clearTopoGeom"/></para>
+			</refsection>
+		</refentry>
+
 		<refentry xml:id="ValidateTopology">
 			<refnamediv>
 				<refname>ValidateTopology</refname>

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -124,6 +124,7 @@ topology_upgrade.sql: ../postgis/common_before_upgrade.sql topology_before_upgra
 	echo "COMMIT;" >> $@
 
 topology.sql: \
+	sql/cleanup/DropOrphanedTopoGeometries.sql.in \
 	sql/cleanup/RemoveUnusedPrimitives.sql.in \
 	sql/sqlmm.sql.in \
 	sql/populate.sql.in \

--- a/topology/sql/cleanup/DropOrphanedTopoGeometries.sql.in
+++ b/topology/sql/cleanup/DropOrphanedTopoGeometries.sql.in
@@ -1,0 +1,119 @@
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--
+-- PostGIS - Spatial Types for PostgreSQL
+-- http://postgis.net
+--
+-- Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+--
+-- This is free software; you can redistribute and/or modify it under
+-- the terms of the GNU General Public Licence. See the COPYING file.
+--
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+--{
+-- Drop TopoGeometry relation rows whose TopoGeometry object is no longer
+-- reachable from its registered layer table.
+--
+-- Availability: 3.7.0
+--
+CREATE OR REPLACE FUNCTION topology.DropOrphanedTopoGeometries(
+  topology_name text
+)
+RETURNS BIGINT AS
+$BODY$
+DECLARE
+  topo topology.topology;
+  layerrec RECORD;
+  layer_is_deployed BOOLEAN;
+  sql TEXT;
+  dropped BIGINT;
+  total_deleted BIGINT := 0;
+BEGIN
+  topo := topology.findTopology(topology_name);
+  IF topo.id IS NULL THEN
+    RAISE EXCEPTION 'Could not find topology "%"', topology_name;
+  END IF;
+
+  FOR layerrec IN
+    SELECT *
+    FROM topology.layer
+    WHERE topology_id = topo.id
+    ORDER BY level DESC, layer_id
+  LOOP
+    IF layerrec.feature_column = '' THEN
+      CONTINUE;
+    END IF;
+
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_namespace n
+      JOIN pg_catalog.pg_class c ON c.relnamespace = n.oid
+      JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+      WHERE n.nspname = layerrec.schema_name
+        AND c.relname = layerrec.table_name
+        AND a.attname = layerrec.feature_column
+        AND a.atttypid = 'topology.topogeometry'::regtype
+        AND NOT a.attisdropped
+    )
+    INTO layer_is_deployed;
+
+    IF NOT layer_is_deployed THEN
+      CONTINUE;
+    END IF;
+
+    EXECUTE format(
+      'LOCK TABLE %I.relation IN SHARE ROW EXCLUSIVE MODE',
+      topo.name
+    );
+    EXECUTE format(
+      'LOCK TABLE %I.%I IN SHARE ROW EXCLUSIVE MODE',
+      layerrec.schema_name,
+      layerrec.table_name
+    );
+
+    sql := format(
+      $$
+      WITH orphan_topogeoms AS (
+        SELECT DISTINCT r.layer_id, r.topogeo_id
+        FROM %1$I.relation r
+        WHERE r.layer_id = $1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM %2$I.%3$I f
+          WHERE id(f.%4$I) = r.topogeo_id
+          AND layer_id(f.%4$I) = r.layer_id
+          AND topology_id(f.%4$I) = $2
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM %1$I.relation pr
+          JOIN topology.layer pl ON pl.topology_id = $2
+            AND pl.layer_id = pr.layer_id
+          WHERE pl.child_id = r.layer_id
+          AND pr.element_id = r.topogeo_id
+          AND pr.element_type = r.layer_id
+        )
+      ), deleted_rows AS (
+        DELETE FROM %1$I.relation r
+        USING orphan_topogeoms o
+        WHERE r.layer_id = o.layer_id
+        AND r.topogeo_id = o.topogeo_id
+        RETURNING r.layer_id, r.topogeo_id
+      )
+      SELECT count(DISTINCT (layer_id, topogeo_id)) FROM deleted_rows
+      $$,
+      topo.name,
+      layerrec.schema_name,
+      layerrec.table_name,
+      layerrec.feature_column
+    );
+
+    EXECUTE sql USING layerrec.layer_id, topo.id INTO dropped;
+    total_deleted := total_deleted + dropped;
+  END LOOP;
+
+  RETURN total_deleted;
+END
+$BODY$
+LANGUAGE 'plpgsql' VOLATILE STRICT;
+--} DropOrphanedTopoGeometries

--- a/topology/test/regress/droporphanedtopogeometries.sql
+++ b/topology/test/regress/droporphanedtopogeometries.sql
@@ -1,0 +1,101 @@
+set client_min_messages to WARNING;
+
+\i :top_builddir/topology/test/load_topology.sql
+\i :regdir/../topology/test/load_features.sql
+\i :regdir/../topology/test/more_features.sql
+
+SELECT 'initial-topogeoms', count(DISTINCT (layer_id, topogeo_id))
+FROM city_data.relation;
+
+DELETE FROM features.traffic_signs
+WHERE id(feature) = (
+	SELECT min(id(feature))
+	FROM features.traffic_signs
+);
+
+SELECT 'after-delete-summary',
+	strpos(topology.TopologySummary('city_data'), 'missing topogeoms') > 0;
+
+SELECT 'drop-orphans', topology.DropOrphanedTopoGeometries('city_data');
+
+SELECT 'after-drop-summary',
+	strpos(topology.TopologySummary('city_data'), 'missing topogeoms') > 0;
+
+SELECT 'after-drop-topogeoms', count(DISTINCT (layer_id, topogeo_id))
+FROM city_data.relation;
+
+CREATE TABLE features.traffic_sign_groups (
+	feature_name VARCHAR PRIMARY KEY,
+	fid serial
+);
+SELECT NULL FROM topology.AddTopoGeometryColumn(
+	'city_data',
+	'features',
+	'traffic_sign_groups',
+	'feature',
+	'POINT',
+	2
+);
+CREATE TEMP TABLE protected_child AS
+SELECT id(feature) AS topogeo_id
+FROM features.traffic_signs
+WHERE feature_name = 'S2';
+INSERT INTO features.traffic_sign_groups(feature_name, feature)
+SELECT
+	'S2-group',
+	topology.CreateTopoGeom(
+		'city_data',
+		1,
+		(
+			SELECT layer_id
+			FROM topology.layer
+			WHERE topology_id = id(topology.findTopology('city_data'))
+			AND schema_name = 'features'
+			AND table_name = 'traffic_sign_groups'
+			AND feature_column = 'feature'
+		),
+		ARRAY[ARRAY[topogeo_id, 2]]
+	)
+FROM protected_child;
+DELETE FROM features.traffic_signs
+WHERE id(feature) = (
+	SELECT topogeo_id
+	FROM protected_child
+);
+
+SELECT 'hier-child-protected', topology.DropOrphanedTopoGeometries('city_data');
+
+SELECT 'hier-child-remains', count(*)
+FROM city_data.relation
+WHERE layer_id = 2
+AND topogeo_id = (
+	SELECT topogeo_id
+	FROM protected_child
+);
+
+ALTER TABLE features.city_streets RENAME TO missing_table;
+
+SELECT 'skip-missing-table', topology.DropOrphanedTopoGeometries('city_data');
+
+ALTER TABLE features.missing_table RENAME TO city_streets;
+
+ALTER TABLE features.city_streets RENAME COLUMN feature TO missing_feature;
+
+SELECT 'skip-missing-column', topology.DropOrphanedTopoGeometries('city_data');
+
+ALTER TABLE features.city_streets RENAME COLUMN missing_feature TO feature;
+
+ALTER TABLE city_data.relation DISABLE TRIGGER relation_integrity_checks;
+INSERT INTO city_data.relation(layer_id, topogeo_id, element_id, element_type)
+VALUES (999, 999, 1, 1);
+ALTER TABLE city_data.relation ENABLE TRIGGER relation_integrity_checks;
+
+SELECT 'skip-unregistered-layer', topology.DropOrphanedTopoGeometries('city_data');
+
+SELECT 'unregistered-remains', count(*)
+FROM city_data.relation
+WHERE layer_id = 999
+AND topogeo_id = 999;
+
+SELECT topology.DropTopology('city_data');
+DROP SCHEMA features CASCADE;

--- a/topology/test/regress/droporphanedtopogeometries_expected
+++ b/topology/test/regress/droporphanedtopogeometries_expected
@@ -1,0 +1,12 @@
+initial-topogeoms|25
+after-delete-summary|t
+drop-orphans|1
+after-drop-summary|f
+after-drop-topogeoms|24
+hier-child-protected|0
+hier-child-remains|1
+skip-missing-table|0
+skip-missing-column|0
+skip-unregistered-layer|0
+unregistered-remains|1
+Topology 'city_data' dropped

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -28,6 +28,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/createtopogeom.sql \
 	$(top_srcdir)/topology/test/regress/createtopology.sql \
 	$(top_srcdir)/topology/test/regress/droptopogeometrycolumn.sql \
+	$(top_srcdir)/topology/test/regress/droporphanedtopogeometries.sql \
 	$(top_srcdir)/topology/test/regress/droptopology.sql \
 	$(top_srcdir)/topology/test/regress/findlayer.sql \
 	$(top_srcdir)/topology/test/regress/findtopology.sql \
@@ -101,4 +102,3 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/verifylargeids.sql \
 	$(top_srcdir)/topology/test/regress/fix_topogeometry_columns.sql \
 	$(top_srcdir)/topology/test/regress/findvertexsegmentpairsbelowdistance.sql
-

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -1430,6 +1430,7 @@ LANGUAGE 'plpgsql' VOLATILE STRICT;
 
 -- Cleanup functions
 #include "sql/cleanup/RemoveUnusedPrimitives.sql.in"
+#include "sql/cleanup/DropOrphanedTopoGeometries.sql.in"
 
 
 CREATE OR REPLACE FUNCTION topology.postgis_topology_scripts_installed() RETURNS text


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/1844.

This adds `topology.DropOrphanedTopoGeometries(topology_name text)`, a cleanup helper for TopoGeometry objects that still have rows in a topology `relation` table but are no longer reachable from their registered layer table.

Scope:

- scans registered layers for the named topology
- only processes deployed layers whose registered `schema.table.column` exists and is a `topology.topogeometry` column
- processes higher-level layers before their child layers so deleted orphan parents do not keep children alive for the same call
- locks the topology `relation` table and each processed feature table while selecting and deleting orphan rows
- deletes all relation rows for each orphaned `(layer_id, topogeo_id)` pair
- preserves child TopoGeometry relation rows that are still referenced by a parent-layer relation row
- returns the number of distinct TopoGeometry objects dropped
- skips detached, missing, invalid, or unregistered layer metadata instead of deleting potentially recoverable rows

Validation run locally:

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `git diff --check`
- `make -C doc check`
- `make check-news`
- `sudo make install`
- focused topology regression for `droporphanedtopogeometries`, fresh and upgrade: `Run tests: 2 Failed: 0`
- full topology regression, fresh and upgrade: `Run tests: 85 Failed: 0`

Rebase and review-follow-up validation on current `master` (`a4ecc46176c3fc0ab3fa69cf117d408bc622e592`) at head `0fc1be8142f8c145c1bdbb6751880e1f650f4a86`:

- `make -C topology topology.sql`
- `make -C topology -j32`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_topology install`
- focused topology regression for `droporphanedtopogeometries`, fresh and upgrade: `Run tests: 2 Failed: 0`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- topology/Makefile.in topology/sql/cleanup/DropOrphanedTopoGeometries.sql.in topology/test/regress/droporphanedtopogeometries.sql topology/test/regress/droporphanedtopogeometries_expected topology/topology.sql.in topology/test/tests.mk doc/extras_topology.xml NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/325