### PR TITLE
Speed up topology face reconstruction

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -130,6 +130,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2808, Clarify postgis_full_version() output when installed component
           scripts are newer than core scripts (Darafei Praliaskouski)
+ - #4966, [topology] Speed up ST_GetFaceGeometry for faces with many holes
+          (Darafei Praliaskouski)
  - #3179, Mark truncated libpgcommon PostgreSQL messages instead of silently
           dropping the tail (Darafei Praliaskouski)
  - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for

--- a/liblwgeom/lwgeom_geos.c
+++ b/liblwgeom/lwgeom_geos.c
@@ -1101,6 +1101,100 @@ lwgeom_buildarea(const LWGEOM* geom)
 	return result;
 }
 
+LWGEOM *
+lwgeom_buildarea_polygonize_largest(const LWGEOM *geom)
+{
+	LWGEOM *result;
+	int32_t srid = RESULT_SRID(geom);
+	uint8_t is3d = FLAGS_GET_Z(geom->flags);
+	const GEOSGeometry *polylines[1];
+	GEOSGeometry *g1, *g3;
+	const GEOSGeometry *candidate;
+	int numgeoms, i;
+	double largest_shell_area = -1;
+
+	if (srid == SRID_INVALID)
+		return NULL;
+
+	if (lwgeom_is_empty(geom))
+		return (LWGEOM *)lwpoly_construct_empty(srid, is3d, 0);
+
+	initGEOS(lwnotice, lwgeom_geos_error);
+
+	if (!(g1 = LWGEOM2GEOS(geom, AUTOFIX)))
+		GEOS_FAIL();
+
+	polylines[0] = g1;
+	g3 = GEOSPolygonize(polylines, 1);
+	if (!g3)
+		GEOS_FREE_AND_FAIL(g1);
+	GEOSSetSRID(g3, srid);
+
+	numgeoms = GEOSGetNumGeometries(g3);
+	if (numgeoms == 0)
+	{
+		GEOS_FREE(g1, g3);
+		return NULL;
+	}
+
+	result = NULL;
+	for (i = 0; i < numgeoms; i++)
+	{
+		double shell_area;
+		LWGEOM *candidate_lwgeom;
+		LWPOLY *candidate_poly;
+
+		candidate = GEOSGetGeometryN(g3, i);
+		if (!candidate)
+			continue;
+
+		if (!(candidate_lwgeom = GEOS2LWGEOM(candidate, is3d)))
+		{
+			if (result)
+				lwgeom_free(result);
+			GEOS_FREE(g1, g3);
+			return NULL;
+		}
+
+		candidate_poly = lwgeom_as_lwpoly(candidate_lwgeom);
+		if (!candidate_poly || candidate_poly->nrings == 0)
+		{
+			lwgeom_free(candidate_lwgeom);
+			continue;
+		}
+
+		/*
+		 * Polygonize emits both the shell-with-holes polygon and polygons
+		 * filling the holes. Select by shell footprint, not net polygon area,
+		 * so a large hole cannot outrank its containing face.
+		 */
+		shell_area = fabs(ptarray_signed_area(candidate_poly->rings[0]));
+		if (shell_area > largest_shell_area)
+		{
+			if (result)
+				lwgeom_free(result);
+			result = candidate_lwgeom;
+			largest_shell_area = shell_area;
+		}
+		else
+		{
+			lwgeom_free(candidate_lwgeom);
+		}
+	}
+
+	if (!result)
+	{
+		GEOS_FREE(g1, g3);
+		return NULL;
+	}
+
+	result->srid = srid;
+
+	GEOS_FREE(g1, g3);
+
+	return result;
+}
+
 /* ------------ end of BuildArea stuff ---------------------------------------------------------------------} */
 
 int

--- a/liblwgeom/lwgeom_geos.h
+++ b/liblwgeom/lwgeom_geos.h
@@ -54,6 +54,7 @@ int union_dbscan(LWGEOM **geoms,
 		 uint8_t **is_in_cluster_ret);
 
 POINTARRAY* ptarray_from_GEOSCoordSeq(const GEOSCoordSequence* cs, uint8_t want3d);
