### PR TITLE
loader: add shp2pgsql drop-before-create option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
  - #1124, shp2pgsql can create UNLOGGED tables for transient staging loads
           (Darafei Praliaskouski)
+ - #2935, shp2pgsql can emit DROP TABLE before prepare output
+          (Darafei Praliaskouski)
  - #4208, Add single-geometry variants of ST_MaxDistance and ST_LongestLine
           (Darafei Praliaskouski)
  - [topology] FindVertexSegmentPairsBelowDistance function (Sandro Santilli)

--- a/doc/man/shp2pgsql.1
+++ b/doc/man/shp2pgsql.1
@@ -48,6 +48,10 @@ Only produces the table creation SQL code, without adding any actual data.
 This can be used if you need to completely separate the table creation and 
 data loading steps.
 .TP 
+\fB\-r\fR
+Emits a DROP TABLE IF EXISTS statement before table creation. This can be
+combined with \-c or \-p, but not with \-a.
+.TP
 \fB\-D\fR
 Use the PostgreSQL "dump" format for the output data. This can be combined 
 with \-a, \-c and \-d. It is much faster to load than the default "insert"

--- a/loader/README.shp2pgsql
+++ b/loader/README.shp2pgsql
@@ -48,6 +48,9 @@ OPTIONS
               actual  data.   This can be used if you need to completely sepa-
               rate the table creation and data loading steps.
 
+       -r     Emits  a  DROP  TABLE IF EXISTS statement before table creation.
+              This can be combined with -c or -p, but not with -a.
+
        -D     Use the PostgreSQL "dump" format for the output data.  This  can
               be  combined  with -a, -c and -d. It is much faster to load than
               the default "insert" SQL format. Use this for  very  large  data

--- a/loader/cunit/cu_shp2pgsql.c
+++ b/loader/cunit/cu_shp2pgsql.c
@@ -12,10 +12,12 @@
 #include "cu_shp2pgsql.h"
 #include "cu_tester.h"
 #include "../shp2pgsql-core.h"
+#include <string.h>
 
 /* Test functions */
 void test_ShpLoaderCreate(void);
 void test_ShpLoaderDestroy(void);
+void test_ShpLoaderGetSQLHeader_drop_prepare(void);
 
 SHPLOADERCONFIG *loader_config;
 SHPLOADERSTATE *loader_state;
@@ -33,10 +35,10 @@ CU_pSuite register_shp2pgsql_suite(void)
 		return NULL;
 	}
 
-	if (
-	    (NULL == CU_add_test(pSuite, "test_ShpLoaderCreate()", test_ShpLoaderCreate)) ||
-	    (NULL == CU_add_test(pSuite, "test_ShpLoaderDestroy()", test_ShpLoaderDestroy))
-	)
+	if ((NULL == CU_add_test(pSuite, "test_ShpLoaderCreate()", test_ShpLoaderCreate)) ||
+	    (NULL == CU_add_test(pSuite, "test_ShpLoaderDestroy()", test_ShpLoaderDestroy)) ||
+	    (NULL ==
+	     CU_add_test(pSuite, "test_ShpLoaderGetSQLHeader_drop_prepare()", test_ShpLoaderGetSQLHeader_drop_prepare)))
 	{
 		CU_cleanup_registry();
 		return NULL;
@@ -73,5 +75,34 @@ void test_ShpLoaderCreate(void)
 
 void test_ShpLoaderDestroy(void)
 {
+	ShpLoaderDestroy(loader_state);
+}
+
+void
+test_ShpLoaderGetSQLHeader_drop_prepare(void)
+{
+	char *header = NULL;
+	const char *drop;
+	const char *create;
+
+	loader_config = (SHPLOADERCONFIG *)calloc(1, sizeof(SHPLOADERCONFIG));
+	set_loader_config_defaults(loader_config);
+	loader_config->opt = 'p';
+	loader_config->drop_table = 1;
+	loader_config->table = "loadedshp";
+	loader_config->geo_col = "the_geom";
+
+	loader_state = ShpLoaderCreate(loader_config);
+	CU_ASSERT_EQUAL(ShpLoaderGetSQLHeader(loader_state, &header), SHPLOADEROK);
+	CU_ASSERT_PTR_NOT_NULL(header);
+
+	drop = strstr(header, "DROP TABLE IF EXISTS \"loadedshp\";");
+	create = strstr(header, "CREATE TABLE \"loadedshp\"");
+	CU_ASSERT_PTR_NOT_NULL(drop);
+	CU_ASSERT_PTR_NOT_NULL(create);
+	CU_ASSERT_PTR_NULL(strstr(header, "DropGeometryColumn"));
+	CU_ASSERT(drop < create);
+
+	free(header);
 	ShpLoaderDestroy(loader_state);
 }

--- a/loader/shp2pgsql-cli.c
+++ b/loader/shp2pgsql-cli.c
@@ -63,6 +63,7 @@ usage()
 	          "      attribute column. (default: \"UTF-8\")\n" ));
 	printf(_( "  -N <policy> NULL geometries handling policy (insert*,skip,abort).\n" ));
 	printf(_( "  -n  Only import DBF file.\n" ));
