### PR TITLE
postgis_restore: convert constraint geometry columns to typmod

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -101,6 +101,11 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #1467, postgis_restore can optionally convert 2D constraint-based
+          geometry columns to typmod columns during restore
+          (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -207,9 +212,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
-          (Darafei Praliaskouski)
- - #1467, postgis_restore can optionally convert 2D constraint-based
-          geometry columns to typmod columns during restore
           (Darafei Praliaskouski)
  - #6087, Add a repository-owned CI status checker and static dashboard
           generator (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -208,6 +208,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           GeometryCollections (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
           (Darafei Praliaskouski)
+ - #1467, postgis_restore can optionally convert 2D constraint-based
+          geometry columns to typmod columns during restore
+          (Darafei Praliaskouski)
  - #6087, Add a repository-owned CI status checker and static dashboard
           generator (Darafei Praliaskouski)
  - #2807, [raster] Preserve missing NODATA values in ST_MapAlgebra outputs

--- a/doc/administration.xml
+++ b/doc/administration.xml
@@ -292,6 +292,15 @@ string, and next time you'll need to drop the "next" suffix again:
 
 	  <programlisting language="bash">postgis_restore "/somepath/olddb.backup" | psql -h localhost -p 5432 -U postgres newdb 2&gt; errors.txt</programlisting>
 
+	  <para>
+		If the old database uses constraint-based geometry columns and
+		you want simple two-dimensional geometry columns converted to
+		typmod geometry columns during restore, add the
+		<command>--convert-to-typmod</command> switch:
+	  </para>
+
+	  <programlisting>postgis_restore --convert-to-typmod "/somepath/olddb.backup" | psql -h localhost -p 5432 -U postgres newdb 2&gt; errors.txt</programlisting>
+
 	</listitem>
 
 	</orderedlist>

--- a/doc/man/postgis_restore.1
+++ b/doc/man/postgis_restore.1
@@ -5,7 +5,7 @@ postgis_restore - restore a PostGIS database from an archive file created by pg_
 
 .SH "SYNTAX"
 .LP
-postgis_restore [\fI-v\fR] [\fI-L TOC\fR] [\fI-s schema\fR] \fIdumpfile\fR
+postgis_restore [\fI-v\fR] [\fI-L TOC\fR] [\fI-s schema\fR] [\fI--convert-to-typmod\fR] \fIdumpfile\fR
 
 .SH "DESCRIPTION"
 .LP
@@ -26,6 +26,10 @@ those created with \fIpg_dump -Fc\fR.
 Usage information is printed when the script is invoked with no
 arguments.
 
+Use \fI--convert-to-typmod\fR to convert simple 2D constraint-based geometry
+columns to typmod geometry columns while restoring. This is opt-in because
+some older constraint layouts cannot be represented as typmod columns.
+
 .SH "EXAMPLES"
 .LP
 
@@ -43,7 +47,12 @@ PostGIS-enable the new database:
 
 Restore your data:
 
-	postgis_restore.pl olddb.dump | psql newdb
+	postgis_restore olddb.dump | psql newdb
+
+Restore and convert simple 2D constraint-based geometry columns to typmod
+columns:
+
+	postgis_restore --convert-to-typmod olddb.dump | psql newdb
 
 .SH "AUTHORS"
 .LP

--- a/utils/Makefile.in
+++ b/utils/Makefile.in
@@ -126,7 +126,10 @@ check: check-unit
 create_upgrade_replaced_function_errors_check:
 	srcdir=$(srcdir) PERL=$(PERL) $(SHELL) $(srcdir)/check_create_upgrade_replaced_function_errors.sh
 
-check-unit: postgis_restore-check create_upgrade_replaced_function_errors_check
+postgis_restore-typmod-check: postgis_restore.pl
+	$(PERL) $(srcdir)/test_postgis_restore_typmod.pl ./postgis_restore.pl
+
+check-unit: postgis_restore-check create_upgrade_replaced_function_errors_check postgis_restore-typmod-check
 
 installdir:
 	@mkdir -p $(DESTDIR)$(bindir)

--- a/utils/postgis_restore.pl.in
+++ b/utils/postgis_restore.pl.in
@@ -36,7 +36,7 @@ use strict;
 my $me = $0;
 
 my $usage = qq{
-Usage:	$me [-v] [-L TOC] [-s schema] <dumpfile>
+Usage:	$me [-v] [-L TOC] [-s schema] [--convert-to-typmod] <dumpfile>
         Restore a custom dump (pg_dump -Fc) of a PostGIS-enabled database.
         First dump the old database: pg_dump -Fc MYDB > MYDB.dmp
         Then create a new database: createdb NEWDB
@@ -50,12 +50,15 @@ Usage:	$me [-v] [-L TOC] [-s schema] <dumpfile>
         The -v switch writes detailed report on stderr.
         Use -L to provide a TOC rather than extracting it from the dump.
         Use -s if you installed PostGIS in a custom schema.
+        Use --convert-to-typmod to convert simple 2D constraint-based
+        geometry columns to typmod geometry columns while restoring.
 
 };
 
 my $DEBUG = 0;
 my $POSTGIS_SCHEMA;
 my $POSTGIS_TOC;
+my $CONVERT_TO_TYPMOD = 0;
 
 # NOTE: the SRID limits here are being discussed:
 # http://lists.osgeo.org/pipermail/postgis-devel/2012-February/018440.html
@@ -72,6 +75,9 @@ while (@ARGV && $ARGV[0] =~ /^-/) {
   }
   elsif ( $arg eq '-L' ) {
     $POSTGIS_TOC = shift(@ARGV);
+  }
+  elsif ( $arg eq '--convert-to-typmod' ) {
+    $CONVERT_TO_TYPMOD = 1;
   }
   elsif ( $arg eq '--' ) {
     last;
@@ -292,25 +298,14 @@ while( my $l = <INPUT> ) {
   #
   elsif ( $l =~ /CREATE TABLE *([^ ,]*)/)
   {
-    print STDOUT $l;
+    my @sublines = ($l);
     while( my $subline = <INPUT>)
     {
-      if ( $subline =~ /CONSTRAINT "?enforce_dims_/i ) {
-        $subline =~ s/\bndims\(/st_ndims(/;
-      }
-      if ( $subline =~ /CONSTRAINT "?enforce_srid_/i ) {
-        $subline =~ s/\bsrid\(/st_srid(/;
-        if ( $subline =~ /=\s\(?([-0-9][0-9]*)\)/ ) {
-          my $oldsrid = $1;
-          my $newsrid = clamp_srid($oldsrid);
-          $subline =~ s/=\s*(\(?)[-0-9][0-9]*/= $1$newsrid/;
-        } else {
-          print STDERR "WARNING: could not find SRID value in: $subline";
-        }
-      }
-      print STDOUT $subline;
+      push(@sublines, $subline);
       last if $subline =~ /;[\t ]*$/;
     }
+
+    print STDOUT rewrite_table_spatial_constraints(@sublines);
     next;
   }
 
@@ -573,6 +568,133 @@ sub strip_argument_names {
 	}
 	#print "XXX striped: " . join(',', @out) . "\n";
 	return @out;
+}
+
+sub normalize_sql_identifier
+{
+	my $ident = shift;
+	if ( $ident =~ /^"(.*)"$/s )
+	{
+		$ident = $1;
+		$ident =~ s/""/"/g;
+		return $ident;
+	}
+	return lc($ident);
+}
+
+sub rewrite_table_spatial_constraints
+{
+	my @sublines = @_;
+	my %columns = ();
+	my %constraints = ();
+	my @output = ();
+	my $ident = qr/"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_\$]*/;
+	my $qualified_fn = qr/(?:$ident\.)?/;
+
+	for (my $i = 0; $i <= $#sublines; $i++)
+	{
+		my $subline = $sublines[$i];
+
+		if ( $subline =~ /^(\s*)($ident)\s+((?:(?:$ident)\.)?geometry)(\s*,?\s*)$/i )
+		{
+			$columns{normalize_sql_identifier($2)} = {
+				'index' => $i,
+				'indent' => $1,
+				'name' => $2,
+				'type' => $3,
+				'suffix' => $4
+			};
+		}
+
+		if ( $subline =~ /CONSTRAINT "?enforce_dims_/i )
+		{
+			$subline =~ s/\bndims\(/st_ndims(/;
+			if ( $subline =~ /${qualified_fn}st_ndims\(($ident)\)\s*=\s*\(?([0-9]+)\)?/i )
+			{
+				my $col = normalize_sql_identifier($1);
+				$constraints{$col}{'dims'} = $2;
+				$constraints{$col}{'dims_line'} = $i;
+			}
+		}
+
+		if ( $subline =~ /CONSTRAINT "?enforce_geotype_/i )
+		{
+			if ( $subline =~ /${qualified_fn}geometrytype\(($ident)\)\s*=\s*'([^']+)'::text/i )
+			{
+				my $col = normalize_sql_identifier($1);
+				$constraints{$col}{'geotype'} = $2;
+				$constraints{$col}{'geotype_line'} = $i;
+			}
+		}
+
+		if ( $subline =~ /CONSTRAINT "?enforce_srid_/i )
+		{
+			$subline =~ s/\bsrid\(/st_srid(/;
+			if ( $subline =~ /${qualified_fn}st_srid\(($ident)\)\s*=\s*\(?([-0-9][0-9]*)\)?/i )
+			{
+				my $col = normalize_sql_identifier($1);
+				my $oldsrid = $2;
+				my $newsrid = clamp_srid($oldsrid);
+				$subline =~ s/=\s*(\(?)[-0-9][0-9]*/= $1$newsrid/;
+				$constraints{$col}{'srid'} = $newsrid;
+				$constraints{$col}{'srid_line'} = $i;
+			}
+			else
+			{
+				print STDERR "WARNING: could not find SRID value in: $subline";
+			}
+		}
+
+		$sublines[$i] = $subline;
+	}
+
+	if ( $CONVERT_TO_TYPMOD )
+	{
+		foreach my $col (keys %columns)
+		{
+			next unless defined $constraints{$col};
+			next unless defined $constraints{$col}{'dims'};
+			next unless defined $constraints{$col}{'geotype'};
+			next unless defined $constraints{$col}{'srid'};
+
+			if ( $constraints{$col}{'dims'} != 2 )
+			{
+				print STDERR "  Leaving $columns{$col}{'name'} as constraint-based geometry: only 2D typmod conversion is supported\n" if $DEBUG;
+				next;
+			}
+
+			my $geotype = $constraints{$col}{'geotype'};
+			if ( $geotype !~ /^[A-Z][A-Z0-9]*$/ )
+			{
+				print STDERR "  Leaving $columns{$col}{'name'} as constraint-based geometry: unsupported geometry type $geotype\n" if $DEBUG;
+				next;
+			}
+
+			$sublines[$columns{$col}{'index'}] =
+				$columns{$col}{'indent'} . $columns{$col}{'name'} . ' ' .
+				$columns{$col}{'type'} . '(' . $geotype . ',' .
+				$constraints{$col}{'srid'} . ')' . $columns{$col}{'suffix'};
+			$sublines[$constraints{$col}{'dims_line'}] = undef;
+			$sublines[$constraints{$col}{'geotype_line'}] = undef;
+			$sublines[$constraints{$col}{'srid_line'}] = undef;
+			print STDERR "  Converted $columns{$col}{'name'} to typmod geometry($geotype,$constraints{$col}{'srid'})\n" if $DEBUG;
+		}
+	}
+
+	foreach my $subline (@sublines)
+	{
+		push @output, $subline if defined $subline;
+	}
+
+	for (my $i = 1; $i <= $#output; $i++)
+	{
+		if ( $output[$i] =~ /^\s*\)\s*;?\s*$/ && $output[$i - 1] =~ /,\s*$/ )
+		{
+			$output[$i - 1] =~ s/,\s*$/\n/;
+		}
+	}
+
+	return @output;
 }
 
 

--- a/utils/test_postgis_restore_typmod.pl
+++ b/utils/test_postgis_restore_typmod.pl
@@ -1,0 +1,152 @@
+#!/usr/bin/env perl
+
+#
+# PostGIS - Spatial Types for PostgreSQL
+# http://postgis.net
+#
+# Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+#
+# This is free software; you can redistribute and/or modify it under
+# the terms of the GNU General Public Licence. See the COPYING file.
+#
+
+use warnings;
+use strict;
+
+use File::Temp qw(tempdir);
+
+my $restore_script = shift @ARGV
+  or die "Usage: $0 <postgis_restore.pl>\n";
+
+sub write_file
+{
+	my ($path, $contents) = @_;
+	open(my $fh, '>', $path) || die "Could not write $path: $!\n";
+	print {$fh} $contents;
+	close($fh) || die "Could not close $path: $!\n";
+}
+
+sub install_fake_programs
+{
+	my ($bindir) = @_;
+
+	write_file("$bindir/pg_dump", <<'SH');
+#!/bin/sh
+echo "pg_dump (fake)"
+SH
+	chmod 0755, "$bindir/pg_dump";
+
+	write_file("$bindir/pg_restore", <<'SH');
+#!/bin/sh
+for arg in "$@"; do
+	if test "$arg" = "--version"; then
+		echo "pg_restore (fake)"
+		exit 0
+	fi
+	if test "$arg" = "-l"; then
+		cat "$POSTGIS_RESTORE_TEST_TOC"
+		exit 0
+	fi
+done
+cat "$POSTGIS_RESTORE_TEST_SQL"
+SH
+	chmod 0755, "$bindir/pg_restore";
+}
+
+sub run_restore
+{
+	my ($extra_arg, $sql) = @_;
+	my $dir = tempdir(CLEANUP => 1);
+	my $bindir = "$dir/bin";
+	mkdir $bindir || die "Could not create $bindir: $!\n";
+	install_fake_programs($bindir);
+
+	my $dump = "$dir/test.dump";
+	my $toc_file = "$dir/toc.txt";
+	my $sql_file = "$dir/restore.sql";
+	write_file($dump, "fake dump\n");
+	write_file($toc_file, "1; 0 0 TABLE DATA public spatial_ref_sys postgres\n");
+	write_file($sql_file, $sql);
+
+	local $ENV{PATH} = "$bindir:$ENV{PATH}";
+	local $ENV{POSTGIS_RESTORE_TEST_TOC} = $toc_file;
+	local $ENV{POSTGIS_RESTORE_TEST_SQL} = $sql_file;
+
+	my @args = ($^X, $restore_script);
+	push @args, $extra_arg if defined $extra_arg;
+	push @args, $dump;
+
+	open(my $out, '-|', @args)
+	  || die "Could not run $restore_script: $!\n";
+	my $stdout = do { local $/; <$out> };
+	close($out) || die "$restore_script failed\n";
+
+	return $stdout;
+}
+
+sub assert_contains
+{
+	my ($text, $needle, $label) = @_;
+	die "not ok - $label\nMissing: $needle\nIn:\n$text\n"
+	  if index($text, $needle) < 0;
+}
+
+sub assert_not_contains
+{
+	my ($text, $needle, $label) = @_;
+	die "not ok - $label\nUnexpected: $needle\nIn:\n$text\n"
+	  if index($text, $needle) >= 0;
+}
+
+my $restore_sql = <<'SQL';
+CREATE TABLE public.t (
+    id integer,
+    geom public.geometry,
+    CONSTRAINT enforce_dims_geom CHECK ((public.st_ndims(geom) = 2)),
+    CONSTRAINT enforce_geotype_geom CHECK (((public.geometrytype(geom) = 'POINT'::text) OR (geom IS NULL))),
+    CONSTRAINT enforce_srid_geom CHECK ((public.st_srid(geom) = 4326))
+);
+
+CREATE TABLE public.quoted (
+    "ID" integer,
+    "G" public.geometry,
+    CONSTRAINT "enforce_dims_G" CHECK ((public.st_ndims("G") = 2)),
+    CONSTRAINT "enforce_geotype_G" CHECK (((public.geometrytype("G") = 'MULTIPOLYGON'::text) OR ("G" IS NULL))),
+    CONSTRAINT "enforce_srid_G" CHECK ((public.st_srid("G") = (-1)))
+);
+
+CREATE TABLE public.xyz (
+    id integer,
+    geom3 public.geometry,
+    CONSTRAINT enforce_dims_geom3 CHECK ((public.st_ndims(geom3) = 3)),
+    CONSTRAINT enforce_geotype_geom3 CHECK (((public.geometrytype(geom3) = 'LINESTRING'::text) OR (geom3 IS NULL))),
+    CONSTRAINT enforce_srid_geom3 CHECK ((public.st_srid(geom3) = 4326))
+);
+
+CREATE TABLE public.with_opts (
+    id integer,
+    geom public.geometry,
+    CONSTRAINT enforce_dims_geom CHECK ((public.st_ndims(geom) = 2)),
+    CONSTRAINT enforce_geotype_geom CHECK (((public.geometrytype(geom) = 'POINT'::text) OR (geom IS NULL))),
+    CONSTRAINT enforce_srid_geom CHECK ((public.st_srid(geom) = 4326))
+)
+WITH (fillfactor='70');
+SQL
+
+my $stdout = run_restore(undef, $restore_sql);
+assert_contains($stdout, 'geom public.geometry,', 'leave unrequested geometry column unconstrained');
+assert_contains($stdout, 'CONSTRAINT enforce_dims_geom CHECK ((public.st_ndims(geom) = 2))', 'leave constraints without opt-in');
+
+$stdout = run_restore('--convert-to-typmod', $restore_sql);
+assert_contains($stdout, 'geom public.geometry(POINT,4326)', 'convert simple 2D geometry column to typmod');
+assert_not_contains($stdout, 'CONSTRAINT enforce_dims_geom CHECK ((public.st_ndims(geom) = 2))', 'drop converted dims constraint');
+assert_not_contains($stdout, 'CONSTRAINT enforce_geotype_geom CHECK (((public.geometrytype(geom) = \'POINT\'::text) OR (geom IS NULL)))', 'drop converted geotype constraint');
+assert_not_contains($stdout, 'CONSTRAINT enforce_srid_geom CHECK ((public.st_srid(geom) = 4326))', 'drop converted srid constraint');
+assert_contains($stdout, '"G" public.geometry(MULTIPOLYGON,0)', 'convert quoted geometry column and clamp unknown SRID');
+assert_not_contains($stdout, 'CONSTRAINT "enforce_srid_G"', 'drop converted quoted SRID constraint');
+assert_contains($stdout, 'geom3 public.geometry,', 'leave non-2D geometry column constraint-based');
+assert_contains($stdout, 'CONSTRAINT enforce_dims_geom3 CHECK ((public.st_ndims(geom3) = 3))', 'keep non-2D dimensions constraint');
+assert_contains($stdout, "geom public.geometry(POINT,4326)\n)\nWITH (fillfactor='70');", 'preserve table trailer after typmod conversion');
+assert_not_contains($stdout, "geom public.geometry(POINT,4326),\n)\nWITH", 'drop trailing comma before table trailer');
+
+print "ok - postgis_restore typmod conversion tests\n";


### PR DESCRIPTION
## Summary
- add an opt-in `--convert-to-typmod` switch to `postgis_restore`
- rewrite simple 2D constraint-based geometry columns as typmod geometry columns in streamed `CREATE TABLE` output
- preserve the existing legacy `ndims`/`srid` cleanup path and add fake-`pg_restore` unit coverage for default, converted, quoted, SRID-clamped, non-2D, and table-trailer cases

Closes https://trac.osgeo.org/postgis/ticket/1467

## Notes
This intentionally converts during the restore stream, before table data is loaded, matching the Trac ticket performance goal of avoiding a post-load table rewrite. It is opt-in and limited to simple 2D constraints because older constraint layouts and higher-dimensional constraints are not always representable as an unambiguous typmod.

The current refresh rebases the branch on `4e470f1534795ae4a4c52ad5ad35b8744af9d708` and fixes the reviewed table-trailer case where `pg_dump` can emit a bare `)` before clauses such as `WITH (...)`.

## Validation
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C postgis uninstall_postgis.sql uninstall_legacy.sql`
- `make -C utils check-unit`
- `make -C doc check`
- `make check-news && ./utils/check_news.sh .`
- `perl -c utils/postgis_restore.pl`
- `perl -c utils/test_postgis_restore_typmod.pl`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