+LWGEOM *lwgeom_buildarea_polygonize_largest(const LWGEOM *geom);
 
 extern char lwgeom_geos_errmsg[];
 extern void lwgeom_geos_error(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -2998,6 +2998,7 @@ _lwt_FaceByEdges(LWT_TOPOLOGY *topo, LWT_ISO_EDGE *edges, int numfaceedges)
   LWCOLLECTION *bounds;
   LWGEOM **geoms = lwalloc( sizeof(LWGEOM*) * numfaceedges );
   int i, validedges = 0;
+  int has_same_face_edge = 0;
 
   for ( i=0; i<numfaceedges; ++i )
   {
@@ -3007,6 +3008,10 @@ _lwt_FaceByEdges(LWT_TOPOLOGY *topo, LWT_ISO_EDGE *edges, int numfaceedges)
      * TODO: update legacy tests expectances/unleash this skipping ?
      */
     /* if ( edges[i].face_left == edges[i].face_right ) continue; */
+    if (edges[i].face_left == edges[i].face_right)
+    {
+	    has_same_face_edge = 1;
+    }
     geoms[validedges++] = lwline_as_lwgeom(edges[i].geom);
   }
   if ( ! validedges )
@@ -3024,7 +3029,16 @@ _lwt_FaceByEdges(LWT_TOPOLOGY *topo, LWT_ISO_EDGE *edges, int numfaceedges)
                                   NULL, /* gbox */
                                   validedges,
                                   geoms);
-  outg = lwgeom_buildarea( lwcollection_as_lwgeom(bounds) );
+  /*
+  ** Valid topology faces can be reconstructed directly from polygonized
+  ** boundary linework, avoiding the extra overlay work in GEOSBuildArea.
+  ** Same-face edges are internal linework and can split polygonize output.
+  */
+  outg = has_same_face_edge ? NULL : lwgeom_buildarea_polygonize_largest(lwcollection_as_lwgeom(bounds));
+  if (!outg)
+  {
+	  outg = lwgeom_buildarea(lwcollection_as_lwgeom(bounds));
+  }
   lwcollection_release(bounds);
   lwfree(geoms);
 #if 0

--- a/topology/test/regress/st_getfacegeometry.sql
+++ b/topology/test/regress/st_getfacegeometry.sql
@@ -18,7 +18,7 @@ COPY tt.edge_data(
 	edge_id, start_node, end_node,
 	abs_next_left_edge, abs_next_right_edge,
 	next_left_edge, next_right_edge,
-        left_face, right_face, geom) FROM STDIN;
+	left_face, right_face, geom) FROM STDIN;
 1	1	1	1	1	1	-1	1	2	LINESTRING(2 2, 2  8,  8  8,  8 2, 2 2)
 2	2	2	2	2	2	-2	0	1	LINESTRING(0 0, 0 10, 10 10, 10 0, 0 0)
 3	3	3	3	3	3	-3	0	3	LINESTRING(12 2, 12 8, 18 8, 18 2, 12 2)
@@ -28,6 +28,78 @@ COPY tt.edge_data(
 -- See http://trac.osgeo.org/postgis/ticket/726
 SELECT 'f1 (with hole)', ST_asText(topology.st_getfacegeometry('tt', 1));
 SELECT 'f2 (fill hole)', ST_asText(topology.st_getfacegeometry('tt', 2));
+
+-- Face with multiple holes
+-- See http://trac.osgeo.org/postgis/ticket/4966
+COPY tt.face(face_id, mbr) FROM STDIN;
+10	POLYGON((20 0,20 10,30 10,30 0,20 0))
+11	POLYGON((22 2,22 4,24 4,24 2,22 2))
+12	POLYGON((26 6,26 8,28 8,28 6,26 6))
+\.
+
+COPY tt.node(node_id, geom) FROM STDIN;
+10	POINT(20 0)
+11	POINT(22 2)
+12	POINT(26 6)
+\.
+
+COPY tt.edge_data(
+	edge_id, start_node, end_node,
+	abs_next_left_edge, abs_next_right_edge,
+	next_left_edge, next_right_edge,
+	left_face, right_face, geom) FROM STDIN;
+10	10	10	10	10	10	-10	0	10	LINESTRING(20 0,20 10,30 10,30 0,20 0)
+11	11	11	11	11	11	-11	10	11	LINESTRING(22 2,22 4,24 4,24 2,22 2)
+12	12	12	12	12	12	-12	10	12	LINESTRING(26 6,26 8,28 8,28 6,26 6)
+\.
+
+SELECT 'f10 (two holes)', ST_asText(topology.st_getfacegeometry('tt', 10));
+
+-- Face with a hole larger than the surrounding annulus
+-- See http://trac.osgeo.org/postgis/ticket/4966
+COPY tt.face(face_id, mbr) FROM STDIN;
+20	POLYGON((40 0,40 10,50 10,50 0,40 0))
+21	POLYGON((40.5 0.5,40.5 9.5,49.5 9.5,49.5 0.5,40.5 0.5))
+\.
+
+COPY tt.node(node_id, geom) FROM STDIN;
+20	POINT(40 0)
+21	POINT(40.5 0.5)
+\.
+
+COPY tt.edge_data(
+	edge_id, start_node, end_node,
+	abs_next_left_edge, abs_next_right_edge,
+	next_left_edge, next_right_edge,
+	left_face, right_face, geom) FROM STDIN;
+20	20	20	20	20	20	-20	0	20	LINESTRING(40 0,40 10,50 10,50 0,40 0)
+21	21	21	21	21	21	-21	20	21	LINESTRING(40.5 0.5,40.5 9.5,49.5 9.5,49.5 0.5,40.5 0.5)
+\.
+
+SELECT 'f20 (large hole)', ST_asText(topology.st_getfacegeometry('tt', 20));
+
+-- Face subdivided by a same-face bridge edge should keep the full face.
+-- See http://trac.osgeo.org/postgis/ticket/4966
+COPY tt.face(face_id, mbr) FROM STDIN;
+30	POLYGON((60 0,60 10,70 10,70 0,60 0))
+\.
+
+COPY tt.node(node_id, geom) FROM STDIN;
+30	POINT(60 0)
+31	POINT(60 10)
+32	POINT(70 0)
+\.
+
+COPY tt.edge_data(
+	edge_id, start_node, end_node,
+	abs_next_left_edge, abs_next_right_edge,
+	next_left_edge, next_right_edge,
+	left_face, right_face, geom) FROM STDIN;
+30	30	30	30	30	30	-30	0	30	LINESTRING(60 0,60 10,70 10,70 0,60 0)
+31	31	32	31	31	31	-31	30	30	LINESTRING(60 10,70 0)
+\.
+
+SELECT 'f30 (same-face bridge)', ST_asText(topology.st_getfacegeometry('tt', 30));
 
 -- Universal face has no geometry
 -- See http://trac.osgeo.org/postgis/ticket/973

--- a/topology/test/regress/st_getfacegeometry_expected
+++ b/topology/test/regress/st_getfacegeometry_expected
@@ -1,6 +1,9 @@
 t
 f1 (with hole)|POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,8 2,8 8,2 8,2 2))
 f2 (fill hole)|POLYGON((2 2,2 8,8 8,8 2,2 2))
