### PR TITLE
Add ST_Simplify support for geography

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,9 @@ These are only changes since 3.7.0beta1.
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
 
+ - #3377, Add ST_Simplify support for geography
+          (Darafei Praliaskouski)
+
 PostGIS 3.7.0beta1
 2026/07/20
 
@@ -95,10 +98,6 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
- - #3377, Add ST_Simplify support for geography
-          (Darafei Praliaskouski)
-
-
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #3377, Add ST_Simplify support for geography
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/NEWS
+++ b/NEWS
@@ -153,6 +153,10 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #3377, Add ST_Simplify support for geography
+          (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -233,8 +237,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4678, [raster] Move st_sum4ma neighborhood callback to C
           (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
-          (Darafei Praliaskouski)
- - #3377, Add ST_Simplify support for geography
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -234,6 +234,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
           (Darafei Praliaskouski)
+ - #3377, Add ST_Simplify support for geography
+          (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)

--- a/NEWS
+++ b/NEWS
@@ -183,6 +183,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
           (Darafei Praliaskouski)
+ - #3377, Add ST_Simplify support for geography
+          (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors

--- a/NEWS
+++ b/NEWS
@@ -95,6 +95,10 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #3377, Add ST_Simplify support for geography
+          (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -182,8 +186,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4678, [raster] Move st_sum4ma neighborhood callback to C
           (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
-          (Darafei Praliaskouski)
- - #3377, Add ST_Simplify support for geography
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks
           and pass callback call data as actual arguments (Darafei Praliaskouski)

--- a/doc/reference_processing.xml
+++ b/doc/reference_processing.xml
@@ -2228,7 +2228,7 @@ MULTILINESTRING((76 175,101 150),(126 125,126 156.25)))</screen>
     <refentry xml:id="ST_Simplify">
       <refnamediv>
         <refname>ST_Simplify</refname>
-        <refpurpose>Returns a simplified representation of a geometry, using the Douglas-Peucker algorithm.</refpurpose>
+        <refpurpose>Returns a simplified representation of a geometry or geography, using the Douglas-Peucker algorithm.</refpurpose>
       </refnamediv>
 
       <refsynopsisdiv>
@@ -2244,6 +2244,17 @@ MULTILINESTRING((76 175,101 150),(126 125,126 156.25)))</screen>
             <paramdef><type>float</type> <parameter>tolerance</parameter></paramdef>
             <paramdef><type>boolean</type> <parameter>preserveCollapsed</parameter></paramdef>
           </funcprototype>
+          <funcprototype>
+            <funcdef>geography <function>ST_Simplify</function></funcdef>
+            <paramdef><type>geography</type> <parameter>geog</parameter></paramdef>
+            <paramdef><type>float</type> <parameter>tolerance</parameter></paramdef>
+          </funcprototype>
+          <funcprototype>
+            <funcdef>geography <function>ST_Simplify</function></funcdef>
+            <paramdef><type>geography</type> <parameter>geog</parameter></paramdef>
+            <paramdef><type>float</type> <parameter>tolerance</parameter></paramdef>
+            <paramdef><type>boolean</type> <parameter>preserveCollapsed</parameter></paramdef>
+          </funcprototype>
         </funcsynopsis>
       </refsynopsisdiv>
 
@@ -2254,6 +2265,11 @@ MULTILINESTRING((76 175,101 150),(126 125,126 156.25)))</screen>
             The simplification <varname>tolerance</varname> is a distance value, in the units of the input SRS.
             Simplification removes vertices which are within the tolerance distance of the simplified linework.
             The result may not be valid even if the input is.
+            </para>
+          <para>
+            For geography inputs, the tolerance is specified in meters.
+            The geography is transformed to a best-fit planar spatial reference system,
+            simplified there, and transformed back to geography.
             </para>
           <para>
             The function can be called with any kind of geometry (including GeometryCollections),
@@ -2273,6 +2289,7 @@ MULTILINESTRING((76 175,101 150),(126 125,126 156.25)))</screen>
         <note><para>This function does not preserve boundaries shared between polygons.  Use <xref linkend="ST_CoverageSimplify"/> if this is required.</para></note>
 
         <para role="availability" conformance="1.2.2">Availability: 1.2.2</para>
+        <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 support for geography was introduced.</para>
       </refsection>
 
           <refsection>
@@ -2302,6 +2319,15 @@ np100_geometrygoesaway   | t</screen>
     <programlisting>SELECT ST_Simplify('MULTIPOLYGON (((90 110,80 180,50 160,10 170,10 140,20 110,90 110)),((40 80,100 100,120 160,170 180,190 70,140 10,110 40,60 40,40 80),(180 70,170 110,142.5 128.5,128.5 77.5,90 60,180 70)))'::geometry,
 40);</programlisting>
 <screen role="visual-primary text-primary">MULTIPOLYGON(((90 110,80 180,10 170,20 110,90 110)),((40 80,170 180,140 10,40 80),(180 70,142.5 128.5,90 60,180 70)))</screen>
+
+    <para>Simplifying a geographic line, using a tolerance in meters.</para>
+    <programlisting>SELECT ST_AsText(ST_Simplify(
+  'LINESTRING(-71.060316 48.432044,-71.0608 48.4327,-71.0612 48.4334,-71.062 48.434)'::geography,
+    75), 6);
+ st_astext
+----------------------------
+ LINESTRING(-71.060316 48.432044,-71.062 48.434)
+</programlisting>
 
           </refsection>
           <refsection>

--- a/doc/reference_processing.xml
+++ b/doc/reference_processing.xml
@@ -2323,11 +2323,8 @@ np100_geometrygoesaway   | t</screen>
     <para>Simplifying a geographic line, using a tolerance in meters.</para>
     <programlisting>SELECT ST_AsText(ST_Simplify(
   'LINESTRING(-71.060316 48.432044,-71.0608 48.4327,-71.0612 48.4334,-71.062 48.434)'::geography,
-    75), 6);
- st_astext
-----------------------------
- LINESTRING(-71.060316 48.432044,-71.062 48.434)
-</programlisting>
+    75), 6);</programlisting>
+<screen>LINESTRING(-71.060316 48.432044,-71.062 48.434)</screen>
 
           </refsection>
           <refsection>

