### PR TITLE
Add array overloads for geometry accessors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,12 @@ These are only changes since 3.7.0alpha1.
             (Bas Couwenberg)
 
 * Enhancements *
+* New Features *
+
+ - #926, Add array overloads for ST_GeometryN, ST_InteriorRingN,
+          and ST_PointN
+          (Darafei Praliaskouski)
+
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)
@@ -167,11 +173,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
  - [fuzzers] Centralize OSS-Fuzz build/dependency logic in PostGIS scripts,
-         prefer requested CXX over pg_config --cc for internal C++ checks, and
-         make fuzzer linking/runtime dependency packaging portable
-         (Darafei Praliaskouski)
- - #926, Add array overloads for ST_GeometryN, ST_InteriorRingN,
-          and ST_PointN
+          prefer requested CXX over pg_config --cc for internal C++ checks, and
+          make fuzzer linking/runtime dependency packaging portable
           (Darafei Praliaskouski)
 
 * Enhancements *

--- a/NEWS
+++ b/NEWS
@@ -167,8 +167,11 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)
  - [fuzzers] Centralize OSS-Fuzz build/dependency logic in PostGIS scripts,
-          prefer requested CXX over pg_config --cc for internal C++ checks, and
-          make fuzzer linking/runtime dependency packaging portable
+         prefer requested CXX over pg_config --cc for internal C++ checks, and
+         make fuzzer linking/runtime dependency packaging portable
+         (Darafei Praliaskouski)
+ - #926, Add array overloads for ST_GeometryN, ST_InteriorRingN,
+          and ST_PointN
           (Darafei Praliaskouski)
 
 * Enhancements *

--- a/doc/reference_accessor.xml
+++ b/doc/reference_accessor.xml
@@ -1191,6 +1191,11 @@ GROUP BY gid;</programlisting>
 			<paramdef><type>geometry </type> <parameter>geomA</parameter></paramdef>
 			<paramdef><type>integer </type> <parameter>n</parameter></paramdef>
 		  </funcprototype>
+		  <funcprototype>
+			<funcdef>setof geometry <function>ST_GeometryN</function></funcdef>
+			<paramdef><type>geometry </type> <parameter>geomA</parameter></paramdef>
+			<paramdef><type>integer[] </type> <parameter>narray</parameter></paramdef>
+		  </funcprototype>
 		</funcsynopsis>
 	  </refsynopsisdiv>
 
@@ -1203,6 +1208,8 @@ GROUP BY gid;</programlisting>
 			an index of 1 returns the input geometry and any other index returns NULL.
 			Use <xref linkend="ST_PatchN"/> and <xref linkend="ST_NumPatches"/> to
 			access and count the faces of a TIN or PolyhedralSurface.</para>
+		<para>The integer array variant returns one row for each array entry in array order,
+			emitting NULL rows for NULL or out-of-range indexes.</para>
 
 		<note>
 		  <para>Index is 1-based as for OGC specs since version 0.8.0.
@@ -1213,6 +1220,7 @@ GROUP BY gid;</programlisting>
 		  <para>To extract all elements of a geometry, <xref linkend="ST_Dump"/> is more efficient and works for atomic geometries.</para>
 		</note>
 		<para role="enhanced" conformance="2.0.0">Enhanced: 2.0.0 support for Polyhedral surfaces, Triangles and TIN was introduced.</para>
+		<para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 support for selecting multiple elements with an integer array was introduced.</para>
 		<para role="changed" conformance="2.0.0">Changed: 2.0.0 Prior versions would return NULL for singular geometries.  This was changed to return the geometry for ST_GeometryN(..,1) case.</para>
 		<para role="changed" conformance="3.6.0">Changed: 3.6.0 TIN and PolyhedralSurface are treated as unitary geometries and are not decomposed into patches; use ST_PatchN to access faces.</para>
 		<para>&sfs_compliant;</para>
