### PR TITLE
Add topology RecomputeEdgeLinking

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - ST_MinimumSpanningTree, window function to calculate MST (Paul Ramsey)
  - #5993, [topology] Add max_edges parameter to TopoGeo_AddLinestring
           (Sandro Santilli)
+ - #4942, [topology] Add RecomputeEdgeLinking repair function
+          (Darafei Praliaskouski)
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)
  - #2858, ST_MMin and ST_MMax (Paul Ramsey)
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -3672,6 +3672,55 @@ faceid
 		  </refsection>
 	</refentry>
 
+	<refentry xml:id="TP_RecomputeEdgeLinking">
+	  <refnamediv>
+		<refname>RecomputeEdgeLinking</refname>
+		<refpurpose>Recomputes topology edge-linking fields.</refpurpose>
+	  </refnamediv>
+
+	  <refsynopsisdiv>
+		<funcsynopsis>
+		  <funcprototype>
+			<funcdef>bigint <function>RecomputeEdgeLinking</function></funcdef>
+			<paramdef><type>text</type> <parameter>topology_name</parameter></paramdef>
+			<paramdef choice="opt"><type>geometry</type> <parameter>bbox</parameter></paramdef>
+		  </funcprototype>
+		</funcsynopsis>
+	  </refsynopsisdiv>
+
+	  <refsection>
+		<title>Description</title>
+		<para>
+Recomputes the <varname>next_left_edge</varname>,
+<varname>abs_next_left_edge</varname>, <varname>next_right_edge</varname>,
+and <varname>abs_next_right_edge</varname> fields for edges incident to
+topology nodes selected by the optional bounding box.  When no bounding
+box is provided, links are recomputed for all non-isolated nodes in the
+topology.
+        </para>
+
+        <para>
+The function relies on correct edge endpoint metadata
+(<varname>start_node</varname> and <varname>end_node</varname>) and edge
+geometry direction.  It repairs edge-linking invalidities reported by
+<xref linkend="ValidateTopology"/>, but it does not repair broken node
+membership, edge geometry, or face labels.
+        </para>
+
+        <para>The return value is the number of edge rows updated.</para>
+
+		<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+	  </refsection>
+
+		  <refsection>
+			<title>See Also</title>
+			<para>
+<xref linkend="ValidateTopology"/>,
+<xref linkend="GetNodeEdges"/>
+            </para>
+		  </refsection>
+	</refentry>
+
 	<refentry xml:id="TP_RemoveUnusedPrimitives">
 	  <refnamediv>
 		<refname>RemoveUnusedPrimitives</refname>

--- a/topology/Makefile.in
+++ b/topology/Makefile.in
@@ -125,6 +125,7 @@ topology_upgrade.sql: ../postgis/common_before_upgrade.sql topology_before_upgra
 
 topology.sql: \
 	sql/cleanup/RemoveUnusedPrimitives.sql.in \
+	sql/cleanup/RecomputeEdgeLinking.sql.in \
 	sql/sqlmm.sql.in \
 	sql/populate.sql.in \
 	sql/polygonize.sql.in \

