### PR TITLE
Fix TopoGeo_AddLineString start-on-edge noding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -90,6 +90,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
  - #2807, [raster] Preserve missing NODATA values in ST_MapAlgebra outputs
           (Darafei Praliaskouski)
+ - #2038, [topology] Split existing edges before adding lines that start on
+          the edge and leave it (Darafei Praliaskouski)
  - #2832, [raster] Avoid padding single-tile raster2pgsql overviews
           when padding is not requested (Darafei Praliaskouski)
  - #2623, Generate a pgsql2shp GID field when exporting geometry-only

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7071,6 +7071,159 @@ lwt_AddPoint(LWT_TOPOLOGY* topo, LWPOINT* point, double tol)
   return _lwt_AddPoint(topo, point, tol, 1, NULL, NULL);
 }
 
+static int
+_lwt_LineVertexLeavesEdge(const LWLINE *line, uint32_t vertex, const POINT2D *edgeStart, const POINT2D *edgeEnd)
+{
+	const int isClosed = lwline_is_closed(line);
+	const uint32_t npoints = line->points->npoints;
+	const POINT2D *prev = NULL;
+	const POINT2D *next = NULL;
+
+	if (vertex > 0)
+		prev = getPoint2d_cp(line->points, vertex - 1);
+	else if (isClosed && npoints > 2)
+		prev = getPoint2d_cp(line->points, npoints - 2);
+
+	if (vertex + 1 < npoints)
+		next = getPoint2d_cp(line->points, vertex + 1);
+	else if (isClosed && npoints > 2)
+		next = getPoint2d_cp(line->points, 1);
+
+	if (prev && lw_segment_side(edgeStart, edgeEnd, prev) != 0)
+		return 1;
+	if (next && lw_segment_side(edgeStart, edgeEnd, next) != 0)
+		return 1;
+
+	return 0;
+}
+
+static int
+_lwt_EdgeShouldSplitAtLineVertex(const LWT_ISO_EDGE *edge,
+				 const LWLINE *line,
+				 uint32_t vertex,
+				 const POINT2D *point,
+				 double tol)
+{
+	double dist;
+	double segLen2;
+	double location;
+	int closestSeg = ptarray_closest_segment_2d(edge->geom->points, point, &dist);
+	const POINT2D *segStart = getPoint2d_cp(edge->geom->points, closestSeg);
+	const POINT2D *segEnd = getPoint2d_cp(edge->geom->points, closestSeg + 1);
+
+	if (dist != 0 && dist >= tol)
+		return 0;
+
+	segLen2 = (segEnd->x - segStart->x) * (segEnd->x - segStart->x) +
+		  (segEnd->y - segStart->y) * (segEnd->y - segStart->y);
+	if (segLen2 == 0)
+		return 0;
+
+	location = ((point->x - segStart->x) * (segEnd->x - segStart->x) +
+		    (point->y - segStart->y) * (segEnd->y - segStart->y)) /
+		   segLen2;
+	/* Actual edge endpoints already have topology nodes; intermediate shape vertices do not. */
+	if (location <= 0 && closestSeg == 0)
+		return 0;
+	if (location >= 1 && (uint32_t)(closestSeg + 1) == edge->geom->points->npoints - 1)
+		return 0;
+
+	return _lwt_LineVertexLeavesEdge(line, vertex, segStart, segEnd);
+}
+
+static int
+_lwt_SplitEdgesByLineVertices(LWT_TOPOLOGY *topo, const LWLINE *line, double tol)
+{
+	int numSplitEdges = 0;
+	const int isClosed = lwline_is_closed(line);
+	uint32_t i;
+
+	for (i = 0; i < line->points->npoints; ++i)
+	{
+		LWPOINT *point;
+		LWGEOM *pointGeom;
+		const POINT2D *p2d;
+		double ptol;
+		double node_tol;
+		uint64_t numNodes = 0;
+		uint64_t numEdges = 0;
+		uint64_t n;
+		int pointIsExistingNode = 0;
+		LWT_ISO_NODE *nodes;
+		LWT_ISO_EDGE *edges;
+
+		if (isClosed && i == line->points->npoints - 1)
+			continue;
+		if (i != 0)
+			continue;
+
+		point = lwline_get_lwpoint(line, i);
+		pointGeom = lwpoint_as_lwgeom(point);
+		p2d = getPoint2d_cp(point->point, 0);
+		ptol = _lwt_minTolerance(pointGeom);
+		/* Match the later snap tolerance when deciding whether a pre-split
+		 * would duplicate an existing endpoint node. */
+		node_tol = FP_MAX(ptol, tol);
+
+		nodes = lwt_be_getNodeWithinDistance2D(
+		    topo, point, node_tol, &numNodes, LWT_COL_NODE_NODE_ID | LWT_COL_NODE_GEOM, 0);
+		if (numNodes == UINT64_MAX)
+		{
+			lwpoint_free(point);
+			PGTOPO_BE_ERROR();
+			return -1;
+		}
+		for (n = 0; n < numNodes; ++n)
+		{
+			LWGEOM *nodeGeom = lwpoint_as_lwgeom(nodes[n].geom);
+			double dist = lwgeom_mindistance2d(nodeGeom, pointGeom);
+			if (dist == 0 || dist < node_tol)
+			{
+				pointIsExistingNode = 1;
+				break;
+			}
+		}
+		if (numNodes)
+			_lwt_release_nodes(nodes, numNodes);
+		if (pointIsExistingNode)
+		{
+			lwpoint_free(point);
+			continue;
+		}
+
+		edges = lwt_be_getEdgeWithinDistance2D(topo, point, ptol, &numEdges, LWT_COL_EDGE_ALL, 0);
+		if (numEdges == UINT64_MAX)
+		{
+			lwpoint_free(point);
+			PGTOPO_BE_ERROR();
+			return -1;
+		}
+		for (n = 0; n < numEdges; ++n)
+		{
+			LWT_ELEMID id;
+			int moved = 0;
+
+			if (!_lwt_EdgeShouldSplitAtLineVertex(&(edges[n]), line, i, p2d, ptol))
+				continue;
+
+			id = _lwt_SplitAllEdgesToNewNode(topo, &(edges[n]), 1, point, ptol, &moved);
+			if (id == -1)
+			{
+				if (numEdges)
+					_lwt_release_edges(edges, numEdges);
+				lwpoint_free(point);
+				return -1;
+			}
+			++numSplitEdges;
+		}
+		if (numEdges)
+			_lwt_release_edges(edges, numEdges);
+		lwpoint_free(point);
+	}
+
+	return numSplitEdges;
+}
+
 /*
  * Add a pre-noded pre-split line edge. Used by lwt_AddLine
  * Return edge id, 0 if none added (empty edge), -1 on error
@@ -7343,6 +7496,7 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
   GBOX qbox;
   int forward;
   int input_was_closed = 0;
+  double min_geometric_tol;
   POINT4D originalStartPoint;
 
   if ( lwline_is_empty(line) )
@@ -7362,8 +7516,24 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
 
   /* Get tolerance, if 0 was given */
   if ( tol == -1 ) tol = _LWT_MINTOLERANCE( topo, (LWGEOM*)line );
