### PR TITLE
Mark topology catalogs in unpackaged upgrades

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -78,6 +78,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           geometry_columns lookups (Darafei Praliaskouski)
  - #6038, Avoid stale relation lookups in geometry_columns after topology
           objects are dropped (Darafei Praliaskouski)
+ - #2536, [topology] Mark editable catalog rows in unpackaged upgrade
+          scripts (Darafei Praliaskouski)
  - #5655, [doc] Skip XML validation during `make check` when xsltproc is
           unavailable (Darafei Praliaskouski)
  - #5487, Improve error detail for repeated upgrades after an incomplete

--- a/extensions/postgis_topology/Makefile.in
+++ b/extensions/postgis_topology/Makefile.in
@@ -69,10 +69,11 @@ sql/topology.sql: ../../topology/topology.sql | sql
 sql/$(EXTENSION)--unpackaged.sql: Makefile | sql
 	echo "-- Nothing to do here" > $@
 
-sql/$(EXTENSION)--unpackaged--$(EXTVERSION).sql: ../../topology/topology.sql ../../utils/create_unpackaged.pl sql/topology_upgrade.sql Makefile | sql
+sql/$(EXTENSION)--unpackaged--$(EXTVERSION).sql: ../../topology/topology.sql ../../utils/create_unpackaged.pl sql/topology_upgrade.sql sql_bits/mark_editable_objects.sql.in Makefile | sql
 	cat $< | $(PERL) @top_srcdir@/utils/create_unpackaged.pl postgis_topology > $@
 	# Upgrade after packaging (TODO: use ANY--TARGET path?)
 	cat sql/topology_upgrade.sql >> $@
+	cat sql_bits/mark_editable_objects.sql.in >> $@
 
 #upgrade script should have everything but table, schema, type creation/alter
 #NOTE: we assume all object definitions end in ;


### PR DESCRIPTION
## Summary

This updates the generated `postgis_topology--unpackaged--<version>.sql` upgrade path to append `sql_bits/mark_editable_objects.sql.in` after packaging and upgrading topology objects.

The regular install and `ANY--<version>` topology scripts already include this step; the unpackaged upgrade script did not, so topology catalog tables and the topology id sequence were not marked with `pg_extension_config_dump` on that path.

References https://trac.osgeo.org/postgis/ticket/2536.

## Tests

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C topology topology.sql topology_upgrade.sql`
- `make -C extensions/postgis_topology clean all`
- `rg -n "pg_extension_config_dump\('topology\.(topology_id_seq|topology|layer)'" extensions/postgis_topology/sql/postgis_topology--unpackaged--3.7.0dev.sql extensions/postgis_topology/sql/postgis_topology--ANY--3.7.0dev.sql extensions/postgis_topology/sql/postgis_topology--3.7.0dev.sql`
- `make -C regress staged-install`
- `./utils/check_news.sh`
- `git diff --check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/314
