### PR TITLE
Add raster ST_Blur

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -157,6 +157,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)
  - #5109, Document the meaning of topology.next_left_edge and topology.next_right_edge links (Darafei Praliaskouski)
  - #5889, [topology] Include representative locations in topology build errors (Darafei Praliaskouski)
+ - #2598, [raster] Add ST_Blur Gaussian convolution filter (Darafei Praliaskouski)
  - #2614, Use GEOSPreparedDistance and caching to accelerate ST_DWithin (Paul Ramsey)
  - #6022, Document ST_AsMVTGeom tile-coordinate simplification (Darafei Praliaskouski)
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)

--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,10 @@ These are only changes since 3.7.0alpha1.
             (Bas Couwenberg)
 
 * Enhancements *
+* New Features *
+
+ - #2598, [raster] Add ST_Blur Gaussian convolution filter (Darafei Praliaskouski)
+
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)
@@ -157,7 +161,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)
  - #5109, Document the meaning of topology.next_left_edge and topology.next_right_edge links (Darafei Praliaskouski)
  - #5889, [topology] Include representative locations in topology build errors (Darafei Praliaskouski)
- - #2598, [raster] Add ST_Blur Gaussian convolution filter (Darafei Praliaskouski)
  - #2614, Use GEOSPreparedDistance and caching to accelerate ST_DWithin (Paul Ramsey)
  - #6022, Document ST_AsMVTGeom tile-coordinate simplification (Darafei Praliaskouski)
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -13021,6 +13021,70 @@ WHERE rid = 2;</programlisting>
         <section xml:id="Raster_Processing_DEM">
             <title>Raster Processing: DEM (Elevation)</title>
 
+            <refentry xml:id="RT_ST_Blur">
+                <refnamediv>
+                    <refname>ST_Blur</refname>
+                    <refpurpose>Returns a raster band blurred with a Gaussian convolution filter.</refpurpose>
+                </refnamediv>
+
+                <refsynopsisdiv>
+                    <funcsynopsis>
+                        <funcprototype>
+                            <funcdef>raster <function>ST_Blur</function></funcdef>
+                            <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>radius</parameter></paramdef>
+                            <paramdef><type>double precision </type> <parameter>sigma</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>pixeltype=64BF</parameter></paramdef>
+                        </funcprototype>
+
+                        <funcprototype>
+                            <funcdef>raster <function>ST_Blur</function></funcdef>
+                            <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>nband</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>radius</parameter></paramdef>
+                            <paramdef><type>double precision </type> <parameter>sigma</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>pixeltype=64BF</parameter></paramdef>
+                        </funcprototype>
+                    </funcsynopsis>
+                </refsynopsisdiv>
+
+                <refsection>
+                    <title>Description</title>
+
+                    <para>Returns a raster band blurred with a Gaussian convolution filter. The <varname>radius</varname> parameter controls the neighborhood distance in pixels, and <varname>sigma</varname> controls the Gaussian standard deviation.</para>
+
+                    <para>NODATA pixels are ignored and the Gaussian weights are renormalized for the remaining values. This also prevents darkening along raster edges where the full neighborhood is not available.</para>
+
+                    <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                </refsection>
+
+                <refsection>
+                    <title>Examples</title>
+                    <programlisting>
+WITH foo AS (
+    SELECT ST_SetValues(
+        ST_AddBand(ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 0, NULL),
+        1, 1, 1, ARRAY[
+            [0, 0, 0],
+            [0, 100, 0],
+            [0, 0, 0]
+        ]::double precision[][]
+    ) AS rast
+)
+SELECT ST_DumpValues(ST_Blur(rast, 1, 1.0))
+FROM foo;
+                    </programlisting>
+                </refsection>
+
+                <refsection>
+                    <title>See Also</title>
+                    <para>
+                        <xref linkend="RT_ST_MapAlgebra"/>,
+                        <xref linkend="RT_ST_Neighborhood"/>
+                    </para>
+                </refsection>
+            </refentry>
+
             <refentry xml:id="RT_ST_Aspect">
                 <refnamediv>
                     <refname>ST_Aspect</refname>

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -2816,6 +2816,117 @@ CREATE OR REPLACE FUNCTION _st_convertarray4ma(value double precision[][])
 	END;
 	$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION _st_blur4ma(value double precision[][][], pos integer[][], VARIADIC userargs text[] DEFAULT NULL)
