### PR TITLE
Infer geometry_columns constraints for direct views

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -91,6 +91,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #3103, Add regression coverage for exact-schema find_srid and
           geometry_columns lookups (Darafei Praliaskouski)
+ - #1705, Infer constraint metadata for direct view and materialized view
+          geometry columns (Darafei Praliaskouski)
  - #6038, Avoid stale relation lookups in geometry_columns after topology
           objects are dropped (Darafei Praliaskouski)
  - #5655, [doc] Skip XML validation during `make check` when xsltproc is

--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -1768,9 +1768,10 @@ SELECT populate_geometry_columns('myschema.my_special_pois'::regclass);
 -- set optional use_typmod argument to false
 SELECT populate_geometry_columns('myschema.my_special_pois'::regclass, false); </programlisting>
 
-<para>Although the old-constraint based method is still supported, a constraint-based geometry column used directly
-in a view, will not register correctly in geometry_columns, as will a typmod one.
-In this example we define a column using typmod and another using constraints.</para>
+<para>Although the old constraint-based method is still supported, direct
+pass-through view columns register correctly in <varname>geometry_columns</varname>
+for both typmod-based and constraint-based source columns. In this example we
+define a column using typmod and another using constraints.</para>
 <programlisting>CREATE TABLE pois_ny(gid SERIAL PRIMARY KEY, poi_name text, cat text, geom geometry(POINT,4326));
 SELECT AddGeometryColumn('pois_ny', 'geom_2160', 2160, 'POINT', 2, false);</programlisting>
 <para>If we run in psql</para>
@@ -1809,20 +1810,21 @@ SELECT *
 SELECT f_table_name, f_geometry_column, srid, type
 	FROM geometry_columns
 	WHERE f_table_name = 'vw_pois_ny_parks';</programlisting>
-<para>The typmod based geom view column registers correctly,
-but the constraint based one does not.</para>
+<para>Both the typmod based geom view column and the direct constraint based
+view column register correctly.</para>
 <screen>   f_table_name   | f_geometry_column | srid |   type
 ------------------+-------------------+------+----------
  vw_pois_ny_parks | geom              | 4326 | POINT
- vw_pois_ny_parks | geom_2160         |    0 | GEOMETRY</screen>
+ vw_pois_ny_parks | geom_2160         | 2160 | POINT</screen>
 
-<para>This may change in future versions of PostGIS, but for now
-to force the constraint-based view column to register correctly, you need to do this:</para>
+<para>If the view applies a spatial function to the geometry, such as
+<function>ST_Transform</function>, you still need to cast the transformed
+column explicitly so the view can expose the correct type and SRID:</para>
 <programlisting>DROP VIEW vw_pois_ny_parks;
 CREATE VIEW vw_pois_ny_parks AS
 SELECT gid, poi_name, cat,
   geom,
-  geom_2160::geometry(POINT,2160) As geom_2160
+  ST_Transform(geom, 2160)::geometry(POINT,2160) As geom_2160
   FROM pois_ny
   WHERE cat = 'park';
 SELECT f_table_name, f_geometry_column, srid, type

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -6595,6 +6595,28 @@ SELECT current_database()::character varying(256) AS f_table_catalog,
      JOIN pg_attribute a ON a.attrelid = c.oid AND NOT a.attisdropped
      JOIN pg_namespace n ON c.relnamespace = n.oid
      JOIN pg_type t ON a.atttypid = t.oid