+	printf(_("  -r  Emit DROP TABLE IF EXISTS before create or prepare output.\n"));
 	printf(_( "  -T <tablespace> Specify the tablespace for the new table.\n"
                   "      Note that indexes will still use the default tablespace unless the\n"
                   "      -X flag is also used.\n"));
@@ -106,7 +107,7 @@ main (int argc, char **argv)
 	set_loader_config_defaults(config);
 
 	/* Keep the flag list alphabetic so it's easy to see what's left. */
-	while ((c = pgis_getopt(argc, argv, "-?acdeg:ikm:nps:t:uwDGIN:ST:W:X:Z")) != EOF)
+	while ((c = pgis_getopt(argc, argv, "-?acdeg:ikm:nprs:t:uwDGIN:ST:W:X:Z")) != EOF)
 	{
 		// can not do this inside the switch case
 		if ('-' == c)
@@ -191,6 +192,10 @@ main (int argc, char **argv)
 			config->readshape = 0;
 			break;
 
+		case 'r':
+			config->drop_table = 1;
+			break;
+
 		case 'W':
 			free(config->encoding);
 			config->encoding = strdup(pgis_optarg);
@@ -264,6 +269,12 @@ main (int argc, char **argv)
 	if (config->dump_format && !config->usetransaction)
 	{
 		fprintf(stderr, "Invalid argument combination - cannot use both -D and -e\n");
+		exit(1);
+	}
+
+	if (config->drop_table && config->opt == 'a')
+	{
+		fprintf(stderr, "Invalid argument combination - cannot use both -r and -a\n");
 		exit(1);
 	}
 

--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -771,6 +771,7 @@ set_loader_config_defaults(SHPLOADERCONFIG *config)
 	config->forceint4 = 0;
 	config->createindex = 0;
 	config->unlogged = 0;
+	config->drop_table = 0;
 	config->analyze = 1;
 	config->readshape = 1;
 	config->force_output = FORCE_OUTPUT_DISABLE;
@@ -1300,7 +1301,7 @@ ShpLoaderGetSQLHeader(SHPLOADERSTATE *state, char **strheader)
 	stringbuffer_aprintf(sb, "SET STANDARD_CONFORMING_STRINGS TO ON;\n");
 
 	/* Drop table if requested */
-	if (state->config->opt == 'd')
+	if (state->config->opt == 'd' || state->config->drop_table)
 	{
 		/**
 		 * TODO: if the table has more then one geometry column
@@ -1315,7 +1316,7 @@ ShpLoaderGetSQLHeader(SHPLOADERSTATE *state, char **strheader)
 		 */
 		if (state->config->schema)
 		{
-			if (state->config->readshape == 1 && (! state->config->geography) )
+			if (state->config->opt == 'd' && state->config->readshape == 1 && (!state->config->geography))
 			{
 				stringbuffer_aprintf(sb, "SELECT DropGeometryColumn('%s','%s','%s');\n",
 				                     state->config->schema, state->config->table, state->geo_col);
@@ -1326,7 +1327,7 @@ ShpLoaderGetSQLHeader(SHPLOADERSTATE *state, char **strheader)
 		}
 		else
 		{
-			if (state->config->readshape == 1  && (! state->config->geography) )
+			if (state->config->opt == 'd' && state->config->readshape == 1 && (!state->config->geography))
 			{
 				stringbuffer_aprintf(sb, "SELECT DropGeometryColumn('','%s','%s');\n",
 				                     state->config->table, state->geo_col);

--- a/loader/shp2pgsql-core.h
+++ b/loader/shp2pgsql-core.h
@@ -117,7 +117,10 @@ typedef struct shp_loader_config
 	/* 0 = logged table, 1 = create as UNLOGGED table */
 	int unlogged;
 
-    /* 0 = don't analyze tables , 1 = analyze tables */
+	/* 0 = do not emit DROP TABLE, 1 = emit DROP TABLE before create/prepare */
+	int drop_table;
+
+	/* 0 = don't analyze tables , 1 = analyze tables */
 	int analyze;
 
 	/* 0 = load DBF file only, 1 = load everything */


### PR DESCRIPTION
## Summary
- add `shp2pgsql -r` to emit `DROP TABLE IF EXISTS` before create/prepare output
- reject `-r -a`, since append mode has no create step to precede
- document the option in CLI usage, README, man page, and NEWS

Closes https://trac.osgeo.org/postgis/ticket/2935

## Testing
- `./utils/check_news.sh`
- `git diff --check`
- `git clang-format --diff upstream/master -- loader/shp2pgsql-core.c loader/shp2pgsql-core.h loader/shp2pgsql-cli.c loader/cunit/cu_shp2pgsql.c`
- `make -C loader -j32 && make -C loader/cunit check`
- `./loader/shp2pgsql -p -r -g the_geom regress/loader/Point.shp loadedshp | sed -n 1,12p`
- `./loader/shp2pgsql -a -r regress/loader/Point.shp loadedshp` exits 1 with `Invalid argument combination - cannot use both -r and -a`