### PR TITLE
topology: import renamed TopoGeometry columns

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -96,6 +96,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           shapefiles (Darafei Praliaskouski)
  - #2838, Emit valid X3D Coordinate nodes for 2D polygon output
           (Darafei Praliaskouski)
+ - #5284, [topology] Allow pgtopo_export/import to reload manually
+          renamed TopoGeometry columns (Darafei Praliaskouski)
  - Fix WKB and TWKB parser resource exhaustion on malformed input
           (Darafei Praliaskouski)
  - #2850, Preserve pgsql2shp numeric precision and scale in DBF metadata

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -167,6 +167,8 @@ uninstall_topology.sql: topology.sql ../utils/create_uninstall.pl
 	$(PERL) @top_srcdir@/utils/create_uninstall.pl $< $(POSTGIS_PGSQL_VERSION) > $@
 
 check-unit:
+	$(SHELL) @top_srcdir@/topology/test/test_pgtopo_export.sh @top_srcdir@/topology/loader/pgtopo_export
+	$(SHELL) @top_srcdir@/topology/test/test_pgtopo_import.sh @top_srcdir@/topology/loader/pgtopo_import
 
 check-regress: topology.sql
 	$(MAKE) -C test $@

--- a/topology/loader/pgtopo_export
+++ b/topology/loader/pgtopo_export
@@ -112,16 +112,55 @@ COPY (
     layer_id,
     schema_name,
     table_name,
-    feature_column,
+    COALESCE(actual_feature_column.feature_column, l.feature_column),
     feature_type,
     level,
     child_id
   FROM
-    topology.layer l,
-    topology.topology t
+    topology.layer l
+    JOIN topology.topology t
+      ON l.topology_id = t.id
+    LEFT JOIN LATERAL (
+      SELECT CASE WHEN count(*) = 1 THEN min(feature_column) END AS feature_column
+      FROM (
+        SELECT DISTINCT a.attname AS feature_column
+        FROM pg_catalog.pg_namespace n
+        JOIN pg_catalog.pg_class c
+          ON c.relnamespace = n.oid
+        JOIN pg_catalog.pg_attribute a
+          ON a.attrelid = c.oid
+        JOIN pg_catalog.pg_constraint con
+          ON con.conrelid = c.oid
+        WHERE n.nspname = l.schema_name
+          AND c.relname = l.table_name
+          AND a.atttypid = 'topology.TopoGeometry'::regtype
+          AND NOT a.attisdropped
+          AND con.contype = 'c'
+          AND con.conname LIKE 'check_topogeom_%'
+          AND ARRAY[a.attnum] <@ con.conkey
+          AND (
+            pg_catalog.pg_get_constraintdef(con.oid) ~
+              ('topology_id\(' || pg_catalog.quote_ident(a.attname) || '\) = ' || l.topology_id || '([^0-9]|$)')
+            OR pg_catalog.pg_get_constraintdef(con.oid) ~
+              ('\(' || pg_catalog.quote_ident(a.attname) || '\)\.topology_id = ' || l.topology_id || '([^0-9]|$)')
+          )
+          AND (
+            pg_catalog.pg_get_constraintdef(con.oid) ~
+              ('layer_id\(' || pg_catalog.quote_ident(a.attname) || '\) = ' || l.layer_id || '([^0-9]|$)')
+            OR pg_catalog.pg_get_constraintdef(con.oid) ~
+              ('\(' || pg_catalog.quote_ident(a.attname) || '\)\.layer_id = ' || l.layer_id || '([^0-9]|$)')
+          )
+          AND (
+            pg_catalog.pg_get_constraintdef(con.oid) ~
+              ('type\(' || pg_catalog.quote_ident(a.attname) || '\) = ' || l.feature_type || '([^0-9]|$)')
+            OR pg_catalog.pg_get_constraintdef(con.oid) ~
+              ('\(' || pg_catalog.quote_ident(a.attname) || '\)\.type = ' || l.feature_type || '([^0-9]|$)')
+          )
+      ) candidate
+    ) actual_feature_column
+      ON true
   WHERE
     t.name = '${TOPONAME}'
-    AND l.topology_id = t.id
 )
 TO STDOUT;
 EOF

--- a/topology/loader/pgtopo_import
+++ b/topology/loader/pgtopo_import
@@ -242,6 +242,7 @@ if test "$SKIP_LAYERS" = "no"; then # {
 DO \$BODY\$
 DECLARE
   t topology.topology;
+  topogeom_constraint name;
 BEGIN
   SELECT * FROM topology.topology
   WHERE name = '${TOPONAME}'