+  min_geometric_tol = _lwt_minTolerance((LWGEOM *)line);
   LWDEBUGF(1, "Working tolerance:%.15g", tol);
   LWDEBUGF(1, "Input line has srid=%d", line->srid);
+
+  if (tol <= min_geometric_tol)
+  {
+	  num_new_edges = _lwt_SplitEdgesByLineVertices(topo, line, tol);
+	  if (num_new_edges < 0)
+	  {
+		  return NULL;
+	  }
+	  if (maxNewEdges >= 0 && num_new_edges > maxNewEdges)
+	  {
+		  lwerror("Adding line to topology requires creating more edges than the requested limit of %d",
+			  maxNewEdges);
+		  return NULL;
+	  }
+  }
 
   /* Remove consecutive vertices below given tolerance upfront */
   if ( tol )

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -248,6 +248,69 @@ SELECT check_changes('#1706.2');
 -- Consistency check
 SELECT * FROM ValidateTopology('city_data');
 
+-- Test re-noding after snapped endpoint splits an edge
+-- See http://trac.osgeo.org/postgis/ticket/2038
+
+DELETE FROM city_data.edge_data; DELETE FROM city_data.node;
+DELETE FROM city_data.face where face_id > 0;
+
+SELECT '#2038.1', TopoGeo_AddLineString('city_data',
+  ST_GeometryFromText('LINESTRING( 72.91981 20.95009,72.91082 20.95759)',4326));
+
+SELECT '#2038.2', count(*) FROM TopoGeo_AddLineString('city_data',
+  ST_GeometryFromText('LINESTRING(72.9123215921439 20.9563372813038,72.9122229474764 20.9564195766326, 72.9130010661966 20.9562352183313,72.9123215921439 20.9563372813038)',4326));
+
+-- Consistency check
+SELECT '#2038.invalidity', * FROM ValidateTopology('city_data');
+
+DELETE FROM city_data.edge_data; DELETE FROM city_data.node;
+DELETE FROM city_data.face where face_id > 0;
+
+SELECT '#2038.vertex.1', count(*) FROM TopoGeo_AddLineString('city_data',
+  ST_GeometryFromText('LINESTRING(0 0,5 0,10 0)',4326));
+
+SELECT '#2038.vertex.2', count(*) FROM TopoGeo_AddLineString('city_data',
+  ST_GeometryFromText('LINESTRING(5 0,5 5)',4326));
+
+SELECT '#2038.vertex.edges', count(*) FROM city_data.edge_data;
+
+-- Consistency check
+SELECT '#2038.vertex.invalidity', * FROM ValidateTopology('city_data');
+
+SELECT '#2038.precision.start', CreateTopology('t2038_precision', 4326, 1) > 0;
+
+SELECT '#2038.precision.edge.1', count(*) FROM TopoGeo_AddLineString(
+  't2038_precision',
+  'SRID=4326;LINESTRING(0 0,10 0)'::geometry, -1.0::float8, -1);
+
+SELECT '#2038.precision.edge.2', count(*) FROM TopoGeo_AddLineString(
+  't2038_precision',
+  'SRID=4326;LINESTRING(0.5 0,0.5 1)'::geometry, -1.0::float8, -1);
+
+SELECT '#2038.precision.nodes', count(*), string_agg(ST_AsText(geom), ',' ORDER BY node_id)
+  FROM t2038_precision.node;
+
+SELECT '#2038.precision.invalidity', count(*) FROM ValidateTopology('t2038_precision');
+
+SELECT DropTopology('t2038_precision');
+
+SELECT '#2038.endpoint_tol.start', CreateTopology('t2038_endpoint_tol', 4326) > 0;
+
+SELECT '#2038.endpoint_tol.edge.1', count(*) FROM TopoGeo_AddLineString('t2038_endpoint_tol',
+  'SRID=4326;LINESTRING(0 0,10 0)'::geometry);
+
+SELECT '#2038.endpoint_tol.edge.2', count(*) FROM TopoGeo_AddLineString('t2038_endpoint_tol',
+  'SRID=4326;LINESTRING(0.000001 0,1000000000 1)'::geometry);
+
+SELECT '#2038.endpoint_tol.nodes', count(*), string_agg(ST_AsText(geom), ',' ORDER BY node_id)
+  FROM t2038_endpoint_tol.node;
+
+SELECT '#2038.endpoint_tol.edges', count(*) FROM t2038_endpoint_tol.edge_data;
+
+SELECT '#2038.endpoint_tol.invalidity', count(*) FROM ValidateTopology('t2038_endpoint_tol');
+
+SELECT DropTopology('t2038_endpoint_tol');
+
 -- Test noding after snap
 -- See http://trac.osgeo.org/postgis/ticket/1714
 

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -163,9 +163,27 @@ iso_ex_2segs|28
 #1706.2|E|LINESTRING(10 10,9 12)
 #1706.2|E|LINESTRING(20 10,15 10)
 #1706.2|E|LINESTRING(9 12,10 20)