--- a/postgis/geography.sql.in
+++ b/postgis/geography.sql.in
@@ -791,6 +791,145 @@ CREATE OR REPLACE FUNCTION ST_Intersects(geog1 geography, geog2 geography)
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_HIGH;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION _ST_GeographyHasAntipodalEdge(geom geometry)
+	RETURNS boolean AS
+	$$
+	WITH segments AS (
+		SELECT @extschema@.ST_StartPoint(segment.geom) AS start_pt,
+			@extschema@.ST_EndPoint(segment.geom) AS end_pt
+		FROM @extschema@.ST_DumpSegments($1) AS segment
+	)
+	SELECT EXISTS (
+		SELECT 1
+		FROM segments
+		WHERE abs(@extschema@.ST_Y(start_pt) + @extschema@.ST_Y(end_pt)) <= 1e-11
+			AND abs(abs(@extschema@.ST_X(start_pt) - @extschema@.ST_X(end_pt)) - 180) <= 1e-11
+	);
+	$$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION _ST_GeographySimplifyPreservesVertices(input geometry, candidate geometry, tolerance float8, preserveCollapsed boolean)
+	RETURNS boolean AS
+	$$
+	WITH components AS (
+		SELECT input_part.path, input_part.geom AS input_geom, candidate_part.geom AS candidate_geom
+		FROM @extschema@.ST_Dump($1) AS input_part
+		LEFT JOIN @extschema@.ST_Dump($2) AS candidate_part
+		ON input_part.path = candidate_part.path
+	),
+	component_points AS (
+		SELECT
+			components.candidate_geom,
+			@extschema@.ST_Dimension(components.input_geom) AS input_dimension,
+			dump.geom AS point_geom
+		FROM components
+		CROSS JOIN LATERAL @extschema@.ST_DumpPoints(input_geom) AS dump
+		WHERE @extschema@.ST_Dimension(input_geom) <> 2
+			AND (components.candidate_geom IS NOT NULL OR $4)
+		UNION ALL
+		SELECT
+			components.candidate_geom,
+			2 AS input_dimension,
+			dump.geom AS point_geom
+		FROM components
+		CROSS JOIN LATERAL @extschema@.ST_DumpRings(input_geom) AS input_ring
+		CROSS JOIN LATERAL @extschema@.ST_DumpPoints(input_ring.geom) AS dump
+		WHERE @extschema@.ST_Dimension(input_geom) = 2
+			AND (
+				input_ring.path[1] = 0 OR
+				$4 OR
+				(
+					components.candidate_geom IS NOT NULL AND
+					@extschema@.ST_Dimension(components.candidate_geom) = 2 AND
+					EXISTS (
+						SELECT 1
+						FROM @extschema@.ST_DumpRings(components.candidate_geom) AS candidate_ring
+						WHERE candidate_ring.path = input_ring.path
+					)
+				)
+			)
+	)
+	SELECT NOT EXISTS (
+		SELECT 1
+		FROM component_points
+		WHERE candidate_geom IS NULL OR
+			CASE
+				WHEN @extschema@._ST_GeographyHasAntipodalEdge(candidate_geom) THEN true
+				ELSE NOT @extschema@.ST_DWithin(
+					@extschema@.geography(point_geom),
+					@extschema@.geography(
+						CASE
+							WHEN input_dimension = 2 AND @extschema@.ST_Dimension(candidate_geom) = 2 THEN @extschema@.ST_Boundary(candidate_geom)
+							ELSE candidate_geom
+						END
+					),
+					$3
+				)
+			END
+	);
+	$$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_Simplify(geog geography, tolerance float8)
+	RETURNS geography
+	AS 'WITH input AS (
+			SELECT @extschema@.geometry($1) AS geom
+		)
+		SELECT CASE
+			WHEN @extschema@.ST_IsEmpty(geom) THEN $1
+			ELSE (
+				SELECT CASE
+					WHEN simplified.geom IS NULL OR @extschema@.ST_IsEmpty(simplified.geom) THEN @extschema@.geography(simplified.geom)
+					WHEN @extschema@._ST_GeographyHasAntipodalEdge(simplified.geom) THEN $1
+					WHEN @extschema@._ST_GeographySimplifyPreservesVertices(input.geom, simplified.geom, $2, false) THEN @extschema@.geography(simplified.geom)
+					ELSE $1
+				END
+				FROM (
+					SELECT @extschema@.ST_Transform(@extschema@.ST_Simplify(@extschema@.ST_Transform(input.geom, @extschema@._ST_BestSRID($1)), $2), @extschema@.ST_SRID($1)) AS geom
+				) AS simplified
+			)
+		END
+		FROM input'
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_Simplify(geog geography, tolerance float8, preserveCollapsed boolean)
+	RETURNS geography
+	AS 'WITH input AS (
+			SELECT @extschema@.geometry($1) AS geom
+		)
+		SELECT CASE
+			WHEN @extschema@.ST_IsEmpty(geom) THEN $1
+			ELSE (
+				SELECT CASE
+					WHEN simplified.geom IS NULL OR @extschema@.ST_IsEmpty(simplified.geom) THEN @extschema@.geography(simplified.geom)
+					WHEN @extschema@._ST_GeographyHasAntipodalEdge(simplified.geom) THEN $1
+					WHEN @extschema@._ST_GeographySimplifyPreservesVertices(input.geom, simplified.geom, $2, $3) THEN @extschema@.geography(simplified.geom)
+					ELSE $1
+				END
+				FROM (
+					SELECT @extschema@.ST_Transform(@extschema@.ST_Simplify(@extschema@.ST_Transform(input.geom, @extschema@._ST_BestSRID($1)), $2, $3), @extschema@.ST_SRID($1)) AS geom
+				) AS simplified
+			)
+		END
+		FROM input'
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Availability: 3.7.0 - this is just a hack to prevent unknown from causing ambiguous name because of geography
+CREATE OR REPLACE FUNCTION ST_Simplify(text, float8)
+	RETURNS geometry AS
+	$$ SELECT @extschema@.ST_Simplify($1::@extschema@.geometry, $2);  $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Availability: 3.7.0 - this is just a hack to prevent unknown from causing ambiguous name because of geography
+CREATE OR REPLACE FUNCTION ST_Simplify(text, float8, boolean)
+	RETURNS geometry AS
+	$$ SELECT @extschema@.ST_Simplify($1::@extschema@.geometry, $2, $3);  $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
+
 -- Availability: 1.5.0
 CREATE OR REPLACE FUNCTION ST_Buffer(geography, float8)
 	RETURNS geography

