### PR TITLE
Honor topology precision in ST_NewEdgesSplit

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -96,6 +96,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           shapefiles (Darafei Praliaskouski)
  - #2838, Emit valid X3D Coordinate nodes for 2D polygon output
           (Darafei Praliaskouski)
+ - #785, [topology] ST_NewEdgesSplit honors non-zero topology precision
+          when splitting near an edge (Darafei Praliaskouski)
  - Fix WKB and TWKB parser resource exhaustion on malformed input
           (Darafei Praliaskouski)
  - #2850, Preserve pgsql2shp numeric precision and scale in DBF metadata

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -2578,11 +2578,12 @@ Returns the id of the new node created that joins the new edges.
 Updates all existing joined edges and relationships accordingly.
 		</para>
 
-                <para>If the spatial reference system (srid) of the point geometry is not the same as the topology, the <varname>apoint</varname> is not a point geometry, the point is null, the point already exists as a node, the edge does not correspond to an existing edge or the point is not within the edge then an exception is thrown.</para>
+                <para>If the spatial reference system (srid) of the point geometry is not the same as the topology, the <varname>apoint</varname> is not a point geometry, the point is null, the point already exists as a node, the edge does not correspond to an existing edge or the point is not within the edge then an exception is thrown. If the topology has a non-zero precision, a point within that tolerance of the edge is snapped to the edge before splitting.</para>
 
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="1.1">Availability: 1.1 </para>
+                <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 support for splitting with a point within the topology precision of the edge.</para>
 	<para>&sqlmm_compliant; SQL-MM: Topo-Net Routines:  X.3.8</para>
 			</refsection>
 

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -1069,7 +1069,61 @@ lwt_AddIsoEdge( LWT_TOPOLOGY* topo, LWT_ELEMID startNode,
 }
 
 static LWCOLLECTION *
