### PR TITLE
topology: preserve collapsed ST_Simplify line results

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -76,6 +76,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
  - #2807, [raster] Preserve missing NODATA values in ST_MapAlgebra outputs
           (Darafei Praliaskouski)
+ - #5093, [topology] Preserve collapsed TopoGeometry line simplification
+          results instead of returning NULL (Darafei Praliaskouski)
  - #2832, [raster] Avoid padding single-tile raster2pgsql overviews
           when padding is not requested (Darafei Praliaskouski)
  - Fix WKB and TWKB parser resource exhaustion on malformed input

--- a/topology/sql/topogeometry/simplify.sql.in
+++ b/topology/sql/topogeometry/simplify.sql.in
@@ -101,7 +101,7 @@ BEGIN
 
     sql :=
       'SELECT st_multi(ST_LineMerge(ST_Node(ST_Collect(ST_Simplify(e.geom,'
-      || tolerance || '))))) as g FROM '
+      || tolerance || ', true))))) as g FROM '
       || quote_ident(topology_info.name) || '.edge e, '
       || quote_ident(topology_info.name) || '.relation r '
       || ' WHERE r.topogeo_id = ' || tg.id
@@ -130,7 +130,7 @@ BEGIN
       || ' AND element_type = 3 ), '
       || 'lines AS ( '
       || 'SELECT st_multi(ST_LineMerge(ST_Collect(ST_Simplify(e.geom,'
-      || tolerance || ')))) as g FROM '
+      || tolerance || ', true)))) as g FROM '
       || quote_ident(topology_info.name) || '.edge e, '
       || quote_ident(topology_info.name) || '.relation r '
       || ' WHERE r.topogeo_id = ' || tg.id
@@ -161,4 +161,3 @@ END
 $$
 LANGUAGE 'plpgsql' VOLATILE STRICT;
 -- }
-

--- a/topology/test/regress/st_simplify.sql
+++ b/topology/test/regress/st_simplify.sql
@@ -49,3 +49,17 @@ SELECT 'HS2',
 FROM tt.bigareas WHERE id = 2;
 
 SELECT DropTopology('tt') IS NULL;
+
+-- See http://trac.osgeo.org/postgis/ticket/5093
+SELECT CreateTopology('tl') > 0;
+CREATE TABLE tl.lines(id serial, g geometry);
+INSERT INTO tl.lines(g) VALUES ('LINESTRING(0 0,10 0,10 10,0 0)');
+SELECT 'L' || AddTopoGeometryColumn('tl', 'tl', 'lines', 'tg', 'line');
+UPDATE tl.lines SET tg = toTopoGeom(g, 'tl', 1);
+
+SELECT 'S3',
+  ST_AsText(ST_Simplify(tg, 100)),
+  ST_Simplify(tg, 100) IS NULL
+FROM tl.lines WHERE id = 1;
+
+SELECT DropTopology('tl') IS NULL;

--- a/topology/test/regress/st_simplify_expected
+++ b/topology/test/regress/st_simplify_expected
@@ -7,3 +7,7 @@ L2
 HS1|f|t
 HS2|f|t
 f
+t
+L1
+S3|GEOMETRYCOLLECTION EMPTY|f
+f


### PR DESCRIPTION
For topology line layers, `topology.ST_Simplify` used the two-argument geometry `ST_Simplify`, so edges that collapsed under a large tolerance were dropped all the way to `NULL`. Switch the line simplification paths to the three-argument form with `preserveCollapsed = true`, keeping the TopoGeometry result non-NULL for collapsed line inputs.

Adds regression coverage for Trac ticket https://trac.osgeo.org/postgis/ticket/5093.

Closes #5093.

Validation run locally:
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32`
- `sudo make install`
- `make -C topology -j8`
- `sudo -n make -C topology install`
- `make -C extensions/postgis_topology -j8`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology check RUNTESTFLAGS="--extension --topology --verbose" TESTS="$(pwd)/topology/test/regress/st_simplify"`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/313