--- a/postgis/postgis_before_upgrade.sql
+++ b/postgis/postgis_before_upgrade.sql
@@ -134,6 +134,9 @@ SELECT _postgis_drop_function_by_identity
 -- to ST_CoverageInvalidEdges
 DROP FUNCTION IF EXISTS ST_CoverageInvalidLocations(geometry, double precision);
 
+-- FUNCTION _ST_GeographySimplifyPreservesVertices changed to add preserveCollapsed
+DROP FUNCTION IF EXISTS _ST_GeographySimplifyPreservesVertices(geometry, geometry, double precision);
+
 -- geometry_columns changed parameter types so we verify if it needs to be dropped
 -- We check the catalog to see if the view (geometry_columns) has a column
 -- with name `f_table_schema` and type `character varying(256)` as it was

--- a/postgis/postgis_before_upgrade.sql
+++ b/postgis/postgis_before_upgrade.sql
@@ -143,6 +143,9 @@ SELECT _postgis_drop_function_by_identity
 -- to ST_CoverageInvalidEdges
 DROP FUNCTION IF EXISTS ST_CoverageInvalidLocations(geometry, double precision);
 
+-- FUNCTION _ST_GeographySimplifyPreservesVertices changed to add preserveCollapsed
+DROP FUNCTION IF EXISTS _ST_GeographySimplifyPreservesVertices(geometry, geometry, double precision);
+
 -- geometry_columns changed parameter types so we verify if it needs to be dropped
 -- We check the catalog to see if the view (geometry_columns) has a column
 -- with name `f_table_schema` and type `character varying(256)` as it was