+f10 (two holes)|POLYGON((20 0,20 10,30 10,30 0,20 0),(22 2,24 2,24 4,22 4,22 2),(26 6,28 6,28 8,26 8,26 6))
+f20 (large hole)|POLYGON((40 0,40 10,50 10,50 0,40 0),(40.5 0.5,49.5 0.5,49.5 9.5,40.5 9.5,40.5 0.5))
+f30 (same-face bridge)|POLYGON((60 0,60 10,70 10,70 0,60 0))
 ERROR:  SQL/MM Spatial exception - universal face has no geometry
 ERROR:  SQL/MM Spatial exception - null argument
 ERROR:  SQL/MM Spatial exception - null argument


### PR DESCRIPTION
## Summary

Trac ticket: https://trac.osgeo.org/postgis/ticket/4966

This adds a topology fast path for `ST_GetFaceGeometry`: valid face boundary linework is polygonized and a face polygon is returned directly, avoiding the extra `GEOSBuildArea` overlay work that dominates faces with many holes. If polygonization cannot produce a polygon, the code falls back to the existing `lwgeom_buildarea` path.

Polygonized candidates are ranked by exterior-shell footprint rather than net polygon area, so a large filled-hole polygon cannot outrank the containing shell-with-hole face.

When same-face bridge or cut edges are present, the wrapper skips the polygonize fast path and falls back to `GEOSBuildArea`, because internal linework can split polygonize output and otherwise return only part of the face.

Regression coverage adds:

- a face containing two holes
- a 10x10 shell with a 9x9 hole, where the expected result keeps the shell-with-hole polygon
- a square face containing a diagonal same-face edge, where the expected result remains the full square

## Validation

Current head: `17134df4b2bb5113da7ca43d7e2c2f1faf198c1b`

Rebased onto `upstream/master` at `902880616da9cf054786b24bd243a7e454c3c34a`.

Commands run:

```bash
make -C liblwgeom -j32
make -C topology -j32
sudo -n make -C topology install
sudo -n make -C extensions/postgis_topology install
dropdb --if-exists postgis_reg
PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/st_getfacegeometry"
make -C liblwgeom/cunit cu_tester
./liblwgeom/cunit/cu_tester topology
make -C extensions/postgis_topology -j1
./utils/check_news.sh .
git diff --check
git diff upstream/master..HEAD --check
git clang-format --diff upstream/master -- liblwgeom/topo/lwgeom_topo.c liblwgeom/lwgeom_geos.c liblwgeom/lwgeom_geos.h topology/test/regress/st_getfacegeometry.sql topology/test/regress/st_getfacegeometry_expected NEWS
```

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/317
