### PR TITLE
Document AddEdge deprecation in SQL comments

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
+ - #4934, [topology] Surface the AddEdge deprecation in generated SQL
+          comments (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -3469,7 +3469,7 @@ nodeid
 			<refnamediv>
 				<refname>AddEdge</refname>
 
-				<refpurpose>Adds a linestring edge to the edge table and associated start and end points to the point nodes table of the specified topology schema using the specified linestring geometry and returns the edgeid of the new (or existing) edge.</refpurpose>
+				<refpurpose>Deprecated: adds a linestring edge to the edge table and associated start and end points to the point nodes table of the specified topology schema using the specified linestring geometry and returns the edgeid of the new (or existing) edge.</refpurpose>
 			</refnamediv>
 
 			<refsynopsisdiv>


### PR DESCRIPTION
## Summary

This makes the existing `AddEdge` deprecation visible in generated topology SQL comments by moving the deprecation signal into the documented refpurpose. The manual already had the warning; generated comments now carry it too.

This is the bounded AddEdge generated-comment slice of the broader invalid-topology constructor deprecation ticket.

References https://trac.osgeo.org/postgis/ticket/4934

## Validation

- `./utils/check_news.sh .`
- `make -C doc comments`
- `make -C doc check`
- `git diff --check upstream/master..HEAD`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/322
