### PR TITLE
Add topology GetRelatedTopoGeom

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - ST_MinimumSpanningTree, window function to calculate MST (Paul Ramsey)
  - #5993, [topology] Add max_edges parameter to TopoGeo_AddLinestring
           (Sandro Santilli)
+ - #2519, [topology] GetRelatedTopoGeom function (Darafei Praliaskouski)
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)
  - #2858, ST_MMin and ST_MMax (Paul Ramsey)
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -4376,6 +4376,56 @@ Refer to <xref linkend="toTopoGeom"/>.
 			</refsection>
 		</refentry>
 
+		<refentry xml:id="GetRelatedTopoGeom">
+			<refnamediv>
+				<refname>GetRelatedTopoGeom</refname>
+
+				<refpurpose>Returns TopoGeometry objects in a target layer that share at least one topology node with a given TopoGeometry.</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>setof topogeometry <function>GetRelatedTopoGeom</function></funcdef>
+					<paramdef><type>varchar </type> <parameter>toponame</parameter></paramdef>
+					<paramdef><type>integer </type> <parameter>layer_id</parameter></paramdef>
+					<paramdef><type>bigint</type> <parameter>tg_id</parameter></paramdef>
+					<paramdef><type>integer </type> <parameter>target_layer_id</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+				<funcsynopsis>
+					<funcprototype>
+					<funcdef>setof topogeometry <function>GetRelatedTopoGeom</function></funcdef>
+					<paramdef><type>topogeometry </type> <parameter>tg</parameter></paramdef>
+					<paramdef><type>integer </type> <parameter>target_layer_id</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+				<title>Description</title>
+
+				<para>Returns TopoGeometry objects from <varname>target_layer_id</varname> in the same topology as the input TopoGeometry where the two objects share at least one topology node.  A TopoGeometry node footprint includes direct node elements, edge endpoints, and face boundary nodes.</para>
+				<para><varname>tg_id</varname> is the topogeometry id of the topogeometry object in the topology layer denoted by <varname>layer_id</varname>.</para>
+
+				<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+			</refsection>
+
+			<refsection>
+				<title>Examples</title>
+				<programlisting>SELECT topology.GetRelatedTopoGeom('city_data', 3, 1, 2);</programlisting>
+			</refsection>
+
+			<refsection>
+				<title>See Also</title>
+				<para>
+					<xref linkend="GetTopoGeomElements"/>,
+					<xref linkend="GetTopoGeomElementArray"/>,
+					<xref linkend="topogeometry"/>
+				</para>
+			</refsection>
+		</refentry>
+
     <refentry xml:id="TG_ST_SRID">
 	  <refnamediv>
 		<refname>ST_SRID</refname>

--- a/topology/test/regress/getrelatedtopogeom.sql
+++ b/topology/test/regress/getrelatedtopogeom.sql
@@ -1,0 +1,32 @@
+set client_min_messages to WARNING;
+
+\i :top_builddir/topology/test/load_topology.sql
+\i ../load_features.sql
+
+SELECT 'street R1 signs', (tg).layer_id, (tg).id, (tg).type
+FROM topology.GetRelatedTopoGeom('city_data', 3, 1, 2) AS tg
+ORDER BY (tg).id;
+
+SELECT 'street R2 signs', (tg).layer_id, (tg).id, (tg).type
+FROM topology.GetRelatedTopoGeom('city_data', 3, 2, 2) AS tg
+ORDER BY (tg).id;
+
+SELECT 'street R4 signs count', count(*)
+FROM topology.GetRelatedTopoGeom('city_data', 3, 4, 2) AS tg;
+
+SELECT 'sign S1 streets', (tg).layer_id, (tg).id, (tg).type
+FROM topology.GetRelatedTopoGeom(
+  (SELECT feature FROM features.traffic_signs WHERE feature_name = 'S1'),
+  3
+) AS tg
+ORDER BY (tg).id;
+
+SELECT 'parcel P5 streets', (tg).layer_id, (tg).id, (tg).type
+FROM topology.GetRelatedTopoGeom(
+  (SELECT feature FROM features.land_parcels WHERE feature_name = 'P5'),
+  3
+) AS tg
+ORDER BY (tg).id;
+
+SELECT topology.DropTopology('city_data');
+DROP SCHEMA features CASCADE;