+	RETURNS double precision
+	AS $$
+	DECLARE
+		_value double precision[][][];
+		ndims int;
+		sigma double precision;
+		sigma2 double precision;
+		sum double precision;
+		weight_sum double precision;
+		weight double precision;
+		cx int;
+		cy int;
+		x int;
+		y int;
+		z int;
+		dx int;
+		dy int;
+	BEGIN
+		IF userargs IS NULL OR COALESCE(array_length(userargs, 1), 0) < 1 THEN
+			RAISE EXCEPTION 'Sigma must be provided';
+		END IF;
+
+		sigma := userargs[array_lower(userargs, 1)]::double precision;
+		IF sigma IS NULL OR sigma <= 0 OR sigma::text = 'NaN' OR abs(sigma) = 'Infinity'::double precision THEN
+			RAISE EXCEPTION 'Sigma must be finite and greater than zero';
+		END IF;
+
+		ndims := array_ndims(value);
+		IF ndims = 2 THEN
+			_value := @extschema@._ST_convertarray4ma(value);
+		ELSEIF ndims != 3 THEN
+			RAISE EXCEPTION 'First parameter of function must be a 3-dimension array';
+		ELSE
+			_value := value;
+		END IF;
+
+		IF array_length(_value, 1) > 1 THEN
+			RAISE NOTICE 'Only using the values from the first raster';
+		END IF;
+		z := array_lower(_value, 1);
+
+		cy := array_lower(_value, 2) + (array_length(_value, 2) - 1) / 2;
+		cx := array_lower(_value, 3) + (array_length(_value, 3) - 1) / 2;
+		sigma2 := 2.0 * sigma * sigma;
+		sum := 0;
+		weight_sum := 0;
+
+		FOR y IN array_lower(_value, 2)..array_upper(_value, 2) LOOP
+			FOR x IN array_lower(_value, 3)..array_upper(_value, 3) LOOP
+				IF _value[z][y][x] IS NULL THEN
+					CONTINUE;
+				END IF;
+
+				dx := x - cx;
+				dy := y - cy;
+				weight := exp(-((dx * dx + dy * dy)::double precision) / sigma2);
+				sum := sum + _value[z][y][x] * weight;
+				weight_sum := weight_sum + weight;
+			END LOOP;
+		END LOOP;
+
+		IF weight_sum = 0 THEN
+			RETURN NULL;
+		END IF;
+
+		RETURN sum / weight_sum;
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_blur(
+	rast raster,
+	nband integer,
+	radius integer,
+	sigma double precision,
+	pixeltype text DEFAULT '64BF'
+)
+	RETURNS raster
+	AS $$
+	BEGIN
+		IF radius IS NULL OR radius < 1 THEN
+			RAISE EXCEPTION 'Radius must be greater than zero';
+		END IF;
+		IF sigma IS NULL OR sigma <= 0 OR sigma::text = 'NaN' OR abs(sigma) = 'Infinity'::double precision THEN
+			RAISE EXCEPTION 'Sigma must be finite and greater than zero';
+		END IF;
+
+		RETURN @extschema@.ST_MapAlgebra(
+			rast,
+			nband,
+			'@extschema@._ST_Blur4ma(double precision[][][], integer[][], text[])'::regprocedure,
+			pixeltype,
+			'FIRST',
+			NULL::@extschema@.raster,
+			radius,
+			radius,
+			sigma::text
+		);
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_blur(
+	rast raster,
+	radius integer,
+	sigma double precision,
+	pixeltype text DEFAULT '64BF'
+)
+	RETURNS raster
+	AS $$ SELECT @extschema@.ST_Blur($1, 1, $2, $3, $4) $$
+	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION st_max4ma(value double precision[][][], pos integer[][], VARIADIC userargs text[] DEFAULT NULL)
 	RETURNS double precision
 	AS $$

