### PR TITLE
Document RETURNS TABLE columns in manual

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           GeometryCollections (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
           (Darafei Praliaskouski)
+ - #1558, Document RETURNS TABLE signatures with returned columns
+          (Darafei Praliaskouski)
 
 * Bug Fixes *
 

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -615,7 +615,7 @@ SELECT topology.FixCorruptTopoGeometryColumn(schema_name, table_name, feature_co
 			<refsynopsisdiv>
 				<funcsynopsis>
 					<funcprototype>
-					<funcdef>setof record <function>Populate_Topology_Layer</function></funcdef>
+					<funcdef>table(schema_name text, table_name text, feature_column text) <function>Populate_Topology_Layer</function></funcdef>
 					<paramdef></paramdef>
 					</funcprototype>
 				</funcsynopsis>
@@ -1007,7 +1007,7 @@ face without edges |   1 |
 			<refsynopsisdiv>
 				<funcsynopsis>
 					<funcprototype>
-					<funcdef>setof record <function>ValidateTopologyRelation</function></funcdef>
+					<funcdef>table(error text, layer_id int, topogeo_id bigint, element_id bigint) <function>ValidateTopologyRelation</function></funcdef>
 					<paramdef><type>varchar </type> <parameter>toponame</parameter></paramdef>
 					</funcprototype>
 				</funcsynopsis>
@@ -3325,7 +3325,7 @@ and is thus usable to build edge ring linking.
 			<refsynopsisdiv>
 				<funcsynopsis>
 					<funcprototype>
-					<funcdef>setof record <function>FindVertexSegmentPairsBelowDistance</function></funcdef>
+					<funcdef>table(seg_edge int, segno int, vert_edge int, vertno int, vert_geom geometry) <function>FindVertexSegmentPairsBelowDistance</function></funcdef>
 					<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
 					<paramdef><type>float8 </type> <parameter>tolerance</parameter></paramdef>
 					</funcprototype>

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -3830,12 +3830,12 @@ FROM dummy_rast;
             <refsynopsisdiv>
                 <funcsynopsis>
                   <funcprototype>
-                        <funcdef>(1) record <function>ST_BandMetaData</function></funcdef>
+                        <funcdef>table(pixeltype text, nodatavalue double precision, isoutdb boolean, path text, outdbbandnum integer, filesize bigint, filetimestamp bigint) <function>ST_BandMetaData</function></funcdef>
                         <paramdef><type>raster </type><parameter>rast</parameter></paramdef>
                         <paramdef choice="opt"><type>integer </type><parameter>band=1</parameter></paramdef>
                   </funcprototype>
                   <funcprototype>
-                        <funcdef>(2) record <function>ST_BandMetaData</function></funcdef>
+                        <funcdef>table(bandnum integer, pixeltype text, nodatavalue double precision, isoutdb boolean, path text, outdbbandnum integer, filesize bigint, filetimestamp bigint) <function>ST_BandMetaData</function></funcdef>
                         <paramdef><type>raster </type><parameter>rast</parameter></paramdef>
                         <paramdef choice="opt"><type>integer[] </type><parameter>band</parameter></paramdef>
                   </funcprototype>
@@ -4431,7 +4431,7 @@ WHERE rid=2;
             <refsynopsisdiv>
                 <funcsynopsis>
                   <funcprototype>
-                    <funcdef>setof record <function>ST_PixelAsPolygons</function></funcdef>
+                    <funcdef>table(geom geometry, val double precision, x integer, y integer) <function>ST_PixelAsPolygons</function></funcdef>
                     <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                     <paramdef choice="opt"><type>integer </type> <parameter>band=1</parameter></paramdef>
                     <paramdef choice="opt"><type>boolean </type> <parameter>exclude_nodata_value=TRUE</parameter></paramdef>
@@ -4559,7 +4559,7 @@ SELECT ST_AsText(ST_PixelAsPoint(rast, 1, 1)) FROM dummy_rast WHERE rid = 1;
             <refsynopsisdiv>
                 <funcsynopsis>
                     <funcprototype>
-                        <funcdef>setof record <function>ST_PixelAsPoints</function></funcdef>
+                        <funcdef>table(geom geometry, val double precision, x integer, y integer) <function>ST_PixelAsPoints</function></funcdef>
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef choice="opt"><type>integer </type> <parameter>band=1</parameter></paramdef>
                         <paramdef choice="opt"><type>boolean </type> <parameter>exclude_nodata_value=TRUE</parameter></paramdef>
@@ -4694,7 +4694,7 @@ SELECT ST_AsText(ST_PixelAsCentroid(rast, 1, 1)) FROM dummy_rast WHERE rid = 1;
             <refsynopsisdiv>
                 <funcsynopsis>
                     <funcprototype>
-                        <funcdef>setof record <function>ST_PixelAsCentroids</function></funcdef>
+                        <funcdef>table(geom geometry, val double precision, x integer, y integer) <function>ST_PixelAsCentroids</function></funcdef>
                         <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
                         <paramdef choice="opt"><type>integer </type> <parameter>band=1</parameter></paramdef>
                         <paramdef choice="opt"><type>boolean </type> <parameter>exclude_nodata_value=TRUE</parameter></paramdef>
@@ -6114,7 +6114,7 @@ ORDER BY t1.rid, t2.gid, t3.gid;
             <refsynopsisdiv>
                 <funcsynopsis>
                     <funcprototype>
-                        <funcdef>setof record <function>ST_DumpValues</function></funcdef>
+                        <funcdef>table(nband integer, valarray double precision[][]) <function>ST_DumpValues</function></funcdef>
                         <paramdef>
                             <type>raster </type> <parameter>rast</parameter>
                         </paramdef>
@@ -6220,7 +6220,7 @@ FROM foo;
             <refsynopsisdiv>
                 <funcsynopsis>
                     <funcprototype>
-                        <funcdef>setof record <function>ST_PixelOfValue</function></funcdef>
+                        <funcdef>table(val double precision, x integer, y integer) <function>ST_PixelOfValue</function></funcdef>
                         <paramdef>
                             <type>raster </type> <parameter>rast</parameter>
                         </paramdef>
@@ -6235,7 +6235,7 @@ FROM foo;
                         </paramdef>
                     </funcprototype>
                     <funcprototype>
-                        <funcdef>setof record <function>ST_PixelOfValue</function></funcdef>
+                        <funcdef>table(val double precision, x integer, y integer) <function>ST_PixelOfValue</function></funcdef>
                         <paramdef>
                             <type>raster </type> <parameter>rast</parameter>
                         </paramdef>
@@ -6247,7 +6247,7 @@ FROM foo;
                         </paramdef>
                     </funcprototype>
                     <funcprototype>
-                        <funcdef>setof record <function>ST_PixelOfValue</function></funcdef>
+                        <funcdef>table(x integer, y integer) <function>ST_PixelOfValue</function></funcdef>
                         <paramdef>
                             <type>raster </type> <parameter>rast</parameter>
                         </paramdef>
@@ -6262,7 +6262,7 @@ FROM foo;
                         </paramdef>
                     </funcprototype>
                     <funcprototype>
-                        <funcdef>setof record <function>ST_PixelOfValue</function></funcdef>
+                        <funcdef>table(x integer, y integer) <function>ST_PixelOfValue</function></funcdef>
                         <paramdef>
                             <type>raster </type> <parameter>rast</parameter>
                         </paramdef>
@@ -13926,7 +13926,7 @@ GROUP BY t1.rast;
       <refsynopsisdiv>
         <funcsynopsis>
           <funcprototype>
-            <funcdef>setof record <function>ST_Contour</function></funcdef>
+            <funcdef>table(geom geometry, id integer, value float8) <function>ST_Contour</function></funcdef>
             <paramdef><type>raster </type><parameter>rast</parameter></paramdef>
             <paramdef choice="opt"><type>integer </type><parameter>bandnumber=1</parameter></paramdef>
             <paramdef choice="opt"><type>double precision </type><parameter>level_interval=100.0</parameter></paramdef>

--- a/doc/reference_srs.xml
+++ b/doc/reference_srs.xml
@@ -556,7 +556,7 @@ SELECT * FROM postgis_srs_codes('EPSG') LIMIT 10;
     <refsynopsisdiv>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>setof record <function>postgis_srs</function></funcdef>
+                <funcdef>table(auth_name text, auth_srid text, srname text, srtext text, proj4text text, point_sw geometry, point_ne geometry) <function>postgis_srs</function></funcdef>
                 <paramdef><type>text </type> <parameter>auth_name</parameter></paramdef>
                 <paramdef><type>text </type> <parameter>auth_srid</parameter></paramdef>
             </funcprototype>
@@ -608,7 +608,7 @@ point_ne  | 0101000020E610000085EB51B81E855CC0E17A14AE47014E40
     <refsynopsisdiv>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>setof record <function>postgis_srs_all</function></funcdef>
+                <funcdef>table(auth_name text, auth_srid text, srname text, srtext text, proj4text text, point_sw geometry, point_ne geometry) <function>postgis_srs_all</function></funcdef>
                 <void/>
             </funcprototype>
         </funcsynopsis>
@@ -665,7 +665,7 @@ SELECT auth_name, auth_srid, srname FROM postgis_srs_all() LIMIT 10;
     <refsynopsisdiv>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>setof record <function>postgis_srs_search</function></funcdef>
+                <funcdef>table(auth_name text, auth_srid text, srname text, srtext text, proj4text text, point_sw geometry, point_ne geometry) <function>postgis_srs_search</function></funcdef>
                 <paramdef><type>geometry </type> <parameter>bounds</parameter></paramdef>
                 <paramdef choice="opt"><type>text </type> <parameter>auth_name=EPSG</parameter></paramdef>
             </funcprototype>


### PR DESCRIPTION
## Summary

This updates manual synopses for functions that already use PostgreSQL `RETURNS TABLE` so the returned columns are shown directly in the function signature instead of being represented as `setof record` or generic record output.

Updated docs cover the existing table-returning SRS, raster, and topology functions, including `postgis_srs*`, `ST_BandMetaData`, pixel accessors, `ST_DumpValues`, `ST_PixelOfValue`, `ST_Contour`, `Populate_Topology_Layer`, `ValidateTopologyRelation`, and `FindVertexSegmentPairsBelowDistance`. This is documentation-only; no SQL/runtime behavior changes.

References https://trac.osgeo.org/postgis/ticket/1558.

## Tests

- `./utils/check_news.sh`
- `git diff --check`
- `make -C doc check-xml`
- `make -C doc html`
- `make -C doc comments`
- `make -C doc check-cheatsheets`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/315