@@ -1423,6 +1431,11 @@ FROM
 			<paramdef><type>geometry </type> <parameter>a_polygon</parameter></paramdef>
 			<paramdef><type>integer </type> <parameter>n</parameter></paramdef>
 		  </funcprototype>
+		  <funcprototype>
+			<funcdef>setof geometry <function>ST_InteriorRingN</function></funcdef>
+			<paramdef><type>geometry </type> <parameter>a_polygon</parameter></paramdef>
+			<paramdef><type>integer[] </type> <parameter>n_array</parameter></paramdef>
+		  </funcprototype>
 		</funcsynopsis>
 	  </refsynopsisdiv>
 
@@ -1430,6 +1443,8 @@ FROM
 		<title>Description</title>
 
 		<para>Returns the Nth interior ring (hole) of a POLYGON geometry as a LINESTRING. The index starts at 1. Returns NULL if the geometry is not a polygon or the index is out of range.</para>
+		<para>The integer array variant returns one row for each array entry in array order,
+			emitting NULL rows for NULL or out-of-range indexes.</para>
 
 		<!-- optionally mention that this function uses indexes if appropriate -->
 		<note>
@@ -1440,6 +1455,7 @@ FROM
 		<para>&sfs_compliant;</para>
 		<para>&sqlmm_compliant; SQL-MM 3: 8.2.6, 8.3.5</para>
 		<para>&Z_support;</para>
+		<para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 support for selecting multiple rings with an integer array was introduced.</para>
 
 	  </refsection>
 