--- a/postgis/uninstall_geography.sql.in
+++ b/postgis/uninstall_geography.sql.in
@@ -49,6 +49,13 @@ DROP FUNCTION IF EXISTS ST_Length(text);
 DROP FUNCTION IF EXISTS ST_Covers(text, text);
 DROP FUNCTION IF EXISTS ST_CoveredBy(text, text);
 DROP FUNCTION IF EXISTS ST_Intersects(text, text);
+DROP FUNCTION IF EXISTS ST_Simplify(text, float8);
+DROP FUNCTION IF EXISTS ST_Simplify(text, float8, boolean);
+DROP FUNCTION IF EXISTS ST_Simplify(geography, float8);
+DROP FUNCTION IF EXISTS ST_Simplify(geography, float8, boolean);
+DROP FUNCTION IF EXISTS _ST_GeographyHasAntipodalEdge(geometry);
+DROP FUNCTION IF EXISTS _ST_GeographySimplifyPreservesVertices(geometry, geometry, float8);
+DROP FUNCTION IF EXISTS _ST_GeographySimplifyPreservesVertices(geometry, geometry, float8, boolean);
 DROP FUNCTION IF EXISTS ST_Buffer(text, float8);
 DROP FUNCTION IF EXISTS ST_Intersection(text, text);
 
