### PR TITLE
Clarify newer topology script version reporting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -98,6 +98,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GH-888, [sfcgal] Avoid stale detoasted geometry access in
           CG_Visibility empty-input handling for SFCGAL < 2.2
           (Darafei Praliaskouski)
+ - #2808, Clarify postgis_full_version() output when installed topology
+          scripts are newer than core scripts (Darafei Praliaskouski)
  - #3179, Mark truncated libpgcommon PostgreSQL messages instead of silently
           dropping the tail (Darafei Praliaskouski)
  - #6003, Avoid size_t formats in liblwgeom logging/error wrappers for

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -3326,6 +3326,8 @@ DECLARE
 	rast_lib_ver text := NULL;
 	rast_scr_ver text := NULL;
 	topo_scr_ver text := NULL;
+	topo_scr_ver_int int[];
+	relproc_int int[];
 	json_lib_ver text;
 	protobuf_lib_ver text;
 	wagyu_lib_ver text;
@@ -3471,7 +3473,30 @@ BEGIN
 	IF topo_scr_ver IS NOT NULL THEN
 		fullver = fullver || ' TOPOLOGY';
 		IF topo_scr_ver != relproc THEN
-			fullver = fullver || ' (topology procs from "' || topo_scr_ver || '" need upgrade)';
+			BEGIN
+				topo_scr_ver_int := pg_catalog.string_to_array(
+					pg_catalog.regexp_replace(topo_scr_ver, '[^0-9.].*', ''),
+					'.'
+				)::int[];
+				relproc_int := pg_catalog.string_to_array(
+					pg_catalog.regexp_replace(relproc, '[^0-9.].*', ''),
+					'.'
+				)::int[];
+			EXCEPTION WHEN OTHERS THEN
+				topo_scr_ver_int := NULL;
+				relproc_int := NULL;
+			END;
+
+			IF topo_scr_ver_int IS NOT NULL AND topo_scr_ver_int > relproc_int THEN
+				fullver = pg_catalog.format(
+					'%s (topology procs from "%s" are newer than core procs from "%s")',
+					fullver,
+					topo_scr_ver,
+					relproc
+				);
+			ELSE
+				fullver = fullver || ' (topology procs from "' || topo_scr_ver || '" need upgrade)';
+			END IF;
 		END IF;
 		IF core_is_extension AND NOT EXISTS (
 			SELECT * FROM pg_catalog.pg_extension

--- a/regress/core/postgis_full_version.sql
+++ b/regress/core/postgis_full_version.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_catalog.pg_namespace
+		WHERE nspname = 'topology'
+	) THEN
+		CREATE SCHEMA topology;
+	END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION topology.postgis_topology_scripts_installed()
+RETURNS text
+AS $$ SELECT '1.0.0'::text AS version $$
+LANGUAGE 'sql' IMMUTABLE;
+
+SELECT 'topology_old_scripts',
+	postgis_full_version() ~
+		'TOPOLOGY \(topology procs from "1\.0\.0" need upgrade\)';
+
+CREATE OR REPLACE FUNCTION topology.postgis_topology_scripts_installed()
+RETURNS text
+AS $$ SELECT '999.0.0dev'::text AS version $$
+LANGUAGE 'sql' IMMUTABLE;
+
+SELECT 'topology_newer_scripts',
+	postgis_full_version() ~
+		'TOPOLOGY \(topology procs from "999\.0\.0dev" are newer than core procs from "[^"]+"\)';
+
+ROLLBACK;

--- a/regress/core/postgis_full_version_expected
+++ b/regress/core/postgis_full_version_expected
@@ -1,0 +1,2 @@
+topology_old_scripts|t
+topology_newer_scripts|t

--- a/regress/core/tests.mk.in
+++ b/regress/core/tests.mk.in
@@ -91,6 +91,7 @@ TESTS += \
 	$(top_srcdir)/regress/core/point_coordinates \
 	$(top_srcdir)/regress/core/polygonize \
 	$(top_srcdir)/regress/core/polyhedralsurface \
+	$(top_srcdir)/regress/core/postgis_full_version \
 	$(top_srcdir)/regress/core/postgis_type_name \
 	$(top_srcdir)/regress/core/quantize_coordinates \
 	$(top_srcdir)/regress/core/regress \


### PR DESCRIPTION
## Summary
- compare installed topology script version against the core script version in postgis_full_version()
- report when topology scripts are newer than core scripts instead of saying they need upgrade
- add regression coverage for older and newer topology script versions

## Validation
- make -C postgis -j32
- sudo make -C postgis install
- make -C extensions/postgis -j32
- sudo make -C extensions/postgis install
- make -C regress check RUNTESTFLAGS="--extension" TESTS="$PWD/regress/core/postgis_full_version"
- make -C regress check RUNTESTFLAGS="--extension --topology" TESTS="$PWD/regress/core/postgis_full_version"
- ./utils/check_news.sh

Closes https://trac.osgeo.org/postgis/ticket/2808