+     -- Direct view columns have rewrite-rule target entries with origin metadata.
+     -- Use only top-level bare VAR target entries, so expressions keep needing explicit casts.
+     LEFT JOIN LATERAL (
+           SELECT match[2]::oid AS base_relid,
+                  match[3]::smallint AS base_attnum
+             FROM pg_rewrite AS r
+             CROSS JOIN LATERAL regexp_match(
+               r.ev_action::text,
+               $$.*:targetList \((.*)\) :override 0 :onConflict$$
+             ) AS targetlist
+             CROSS JOIN LATERAL regexp_matches(
+               targetlist[1],
+               $$\{TARGETENTRY :expr \{VAR [^}]*\} :resno ([0-9]+) :resname [^:]+ :ressortgroupref [0-9]+ :resorigtbl ([0-9]+) :resorigcol ([0-9]+) :resjunk false\}$$,
+               'g'
+             ) AS match
+            WHERE c.relkind = ANY (ARRAY['v'::"char", 'm'::"char"])
+              AND r.ev_class = c.oid
+              AND r.rulename = '_RETURN'
+              AND match[1]::smallint = a.attnum
+              AND match[2] <> '0'
+              AND match[3] <> '0'
+     ) AS vco ON true
      LEFT JOIN (
            SELECT s.connamespace,
                   s.conrelid,
@@ -6602,7 +6624,7 @@ SELECT current_database()::character varying(256) AS f_table_catalog,
                   (regexp_match(s.consrc, $$geometrytype\(\w+\)\s*=\s*'(\w+)'$$, 'i'))[1]::text AS type
              FROM constraint_defs AS s
             WHERE s.consrc ~* $$geometrytype\(\w+\)\s*=\s*'\w+'$$::text
-     ) st ON st.connamespace = n.oid AND st.conrelid = c.oid AND (a.attnum = ANY (st.conkey))
+     ) st ON st.conrelid = COALESCE(vco.base_relid, c.oid) AND (COALESCE(vco.base_attnum, a.attnum) = ANY (st.conkey))
      LEFT JOIN (
            SELECT s.connamespace,
                   s.conrelid,
@@ -6610,7 +6632,7 @@ SELECT current_database()::character varying(256) AS f_table_catalog,
                   (regexp_match(s.consrc, $$ndims\(\w+\)\s*=\s*(\d+)$$, 'i'))[1]::integer AS ndims
              FROM constraint_defs AS s
             WHERE s.consrc ~* $$ndims\(\w+\)\s*=\s*\d+$$::text
-     ) sn ON sn.connamespace = n.oid AND sn.conrelid = c.oid AND (a.attnum = ANY (sn.conkey))
+     ) sn ON sn.conrelid = COALESCE(vco.base_relid, c.oid) AND (COALESCE(vco.base_attnum, a.attnum) = ANY (sn.conkey))
      LEFT JOIN (
            SELECT s.connamespace,
                   s.conrelid,
@@ -6618,7 +6640,7 @@ SELECT current_database()::character varying(256) AS f_table_catalog,
                   (regexp_match(s.consrc, $$srid\(\w+\)\s*=\s*(\d+)$$, 'i'))[1]::integer As srid
              FROM constraint_defs AS s
             WHERE s.consrc ~* $$srid\(\w+\)\s*=\s*\d+$$::text
-     ) sr ON sr.connamespace = n.oid AND sr.conrelid = c.oid AND (a.attnum = ANY (sr.conkey))
+     ) sr ON sr.conrelid = COALESCE(vco.base_relid, c.oid) AND (COALESCE(vco.base_attnum, a.attnum) = ANY (sr.conkey))
   WHERE (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'm'::"char", 'f'::"char", 'p'::"char"]))
   AND NOT c.relname = 'raster_columns'::name AND t.typname = 'geometry'::name
   AND NOT pg_is_other_temp_schema(c.relnamespace)

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1654,6 +1654,43 @@ SELECT f_table_schema, f_table_name, f_geometry_column, coord_dimension, srid, t
  ORDER BY f_table_name, f_geometry_column;
 DROP TABLE IF EXISTS test5829, test5978;
 