--- a/topology/sql/cleanup/RecomputeEdgeLinking.sql.in
+++ b/topology/sql/cleanup/RecomputeEdgeLinking.sql.in
@@ -1,0 +1,130 @@
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--
+-- PostGIS - Spatial Types for PostgreSQL
+-- http://postgis.net
+--
+-- Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
+--
+-- This is free software; you can redistribute and/or modify it under
+-- the terms of the GNU General Public Licence. See the COPYING file.
+--
+-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+-- Recompute the next_left_edge and next_right_edge links of edges incident
+-- to nodes selected by the optional bounding box.
+--
+-- Returns number of updated edge rows.
+CREATE OR REPLACE FUNCTION topology.RecomputeEdgeLinking(
+  atopology text,
+  bbox GEOMETRY DEFAULT NULL
+)
+RETURNS BIGINT AS
+$BODY$
+DECLARE
+  topo topology.topology;
+  sql TEXT;
+  updatedEdges BIGINT;
+BEGIN
+
+  topo := topology.findTopology(atopology);
+  IF topo.id IS NULL THEN
+    RAISE EXCEPTION 'Could not find topology "%"', atopology;
+  END IF;
+
+  sql := format(
+    $$
+      WITH
+      nodes AS (
+        SELECT node_id
+        FROM %1$I.node
+        WHERE containing_face IS NULL
+        AND (
+          $1 IS NULL
+          OR geom && $1
+        )
+      ),
+      incident_edges AS (
+        SELECT
+          n.node_id,
+          e.edge_id,
+          e.start_node,
+          e.end_node,
+          ST_RemoveRepeatedPoints(e.geom) AS edge_geom
+        FROM %1$I.edge_data e, nodes n
+        WHERE e.start_node = n.node_id
+        OR e.end_node = n.node_id
+      ),
+      edge_star AS (
+        SELECT
+          node_id,
+          edge_id,
+          ST_Azimuth(ST_StartPoint(edge_geom), ST_PointN(edge_geom, 2)) AS az
+        FROM incident_edges
+        WHERE start_node = node_id
+          UNION ALL
+        SELECT
+          node_id,
+          -edge_id,
+          ST_Azimuth(ST_EndPoint(edge_geom), ST_PointN(edge_geom, ST_NumPoints(edge_geom)-1))
+        FROM incident_edges
+        WHERE end_node = node_id
+      ),
+      sequenced_edge_star AS (
+        SELECT
+          row_number() over (partition by node_id order by az, edge_id) AS seq,
+          count(*) over (partition by node_id) AS seq_count,
+          *
+        FROM edge_star
+      ),
+      links AS (
+        SELECT
+          COALESCE(
+            lag(edge_id) over (
+              partition by node_id
+              order by seq
+            ),
+            last_value(edge_id) over (
+              partition by node_id
+              order by seq
+              rows between unbounded preceding and unbounded following
+            )
+          ) AS edge_id,
+          edge_id AS next_edge
+        FROM sequenced_edge_star
+        WHERE seq_count > 0
+      ),
+      edge_links AS (
+        SELECT
+          abs(edge_id) AS edge_id,
+          max(next_edge) FILTER (WHERE edge_id < 0) AS next_left_edge,
+          max(next_edge) FILTER (WHERE edge_id > 0) AS next_right_edge
+        FROM links
+        GROUP BY abs(edge_id)
+      ),
+      updated AS (
+        UPDATE %1$I.edge_data e
+        SET
+          next_left_edge = COALESCE(el.next_left_edge, e.next_left_edge),
+          abs_next_left_edge = COALESCE(abs(el.next_left_edge), e.abs_next_left_edge),
+          next_right_edge = COALESCE(el.next_right_edge, e.next_right_edge),
+          abs_next_right_edge = COALESCE(abs(el.next_right_edge), e.abs_next_right_edge)
+        FROM edge_links el
+        WHERE e.edge_id = el.edge_id
+        AND (
+          e.next_left_edge IS DISTINCT FROM COALESCE(el.next_left_edge, e.next_left_edge)
+          OR e.abs_next_left_edge IS DISTINCT FROM COALESCE(abs(el.next_left_edge), e.abs_next_left_edge)
+          OR e.next_right_edge IS DISTINCT FROM COALESCE(el.next_right_edge, e.next_right_edge)
+          OR e.abs_next_right_edge IS DISTINCT FROM COALESCE(abs(el.next_right_edge), e.abs_next_right_edge)
+        )
+        RETURNING e.edge_id
+      )
+      SELECT count(*) FROM updated
+    $$,
+    topo.name
+  );
+
+  EXECUTE sql INTO updatedEdges USING bbox;
+  RETURN updatedEdges;
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE;

--- a/topology/test/regress/recomputeedgelinking.sql
+++ b/topology/test/regress/recomputeedgelinking.sql
@@ -1,0 +1,85 @@
+\set VERBOSITY terse
+set client_min_messages to ERROR;
+set search_path to public,pg_catalog;
+
+\i :top_builddir/topology/test/load_topology.sql
+
+SELECT 'unexpected_city_data_invalidities', * FROM topology.ValidateTopology('city_data');
+
+-- Error calls
+
+SELECT 'e1', topology.RecomputeEdgeLinking('non-existent'::text);
+SELECT 'e2', topology.RecomputeEdgeLinking(NULL::text);
+
+-- Full repair
+
+BEGIN;
+UPDATE city_data.edge_data SET next_left_edge = -next_left_edge where edge_id in (9,10,20);
+UPDATE city_data.edge_data SET next_right_edge = -next_right_edge where edge_id = 19;
+UPDATE city_data.edge_data
+SET
+  next_left_edge = -next_left_edge,
+  next_right_edge = -next_right_edge
+where edge_id in (3,25);
+
+SELECT '#4942.full.before', count(*)
+FROM topology.ValidateTopology('city_data')
+WHERE error LIKE 'invalid next_%';
+SELECT '#4942.full.updated', topology.RecomputeEdgeLinking('city_data');
+SELECT '#4942.full.after', * FROM topology.ValidateTopology('city_data')
+UNION
+SELECT '#4942.full.after', '---', null, null
+ORDER BY 1,2,3,4;
+ROLLBACK;
+
+-- Repair also refreshes the absolute next-edge cache columns.
+
+BEGIN;
+UPDATE city_data.edge_data
+SET abs_next_left_edge = abs_next_left_edge + 1000
+WHERE edge_id = 9;
+UPDATE city_data.edge_data
+SET abs_next_right_edge = abs_next_right_edge + 1000
+WHERE edge_id = 19;
+
+SELECT
+  '#4942.abs.before',
+  edge_id,
+  abs_next_left_edge = abs(next_left_edge),
+  abs_next_right_edge = abs(next_right_edge)
+FROM city_data.edge_data
+WHERE edge_id IN (9, 19)
+ORDER BY edge_id;
+SELECT '#4942.abs.updated', topology.RecomputeEdgeLinking('city_data');
+SELECT
+  '#4942.abs.after',
+  edge_id,
+  abs_next_left_edge = abs(next_left_edge),
+  abs_next_right_edge = abs(next_right_edge)
+FROM city_data.edge_data
+WHERE edge_id IN (9, 19)
+ORDER BY edge_id;
+ROLLBACK;
+
+-- Bbox repair is scoped to nodes intersecting the supplied bbox.
+
+BEGIN;
+UPDATE city_data.edge_data SET next_left_edge = -next_left_edge where edge_id in (9,10,20);
+UPDATE city_data.edge_data SET next_right_edge = -next_right_edge where edge_id = 19;
+UPDATE city_data.edge_data
+SET
+  next_left_edge = -next_left_edge,
+  next_right_edge = -next_right_edge
+where edge_id in (3,25);
+
+SELECT '#4942.bbox.updated', topology.RecomputeEdgeLinking(
+  'city_data',
+  (SELECT ST_Expand(geom, 0.1) FROM city_data.node WHERE node_id = 14)
+);
+SELECT '#4942.bbox.remaining', * FROM topology.ValidateTopology('city_data')
+UNION
+SELECT '#4942.bbox.remaining', '---', null, null
+ORDER BY 1,2,3,4;
+ROLLBACK;
+
+SELECT NULL FROM topology.DropTopology('city_data');