@@ -2569,6 +2585,11 @@ VALUES ('POLYHEDRALSURFACE( ((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),
 			<paramdef><type>geometry </type> <parameter>a_linestring</parameter></paramdef>
 			<paramdef><type>integer </type> <parameter>n</parameter></paramdef>
 		  </funcprototype>
+		  <funcprototype>
+			<funcdef>setof geometry <function>ST_PointN</function></funcdef>
+			<paramdef><type>geometry </type> <parameter>a_linestring</parameter></paramdef>
+			<paramdef><type>integer[] </type> <parameter>narray</parameter></paramdef>
+		  </funcprototype>
 		</funcsynopsis>
 	  </refsynopsisdiv>
 
@@ -2578,6 +2599,8 @@ VALUES ('POLYHEDRALSURFACE( ((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),
 		<para>Return the Nth point in a single linestring or circular linestring in the
 			geometry. Negative values are counted backwards from the end of the LineString, so that -1 is the last point. Returns NULL if there is no linestring in the
 			geometry.</para>
+		<para>The integer array variant returns one row for each array entry in array order,
+			emitting NULL rows for NULL or out-of-range indexes.</para>
 
 		<note>
 			  <para>Index is 1-based as for OGC specs since version 0.8.0.
@@ -2599,6 +2622,7 @@ VALUES ('POLYHEDRALSURFACE( ((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),
 	  function and return the start point.  In 2.0.0 it just returns NULL like any other multilinestring.</para>
 		<para role="changed" conformance="2.3.0"> Changed: 2.3.0 : negative indexing available (-1 is last point)
     </para>
+      <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 support for selecting multiple points with an integer array was introduced.</para>
 
 	  </refsection>
 

--- a/postgis/lwgeom_ogc.c
+++ b/postgis/lwgeom_ogc.c
@@ -32,8 +32,11 @@
 
 #include "access/gist.h"
 #include "access/itup.h"
+#include "catalog/pg_type_d.h"
 
 #include "fmgr.h"
+#include "funcapi.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/elog.h"
 
@@ -59,6 +62,7 @@ Datum LWGEOM_numgeometries_collection(PG_FUNCTION_ARGS);
 Datum LWGEOM_numpatches(PG_FUNCTION_ARGS);
 /* ---- GeometryN(geometry, integer) */
 Datum LWGEOM_geometryn_collection(PG_FUNCTION_ARGS);
+Datum LWGEOM_geometryn_collection_array(PG_FUNCTION_ARGS);
 /* ---- PatchN(geometry, integer) */
 Datum LWGEOM_patchn(PG_FUNCTION_ARGS);
 /* ---- Dimension(geometry) */
@@ -67,10 +71,12 @@ Datum LWGEOM_dimension(PG_FUNCTION_ARGS);
 Datum LWGEOM_exteriorring_polygon(PG_FUNCTION_ARGS);
 /* ---- InteriorRingN(geometry, integer) */
 Datum LWGEOM_interiorringn_polygon(PG_FUNCTION_ARGS);
+Datum LWGEOM_interiorringn_polygon_array(PG_FUNCTION_ARGS);
 /* ---- NumInteriorRings(geometry) */
 Datum LWGEOM_numinteriorrings_polygon(PG_FUNCTION_ARGS);
 /* ---- PointN(geometry, integer) */
 Datum LWGEOM_pointn_linestring(PG_FUNCTION_ARGS);
+Datum LWGEOM_pointn_linestring_array(PG_FUNCTION_ARGS);
 /* ---- X(geometry) */
 Datum LWGEOM_x_point(PG_FUNCTION_ARGS);
 /* ---- Y(geometry) */
@@ -452,6 +458,86 @@ Datum LWGEOM_geometryn_collection(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(result);
 }
 
+typedef struct {
+	LWGEOM *lwgeom;
+	Datum *indices;
+	bool *nulls;
+	int nelems;
+	int i;
+} AccessorArrayState;
+
+PG_FUNCTION_INFO_V1(LWGEOM_geometryn_collection_array);
+Datum
+LWGEOM_geometryn_collection_array(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	AccessorArrayState *state;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		ArrayType *array;
+		GSERIALIZED *geom;
+		MemoryContext oldcontext;
+
+		funcctx = SRF_FIRSTCALL_INIT();
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		geom = PG_GETARG_GSERIALIZED_P_COPY(0);
+		array = PG_GETARG_ARRAYTYPE_P(1);
+
+		state = palloc0(sizeof(AccessorArrayState));
+		state->lwgeom = lwgeom_from_gserialized(geom);
+		deconstruct_array(
+		    array, INT4OID, sizeof(int32), true, 'i', &state->indices, &state->nulls, &state->nelems);
+		funcctx->user_fctx = state;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	state = funcctx->user_fctx;
+
+	while (state->i < state->nelems)
+	{
+		LWGEOM *subgeom;
+		LWGEOM *geom_to_serialize;
+		GSERIALIZED *result;
+		int32 idx;
+
+		if (state->nulls[state->i])
+		{
+			state->i++;
+			fcinfo->isnull = true;
+			SRF_RETURN_NEXT(funcctx, (Datum)0);
+		}
+
+		idx = DatumGetInt32(state->indices[state->i++]);
+		subgeom = lwgeom_extract_geometry_n(state->lwgeom, idx, false);
+		if (!subgeom)
+		{
+			fcinfo->isnull = true;
+			SRF_RETURN_NEXT(funcctx, (Datum)0);
+		}
+
+		geom_to_serialize = subgeom;
+		if (subgeom != state->lwgeom)
+		{
+			geom_to_serialize = lwgeom_clone_deep(subgeom);
+			geom_to_serialize->srid = state->lwgeom->srid;
+			if (state->lwgeom->bbox)
+				lwgeom_add_bbox(geom_to_serialize);
+		}
+
+		result = geometry_serialize(geom_to_serialize);
+		if (geom_to_serialize != subgeom)
+			lwgeom_free(geom_to_serialize);
+		fcinfo->isnull = false;
+		SRF_RETURN_NEXT(funcctx, PointerGetDatum(result));
+	}
+
+	SRF_RETURN_DONE(funcctx);
+}
+
 /** 1-based offset */
 PG_FUNCTION_INFO_V1(LWGEOM_patchn);
 Datum LWGEOM_patchn(PG_FUNCTION_ARGS)
@@ -742,6 +828,122 @@ Datum LWGEOM_interiorringn_polygon(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(result);
 }
 
+static GSERIALIZED *
+lwgeom_interiorringn(LWGEOM *lwgeom, int32 wanted_index)
+{
+	LWCURVEPOLY *curvepoly = NULL;
+	LWPOLY *poly = NULL;
+	POINTARRAY *ring;
+	LWLINE *line;
+	GSERIALIZED *result;
+	GBOX *bbox = NULL;
+	int type = lwgeom->type;
+
+	if (wanted_index < 1)
+		return NULL;
+
+	if ((type != POLYGONTYPE) && (type != CURVEPOLYTYPE))
+		return NULL;
+
+	if (lwgeom_is_empty(lwgeom))
+		return NULL;
+
+	if (type == POLYGONTYPE)
+	{
+		poly = lwgeom_as_lwpoly(lwgeom);
+
+		if (wanted_index >= (int32)poly->nrings)
+			return NULL;
+
+		ring = poly->rings[wanted_index];
+
+		if (poly->bbox)
+		{
+			bbox = lwalloc(sizeof(GBOX));
+			ptarray_calculate_gbox_cartesian(ring, bbox);
+		}
+
+		line = lwline_construct(poly->srid, bbox, ring);
+		result = geometry_serialize((LWGEOM *)line);
+		lwline_release(line);
+	}
+	else
+	{
+		LWGEOM *ring_to_serialize;
+		curvepoly = lwgeom_as_lwcurvepoly(lwgeom);
+
+		if (wanted_index >= (int32)curvepoly->nrings)
+			return NULL;
+
+		ring_to_serialize = lwgeom_clone_deep(curvepoly->rings[wanted_index]);
+		ring_to_serialize->srid = curvepoly->srid;
+		if (curvepoly->bbox)
+			lwgeom_add_bbox(ring_to_serialize);
+		result = geometry_serialize(ring_to_serialize);
+		lwgeom_free(ring_to_serialize);
+	}
+
+	return result;
+}
+
+PG_FUNCTION_INFO_V1(LWGEOM_interiorringn_polygon_array);
+Datum
+LWGEOM_interiorringn_polygon_array(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	AccessorArrayState *state;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		ArrayType *array;
+		GSERIALIZED *geom;
+		MemoryContext oldcontext;
+
+		funcctx = SRF_FIRSTCALL_INIT();
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		geom = PG_GETARG_GSERIALIZED_P_COPY(0);
+		array = PG_GETARG_ARRAYTYPE_P(1);
+
+		state = palloc0(sizeof(AccessorArrayState));
+		state->lwgeom = lwgeom_from_gserialized(geom);
+		deconstruct_array(
+		    array, INT4OID, sizeof(int32), true, 'i', &state->indices, &state->nulls, &state->nelems);
+		funcctx->user_fctx = state;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	state = funcctx->user_fctx;
+
+	while (state->i < state->nelems)
+	{
+		GSERIALIZED *result;
+		int32 idx;
+
+		if (state->nulls[state->i])
+		{
+			state->i++;
+			fcinfo->isnull = true;
+			SRF_RETURN_NEXT(funcctx, (Datum)0);
+		}
+
+		idx = DatumGetInt32(state->indices[state->i++]);
+		result = lwgeom_interiorringn(state->lwgeom, idx);
+		if (!result)
+		{
+			fcinfo->isnull = true;
+			SRF_RETURN_NEXT(funcctx, (Datum)0);
+		}
+
+		fcinfo->isnull = false;
+		SRF_RETURN_NEXT(funcctx, PointerGetDatum(result));
+	}
+
+	SRF_RETURN_DONE(funcctx);
+}
+
 /**
  * PointN(GEOMETRY,INTEGER) -- find the first linestring in GEOMETRY,
  * @return the point at index INTEGER (1 is 1st point).  Return NULL if
@@ -789,6 +991,94 @@ Datum LWGEOM_pointn_linestring(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	PG_RETURN_POINTER(geometry_serialize(lwpoint_as_lwgeom(lwpoint)));
+}
+
+static LWPOINT *
+lwgeom_pointn(LWGEOM *lwgeom, int where)
+{
+	LWPOINT *lwpoint = NULL;
+	int type = lwgeom->type;
+	int count = -1;
+
+	if (type == LINETYPE || type == CIRCSTRINGTYPE || type == COMPOUNDTYPE)
+		count = lwgeom_count_vertices(lwgeom);
+
+	if (where < 1)
+	{
+		if (count > 0)
+			where = where + count + 1;
+		if (where < 1)
+			return NULL;
+	}
+	if (count > 0 && where > count)
+		return NULL;
+
+	if (type == LINETYPE || type == CIRCSTRINGTYPE)
+		lwpoint = lwline_get_lwpoint((LWLINE *)lwgeom, where - 1);
+	else if (type == COMPOUNDTYPE)
+		lwpoint = lwcompound_get_lwpoint((LWCOMPOUND *)lwgeom, where - 1);
+
+	return lwpoint;
+}
+
+PG_FUNCTION_INFO_V1(LWGEOM_pointn_linestring_array);
+Datum
+LWGEOM_pointn_linestring_array(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	AccessorArrayState *state;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		ArrayType *array;
+		GSERIALIZED *geom;
+		MemoryContext oldcontext;
+
+		funcctx = SRF_FIRSTCALL_INIT();
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		geom = PG_GETARG_GSERIALIZED_P_COPY(0);
+		array = PG_GETARG_ARRAYTYPE_P(1);
+
+		state = palloc0(sizeof(AccessorArrayState));
+		state->lwgeom = lwgeom_from_gserialized(geom);
+		deconstruct_array(
+		    array, INT4OID, sizeof(int32), true, 'i', &state->indices, &state->nulls, &state->nelems);
+		funcctx->user_fctx = state;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	state = funcctx->user_fctx;
+
+	while (state->i < state->nelems)
+	{
+		LWPOINT *lwpoint;
+		GSERIALIZED *result;
+		int32 idx;
+
+		if (state->nulls[state->i])
+		{
+			state->i++;
+			fcinfo->isnull = true;
+			SRF_RETURN_NEXT(funcctx, (Datum)0);
+		}
+
+		idx = DatumGetInt32(state->indices[state->i++]);
+		lwpoint = lwgeom_pointn(state->lwgeom, idx);
+		if (!lwpoint)
+		{
+			fcinfo->isnull = true;
+			SRF_RETURN_NEXT(funcctx, (Datum)0);
+		}
+
+		result = geometry_serialize(lwpoint_as_lwgeom(lwpoint));
+		fcinfo->isnull = false;
+		SRF_RETURN_NEXT(funcctx, PointerGetDatum(result));
+	}
+
+	SRF_RETURN_DONE(funcctx);
 }
 
 /**

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -5639,6 +5639,13 @@ CREATE OR REPLACE FUNCTION ST_GeometryN(geometry,integer)
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_LOW;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_GeometryN(geometry,integer[])
+	RETURNS SETOF geometry
+	AS 'MODULE_PATHNAME', 'LWGEOM_geometryn_collection_array'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_LOW;
+
 -- PostGIS equivalent function: Dimension(geometry)
 CREATE OR REPLACE FUNCTION ST_Dimension(geometry)
 	RETURNS integer
@@ -5674,6 +5681,13 @@ CREATE OR REPLACE FUNCTION ST_InteriorRingN(geometry,integer)
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_LOW;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_InteriorRingN(geometry,integer[])
+	RETURNS SETOF geometry
+	AS 'MODULE_PATHNAME','LWGEOM_interiorringn_polygon_array'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_LOW;
+
 -- Deprecation in 1.2.3 -- this should not be deprecated (2011-01-04 robe)
 CREATE OR REPLACE FUNCTION GeometryType(geometry)
 	RETURNS text
@@ -5692,6 +5706,13 @@ CREATE OR REPLACE FUNCTION ST_GeometryType(geometry)
 CREATE OR REPLACE FUNCTION ST_PointN(geometry,integer)
 	RETURNS geometry
 	AS 'MODULE_PATHNAME','LWGEOM_pointn_linestring'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_LOW;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_PointN(geometry,integer[])
+	RETURNS SETOF geometry
+	AS 'MODULE_PATHNAME','LWGEOM_pointn_linestring_array'
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_LOW;
 

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1770,6 +1770,56 @@ SELECT '#5987', ST_AsText(geom), ST_AsText(ST_GeometryN(geom, 1)) FROM test5987;
 DROP TABLE IF EXISTS test5987;
 
 -- -------------------------------------------------------------------------------------
+-- #926, ST_GeometryN/ST_PointN array forms
+SELECT '#926.geom', ord, ST_AsText(g)
+FROM ST_GeometryN(
+  'GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(0 0,1 1),POINT(2 2))'::geometry,
+  ARRAY[2,1,2,4,NULL]::integer[]
+) WITH ORDINALITY AS t(g, ord);
+SELECT '#926.geom.repeat', ord, ST_AsText(g)
+FROM ST_GeometryN(
+  'GEOMETRYCOLLECTION(POLYGON((0 0,1 0,1 1,0 0)),POLYGON((2 2,3 2,3 3,2 2)))'::geometry,
+  ARRAY[2,2]::integer[]
+) WITH ORDINALITY AS t(g, ord);
+SELECT '#926.point', ord, ST_AsText(g)
+FROM ST_PointN(
+  'LINESTRING(0 0,1 1,2 2)'::geometry,
+  ARRAY[1,3,-1,4,NULL,-4]::integer[]
+) WITH ORDINALITY AS t(g, ord);
+SELECT '#926.point.compound', ord, ST_AsText(g)
+FROM ST_PointN(
+  'COMPOUNDCURVE((0 0,1 1),CIRCULARSTRING(1 1,2 2,3 1))'::geometry,
+  ARRAY[1,99,NULL,0]::integer[]
+) WITH ORDINALITY AS t(g, ord);
+SELECT '#926.ring', ord, ST_AsText(g)
+FROM ST_InteriorRingN(
+  'POLYGON((0 0,10 0,10 10,0 10,0 0),(1 1,1 2,2 2,1 1),(3 3,3 4,4 4,3 3))'::geometry,
+  ARRAY[2,1,3,NULL,0]::integer[]
+) WITH ORDINALITY AS t(g, ord);
+SELECT '#926.ring.curve.repeat', ord, ST_AsText(g)
+FROM ST_InteriorRingN(
+  'CURVEPOLYGON(CIRCULARSTRING(0 0,5 5,10 0,5 -5,0 0),(1 1,1 2,2 1,1 1))'::geometry,
+  ARRAY[1,1]::integer[]
+) WITH ORDINALITY AS t(g, ord);
+SELECT '#926.geom.srid', ST_SRID(g), ST_AsEWKT(g)
+FROM ST_GeometryN(
+  'SRID=3857;GEOMETRYCOLLECTION Z(POINT Z(0 0 1),LINESTRING Z(0 0 1,1 1 2))'::geometry,
+  ARRAY[2]::integer[]
+) AS t(g);
+SELECT '#926.point.srid', ST_SRID(g), ST_AsEWKT(g)
+FROM ST_PointN(
+  'SRID=3857;LINESTRING Z(0 0 1,1 1 2)'::geometry,
+  ARRAY[2]::integer[]
+) AS t(g);
+SELECT '#926.ring.srid', ST_SRID(g), ST_AsEWKT(g)
+FROM ST_InteriorRingN(
+  'SRID=3857;POLYGON Z((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0),(1 1 3,1 2 4,2 2 5,1 1 3))'::geometry,
+  ARRAY[1]::integer[]
+) AS t(g);
+SELECT '#926.empty', count(*)
+FROM ST_PointN('LINESTRING(0 0,1 1)'::geometry, ARRAY[]::integer[]);
+
+-- -------------------------------------------------------------------------------------
 -- #5962
 SELECT '#5962',
     ST_AsText(ST_ClipByBox2D(

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -518,6 +518,34 @@ public|test5978|shape|2|4326|POINT
 #3103.3|test3103a|4326
 #4828|4326
 #5987|LINESTRING(20 20,20.1 20,20.2 19.9)|LINESTRING(20 20,20.1 20,20.2 19.9)
+#926.geom|1|LINESTRING(0 0,1 1)
+#926.geom|2|POINT(0 0)
+#926.geom|3|LINESTRING(0 0,1 1)
+#926.geom|4|
+#926.geom|5|
+#926.geom.repeat|1|POLYGON((2 2,3 2,3 3,2 2))
+#926.geom.repeat|2|POLYGON((2 2,3 2,3 3,2 2))
+#926.point|1|POINT(0 0)
+#926.point|2|POINT(2 2)
+#926.point|3|POINT(2 2)
+#926.point|4|
+#926.point|5|
+#926.point|6|
+#926.point.compound|1|POINT(0 0)
+#926.point.compound|2|
+#926.point.compound|3|
+#926.point.compound|4|
+#926.ring|1|LINESTRING(3 3,3 4,4 4,3 3)
+#926.ring|2|LINESTRING(1 1,1 2,2 2,1 1)
+#926.ring|3|
+#926.ring|4|
+#926.ring|5|
+#926.ring.curve.repeat|1|LINESTRING(1 1,1 2,2 1,1 1)
+#926.ring.curve.repeat|2|LINESTRING(1 1,1 2,2 1,1 1)
+#926.geom.srid|3857|SRID=3857;LINESTRING(0 0 1,1 1 2)
+#926.point.srid|3857|SRID=3857;POINT(1 1 2)
+#926.ring.srid|3857|SRID=3857;LINESTRING(1 1 3,1 2 4,2 2 5,1 1 3)
+#926.empty|0
 #5962|MULTIPOINT((1 1),(3 4))|POINT(1 1)
 #5754|LINESTRING(0 0,1 1,2 0,3 1,4 0)|LINESTRING(0 0,1 1,2 0,3 1,4 0)|POLYGON((0 0,1 0,1 1,0 1,0 0))|POLYGON((0 0,10 0,10 10,0 10,0 0),(1 1,1 2,2 2,2 1,1 1))
 #5938|1FF00F212|t


### PR DESCRIPTION
Closes https://trac.osgeo.org/postgis/ticket/926

## Summary
- add C SRF integer-array overloads for `ST_GeometryN`, `ST_InteriorRingN`, and `ST_PointN`
- preserve array order and emit NULL rows for NULL or out-of-range indices
- document the new overloads and cover duplicate, NULL, out-of-range, empty-array, SRID, Z, compound-curve, and repeated curvepolygon-ring cases in tickets regression

## Review follow-up
- avoid mutating cached child geometries while serializing repeated `ST_GeometryN` array results
- clone `CURVEPOLYGON` rings before serializing repeated `ST_InteriorRingN` array results
- return NULL rows for out-of-range `COMPOUNDCURVE` `ST_PointN` array elements instead of aborting the SRF
- guard non-empty `COMPOUNDCURVE` zero indexes after negative/zero conversion, so `ARRAY[0]` emits a NULL row instead of reaching the compound accessor
- clarify in the accessor docs that integer-array overloads preserve array order and emit NULL rows for NULL or out-of-range indexes

## Rebase refresh
- 2026-07-01: rebased over upstream/master `4e470f1534795ae4a4c52ad5ad35b8744af9d708` and force-pushed head `a0e973bfa9c8fe819617541a70f0e9507276faf8`

## Testing
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C libpgcommon -j32`
- `make -C postgis -j32`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `dropdb --if-exists postgis_reg || true`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"` (fresh + automatic upgrade)
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/lwgeom_ogc.c regress/core/tickets.sql regress/core/tickets_expected doc/reference_accessor.xml postgis/postgis.sql.in NEWS`
- `git diff --check upstream/master..HEAD`
- `git diff --check`
- `git diff --cached --check`