--- a/topology/test/regress/getrelatedtopogeom_expected
+++ b/topology/test/regress/getrelatedtopogeom_expected
@@ -1,0 +1,7 @@
+street R1 signs|2|1|1
+street R1 signs|2|2|1
+street R2 signs|2|3|1
+street R4 signs count|0
+sign S1 streets|3|1|2
+parcel P5 streets|3|3|2
+Topology 'city_data' dropped

--- a/topology/test/tests.mk
+++ b/topology/test/tests.mk
@@ -38,6 +38,7 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/getnodebypoint.sql \
 	$(top_srcdir)/topology/test/regress/getnodeedges.sql \
 	$(top_srcdir)/topology/test/regress/getringedges.sql \
+	$(top_srcdir)/topology/test/regress/getrelatedtopogeom.sql \
 	$(top_srcdir)/topology/test/regress/gettopogeomelements.sql \
 	$(top_srcdir)/topology/test/regress/gettopogeomelements_large.sql \
 	$(top_srcdir)/topology/test/regress/gml.sql \
@@ -101,4 +102,3 @@ TESTS += \
 	$(top_srcdir)/topology/test/regress/verifylargeids.sql \
 	$(top_srcdir)/topology/test/regress/fix_topogeometry_columns.sql \
 	$(top_srcdir)/topology/test/regress/findvertexsegmentpairsbelowdistance.sql
-

--- a/topology/topology.sql.in
+++ b/topology/topology.sql.in
@@ -79,6 +79,11 @@
 --    topological elements of the given TopoGeometry (primitive
 --    elements)
 --
+-- FUNCTION GetRelatedTopoGeom(toponame, layer_id, topogeom_id, target_layer_id)
+-- FUNCTION GetRelatedTopoGeom(TopoGeometry, target_layer_id)
+--    Returns a set of TopoGeometry objects from target_layer_id sharing
+--    at least one topology node with the given TopoGeometry.
+--
 -- FUNCTION ValidateTopology(toponame)
 --    Run validity checks on the topology, returning, for each
 --    detected error, a 3-columns row containing error string
@@ -1044,6 +1049,180 @@ $$
 LANGUAGE 'plpgsql' STABLE STRICT;
 
 --} GetTopoGeomElements()