--- a/topology/test/regress/recomputeedgelinking_expected
+++ b/topology/test/regress/recomputeedgelinking_expected
@@ -1,0 +1,16 @@
+ERROR:  Could not find topology "non-existent"
+ERROR:  Could not find topology "<NULL>"
+#4942.full.before|8
+#4942.full.updated|6
+#4942.full.after|---||
+#4942.abs.before|9|f|t
+#4942.abs.before|19|t|f
+#4942.abs.updated|2
+#4942.abs.after|9|t|t
+#4942.abs.after|19|t|t
+#4942.bbox.updated|4
+#4942.bbox.remaining|---||
+#4942.bbox.remaining|invalid next_left_edge|3|-3
+#4942.bbox.remaining|invalid next_left_edge|25|-25
+#4942.bbox.remaining|invalid next_right_edge|3|2
+#4942.bbox.remaining|invalid next_right_edge|25|25

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -51,6 +51,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/polygonize.sql \
 	$(top_srcdir)/topology/test/regress/populate_topology_layer.sql \
 	$(top_srcdir)/topology/test/regress/removeunusedprimitives.sql \
+	$(top_srcdir)/topology/test/regress/recomputeedgelinking.sql \
 	$(top_srcdir)/topology/test/regress/renametopogeometrycolumn.sql \
 	$(top_srcdir)/topology/test/regress/renametopology.sql \
 	$(top_srcdir)/topology/test/regress/share_sequences.sql \

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -1430,6 +1430,7 @@ LANGUAGE 'plpgsql' VOLATILE STRICT;
 
 -- Cleanup functions
 #include "sql/cleanup/RemoveUnusedPrimitives.sql.in"
+#include "sql/cleanup/RecomputeEdgeLinking.sql.in"
 
 
 CREATE OR REPLACE FUNCTION topology.postgis_topology_scripts_installed() RETURNS text


### PR DESCRIPTION
Trac ticket: https://trac.osgeo.org/postgis/ticket/4942

This adds `topology.RecomputeEdgeLinking(topology_name text, bbox geometry DEFAULT NULL)` as a public topology cleanup function. It rebuilds signed `next_left_edge` / `next_right_edge` links from each selected node star using the same node selection, geometry normalization, azimuth ordering, and signed-edge convention used by `ValidateTopology`.

The optional bbox is scoped to topology nodes (`node.geom && bbox`), matching the existing validation behavior. The function updates the incident side for selected nodes, refreshes the `abs_next_left_edge` / `abs_next_right_edge` cache columns, and returns the number of edge rows changed.

Validation run locally:

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32 postgis_revision.h && make -j32 -C postgis && make -j32 -C topology`
- `make -j32 -C extensions`
- `sudo make -C postgis install && sudo make -C topology install && sudo make -C extensions/postgis install && sudo make -C extensions/postgis_topology install`
- `POSTGIS_REGRESS_DB=pgis_4942_recompute_check_1781963477765439048 perl regress/run_test.pl --extension --verbose --topology --nodrop $(pwd)/topology/test/regress/recomputeedgelinking`
- `POSTGIS_REGRESS_DB=pgis_4942_validate_1781963488843357448 perl regress/run_test.pl --extension --verbose --topology --nodrop $(pwd)/topology/test/regress/validatetopology`
- `make -C doc check`
- `./utils/check_news.sh && git diff --check`
- `make -C topology check-unit`

Rebase and review-follow-up validation on current `master` (`902880616da9cf054786b24bd243a7e454c3c34a`) at head `24839412d32b7cc939a3149daa5df5f70b6adb0e`:

- `make -C topology topology.sql`
- `make -C topology -j1`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/recomputeedgelinking"`
- `make -C topology check-unit`
- `make -C doc check`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- topology/sql/cleanup/RecomputeEdgeLinking.sql.in topology/test/regress/recomputeedgelinking.sql topology/test/regress/recomputeedgelinking_expected topology/topology.sql.in topology/test/tests.mk doc/extras_topology.xml NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/319