@@ -269,8 +270,30 @@ BEGIN
   FROM "${schema}"."${table}";
 
   -- drop-constraint (should we not restore them at all instead?)
-  ALTER TABLE "${schema}"."${table}"
-  DROP CONSTRAINT IF EXISTS "check_topogeom_${column}";
+  SELECT con.conname
+  FROM pg_catalog.pg_constraint con
+  JOIN pg_catalog.pg_class cls
+    ON cls.oid = con.conrelid
+  JOIN pg_catalog.pg_namespace nsp
+    ON nsp.oid = cls.relnamespace
+  JOIN pg_catalog.pg_attribute att
+    ON att.attrelid = cls.oid
+    AND att.attname = '${column}'
+  WHERE nsp.nspname = '${schema}'
+    AND cls.relname = '${table}'
+    AND con.contype = 'c'
+    AND con.conname LIKE 'check_topogeom_%'
+    AND ARRAY[att.attnum] <@ con.conkey
+  INTO topogeom_constraint;
+
+  IF topogeom_constraint IS NOT NULL THEN
+    EXECUTE format(
+      'ALTER TABLE %I.%I DROP CONSTRAINT %I',
+      '${schema}',
+      '${table}',
+      topogeom_constraint
+    );
+  END IF;
 
   -- update topology_id
   UPDATE "${schema}"."${table}"

--- a/topology/test/test_pgtopo_export.sh
+++ b/topology/test/test_pgtopo_export.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+#
+# PostGIS - Spatial Types for PostgreSQL
+# http://postgis.net
+#
+# Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+#
+# This is free software; you can redistribute and/or modify it under
+# the terms of the GNU General Public Licence. See the COPYING file.
+#
+
+set -eu
+
+EXPORTER=$1
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR}/pgtopo_export_test.XXXXXX")
+
+cleanup()
+{
+	rm -rf "${WORKDIR}"
+}
+trap cleanup 0
+
+BINDIR="${WORKDIR}/bin"
+mkdir -p "${BINDIR}"
+
+cat > "${BINDIR}/psql" <<'SH'
+#!/bin/sh
+query=$(cat)
+printf '%s\n' "$query" >> "${PGTOPO_EXPORT_TEST_QUERIES}"
+
+if printf '%s\n' "$query" | grep -q 'FROM[[:space:]]*topology.topology'; then
+	printf '0\t0\t0\n'
+elif printf '%s\n' "$query" | grep -q 'actual_feature_column'; then
+	printf '1\tfeatures\tparcels\trenamed_topo\t3\t0\t\\N\n'
+fi
+SH
+chmod +x "${BINDIR}/psql"
+
+cat > "${BINDIR}/pg_dump" <<'SH'
+#!/bin/sh
+outfile=
+while test "$#" -gt 0; do
+	if test "$1" = "-f"; then
+		shift
+		outfile=$1
+	fi
+	shift
+done
+test -n "$outfile" || exit 1
+printf 'fake layer dump\n' > "$outfile"
+SH
+chmod +x "${BINDIR}/pg_dump"
+
+export PATH="${BINDIR}:$PATH"
+export PGTOPO_EXPORT_TEST_QUERIES="${WORKDIR}/queries.sql"
+
+"${EXPORTER}" -f "${WORKDIR}/topology.tgz" fake_db topo5284 > "${WORKDIR}/stdout"
+
+tar xzf "${WORKDIR}/topology.tgz" -C "${WORKDIR}"
+
+grep -q "COALESCE(actual_feature_column.feature_column, l.feature_column)" "${PGTOPO_EXPORT_TEST_QUERIES}"
+grep -q "pg_catalog.pg_get_constraintdef(con.oid)" "${PGTOPO_EXPORT_TEST_QUERIES}"
+grep -Fq "([^0-9]|$)" "${PGTOPO_EXPORT_TEST_QUERIES}"
+if grep -Fq "= ' || l.layer_id || '%'" "${PGTOPO_EXPORT_TEST_QUERIES}"; then
+	echo "pgtopo_export still uses prefix matching for layer ids" >&2
+	exit 1
+fi
+grep -q "renamed_topo" "${WORKDIR}/pgtopo_export/layers"
+
+echo "ok - pgtopo_export records renamed TopoGeometry columns from constraints"