+
+--{
+-- GetRelatedTopoGeom(toponame, layer_id, topogeom_id, target_layer_id)
+-- GetRelatedTopoGeom(TopoGeometry, target_layer_id)
+--
+-- Returns a set of TopoGeometry objects from target_layer_id sharing at least
+-- one topology node with the given TopoGeometry.
+--
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION topology.GetRelatedTopoGeom(toponame varchar, layerid integer, tgid bigint, target_layerid integer)
+  RETURNS SETOF topology.TopoGeometry
+AS
+$$
+DECLARE
+  topoid integer;
+  lyr topology.layer;
+  target_lyr topology.layer;
+  rec RECORD;
+  ret topology.TopoGeometry;
+  query text;
+BEGIN
+  SELECT id INTO topoid
+    FROM topology.topology WHERE name = toponame;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Topology % does not exist', quote_literal(toponame);
+  END IF;
+
+  SELECT * INTO lyr
+    FROM topology.layer
+    WHERE topology_id = topoid
+      AND layer_id = layerid;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Layer % does not exist', layerid;
+  END IF;
+
+  SELECT * INTO target_lyr
+    FROM topology.layer
+    WHERE topology_id = topoid
+      AND layer_id = target_layerid;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Layer % does not exist', target_layerid;
+  END IF;
+
+  query = format($fmt$
+    WITH source_nodes AS (
+      SELECT DISTINCT node_id
+      FROM (
+        SELECT elem[1] AS node_id
+        FROM topology.GetTopoGeomElements(%L, %s, %L) elem
+        WHERE elem[2] = 1
+
+        UNION ALL
+        SELECT e.start_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, %L) elem
+          ON elem[2] = 2
+         AND abs(e.edge_id) = elem[1]
+
+        UNION ALL
+        SELECT e.end_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, %L) elem
+          ON elem[2] = 2
+         AND abs(e.edge_id) = elem[1]
+
+        UNION ALL
+        SELECT e.start_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, %L) elem
+          ON elem[2] = 3
+         AND elem[1] != 0
+         AND (e.left_face = elem[1] OR e.right_face = elem[1])
+
+        UNION ALL
+        SELECT e.end_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, %L) elem
+          ON elem[2] = 3
+         AND elem[1] != 0
+         AND (e.left_face = elem[1] OR e.right_face = elem[1])
+      ) nodes
+    ),
+    target_topogeoms AS (
+      SELECT DISTINCT topogeo_id
+      FROM %I.relation
+      WHERE layer_id = %s
+    )
+    SELECT target_topogeoms.topogeo_id
+    FROM target_topogeoms
+    WHERE EXISTS (
+      SELECT 1
+      FROM source_nodes sn
+      JOIN LATERAL (
+        SELECT elem[1] AS node_id
+        FROM topology.GetTopoGeomElements(%L, %s, target_topogeoms.topogeo_id) elem
+        WHERE elem[2] = 1
+
+        UNION ALL
+        SELECT e.start_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, target_topogeoms.topogeo_id) elem
+          ON elem[2] = 2
+         AND abs(e.edge_id) = elem[1]
+
+        UNION ALL
+        SELECT e.end_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, target_topogeoms.topogeo_id) elem
+          ON elem[2] = 2
+         AND abs(e.edge_id) = elem[1]
+
+        UNION ALL
+        SELECT e.start_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, target_topogeoms.topogeo_id) elem
+          ON elem[2] = 3
+         AND elem[1] != 0
+         AND (e.left_face = elem[1] OR e.right_face = elem[1])
+
+        UNION ALL
+        SELECT e.end_node
+        FROM %I.edge_data e
+        JOIN topology.GetTopoGeomElements(%L, %s, target_topogeoms.topogeo_id) elem
+          ON elem[2] = 3
+         AND elem[1] != 0
+         AND (e.left_face = elem[1] OR e.right_face = elem[1])
+      ) tn USING (node_id)
+    )
+    ORDER BY target_topogeoms.topogeo_id
+    $fmt$,
+    toponame, layerid, tgid,
+    toponame, toponame, layerid, tgid,
+    toponame, toponame, layerid, tgid,
+    toponame, toponame, layerid, tgid,
+    toponame, toponame, layerid, tgid,
+    toponame, target_layerid,
+    toponame, target_layerid,
+    toponame, toponame, target_layerid,
+    toponame, toponame, target_layerid,
+    toponame, toponame, target_layerid,
+    toponame, toponame, target_layerid
+  );
+
+  FOR rec IN EXECUTE query
+  LOOP
+    ret.topology_id = topoid;
+    ret.layer_id = target_layerid;
+    ret.id = rec.topogeo_id;
+    ret.type = target_lyr.feature_type;
+    RETURN NEXT ret;
+  END LOOP;
+
+  RETURN;
+END;
+$$
+LANGUAGE 'plpgsql' STABLE STRICT;
+
+CREATE OR REPLACE FUNCTION topology.GetRelatedTopoGeom(tg topology.TopoGeometry, target_layerid integer)
+  RETURNS SETOF topology.TopoGeometry
+AS
+$$
+DECLARE
+  toponame varchar;
+BEGIN
+  toponame = topology.GetTopologyName(tg.topology_id);
+  RETURN QUERY
+    SELECT * FROM topology.GetRelatedTopoGeom(toponame,
+      tg.layer_id, tg.id, target_layerid);
+  RETURN;
+END;
+$$
+LANGUAGE 'plpgsql' STABLE STRICT;
+
+--} GetRelatedTopoGeom()
 
 --{
 -- Geometry(TopoGeometry)


### PR DESCRIPTION
Adds `topology.GetRelatedTopoGeom` for Trac ticket https://trac.osgeo.org/postgis/ticket/2519.

The new overloads return TopoGeometry objects from a target layer that share at least one topology node with the source TopoGeometry. The node footprint covers direct node elements, edge endpoints, and face boundary nodes, so the road/intersection use case in the ticket is handled without mutating relation rows.

Closes https://trac.osgeo.org/postgis/ticket/2519

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/312

Rebase validation on current `master` (`a4ecc46176c3fc0ab3fa69cf117d408bc622e592`) at head `6865b74d0f4fed316b71281505cafd787cfaa8b0`:
- `git diff --check upstream/master..HEAD`
- `./utils/check_news.sh .`
- `make -C topology topology.sql`
- `make -C topology -j1`
- `sudo -n make -C topology install`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C doc check-xml`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/getrelatedtopogeom"`
