### PR TITLE
Fix raster same-alignment symmetry

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -109,6 +109,10 @@ These are only changes since 3.7.0alpha1.
 
 PostGIS 3.7.0dev
 2026/xx/xx
+ - #4502, [raster] Make ST_SameAlignment symmetric for nearly equal
+          geotransforms (Darafei Praliaskouski)
+PostGIS 3.7.0alpha1
+2026/07/05
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.
 To take advantage of all features postgis extension features, GEOS 3.15+ is needed.

--- a/raster/rt_core/rt_spatial_relationship.c
+++ b/raster/rt_core/rt_spatial_relationship.c
@@ -10,6 +10,7 @@
  * Copyright (C) 2009-2011 Pierre Racine <pierre.racine@sbf.ulaval.ca>
  * Copyright (C) 2009-2011 Mateusz Loskot <mateusz@loskot.net>
  * Copyright (C) 2008-2009 Sandro Santilli <strk@kbt.io>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,6 +31,38 @@
 #include "librtcore.h"
 #include "librtcore_internal.h"
 
+static rt_errorstate
+rt_raster_origin_on_grid(rt_raster grid, rt_raster rast, int *aligned)
+{
+	double xr;
+	double yr;
+	double xw;
+	double yw;
+
+	/* raster coordinates in context of grid raster of rast's upper-left corner */
+	if (rt_raster_geopoint_to_cell(grid, rast->ipX, rast->ipY, &xr, &yr, NULL) != ES_NONE)
+	{
+		rterror("rt_raster_same_alignment: Could not get raster coordinates from spatial coordinates");
+		*aligned = 0;
+		return ES_ERROR;
+	}
+
+	/* spatial coordinates of raster coordinates from above */
+	if (rt_raster_cell_to_geopoint(grid, xr, yr, &xw, &yw, NULL) != ES_NONE)
+	{
+		rterror("rt_raster_same_alignment: Could not get spatial coordinates from raster coordinates");
+		*aligned = 0;
+		return ES_ERROR;
+	}
+
+	RASTER_DEBUGF(4, "rast(ipX, ipxY) = (%f, %f)", rast->ipX, rast->ipY);
+	RASTER_DEBUGF(4, "grid(xr, yr) = (%f, %f)", xr, yr);
+	RASTER_DEBUGF(4, "grid(xw, yw) = (%f, %f)", xw, yw);
+
+	*aligned = FLT_EQ(xw, rast->ipX) && FLT_EQ(yw, rast->ipY);
+	return ES_NONE;
+}
+
 /*
  * Return ES_ERROR if error occurred in function.
  * Parameter aligned returns non-zero if two rasters are aligned
@@ -47,10 +80,8 @@ rt_raster_same_alignment(
 	rt_raster rast2,
 	int *aligned, char **reason
 ) {
-	double xr;
-	double yr;
-	double xw;
-	double yw;
+	int aligned1;
+	int aligned2;
 	int err = 0;
 
 	assert(NULL != rast1);
@@ -87,36 +118,25 @@ rt_raster_same_alignment(
 		return ES_NONE;
 	}
 
-	/* raster coordinates in context of second raster of first raster's upper-left corner */
-	if (rt_raster_geopoint_to_cell(
-			rast2,
-			rast1->ipX, rast1->ipY,
-			&xr, &yr,
-			NULL
-	) != ES_NONE) {
-		rterror("rt_raster_same_alignment: Could not get raster coordinates of second raster from first raster's spatial coordinates");
+	if (rt_raster_origin_on_grid(rast2, rast1, &aligned1) != ES_NONE)
+	{
+		*aligned = 0;
+		return ES_ERROR;
+	}
+	if (rt_raster_origin_on_grid(rast1, rast2, &aligned2) != ES_NONE)
+	{
 		*aligned = 0;
 		return ES_ERROR;
 	}
 
-	/* spatial coordinates of raster coordinates from above */
-	if (rt_raster_cell_to_geopoint(
-		rast2,
-		xr, yr,
-		&xw, &yw,
-		NULL
-	) != ES_NONE) {
-		rterror("rt_raster_same_alignment: Could not get spatial coordinates of second raster from raster coordinates");
-		*aligned = 0;
-		return ES_ERROR;
-	}
-
-	RASTER_DEBUGF(4, "rast1(ipX, ipxY) = (%f, %f)", rast1->ipX, rast1->ipY);
-	RASTER_DEBUGF(4, "rast2(xr, yr) = (%f, %f)", xr, yr);
-	RASTER_DEBUGF(4, "rast2(xw, yw) = (%f, %f)", xw, yw);
-
-	/* spatial coordinates are identical to that of first raster's upper-left corner */
-	if (FLT_EQ(xw, rast1->ipX) && FLT_EQ(yw, rast1->ipY)) {
+	/*
+	 * Scale and skew equality are tolerance based.  Requiring both origins
+	 * to land on the other raster's integer grid keeps the result symmetric
+	 * without accepting pairs that later directional offset calculations
+	 * cannot place safely.
+	 */
+	if (aligned1 && aligned2)
+	{
 		if (reason != NULL) *reason = "The rasters are aligned";
 		*aligned = 1;
 		return ES_NONE;

--- a/raster/test/cunit/cu_spatial_relationship.c
+++ b/raster/test/cunit/cu_spatial_relationship.c
@@ -4,6 +4,7 @@
  *
  * Copyright (C) 2012 Regents of the University of California
  *   <bkpark@ucdavis.edu>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -4774,6 +4775,40 @@ static void test_raster_same_alignment(void) {
 	CU_ASSERT_EQUAL(aligned, 0);
 	CU_ASSERT_STRING_EQUAL(reason, "The rasters (pixel corner coordinates) are not aligned");
 
+	rt_raster_set_srid(rast1, 4269);
+	rt_raster_set_scale(rast1, 9.259259252584582e-05, -9.259259252584056e-05);
+	rt_raster_set_skews(rast1, 0, 0);
+	rt_raster_set_offsets(rast1, -95.63944444404353, 41.78759259228624);
+	rt_raster_set_srid(rast2, 4269);
+	rt_raster_set_scale(rast2, 9.259259260902374e-05, -9.259259252584056e-05);
+	rt_raster_set_skews(rast2, 0, 0);
+	rt_raster_set_offsets(rast2, -96.76907407407123, 41.991296295843085);
+
+	rtn = rt_raster_same_alignment(rast1, rast2, &aligned, &reason);
+	CU_ASSERT_EQUAL(rtn, ES_NONE);
+	CU_ASSERT_EQUAL(aligned, 0);
+	CU_ASSERT_STRING_EQUAL(reason, "The rasters (pixel corner coordinates) are not aligned");
+	rtn = rt_raster_same_alignment(rast2, rast1, &aligned, &reason);
+	CU_ASSERT_EQUAL(rtn, ES_NONE);
+	CU_ASSERT_EQUAL(aligned, 0);
+	CU_ASSERT_STRING_EQUAL(reason, "The rasters (pixel corner coordinates) are not aligned");
+
+	rt_raster_set_srid(rast1, 0);
+	rt_raster_set_scale(rast1, 1, 1);
+	rt_raster_set_offsets(rast1, 0, 0);
+	rt_raster_set_srid(rast2, 0);
+	rt_raster_set_scale(rast2, 1 + 5e-8, 1);
+	rt_raster_set_offsets(rast2, 100, 0);
+
+	rtn = rt_raster_same_alignment(rast1, rast2, &aligned, &reason);
+	CU_ASSERT_EQUAL(rtn, ES_NONE);
+	CU_ASSERT_EQUAL(aligned, 0);
+	CU_ASSERT_STRING_EQUAL(reason, "The rasters (pixel corner coordinates) are not aligned");
+	rtn = rt_raster_same_alignment(rast2, rast1, &aligned, &reason);
+	CU_ASSERT_EQUAL(rtn, ES_NONE);
+	CU_ASSERT_EQUAL(aligned, 0);
+	CU_ASSERT_STRING_EQUAL(reason, "The rasters (pixel corner coordinates) are not aligned");
+
 	cu_free_raster(rast2);
 	cu_free_raster(rast1);
 }
@@ -4794,4 +4829,3 @@ void spatial_relationship_suite_setup(void)
 	PG_ADD_TEST(suite, test_raster_intersects);
 	PG_ADD_TEST(suite, test_raster_same_alignment);
 }
-


### PR DESCRIPTION
## Summary

This fixes https://trac.osgeo.org/postgis/ticket/4502 by making raster grid-alignment checks symmetric after the existing SRID, scale, and skew checks pass.

`ST_SameAlignment(a, b)` previously checked only whether `a`'s upper-left corner round-tripped through `b`'s grid. With nearly equal geotransforms accepted by the existing tolerance, accumulated roundoff could make `ST_SameAlignment(a, b)` disagree with `ST_SameAlignment(b, a)`.

The patch checks both origins and requires each origin to land on the other raster's integer grid. This keeps the result symmetric without accepting reverse-only alignment that later directional offset calculations cannot place safely.

## Ticket

Closes https://trac.osgeo.org/postgis/ticket/4502

## Validation

Current head: `283d9a2384cb52e449e53c59d56c1e72581e89af`

Rebased onto `upstream/master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`.

Commands run:

```bash
./autogen.sh
./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal
./config.status --file=regress/dumper/tests.mk
./config.status --file=raster/test/regress/tests.mk
make postgis_revision.h
make -C raster/rt_core -j32
make -C liblwgeom -j32
make -C raster/test/cunit -j32 check
make -C raster -j32
sudo -n make -C raster install
make -C extensions postgis_extension_helper.sql
make -C extensions/postgis -j1
make -C extensions/postgis_raster -j1
sudo -n make -C extensions/postgis_raster install
PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster check RUNTESTFLAGS="--extension --raster --verbose --upgrade" TESTS="$(pwd)/raster/test/regress/rt_samealignment"
PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/raster/test/regress/rt_samealignment"
make check-news
git clang-format --diff upstream/master -- raster/rt_core/rt_spatial_relationship.c raster/test/cunit/cu_spatial_relationship.c NEWS
git diff --check upstream/master..HEAD
git diff --check
git diff --cached --check
```