--- a/raster/test/regress/rt_mapalgebra_mask.sql
+++ b/raster/test/regress/rt_mapalgebra_mask.sql
@@ -120,5 +120,50 @@ FROM (SELECT rid, st_dumpvalues(st_mapalgebra(rast,1,'raster_nmapalgebra_test(do
     from raster_nmapalgebra_mask_in) AS f
 ORDER BY rid, (dv).nband;
 
+SELECT 'st_blur_empty_args';
+SELECT _ST_Blur4ma(
+	ARRAY[[[1]]]::double precision[][][],
+	ARRAY[[1, 1], [1, 1]]::integer[][],
+	VARIADIC ARRAY[]::text[]
+);
+
+SELECT 'st_blur_null_sigma';
+SELECT _ST_Blur4ma(
+	ARRAY[[[1]]]::double precision[][][],
+	ARRAY[[1, 1], [1, 1]]::integer[][],
+	VARIADIC ARRAY[NULL]::text[]
+);
+
+WITH r AS (
+	SELECT ST_SetValues(
+		ST_AddBand(ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 0, NULL),
+		1, 1, 1, ARRAY[
+			[0, 0, 0],
+			[0, 100, 0],
+			[0, 0, 0]
+		]::double precision[][]
+	) AS rast
+), b AS (
+	SELECT ST_Blur(rast, 1, 1.0) AS rast
+	FROM r
+)
+SELECT
+	'st_blur_impulse',
+	round(ST_Value(rast, 2, 2)::numeric, 6),
+	round(ST_Value(rast, 1, 1)::numeric, 6)
+FROM b;
+
+WITH r AS (
+	SELECT ST_SetValues(
+		ST_AddBand(ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0), 1, '16BUI', 10, 10),
+		1, 2, 2, ARRAY[[100]]::double precision[][]
+	) AS rast
+), b AS (
+	SELECT ST_Blur(rast, 1, 1.0) AS rast
+	FROM r
+)
+SELECT 'st_blur_nodata', round(ST_Value(rast, 2, 2)::numeric, 6)
+FROM b;
+
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test(double precision[], int[], text[]);
 DROP TABLE IF EXISTS raster_nmapalgebra_mask_in;

--- a/raster/test/regress/rt_mapalgebra_mask_expected
+++ b/raster/test/regress/rt_mapalgebra_mask_expected
@@ -593,3 +593,9 @@ NOTICE:  userargs = <NULL>
 2|(1,"{{255,255},{255,255}}")
 3|(1,"{{255,255},{255,255}}")
 4|(1,"{{255,255},{255,255}}")
+st_blur_empty_args
+ERROR:  Sigma must be provided
+st_blur_null_sigma
+ERROR:  Sigma must be finite and greater than zero
+st_blur_impulse|20.417996|14.253696
+st_blur_nodata|100.000000


### PR DESCRIPTION
## Summary
- add `ST_Blur(raster, radius, sigma, pixeltype)` and band-aware `ST_Blur(raster, nband, radius, sigma, pixeltype)` wrappers
- implement Gaussian neighborhood weighting with edge/nodata renormalization via a mapalgebra callback
- keep callback argument validation explicit for empty/NULL sigma arguments
- document the function and cover impulse/nodata behavior, empty callback arguments, and null sigma handling in raster regression output

## Ticket
Closes https://trac.osgeo.org/postgis/ticket/2598

## Validation
- rebased over current `upstream/master` at `4e470f153`
- `./config.status --file=regress/dumper/tests.mk`
- `./config.status --file=raster/test/regress/tests.mk`
- `make postgis_revision.h`
- `make -C raster/rt_pg -j32`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C raster/rt_pg install`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --raster" TESTS="$(pwd)/raster/test/regress/rt_mapalgebra_mask"`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --schema=postgis_ci --raster" TESTS="$(pwd)/raster/test/regress/rt_mapalgebra_mask"`
- `make -C doc check`
- `make check-news`
- `git clang-format --diff upstream/master -- NEWS doc/reference_raster.xml raster/rt_pg/rtpostgis.sql.in raster/test/regress/rt_mapalgebra_mask.sql raster/test/regress/rt_mapalgebra_mask_expected`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