-#1714.1|N|77
+#2038.1|75
+#2038.2|2
+#2038.vertex.1|1
+#2038.vertex.2|1
+#2038.vertex.edges|3
+#2038.precision.start|t
+#2038.precision.edge.1|1
+#2038.precision.edge.2|1
+#2038.precision.nodes|3|POINT(0 0),POINT(10 0),POINT(0.5 1)
+#2038.precision.invalidity|0
+Topology 't2038_precision' dropped
+#2038.endpoint_tol.start|t
+#2038.endpoint_tol.edge.1|1
+#2038.endpoint_tol.edge.2|2
+#2038.endpoint_tol.nodes|3|POINT(0 0),POINT(10 0),POINT(1000000000 1)
+#2038.endpoint_tol.edges|2
+#2038.endpoint_tol.invalidity|0
+Topology 't2038_endpoint_tol' dropped
+#1714.1|N|85
 #1714.1|N|0|POINT(10 0)
-#1714.2|E*|75
+#1714.2|E*|82
 #1714.2|N||POINT(0 20)
 #1714.2|E|LINESTRING(10 0,0 20)
 Topology 'city_data' dropped


### PR DESCRIPTION
## Summary
- split an existing edge before line insertion when the new line starts on that edge and immediately leaves it
- handle both interior points on a segment and intermediate shape vertices of multi-segment edges
- keep the pre-split limited to geometric minimum-tolerance first endpoints so topology-precision snapping paths keep existing behavior
- check nearby endpoint nodes with the working tolerance before pre-splitting, so wide-coordinate input lines do not create duplicate raw-coordinate nodes inside snap tolerance
- add regression coverage for Trac #2038, including the intermediate-vertex case, a nonzero-precision topology case, and a wide-coordinate endpoint-tolerance case from review

Closes https://trac.osgeo.org/postgis/ticket/2038

## Review follow-up
- use geometric minimum tolerance, not topology precision, for the pre-split gate
- cover default-tolerance insertion in a precision-1 topology so a precision-close start point snaps through the existing endpoint path instead of creating a raw start-coordinate node
- keep the pre-split path from duplicating an existing endpoint node when the whole-line working tolerance is larger than the start point's geometric tolerance

## Rebase refresh
- 2026-06-22: rebased over upstream/master `902880616da9cf054786b24bd243a7e454c3c34a` and force-pushed head `c4e96c3d889e071776c486bd790f974003877962`

## Testing
- `make -C liblwgeom -j32`
- `make -C topology -j32`
- `make -C extensions/postgis_topology -j1`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres PGPASSWORD=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring"` (fresh + automatic upgrade)
- `./utils/check_news.sh .`
- `git diff --check && git diff upstream/master..HEAD --check`
- `git clang-format --diff upstream/master -- liblwgeom/topo/lwgeom_topo.c topology/test/regress/topogeo_addlinestring.sql topology/test/regress/topogeo_addlinestring_expected NEWS`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/318