+-- #1705, constraint-based geometry metadata for direct view columns
+CREATE TABLE test1705 (
+  gid integer,
+  geom geometry(Point, 4326),
+  geom_2160 geometry);
+ALTER TABLE test1705
+  ADD CONSTRAINT enforce_dims_geom_2160
+  CHECK (st_ndims(geom_2160) = 2);
+ALTER TABLE test1705
+  ADD CONSTRAINT enforce_srid_geom_2160
+  CHECK (st_srid(geom_2160) = 2160);
+ALTER TABLE test1705
+  ADD CONSTRAINT enforce_geotype_geom_2160
+  CHECK (geometrytype(geom_2160) = 'POINT'::text OR geom_2160 IS NULL);
+CREATE VIEW test1705_view AS
+  SELECT *
+    FROM test1705
+   WHERE gid > 0;
+CREATE VIEW test1705_alias_view AS
+  SELECT geom_2160 AS shape
+    FROM test1705;
+CREATE VIEW test1705_buffer_view AS
+  SELECT ST_Buffer(geom_2160, 1) AS geom_2160
+    FROM test1705;
+CREATE VIEW test1705_nested_buffer_view AS
+  SELECT ST_Buffer(geom_2160, 1) AS geom_2160
+    FROM (SELECT geom_2160 FROM test1705) AS nested;
+CREATE MATERIALIZED VIEW test1705_matview AS
+  SELECT geom_2160
+    FROM test1705;
+SELECT '#1705', f_table_schema, f_table_name, f_geometry_column, coord_dimension, srid, type
+ FROM geometry_columns WHERE f_table_name IN ('test1705', 'test1705_view', 'test1705_alias_view', 'test1705_buffer_view', 'test1705_nested_buffer_view', 'test1705_matview')
+ ORDER BY f_table_name, f_geometry_column;
+DROP MATERIALIZED VIEW test1705_matview;
+DROP VIEW test1705_alias_view, test1705_buffer_view, test1705_nested_buffer_view, test1705_view;
+DROP TABLE test1705;
+
 -- -------------------------------------------------------------------------------------
 -- #3103, geometry_columns/find_srid exact-match behavior
 CREATE SCHEMA test3103a;

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -499,6 +499,14 @@ public.test5978.geometry SRID:4326 TYPE:POINT DIMS:2
 public|test5829|geom|2|4326|GEOMETRY
 public|test5978|geometry|2|4326|POINT
 public|test5978|shape|2|4326|POINT
+#1705|public|test1705|geom|2|4326|POINT
+#1705|public|test1705|geom_2160|2|2160|POINT
+#1705|public|test1705_alias_view|shape|2|2160|POINT
+#1705|public|test1705_buffer_view|geom_2160|2|0|GEOMETRY
+#1705|public|test1705_matview|geom_2160|2|2160|POINT
+#1705|public|test1705_nested_buffer_view|geom_2160|2|0|GEOMETRY
+#1705|public|test1705_view|geom|2|4326|POINT
+#1705|public|test1705_view|geom_2160|2|2160|POINT
 #3103.1|4326
 #3103.2|3857
 #3103.3|test3103b|3857


### PR DESCRIPTION
## Summary

Trac: https://trac.osgeo.org/postgis/ticket/1705

This teaches `geometry_columns` to inherit constraint-derived geometry metadata for direct view and materialized-view columns. It uses PostgreSQL rewrite-rule origin metadata for top-level bare `VAR` target entries, so expression columns such as `ST_Buffer(geom)` still require an explicit typmod cast.

The follow-up narrows rewrite-rule scanning to the top-level serialized target list so bare `VAR` entries inside nested subqueries cannot be mistaken for the outer view column. The regression now covers the nested-subquery false-positive shape from review.

The regression covers:

- base constraint metadata
- direct pass-through views
- aliased direct view columns
- materialized views
- transformed geometry expressions staying `GEOMETRY`/SRID 0
- transformed geometry expressions over nested subqueries staying `GEOMETRY`/SRID 0

Docs describe the direct-view behavior consistently and keep the explicit-cast guidance for transformed geometry expressions.

## Testing

- /usr/bin/perl ./utils/repo_revision.pl
- make postgis_revision.h
- make -C postgis -j32
- make -C extensions postgis_extension_helper.sql
- make -C extensions/postgis -j1
- sudo -n make -C postgis install
- sudo -n make -C extensions/postgis install
- make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"
- make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/tickets"
- make -C doc check-xml
- ./utils/check_news.sh .
- git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check
- git clang-format --diff upstream/master -- postgis/postgis.sql.in regress/core/tickets.sql regress/core/tickets_expected doc/using_postgis_dataman.xml NEWS
- find . \! -user $(id -u) -print | head -20