@@ -139,4 +146,3 @@ DROP FUNCTION IF EXISTS geography_analyze(internal);
 -- DROP FUNCTION IF EXISTS gidx_in(cstring);
 -- DROP FUNCTION IF EXISTS gidx_out(gidx);
 DROP TYPE gidx CASCADE;
-

--- a/regress/core/geography.sql
+++ b/regress/core/geography.sql
@@ -103,6 +103,101 @@ SELECT 'segmentize_geography2', st_dwithin(st_pointn(st_segmentize('linestring(1
 SELECT 'segmentize_geography_3667', abs(ST_Length(geog) - ST_Length(ST_Segmentize(geog, 30000))) < 0.00001
   FROM (SELECT ST_GeographyFromText('LINESTRING(38.769917 10.780694, 38.769917 9.106194)') As geog) AS f;
 
+-- Test simplify on geography
+WITH geog AS (
+    SELECT 'LINESTRING(-71.060316 48.432044,-71.0608 48.4327,-71.0612 48.4334,-71.062 48.434)'::geography AS g
+)
+SELECT 'simplify_geography',
+  ST_NPoints(g::geometry),
+  ST_NPoints(ST_Simplify(g, 75)::geometry),
+  ST_SRID(ST_Simplify(g, 75)) FROM geog;
+
+SELECT 'simplify_geography_preserve_collapsed',
+  ST_NPoints(ST_Simplify('LINESTRING(0 0, 0.0001 0)'::geography, 1000, false)::geometry),
+  ST_NPoints(ST_Simplify('LINESTRING(0 0, 0.0001 0)'::geography, 1000, true)::geometry),
+  ST_SRID(ST_Simplify('LINESTRING(0 0, 0.0001 0)'::geography, 1000, true));
+
+SELECT 'simplify_geography_collapse_polygon',
+  ST_Simplify('POLYGON((0 0, 0.0001 0, 0.0001 0.0001, 0 0))'::geography, 1000, false) IS NULL,
+  GeometryType(ST_Simplify('POLYGON((0 0, 0.0001 0, 0.0001 0.0001, 0 0))'::geography, 1000, true)::geometry),
+  ST_NPoints(ST_Simplify('POLYGON((0 0, 0.0001 0, 0.0001 0.0001, 0 0))'::geography, 1000, true)::geometry);
+
+SELECT 'simplify_geography_drop_collapsed_hole',
+  ST_NumInteriorRings(ST_Simplify('POLYGON((0 0, 0 0.01, 0.01 0.01, 0.01 0, 0 0),(0.005 0.005, 0.00501 0.005, 0.005 0.00501, 0.005 0.005))'::geography, 100, false)::geometry),
+  ST_NumInteriorRings(ST_Simplify('POLYGON((0 0, 0 0.01, 0.01 0.01, 0.01 0, 0 0),(0.005 0.005, 0.00501 0.005, 0.005 0.00501, 0.005 0.005))'::geography, 100, true)::geometry);
+
+SELECT 'simplify_text_literal',
+  GeometryType(ST_Simplify('LINESTRING(0 0, 0.5 0, 1 0)', 0.1)),
+  GeometryType(ST_Simplify('LINESTRING(0 0, 0.5 0, 1 0)', 0.1, true));
+
+SELECT 'simplify_geography_empty',
+  ST_AsText(ST_Simplify('SRID=4326;LINESTRING EMPTY'::geography, 75)::geometry),
+  ST_AsText(ST_Simplify('SRID=4326;LINESTRING EMPTY'::geography, 75, true)::geometry),
+  ST_SRID(ST_Simplify('SRID=4326;LINESTRING EMPTY'::geography, 75));
+
+WITH geog AS (
+    SELECT 'LINESTRING(-170 0,0 0,170 0)'::geography AS g
+)
+SELECT 'simplify_geography_antimeridian',
+  ST_AsText(ST_Simplify(g, 1)::geometry),
+  round(ST_Length(g)::numeric, 3),
+  round(ST_Length(ST_Simplify(g, 1))::numeric, 3) FROM geog;
+
+WITH geog AS (
+    SELECT 'LINESTRING(170 0,179 0,-179 0,-170 0)'::geography AS g
+)
+SELECT 'simplify_geography_existing_dateline',
+  ST_NPoints(ST_Simplify(g, 1)::geometry),
+  round(ST_Length(g)::numeric, 3),
+  round(ST_Length(ST_Simplify(g, 1))::numeric, 3) FROM geog;
+
+WITH geog AS (
+    SELECT 'LINESTRING(-80 45,0 45,80 45)'::geography AS g
+)
+SELECT 'simplify_geography_preserve_wide_route',
+  ST_AsText(ST_Simplify(g, 1)::geometry),
+  ST_AsText(ST_Simplify(g, 1, true)::geometry),
+  round(ST_Length(g)::numeric, 3),
+  round(ST_Length(ST_Simplify(g, 1))::numeric, 3) FROM geog;
+
+WITH geog AS (
+    SELECT 'LINESTRING(0 0,90 0,180 0)'::geography AS g
+)
+SELECT 'simplify_geography_preserve_antipodal_candidate',
+  ST_AsText(ST_Simplify(g, 1)::geometry),
+  round((ST_Length(g) - ST_Length(ST_Simplify(g, 1)))::numeric, 3) FROM geog;
+
+WITH geog AS (
+    SELECT 'LINESTRING(0 0,90 0,179.999999999998 0)'::geography AS g
+)
+SELECT 'simplify_geography_preserve_near_antipodal_candidate',
+  ST_AsText(ST_Simplify(g, 1)::geometry),
+  round((ST_Length(g) - ST_Length(ST_Simplify(g, 1)))::numeric, 3) FROM geog;
+
+WITH geog AS (
+    SELECT 'GEOMETRYCOLLECTION(POLYGON((0 0, 0.001 0, 0.002 0, 0.002 0.002, 0 0)), POINT(10 10))'::geography AS g
+)
+SELECT 'simplify_geography_collection_polygon_point',
+  ST_NPoints(g::geometry),
+  ST_NPoints(ST_Simplify(g, 75)::geometry),
+  ST_AsText(ST_GeometryN(ST_Simplify(g, 75)::geometry, 2), 6) FROM geog;
+
+WITH geog AS (
+    SELECT 'GEOMETRYCOLLECTION(LINESTRING(0 0, 0.0001 0, 0.0002 0), POINT(1 1))'::geography AS g
+)
+SELECT 'simplify_geography_collection_line_point',
+  ST_NPoints(g::geometry),
+  ST_NPoints(ST_Simplify(g, 20)::geometry),
+  ST_AsText(ST_GeometryN(ST_Simplify(g, 20)::geometry, 2)) FROM geog;
+
+SELECT 'simplify_geography_preserve_collection_components',
+  _ST_GeographySimplifyPreservesVertices(
+    'GEOMETRYCOLLECTION(POLYGON((0 0, 0 0.001, 0.001 0.001, 0.001 0, 0 0)), LINESTRING(0 0.0005, 0.0005 0, 0.001 0.0005))'::geometry,
+    'GEOMETRYCOLLECTION(POLYGON((0 0, 0 0.001, 0.001 0.001, 0.001 0, 0 0)), LINESTRING(0 0.0005, 0.001 0.0005))'::geometry,
+    1,
+    false
+  );
+
 -- typmod checks
 select 'typmod_point_4326', geography_typmod_out(geography_typmod_in('{Point,4326}'));
 select 'typmod_point_0', geography_typmod_out(geography_typmod_in('{Point,0}'));

--- a/regress/core/geography_expected
+++ b/regress/core/geography_expected
@@ -30,6 +30,20 @@ geog_precision_pazafir|0|0
 segmentize_geography|39092
 segmentize_geography2|t
 segmentize_geography_3667|t
+simplify_geography|4|2|4326
+simplify_geography_preserve_collapsed|2|2|4326
+simplify_geography_collapse_polygon|t|POLYGON|4
+simplify_geography_drop_collapsed_hole|0|1
+simplify_text_literal|LINESTRING|LINESTRING
+simplify_geography_empty|LINESTRING EMPTY|LINESTRING EMPTY|4326
+simplify_geography_antimeridian|LINESTRING(-170 0,0 0,170 0)|37848626.870|37848626.870
+simplify_geography_existing_dateline|4|2226389.816|2226389.816
+simplify_geography_preserve_wide_route|LINESTRING(-80 45,0 45,80 45)|LINESTRING(-80 45,0 45,80 45)|12057688.485|12057688.485
+simplify_geography_preserve_antipodal_candidate|LINESTRING(0 0,90 0,180 0)|0.000
+simplify_geography_preserve_near_antipodal_candidate|LINESTRING(0 0,90 0,179.999999999998 0)|0.000
+simplify_geography_collection_polygon_point|6|5|POINT(10 10)
+simplify_geography_collection_line_point|4|3|POINT(1 1)
+simplify_geography_preserve_collection_components|f
 typmod_point_4326|(Point,4326)
 typmod_point_0|(Point,4326)
 NOTICE:  SRID value -1 converted to the officially unknown SRID value 0


### PR DESCRIPTION
## Summary

Adds geography overloads for `ST_Simplify(geography, float8)` and
`ST_Simplify(geography, float8, boolean)`.

The geography wrapper follows the existing geography processing pattern: transform
to `_ST_BestSRID`, simplify with the existing geometry Douglas-Peucker function,
then transform back to the input geography SRID. Empty geographies return before
any best-SRID transform or simplification work is attempted.

To avoid introducing geodesic shortcuts, the wrapper accepts a simplified
candidate only when `_ST_GeographySimplifyPreservesVertices` confirms original
vertices remain within the requested tolerance of the corresponding candidate
component. Polygon checks compare against boundaries, and interior rings that
collapse away are allowed only when `preserveCollapsed = false`.

Collapsed `NULL` or empty simplification results are returned directly, so
`preserveCollapsed = false` continues to honor the existing geometry simplifier
behavior. Simplified candidates that would introduce an exact or near-antipodal
geography edge are rejected before any geography cast can throw, so the wrapper
falls back to the original valid route.

The helper is schema-safe for non-public extension installs by using
`@extschema@.geography(...)` conversions instead of unqualified `::geography`
casts. Upgrade and uninstall scripts also clean up the old private helper
signature.

Trac ticket: https://trac.osgeo.org/postgis/ticket/3377

## Validation

- current head `d1427ebe3909eb5495839f2a7fe56bda64a3a696`
- rebased to upstream/master `4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make postgis_revision.h && make -C postgis -j32 && make -C extensions/postgis -j1`
- `sudo -n make -C postgis install && sudo -n make -C extensions/postgis install`
- `dropdb --if-exists postgis_reg || true && PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/geography"`
- `dropdb --if-exists postgis_reg || true && PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose --schema=postgis_ci" TESTS="$(pwd)/regress/core/geography"`
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/geography.sql.in postgis/uninstall_geography.sql.in postgis/postgis_before_upgrade.sql regress/core/geography.sql regress/core/geography_expected doc/reference_processing.xml NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`

Regression coverage includes the base geography simplify path, text literal
shim resolution, empty geographies, collapse-vs-preserveCollapsed behavior,
dropped interior rings, the original long-route antimeridian case, an existing
dateline-crossing route, a wide non-dateline route, exact and near-antipodal
candidate fallbacks, mixed geography collections, and a direct component-aware
vertex-preservation regression.

Closes https://trac.osgeo.org/postgis/ticket/3377