-_lwt_EdgeSplit( LWT_TOPOLOGY* topo, LWT_ELEMID edge, LWPOINT* pt, int skipISOChecks, LWT_ISO_EDGE** oldedge )
+_lwt_SplitLineByPointAtSegment(const LWLINE *line, LWPOINT *pt, uint32_t seg)
+{
+	POINT4D q, p1, p2, projected;
+	POINTARRAY *pa1;
+	POINTARRAY *pa2;
+	LWCOLLECTION *split_col;
+	uint32_t i, nsegs;
+
+	getPoint4d_p(pt->point, 0, &q);
+	getPoint4d_p(line->points, seg, &p1);
+	getPoint4d_p(line->points, seg + 1, &p2);
+	closest_point_on_segment(&q, &p1, &p2, &projected);
+
+	nsegs = line->points->npoints - 1;
+	if (((seg == 0) && (projected.x == p1.x) && (projected.y == p1.y)) ||
+	    ((seg == nsegs - 1) && (projected.x == p2.x) && (projected.y == p2.y)))
+	{
+		lwerror("SQL/MM Spatial exception - point not on edge");
+		return NULL;
+	}
+
+	ptarray_set_point4d(pt->point, 0, &projected);
+
+	pa1 = ptarray_construct_empty(FLAGS_GET_Z(line->points->flags), FLAGS_GET_M(line->points->flags), seg + 2);
+	for (i = 0; i <= seg; ++i)
+	{
+		getPoint4d_p(line->points, i, &p1);
+		ptarray_append_point(pa1, &p1, LW_FALSE);
+	}
+	ptarray_append_point(pa1, &projected, LW_FALSE);
+
+	pa2 = ptarray_construct_empty(
+	    FLAGS_GET_Z(line->points->flags), FLAGS_GET_M(line->points->flags), line->points->npoints - seg);
+	ptarray_append_point(pa2, &projected, LW_FALSE);
+	for (i = seg + 1; i < line->points->npoints; ++i)
+	{
+		getPoint4d_p(line->points, i, &p1);
+		ptarray_append_point(pa2, &p1, LW_FALSE);
+	}
+
+	split_col = lwcollection_construct_empty(
+	    COLLECTIONTYPE, line->srid, FLAGS_GET_Z(line->flags), FLAGS_GET_M(line->flags));
+	lwcollection_add_lwgeom(split_col, (LWGEOM *)lwline_construct(line->srid, NULL, pa1));
+	lwcollection_add_lwgeom(split_col, (LWGEOM *)lwline_construct(line->srid, NULL, pa2));
+
+	return split_col;
+}
+
+static LWCOLLECTION *
+_lwt_EdgeSplit(LWT_TOPOLOGY *topo,
+	       LWT_ELEMID edge,
+	       LWPOINT *pt,
+	       int skipISOChecks,
+	       int snapToPrecision,
+	       LWT_ISO_EDGE **oldedge)
 {
   LWGEOM *split;
   LWCOLLECTION *split_col;
@@ -1120,6 +1174,37 @@ _lwt_EdgeSplit( LWT_TOPOLOGY* topo, LWT_ELEMID edge, LWPOINT* pt, int skipISOChe
     LWDEBUG(1, "lwt_be_ExistsCoincidentNode returned");
   }
 
+  /*
+   * When the topology has a precision tolerance, accept a split point that is
+   * within that tolerance of the edge by projecting it to the closest segment.
+   * lwgeom_split requires exact 2D incidence, while topology editing functions
+   * generally interpret a non-zero topology precision as snapping tolerance.
+   */
+  if (snapToPrecision && topo->precision > 0)
+  {
+	  POINT4D q;
+	  POINT2D q2d;
+	  double dist;
+	  uint32_t seg;
+
+	  if (getPoint4d_p(pt->point, 0, &q))
+	  {
+		  q2d.x = q.x;
+		  q2d.y = q.y;
+		  seg = ptarray_closest_segment_2d((*oldedge)->geom->points, &q2d, &dist);
+
+		  if (dist > 0 && dist <= topo->precision)
+		  {
+			  split_col = _lwt_SplitLineByPointAtSegment((*oldedge)->geom, pt, seg);
+			  if (!split_col)
+			  {
+				  _lwt_release_edges(*oldedge, 1);
+			  }
+			  return split_col;
+		  }
+	  }
+  }
+
   /* Split edge */
   split = lwgeom_split((LWGEOM*)(*oldedge)->geom, (LWGEOM*)pt);
   if ( ! split )
@@ -1167,7 +1252,7 @@ lwt_ModEdgeSplit( LWT_TOPOLOGY* topo, LWT_ELEMID edge,
   LWT_ISO_EDGE seledge = {0}, updedge = {0}, excedge = {0};
   int ret;
 
-  split_col = _lwt_EdgeSplit( topo, edge, pt, skipISOChecks, &oldedge );
+  split_col = _lwt_EdgeSplit(topo, edge, pt, skipISOChecks, 0, &oldedge);
   if ( ! split_col ) return -1; /* should have raised an exception */
   oldedge_geom = split_col->geoms[0];
   newedge_geom = split_col->geoms[1];
@@ -1324,7 +1409,7 @@ lwt_NewEdgesSplit( LWT_TOPOLOGY* topo, LWT_ELEMID edge,
   LWT_ISO_EDGE seledge = {0}, updedge = {0};
   int ret;
 
-  split_col = _lwt_EdgeSplit( topo, edge, pt, skipISOChecks, &oldedge );
+  split_col = _lwt_EdgeSplit(topo, edge, pt, skipISOChecks, 1, &oldedge);
   if ( ! split_col ) return -1; /* should have raised an exception */
   oldedge_geom = split_col->geoms[0];
   newedge_geom = split_col->geoms[1];

--- a/topology/test/regress/st_newedgessplit.sql
+++ b/topology/test/regress/st_newedgessplit.sql
@@ -141,6 +141,29 @@ WHERE n.node_id = t.node_id
 
 DROP TABLE t;
 
+-- ST_NewEdgesSplit honors non-zero topology precision (#785)
+SELECT '#785.start' FROM (SELECT topology.CreateTopology('t785', 26986, 0.5)) q;
+SELECT '#785.N' || topology.ST_AddIsoNode('t785', 0,
+  'SRID=26986;POINT(227575.8 893917.2)'::geometry);
+SELECT '#785.N' || topology.ST_AddIsoNode('t785', 0,
+  'SRID=26986;POINT(227591.9 893900.4)'::geometry);
+SELECT '#785.E' || topology.ST_AddIsoEdge('t785', 1, 2,
+  'SRID=26986;LINESTRING(227575.8 893917.2,227591.9 893900.4)'::geometry);
+SELECT '#785.N' || topology.ST_NewEdgesSplit('t785', 1,
+  'SRID=26986;POINT(227578.909683258 893913.955113122)'::geometry);
+SELECT '#785.node',
+       ST_AsText(ST_SnapToGrid(geom, 0.001))
+FROM t785.node
+WHERE node_id = 3;
+SELECT '#785.edge',
+       edge_id,
+       start_node,
+       end_node,
+       ST_AsText(ST_SnapToGrid(geom, 0.001))
+FROM t785.edge
+ORDER BY edge_id;
+SELECT '#785.drop' FROM (SELECT topology.DropTopology('t785')) q;
+
 DROP FUNCTION check_changes();
 SELECT DropTopology('city_data');
 

--- a/topology/test/regress/st_newedgessplit_expected
+++ b/topology/test/regress/st_newedgessplit_expected
@@ -35,6 +35,15 @@ E|37|sn28|en18|nl8|nr-7|lf0|rf4
 seq_reset|1|1|1
 robust.1|E1|N3
 robust.2|t|t
+#785.start
+#785.N1
+#785.N2
+#785.E1
+#785.N3
+#785.node|POINT(227578.91 893913.955)
+#785.edge|2|1|3|LINESTRING(227575.8 893917.2,227578.91 893913.955)
+#785.edge|3|3|2|LINESTRING(227578.91 893913.955,227591.9 893900.4)
+#785.drop
 Topology 'city_data' dropped
 ---
 #5795|Regression test starting


### PR DESCRIPTION
## Summary
- make `topology.ST_NewEdgesSplit` accept a split point within non-zero topology precision by projecting it onto the target edge before splitting
- preserve exact split points and direct `ST_ModEdgeSplit` on the existing exact split path
- add regression coverage using the coordinate case from the Trac ticket and document the `ST_NewEdgesSplit` precision behavior

This is a bounded `ST_NewEdgesSplit` slice of the broader topology tolerance ticket.

Trac: https://trac.osgeo.org/postgis/ticket/785

## Maintenance
- rebased on current `upstream/master` (`902880616da9cf054786b24bd243a7e454c3c34a`)
- resolved the `NEWS` conflict by preserving current bug-fix entries and the #785 note
- kept the prior exact-on-edge review fix: the precision path only handles `dist > 0`, leaving exact split points on the original `lwgeom_split` path

## Validation
- `make -C liblwgeom -j16`
- `make -C topology -j16`
- `make -C extensions/postgis_topology -j8`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `dropdb --if-exists postgis_reg && make -C topology/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/topology/test/regress/st_newedgessplit $(pwd)/topology/test/regress/st_modedgesplit"` (fresh and automatic-upgrade)
- `make -C doc check-xml`
- `./utils/check_news.sh .`
- `git diff --check`
- `git diff upstream/master..HEAD --check`
- `git clang-format --diff upstream/master -- liblwgeom/topo/lwgeom_topo.c topology/test/regress/st_newedgessplit.sql topology/test/regress/st_newedgessplit_expected doc/extras_topology.xml NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/323
