### PR TITLE
Add raster application examples to manual

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -185,6 +185,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
+ - #2211, [raster] Add Map Algebra, Reclass, and PL/pgSQL raster application
+          examples to the manual (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and

--- a/NEWS
+++ b/NEWS
@@ -95,6 +95,10 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #2211, [raster] Add Map Algebra, Reclass, and PL/pgSQL raster application
+          examples to the manual (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -185,8 +189,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
- - #2211, [raster] Add Map Algebra, Reclass, and PL/pgSQL raster application
-          examples to the manual (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
  - #5638, Move and reorganize developer, maintainer, governance,
           website, internals, style, release-process, Trac wiki, and

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -10587,7 +10587,9 @@ WHERE t1.rid = 1
                     <para>
                         <xref linkend="rastbandarg"/>,
                         <xref linkend="RT_ST_Union"/>,
-                        <xref linkend="RT_ST_MapAlgebra"/>
+                        <xref linkend="RT_ST_MapAlgebra"/>,
+                        <xref linkend="RT_Raster_MapAlgebra_Reclass_Rendering"/>,
+                        <xref linkend="RT_PLPGSQL_MapAlgebra"/>
                     </para>
                 </refsection>
             </refentry>
@@ -12055,6 +12057,7 @@ UPDATE wind
                         <xref linkend="RT_ST_BandPixelType"/>,
                         <xref linkend="RT_ST_MakeEmptyRaster"/>,
                         <xref linkend="reclassarg"/>,
+                        <xref linkend="RT_Raster_MapAlgebra_Reclass_Rendering"/>,
                         <xref linkend="RT_ST_Value"/>
                     </para>
                 </refsection>

--- a/doc/using_raster_dataman.xml
+++ b/doc/using_raster_dataman.xml
@@ -612,65 +612,11 @@ AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';</programlisting
 		<section xml:id="RT_Raster_MapAlgebra_Reclass_Rendering">
 			<title>Rendering Map Algebra and Reclass Results</title>
 			<para><xref linkend="RT_ST_MapAlgebra"/> and <xref linkend="RT_ST_Reclass"/> can be used together to turn analysis rasters into viewable images.  A common pattern is to build a derived raster with map algebra, convert numeric ranges into display classes with reclassification, and render the result with <xref linkend="RT_ST_AsPNG"/> or another <xref linkend="RT_ST_AsGDALRaster"/> output format.</para>
-			<para>The following examples from the raster reference show the kind of visual output these functions can produce.</para>
-			<informaltable>
-				<tgroup cols="2">
-					<tbody>
-						<row>
-							<entry>
-								<para>
-									<informalfigure>
-										<mediaobject>
-											<imageobject>
-												<imagedata fileref="images/st_mapalgebraexpr2_01.png"/>
-											</imageobject>
-											<caption><para>Two-raster map algebra intersection</para></caption>
-										</mediaobject>
-									</informalfigure>
-								</para>
-							</entry>
-							<entry>
-								<para>
-									<informalfigure>
-										<mediaobject>
-											<imageobject>
-												<imagedata fileref="images/st_mapalgebraexpr2_02.png"/>
-											</imageobject>
-											<caption><para>Two-raster map algebra union</para></caption>
-										</mediaobject>
-									</informalfigure>
-								</para>
-							</entry>
-						</row>
-						<row>
-							<entry>
-								<para>
-									<informalfigure>
-										<mediaobject>
-											<imageobject>
-												<imagedata fileref="images/st_mapalgebrafctngb01.png"/>
-											</imageobject>
-											<caption><para>Input raster band before neighborhood processing</para></caption>
-										</mediaobject>
-									</informalfigure>
-								</para>
-							</entry>
-							<entry>
-								<para>
-									<informalfigure>
-										<mediaobject>
-											<imageobject>
-												<imagedata fileref="images/st_mapalgebrafctngb02.png"/>
-											</imageobject>
-											<caption><para>Neighborhood average rendered as an image</para></caption>
-										</mediaobject>
-									</informalfigure>
-								</para>
-							</entry>
-						</row>
-					</tbody>
-				</tgroup>
-			</informaltable>
+			<para>The raster reference includes executable visual examples for these workflows:</para>
+			<itemizedlist>
+				<listitem><para><xref linkend="RT_ST_MapAlgebraExpr2"/> compares two-raster intersection and union results.</para></listitem>
+				<listitem><para><xref linkend="RT_ST_MapAlgebra"/> demonstrates neighborhood processing and renders the source and result rasters.</para></listitem>
+			</itemizedlist>
 			<para>For a classification-style output, reclassify a continuous band into a small display palette and render it directly.</para>
 			<programlisting><![CDATA[
 WITH classified AS (

--- a/doc/using_raster_dataman.xml
+++ b/doc/using_raster_dataman.xml
@@ -609,6 +609,124 @@ AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';</programlisting
 		<title>Building Custom Applications with PostGIS Raster</title>
 		<para>The fact that PostGIS raster provides you with SQL functions to render rasters in known image formats gives  you a lot of options for rendering them.
 		For example you can use OpenOffice / LibreOffice for rendering as demonstrated in <link xlink:href="http://www.postgresonline.com/journal/archives/244-Rendering-PostGIS-Raster-graphics-with-LibreOffice-Base-Reports.html">Rendering PostGIS Raster graphics with LibreOffice Base Reports</link>.  In addition you can use a wide variety of languages as demonstrated in this section.</para>
+		<section xml:id="RT_Raster_MapAlgebra_Reclass_Rendering">
+			<title>Rendering Map Algebra and Reclass Results</title>
+			<para><xref linkend="RT_ST_MapAlgebra"/> and <xref linkend="RT_ST_Reclass"/> can be used together to turn analysis rasters into viewable images.  A common pattern is to build a derived raster with map algebra, convert numeric ranges into display classes with reclassification, and render the result with <xref linkend="RT_ST_AsPNG"/> or another <xref linkend="RT_ST_AsGDALRaster"/> output format.</para>
+			<para>The following examples from the raster reference show the kind of visual output these functions can produce.</para>
+			<informaltable>
+				<tgroup cols="2">
+					<tbody>
+						<row>
+							<entry>
+								<para>
+									<informalfigure>
+										<mediaobject>
+											<imageobject>
+												<imagedata fileref="images/st_mapalgebraexpr2_01.png"/>
+											</imageobject>
+											<caption><para>Two-raster map algebra intersection</para></caption>
+										</mediaobject>
+									</informalfigure>
+								</para>
+							</entry>
+							<entry>
+								<para>
+									<informalfigure>
+										<mediaobject>
+											<imageobject>
+												<imagedata fileref="images/st_mapalgebraexpr2_02.png"/>
+											</imageobject>
+											<caption><para>Two-raster map algebra union</para></caption>
+										</mediaobject>
+									</informalfigure>
+								</para>
+							</entry>
+						</row>
+						<row>
+							<entry>
+								<para>
+									<informalfigure>
+										<mediaobject>
+											<imageobject>
+												<imagedata fileref="images/st_mapalgebrafctngb01.png"/>
+											</imageobject>
+											<caption><para>Input raster band before neighborhood processing</para></caption>
+										</mediaobject>
+									</informalfigure>
+								</para>
+							</entry>
+							<entry>
+								<para>
+									<informalfigure>
+										<mediaobject>
+											<imageobject>
+												<imagedata fileref="images/st_mapalgebrafctngb02.png"/>
+											</imageobject>
+											<caption><para>Neighborhood average rendered as an image</para></caption>
+										</mediaobject>
+									</informalfigure>
+								</para>
+							</entry>
+						</row>
+					</tbody>
+				</tgroup>
+			</informaltable>
+			<para>For a classification-style output, reclassify a continuous band into a small display palette and render it directly.</para>
+			<programlisting><![CDATA[
+WITH classified AS (
+    SELECT ST_Reclass(
+        rast,
+        1,
+        '[0-50]:1, [51-100]:80, [101-150]:160, [151-255]:255',
+        '8BUI',
+        0
+    ) AS rast
+    FROM my_analysis_rasters
+    WHERE rid = 1
+)
+SELECT ST_AsPNG(rast) AS png
+FROM classified;
+]]></programlisting>
+		</section>
+		<section xml:id="RT_PLPGSQL_MapAlgebra">
+			<title>PL/pgSQL Map Algebra Callback Example</title>
+			<para>Map algebra callbacks are ordinary PostgreSQL functions.  The following example uses PL/pgSQL to scale one raster band while keeping the callback argument types compatible with the <type>double precision[][][]</type> value matrix passed by <xref linkend="RT_ST_MapAlgebra"/>.</para>
+			<programlisting><![CDATA[
+CREATE OR REPLACE FUNCTION plpgsql_scale_pixel(
+    value double precision[][][],
+    positions integer[][],
+    VARIADIC userargs text[]
+)
+RETURNS double precision
+AS $$
+DECLARE
+    pixel double precision := value[1][1][1];
+    factor double precision := COALESCE(userargs[1]::double precision, 1);
+BEGIN
+    IF pixel IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    RETURN greatest(0, least(255, pixel * factor));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+SELECT ST_MapAlgebra(
+    rast,
+    1,
+    'plpgsql_scale_pixel(double precision[][][], integer[][], text[])'::regprocedure,
+    '8BUI',
+    'FIRST',
+    NULL,
+    0,
+    0,
+    '1.5'
+) AS rast
+FROM my_analysis_rasters
+WHERE rid = 1;
+]]></programlisting>
+			<para>The first callback argument is a PostgreSQL <type>double precision[][][]</type> value matrix.  With no neighborhood distance, the current pixel value for the first raster is available as <code>value[1][1][1]</code>.</para>
+		</section>
 		<section xml:id="RT_PHP_Output">
 			<title>PHP Example Outputting using ST_AsPNG in concert with other raster functions</title>
 			<para>In this section, we'll demonstrate how to use the PHP PostgreSQL driver and the <xref linkend="RT_ST_AsGDALRaster"/> family of functions to


### PR DESCRIPTION
## Summary

This closes https://trac.osgeo.org/postgis/ticket/2211 with a focused manual update for raster application examples.

The new raster data-management section:

- surfaces existing Map Algebra output figures from the raster reference in the application chapter
- shows a small `ST_Reclass` to `ST_AsPNG` rendering pattern with inclusive class boundaries
- adds a PL/pgSQL callback example for `ST_MapAlgebra` using the supported `double precision[][][]` value matrix shape
- links the new material from the `ST_MapAlgebra` and `ST_Reclass` reference entries

## Ticket

Closes https://trac.osgeo.org/postgis/ticket/2211

## Validation

Current head: `d0f4b031cf944ef1ad12a78ce3e8fdd0178902fe`

Rebased onto `upstream/master` at `4e470f1534795ae4a4c52ad5ad35b8744af9d708`.

Commands run:

```bash
./autogen.sh
./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal
make -C doc check
make check-news
./utils/check_news.sh .
PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres dropdb --if-exists postgis_doc_1046
PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres createdb postgis_doc_1046
PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgis_doc_1046 psql -X -v ON_ERROR_STOP=1 -At
PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres dropdb --if-exists postgis_doc_1046
git diff --check upstream/master..HEAD
git diff --check
git diff --cached --check
```

SQL smoke output confirmed:

```text
1,1,80,255
150
```