--- a/topology/test/test_pgtopo_import.sh
+++ b/topology/test/test_pgtopo_import.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+#
+# PostGIS - Spatial Types for PostgreSQL
+# http://postgis.net
+#
+# Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+#
+# This is free software; you can redistribute and/or modify it under
+# the terms of the GNU General Public Licence. See the COPYING file.
+#
+
+set -eu
+
+IMPORTER=$1
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR}/pgtopo_import_test.XXXXXX")
+
+cleanup()
+{
+	rm -rf "${WORKDIR}"
+}
+trap cleanup 0
+
+DUMPDIR="${WORKDIR}/pgtopo_export"
+mkdir -p "${DUMPDIR}"
+
+printf '1\n' > "${DUMPDIR}/pgtopo_dump_version"
+printf '0\t0\t0\n' > "${DUMPDIR}/topology"
+printf '\\N\n' > "${DUMPDIR}/face"
+printf '\\N\n' > "${DUMPDIR}/node"
+printf '\\N\n' > "${DUMPDIR}/edge_data"
+printf '\\N\n' > "${DUMPDIR}/relation"
+printf '1\tfeatures\tparcels\trenamed_topo\t3\t0\t\\N\n' > "${DUMPDIR}/layers"
+
+(
+	cd "${WORKDIR}"
+	tar czf topology.tgz pgtopo_export
+)
+
+"${IMPORTER}" -f "${WORKDIR}/topology.tgz" restored_topology > "${WORKDIR}/restore.sql"
+
+grep -q "FROM pg_catalog.pg_constraint con" "${WORKDIR}/restore.sql"
+grep -q "con.conname LIKE 'check_topogeom_%'" "${WORKDIR}/restore.sql"
+grep -q "att.attname = 'renamed_topo'" "${WORKDIR}/restore.sql"
+grep -q "ALTER TABLE %I.%I DROP CONSTRAINT %I" "${WORKDIR}/restore.sql"
+
+if grep -q 'DROP CONSTRAINT IF EXISTS "check_topogeom_renamed_topo"' "${WORKDIR}/restore.sql"; then
+	echo "pgtopo_import still drops only the canonical constraint name" >&2
+	exit 1
+fi
+
+echo "ok - pgtopo_import drops renamed TopoGeometry constraints by catalog lookup"


### PR DESCRIPTION
## What

Fixes topology dump/reload for manually renamed TopoGeometry columns, as reported in Trac #5284.

`ALTER TABLE ... RENAME COLUMN` can leave `topology.layer.feature_column` and the restored `check_topogeom_*` constraint name out of sync with the actual column. This patch:

- lets `pgtopo_export` prefer the real TopoGeometry column when a single matching `check_topogeom_%` constraint proves the topology/layer/type metadata;
- matches that constraint metadata with numeric boundaries, so layer `1` cannot match layer `10`;
- lets `pgtopo_import` drop the restored TopoGeometry check constraint by catalog lookup before updating topology ids, then recreate the canonical constraint for the imported column;
- adds shell unit coverage for both loader scripts.

Closes https://trac.osgeo.org/postgis/ticket/5284

## Rebase

- Rebased on `upstream/master` `902880616da9cf054786b24bd243a7e454c3c34a`.
- Current head: `7bcd6071496a77cf5b1ec3eeaed8fdd30792fe41`.

## Validation

- `make -C topology check-unit`
- `sh -n topology/loader/pgtopo_export`
- `sh -n topology/loader/pgtopo_import`
- `sh -n topology/test/test_pgtopo_export.sh`
- `sh -n topology/test/test_pgtopo_import.sh`
- `make -C liblwgeom -j32`
- `make -C libpgcommon -j32`
- `make -C topology -j32`
- `sudo -n make -C topology install`
- `dropdb --if-exists postgis_reg && make -C topology check-regress RUNTESTFLAGS='--extension --verbose'`
  - first run: fresh leg passed all 84 tests, automatic upgrade leg hit a transient PostgreSQL deadlock while updating `postgis`/analyzing `spatial_ref_sys`;
  - retry: fresh and automatic-upgrade legs both passed all 84 tests.
- live export/import smoke proving a raw-renamed TopoGeometry column is exported and restored as `renamed_topo`
- `./utils/check_news.sh .`
- `git diff --check`
- `git diff upstream/master..HEAD --check`
- `git clang-format --diff upstream/master -- topology/loader/pgtopo_export topology/loader/pgtopo_import topology/test/test_pgtopo_export.sh topology/test/test_pgtopo_import.sh NEWS`

Note: top-level `make check-news` currently stops before running its recipe in this worktree because `GNUmakefile` includes missing generated `regress/dumper/tests.mk`; the direct `utils/check_news.sh` validation passes.

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/321
