### PR TITLE
Improve ST_AsX3D curve and collection output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,8 @@ These are only changes since 3.7.0alpha1.
           preprocessed with AltiVec vector macros (Darafei Praliaskouski)
  - #6094, [upgrade] Avoid legacy string literal warnings in downgrade checks
           with standard_conforming_strings off (Darafei Praliaskouski)
+ - #3705, ST_AsX3D outputs valid coordinate nodes for 2D multi-geometries
+          and GeometryCollections (Darafei Praliaskouski)
  - #5423, Use a DTD-free expanded DocBook input for EPUB builds so
           out-of-tree builds do not need dbtoepub entity path support
           (Darafei Praliaskouski)
@@ -170,7 +172,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           prefer requested CXX over pg_config --cc for internal C++ checks, and
           make fuzzer linking/runtime dependency packaging portable
           (Darafei Praliaskouski)
-
+ - #1416, ST_AsX3D outputs curve geometries
+          (Darafei Praliaskouski)
 * Enhancements *
 
  - #2045, pgsql2shp query dumps no longer require temporary table

--- a/NEWS
+++ b/NEWS
@@ -172,7 +172,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           prefer requested CXX over pg_config --cc for internal C++ checks, and
           make fuzzer linking/runtime dependency packaging portable
           (Darafei Praliaskouski)
- - #1416, ST_AsX3D outputs curve geometries
+ - #1416, ST_AsX3D outputs NURBSCURVE as X3D NurbsCurve
+          and linearizes other curve geometries
           (Darafei Praliaskouski)
 * Enhancements *
 

--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1640,9 +1640,9 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
             <entry>linearized, then emitted with the linear geometry mapping</entry>
             </row>
             <row>
-            <entry>NURBSCurve</entry>
-            <entry>NurbsCurve</entry>
-            <entry>NurbsCurve</entry>
+            <entry>NURBSCURVE</entry>
+            <entry>NurbsCurve with controlPoint, knot, weight, and order fields</entry>
+            <entry>NurbsCurve with controlPoint, knot, weight, and order fields</entry>
             </row>
         </tbody>
       </tgroup>
@@ -1654,7 +1654,7 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
     <para>Also check out <link xlink:href="https://git.osgeo.org/gitea/robe/postgis_x3d_viewer">PostGIS minimalist X3D viewer</link>  that utilizes this function and <link xlink:href="http://www.x3dom.org/">x3dDom html/js open source toolkit</link>.</para>
     <para role="availability" conformance="2.0.0">Availability: 2.0.0: ISO-IEC-19776-1.2-X3DEncodings-XML</para>
     <para role="enhanced" conformance="2.2.0">Enhanced: 2.2.0: Support for GeoCoordinates and axis (x/y, long/lat) flipping.  Look at options for details.</para>
-    <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0: Support for curve geometries. NURBSCurve is emitted as NurbsCurve; other curve types are linearized before output.</para>
+    <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0: Support for curve geometries. NURBSCURVE is emitted as X3D NurbsCurve; other curve types are linearized before output.</para>
     <!-- Optionally mention 3d support -->
     <para>&Z_support;</para>
         <!-- Optionally mention supports Polyhedral Surface  -->

--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1606,12 +1606,12 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
           <tbody>
             <row>
             <entry>LINESTRING</entry>
-            <entry>not yet implemented - will be PolyLine2D</entry>
+            <entry>LineSet (coordinates are promoted to 3D)</entry>
             <entry>LineSet</entry>
             </row>
             <row>
             <entry>MULTILINESTRING</entry>
-            <entry>not yet implemented - will be PolyLine2D</entry>
+            <entry>IndexedLineSet (coordinates are promoted to 3D)</entry>
             <entry>IndexedLineSet</entry>
             </row>
             <row>
@@ -1626,7 +1626,7 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
             </row>
             <row>
             <entry>(MULTI) POLYGON, POLYHEDRALSURFACE</entry>
-            <entry>Invalid X3D markup</entry>
+            <entry>IndexedFaceSet (coordinates are promoted to 3D; inner rings currently output as another faceset)</entry>
             <entry>IndexedFaceSet (inner rings currently output as another faceset)</entry>
             </row>
             <row>
@@ -1634,15 +1634,27 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
             <entry>TriangleSet2D (Not Yet Implemented)</entry>
             <entry>IndexedTriangleSet</entry>
             </row>
+            <row>
+            <entry>CIRCULARSTRING, COMPOUNDCURVE, CURVEPOLYGON, MULTICURVE, MULTISURFACE</entry>
+            <entry>linearized, then emitted with the linear geometry mapping</entry>
+            <entry>linearized, then emitted with the linear geometry mapping</entry>
+            </row>
+            <row>
+            <entry>NURBSCurve</entry>
+            <entry>NurbsCurve</entry>
+            <entry>NurbsCurve</entry>
+            </row>
         </tbody>
       </tgroup>
     </informaltable>
     <note><para>2D geometry support not yet complete.  Inner rings currently just drawn as separate polygons.  We are working on these.</para></note>
+    <para>M coordinates are not represented in X3D output.</para>
     <para>Lots of advancements happening in 3D space particularly with <link xlink:href="https://www.web3d.org/wiki/index.php/X3D_and_HTML5">X3D Integration with HTML5</link></para>
     <para>There is also a nice open source X3D viewer you can use to view rendered geometries. Free Wrl <link xlink:href="http://freewrl.sourceforge.net/">http://freewrl.sourceforge.net/</link> binaries available for Mac, Linux, and Windows. Use the FreeWRL_Launcher packaged to view the geometries.</para>
     <para>Also check out <link xlink:href="https://git.osgeo.org/gitea/robe/postgis_x3d_viewer">PostGIS minimalist X3D viewer</link>  that utilizes this function and <link xlink:href="http://www.x3dom.org/">x3dDom html/js open source toolkit</link>.</para>
     <para role="availability" conformance="2.0.0">Availability: 2.0.0: ISO-IEC-19776-1.2-X3DEncodings-XML</para>
     <para role="enhanced" conformance="2.2.0">Enhanced: 2.2.0: Support for GeoCoordinates and axis (x/y, long/lat) flipping.  Look at options for details.</para>
+    <para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0: Support for curve geometries. NURBSCurve is emitted as NurbsCurve; other curve types are linearized before output.</para>
     <!-- Optionally mention 3d support -->
     <para>&Z_support;</para>
         <!-- Optionally mention supports Polyhedral Surface  -->

--- a/liblwgeom/cunit/cu_out_x3d.c
+++ b/liblwgeom/cunit/cu_out_x3d.c
@@ -262,7 +262,7 @@ out_x3d3_test_geoms(void)
 
 	do_x3d3_test(
 	    "NURBSCURVE(2, (0 0, 1 1, 2 0))",
-	    "<NurbsCurve  order='3'><Coordinate containerField='controlPoint' point='0 0 0 1 1 0 2 0 0' /></NurbsCurve>",
+	    "<NurbsCurve  order='3' knot='0 0 0 1 1 1' weight='1 1 1'><Coordinate containerField='controlPoint' point='0 0 0 1 1 0 2 0 0' /></NurbsCurve>",
 	    0,
 	    0);
 
@@ -271,6 +271,8 @@ out_x3d3_test_geoms(void)
 	    "<NurbsCurve  order='3' knot='0 0 0 1 1 1' weight='1 2 1'><Coordinate containerField='controlPoint' point='0 0 0 1 1 0 2 0 0' /></NurbsCurve>",
 	    0,
 	    0);
+
+	do_x3d3_not_contains("NURBSCURVE(2, (0 0, 1 1, 2 0))", "<LineSet", 0, 0);
 
 	do_x3d3_contains("GEOMETRYCOLLECTION(NURBSCURVE(2, (0 0, 1 1, 2 0)))", "<Shape><NurbsCurve", 0, 0);
 

--- a/liblwgeom/cunit/cu_out_x3d.c
+++ b/liblwgeom/cunit/cu_out_x3d.c
@@ -18,9 +18,11 @@
 #include "liblwgeom_internal.h"
 #include "cu_tester.h"
 
-static void do_x3d3_test(char * in, char * out, int precision, int option)
+static void
+do_x3d3_test(char *in, char *out, int precision, int option)
 {
 	LWGEOM *g = lwgeom_from_wkt(in, LW_PARSER_CHECK_NONE);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(g);
 	lwvarlena_t *v = lwgeom_to_x3d3(g, precision, option, "");
 
 	ASSERT_VARLENA_EQUAL(v, out);
@@ -29,52 +31,89 @@ static void do_x3d3_test(char * in, char * out, int precision, int option)
 	lwfree(v);
 }
 
-
-static void do_x3d3_unsupported(char * in, char * out)
+static void
+do_x3d3_contains(char *in, char *needle, int precision, int option)
 {
 	LWGEOM *g = lwgeom_from_wkt(in, LW_PARSER_CHECK_NONE);
-	lwvarlena_t *v = lwgeom_to_x3d3(g, 0, 0, "");
+	CU_ASSERT_PTR_NOT_NULL_FATAL(g);
+	lwvarlena_t *v = lwgeom_to_x3d3(g, precision, option, "");
+	size_t len;
+	char *out;
 
-	ASSERT_STRING_EQUAL(out, cu_error_msg);
-	cu_error_msg_reset();
+	CU_ASSERT_PTR_NOT_NULL_FATAL(v);
+	len = LWSIZE_GET(v->size) - LWVARHDRSZ;
+	out = lwalloc(len + 1);
 
+	memcpy(out, v->data, len);
+	out[len] = '\0';
+
+	if (!strstr(out, needle))
+	{
+		fprintf(stderr, "[%s:%d]\n Expected substring: %s\n Obtained: %s\n", __FILE__, __LINE__, needle, out);
+		CU_FAIL();
+	}
+	else
+		CU_PASS();
+
+	lwfree(out);
 	lwfree(v);
 	lwgeom_free(g);
 }
 
+static void
+do_x3d3_not_contains(char *in, char *needle, int precision, int option)
+{
+	LWGEOM *g = lwgeom_from_wkt(in, LW_PARSER_CHECK_NONE);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(g);
+	lwvarlena_t *v = lwgeom_to_x3d3(g, precision, option, "");
+	size_t len;
+	char *out;
 
-static void out_x3d3_test_precision(void)
+	CU_ASSERT_PTR_NOT_NULL_FATAL(v);
+	len = LWSIZE_GET(v->size) - LWVARHDRSZ;
+	out = lwalloc(len + 1);
+
+	memcpy(out, v->data, len);
+	out[len] = '\0';
+
+	if (strstr(out, needle))
+	{
+		fprintf(stderr, "[%s:%d]\n Unexpected substring: %s\n Obtained: %s\n", __FILE__, __LINE__, needle, out);
+		CU_FAIL();
+	}
+	else
+		CU_PASS();
+
+	lwfree(out);
+	lwfree(v);
+	lwgeom_free(g);
+}
+
+static void
+out_x3d3_test_precision(void)
 {
 	/* 0 precision, i.e a round */
-	do_x3d3_test(
-	    "POINT(1.1111111111111 1.1111111111111 2.11111111111111)",
-	    "1 1 2",
-	    0, 0);
+	do_x3d3_test("POINT(1.1111111111111 1.1111111111111 2.11111111111111)", "1 1 2", 0, 0);
 
 	/* 3 digits precision */
-	do_x3d3_test(
-	    "POINT(1.1111111111111 1.1111111111111 2.11111111111111)",
-	    "1.111 1.111 2.111",
-	    3, 0);
+	do_x3d3_test("POINT(1.1111111111111 1.1111111111111 2.11111111111111)", "1.111 1.111 2.111", 3, 0);
 
 	/* 9 digits precision */
 	do_x3d3_test(
-	    "POINT(1.2345678901234 1.2345678901234 4.123456789001)",
-	    "1.23456789 1.23456789 4.123456789",
-	    9, 0);
+	    "POINT(1.2345678901234 1.2345678901234 4.123456789001)", "1.23456789 1.23456789 4.123456789", 9, 0);
 
 	/* huge data */
 	do_x3d3_test("POINT(1E300 -105E-153 4E300)", "1e+300 -1e-151 4e+300", 0, 0);
 }
 
-
-static void out_x3d3_test_geoms(void)
+static void
+out_x3d3_test_geoms(void)
 {
 	/* Linestring */
-	do_x3d3_test(
-	    "LINESTRING(0 1 5,2 3 6,4 5 7)",
-	    "<LineSet  vertexCount='3'><Coordinate point='0 1 5 2 3 6 4 5 7' /></LineSet>",
-	    0, 0);
+	do_x3d3_test("LINESTRING(0 1 5,2 3 6,4 5 7)",
+		     "<LineSet  vertexCount='3'><Coordinate point='0 1 5 2 3 6 4 5 7' /></LineSet>",
+		     0,
+		     0);
 
 	/* 2D Linestring */
 	do_x3d3_test("LINESTRING(0 1,2 3,4 5)",
@@ -82,11 +121,19 @@ static void out_x3d3_test_geoms(void)
 		     0,
 		     0);
 
+	/* Closed lines keep their closing coordinate because LineSet has no index
+	 * node to point back to the first vertex. */
+	do_x3d3_test("LINESTRING(0 0,1 0,0 0)",
+		     "<LineSet  vertexCount='3'><Coordinate point='0 0 0 1 0 0 0 0 0' /></LineSet>",
+		     0,
+		     0);
+
 	/* Polygon **/
 	do_x3d3_test(
 	    "POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><Coordinate point='15 10 3 13.536 6.464 3 10 5 3 6.464 6.464 3 5 10 3 6.464 13.536 3 10 15 3 13.536 13.536 3 ' /></IndexedFaceSet>",
-	    3, 0);
+	    3,
+	    0);
 
 	/* 2D Polygon */
 	do_x3d3_test(
@@ -98,25 +145,26 @@ static void out_x3d3_test_geoms(void)
 	/* TODO: Polygon - with internal ring - the answer is clearly wrong */
 	/** do_x3d3_test(
 	    "POLYGON((0 1 3,2 3 3,4 5 3,0 1 3),(6 7 3,8 9 3,10 11 3,6 7 3))",
-	        "",
+		"",
 	    NULL, 0); **/
 
 	/* 2D MultiPoint */
-	do_x3d3_test(
-	    "MULTIPOINT(0 1,2 3,4 5)",
-	    "<Polypoint2D  point='0 1 2 3 4 5 ' />",
-	    0, 0);
+	do_x3d3_test("MULTIPOINT(0 1,2 3,4 5)", "<Polypoint2D  point='0 1 2 3 4 5 ' />", 0, 0);
 
 	/* 3D MultiPoint */
 	do_x3d3_test(
-	    "MULTIPOINT Z(0 1 1,2 3 4,4 5 5)",
-	    "<PointSet ><Coordinate point='0 1 1 2 3 4 4 5 5 ' /></PointSet>",
-	    0, 0);
+	    "MULTIPOINT Z(0 1 1,2 3 4,4 5 5)", "<PointSet ><Coordinate point='0 1 1 2 3 4 4 5 5 ' /></PointSet>", 0, 0);
 	/* 3D Multiline */
 	do_x3d3_test(
 	    "MULTILINESTRING Z((0 1 1,2 3 4,4 5 5),(6 7 5,8 9 8,10 11 5))",
 	    "<IndexedLineSet  coordIndex='0 1 2 -1 3 4 5'><Coordinate point='0 1 1 2 3 4 4 5 5 6 7 5 8 9 8 10 11 5 ' /></IndexedLineSet>",
-	    0, 0);
+	    0,
+	    0);
+	/* 2D Multiline */
+	do_x3d3_test("MULTILINESTRING((2 3,4 5))",
+		     "<IndexedLineSet  coordIndex='0 1'><Coordinate point='2 3 0 4 5 0 ' /></IndexedLineSet>",
+		     0,
+		     0);
 
 	/* 2D Multiline */
 	do_x3d3_test(
@@ -129,7 +177,14 @@ static void out_x3d3_test_geoms(void)
 	do_x3d3_test(
 	    "MULTIPOLYGON(((0 1 1,2 3 1,4 5 1,0 1 1)),((6 7 1,8 9 1,10 11 1,6 7 1)))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 -1 3 4 5'><Coordinate point='0 1 1 2 3 1 4 5 1 6 7 1 8 9 1 10 11 1 ' /></IndexedFaceSet>",
-	    0, 0);
+	    0,
+	    0);
+	/* 2D MultiPolygon */
+	do_x3d3_test(
+	    "MULTIPOLYGON(((0 0,1 0,0 1,0 0)))",
+	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2'><Coordinate point='0 0 0 1 0 0 0 1 0 ' /></IndexedFaceSet>",
+	    0,
+	    0);
 
 	/* 2D MultiPolygon */
 	do_x3d3_test(
@@ -142,7 +197,8 @@ static void out_x3d3_test_geoms(void)
 	do_x3d3_test(
 	    "POLYHEDRALSURFACE( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)), ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)), ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)), ((1 1 0, 1 1 1, 1 0 1, 1 0 0, 1 1 0)), ((0 1 0, 0 1 1, 1 1 1, 1 1 0, 0 1 0)), ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1)) )",
 	    "<IndexedFaceSet convex='false'  coordIndex='0 1 2 3 -1 4 5 6 7 -1 8 9 10 11 -1 12 13 14 15 -1 16 17 18 19 -1 20 21 22 23'><Coordinate point='0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 1 0 0 1 0 1 0 0 1 1 1 0 1 1 1 1 0 1 1 0 0 0 1 0 0 1 1 1 1 1 1 1 0 0 0 1 1 0 1 1 1 1 0 1 1' /></IndexedFaceSet>",
-	    0, 0);
+	    0,
+	    0);
 
 	/* GeometryCollection with 2D Polygon */
 	do_x3d3_test(
@@ -151,51 +207,111 @@ static void out_x3d3_test_geoms(void)
 	    0,
 	    0);
 
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(POINT(0 1 3),LINESTRING(2 3 3,4 5 3))",
+	    "<Shape><PointSet ><Coordinate point='0 1 3 ' /></PointSet></Shape><Shape><LineSet  vertexCount='2'><Coordinate point='2 3 3 4 5 3' /></LineSet></Shape>",
+	    0,
+	    0);
+
+	do_x3d3_test("GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4))",
+		     "<Shape><Polypoint2D  point='1 2 ' /></Shape><Shape><Polypoint2D  point='3 4 ' /></Shape>",
+		     0,
+		     0);
+
+	do_x3d3_contains("GEOMETRYCOLLECTION(TRIANGLE((0 0,1 1,0 1,0 0)))", "<Shape><IndexedTriangleSet", 0, 0);
+
+	do_x3d3_not_contains(
+	    "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(0 0,1 1)))", "<Shape><Shape>", 0, 0);
+
 	/* TODO:  Implement Empty GeometryCollection correctly or throw a not-implemented */
 	/** do_x3d3_test(
 	    "GEOMETRYCOLLECTION EMPTY",
 	    "",
 	    NULL, 0); **/
 
-	/* CircularString */
-	do_x3d3_unsupported(
-	    "CIRCULARSTRING(-2 0 1,0 2 1,2 0 1,0 2 1,2 4 1)",
-	    "lwgeom_to_x3d3: 'CircularString' geometry type not supported");
+	/* Non-NURBS curves are linearized before output */
+	do_x3d3_contains("CIRCULARSTRING(-2 0 1,0 2 1,2 0 1,0 2 1,2 4 1)",
+			 "<LineSet  vertexCount='129'><Coordinate point='-2 0 1",
+			 0,
+			 0);
 
-	/* CompoundCurve */
-	do_x3d3_unsupported(
-	    "COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,1 0 1),(1 0 1,0 1 1))",
-	    "lwgeom_to_x3d3: 'CompoundCurve' geometry type not supported");
+	do_x3d3_contains("CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)",
+			 "<LineSet  vertexCount='129'><Coordinate point='0 0 1",
+			 0,
+			 0);
 
+	do_x3d3_contains("COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,1 0 1),(1 0 1,0 1 1))",
+			 "<LineSet  vertexCount='98'><Coordinate point='0 0 1",
+			 0,
+			 0);
+
+	do_x3d3_contains(
+	    "CURVEPOLYGON(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1))", "<IndexedFaceSet  convex='false'", 0, 0);
+
+	do_x3d3_contains("GEOMETRYCOLLECTION(CIRCULARSTRING(0 0 1,1 1 1,2 0 1))", "<Shape><LineSet", 0, 0);
+
+	do_x3d3_contains("GEOMETRYCOLLECTION(COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,1 0 1),(1 0 1,0 1 1)))",
+			 "<Shape><LineSet",
+			 0,
+			 0);
+
+	do_x3d3_contains("GEOMETRYCOLLECTION(CURVEPOLYGON(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)))",
+			 "<Shape><IndexedFaceSet",
+			 0,
+			 0);
+
+	do_x3d3_test(
+	    "NURBSCURVE(2, (0 0, 1 1, 2 0))",
+	    "<NurbsCurve  order='3'><Coordinate containerField='controlPoint' point='0 0 0 1 1 0 2 0 0' /></NurbsCurve>",
+	    0,
+	    0);
+
+	do_x3d3_test(
+	    "NURBSCURVE(2, (0 0, 1 1, 2 0), (1, 2, 1), (0, 0, 0, 1, 1, 1))",
+	    "<NurbsCurve  order='3' knot='0 0 0 1 1 1' weight='1 2 1'><Coordinate containerField='controlPoint' point='0 0 0 1 1 0 2 0 0' /></NurbsCurve>",
+	    0,
+	    0);
+
+	do_x3d3_contains("GEOMETRYCOLLECTION(NURBSCURVE(2, (0 0, 1 1, 2 0)))", "<Shape><NurbsCurve", 0, 0);
+
+	do_x3d3_contains("SRID=4326;NURBSCURVE(2, (0 0, 1 1, 2 0))",
+			 "><GeoCoordinate containerField='controlPoint' geoSystem='\"GD\" \"WE\" \"longitude_first\"'",
+			 0,
+			 2);
+
+	do_x3d3_contains("GEOMETRYCOLLECTION(CIRCULARSTRING(0 0,1 1,2 0),TIN(((0 0,1 1,0 1,0 0))))",
+			 "</IndexedTriangleSet></Shape>",
+			 0,
+			 0);
 }
 
-static void out_x3d3_test_option(void)
+static void
+out_x3d3_test_option(void)
 {
 	/* 0 precision, flip coordinates*/
-	do_x3d3_test(
-	    "POINT(3.1111111111111 1.1111111111111 2.11111111111111)",
-	    "1 3 2",
-	    0, 1);
+	do_x3d3_test("POINT(3.1111111111111 1.1111111111111 2.11111111111111)", "1 3 2", 0, 1);
 
 	/* geocoordinate long,lat*/
 	do_x3d3_test(
 	    "SRID=4326;POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"longitude_first\"' point='15 10 3 13.536 6.464 3 10 5 3 6.464 6.464 3 5 10 3 6.464 13.536 3 10 15 3 13.536 13.536 3 ' /></IndexedFaceSet>",
-	    3, 2);
+	    3,
+	    2);
 
 	/* geocoordinate lat long*/
 	do_x3d3_test(
 	    "SRID=4326;POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"latitude_first\"' point='10 15 3 6.464 13.536 3 5 10 3 6.464 6.464 3 10 5 3 13.536 6.464 3 15 10 3 13.536 13.536 3 ' /></IndexedFaceSet>",
-	    3, 3);
+	    3,
+	    3);
 }
-
 
 /*
 ** Used by test harness to register the tests in this file.
 */
 void out_x3d_suite_setup(void);
-void out_x3d_suite_setup(void)
+void
+out_x3d_suite_setup(void)
 {
 	CU_pSuite suite = CU_add_suite("x3d_output", NULL, NULL);
 	PG_ADD_TEST(suite, out_x3d3_test_precision);

--- a/liblwgeom/lwout_x3d.c
+++ b/liblwgeom/lwout_x3d.c
@@ -497,35 +497,38 @@ static int
 asx3d3_nurbscurve_sb(const LWNURBSCURVE *curve, int precision, int opts, const char *defid, stringbuffer_t *sb)
 {
 	uint32_t i;
+	uint32_t nknots = 0;
+	double *knots;
 
 	if (!curve->points || curve->points->npoints == 0)
 		return LW_SUCCESS;
 
-	stringbuffer_aprintf(sb, "<NurbsCurve %s order='%u'", defid, curve->degree + 1);
-
-	if (curve->knots && curve->nknots > 0)
+	knots = lwnurbscurve_get_or_generate_knots(curve, &nknots);
+	if (!knots || nknots == 0)
 	{
-		stringbuffer_append_len(sb, " knot='", strlen(" knot='"));
-		for (i = 0; i < curve->nknots; i++)
-		{
-			if (i)
-				stringbuffer_append_len(sb, " ", 1);
-			stringbuffer_append_double(sb, curve->knots[i], precision);
-		}
-		stringbuffer_append_len(sb, "'", 1);
+		if (knots)
+			lwfree(knots);
+		return LW_FAILURE;
 	}
 
-	if (curve->weights && curve->nweights > 0)
+	stringbuffer_aprintf(sb, "<NurbsCurve %s order='%u' knot='", defid, curve->degree + 1);
+	for (i = 0; i < nknots; i++)
 	{
-		stringbuffer_append_len(sb, " weight='", strlen(" weight='"));
-		for (i = 0; i < curve->nweights; i++)
-		{
-			if (i)
-				stringbuffer_append_len(sb, " ", 1);
-			stringbuffer_append_double(sb, curve->weights[i], precision);
-		}
-		stringbuffer_append_len(sb, "'", 1);
+		if (i)
+			stringbuffer_append_len(sb, " ", 1);
+		stringbuffer_append_double(sb, knots[i], precision);
 	}
+	stringbuffer_append_len(sb, "' weight='", strlen("' weight='"));
+	lwfree(knots);
+
+	for (i = 0; i < curve->points->npoints; i++)
+	{
+		double weight = (curve->weights && i < curve->nweights) ? curve->weights[i] : 1.0;
+		if (i)
+			stringbuffer_append_len(sb, " ", 1);
+		stringbuffer_append_double(sb, weight, precision);
+	}
+	stringbuffer_append_len(sb, "'", 1);
 
 	if (X3D_USE_GEOCOORDS(opts))
 		stringbuffer_aprintf(

--- a/liblwgeom/lwout_x3d.c
+++ b/liblwgeom/lwout_x3d.c
@@ -24,9 +24,9 @@
  **********************************************************************/
 
 /**
-* @file X3D output routines.
-*
-**********************************************************************/
+ * @file X3D output routines.
+ *
+ **********************************************************************/
 
 #include "lwout_x3d.h"
 
@@ -41,7 +41,7 @@ lwgeom_to_x3d3(const LWGEOM *geom, int precision, int opts, const char *defid)
 	int rv;
 
 	/* Empty varlena for empties */
-	if( lwgeom_is_empty(geom) )
+	if (lwgeom_is_empty(geom))
 	{
 		lwvarlena_t *v = lwalloc(LWVARHDRSZ);
 		LWSIZE_SET(v->size, LWVARHDRSZ);
@@ -51,7 +51,7 @@ lwgeom_to_x3d3(const LWGEOM *geom, int precision, int opts, const char *defid)
 	sb = stringbuffer_create();
 	rv = lwgeom_to_x3d3_sb(geom, precision, opts, defid, sb);
 
-	if ( rv == LW_FAILURE )
+	if (rv == LW_FAILURE)
 	{
 		stringbuffer_destroy(sb);
 		return NULL;
@@ -76,15 +76,17 @@ lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid
 	case LINETYPE:
 		return asx3d3_line_sb((LWLINE *)geom, precision, opts, defid, sb);
 
-	case POLYGONTYPE:
-	{
+	case POLYGONTYPE: {
 		/** We might change this later, but putting a polygon in an indexed face set
-		* seems like the simplest way to go so treat just like a mulitpolygon
-		*/
-		LWCOLLECTION *tmp = (LWCOLLECTION*)lwgeom_as_multi(geom);
-		asx3d3_multi_sb(tmp, precision, opts, defid, sb);
+		 * seems like the simplest way to go so treat just like a mulitpolygon
+		 */
+		LWCOLLECTION *tmp = (LWCOLLECTION *)lwgeom_as_multi(geom);
+		int rv;
+		if (!tmp)
+			return LW_FAILURE;
+		rv = asx3d3_multi_sb(tmp, precision, opts, defid, sb);
 		lwcollection_free(tmp);
-		return LW_SUCCESS;
+		return rv;
 	}
 
 	case TRIANGLETYPE:
@@ -103,6 +105,24 @@ lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid
 
 	case COLLECTIONTYPE:
 		return asx3d3_collection_sb((LWCOLLECTION *)geom, precision, opts, defid, sb);
+
+	case NURBSCURVETYPE:
+		/* X3D has a native NurbsCurve node; do not linearize it. */
+		return asx3d3_nurbscurve_sb((const LWNURBSCURVE *)geom, precision, opts, defid, sb);
+
+	case CIRCSTRINGTYPE:
+	case COMPOUNDTYPE:
+	case CURVEPOLYTYPE:
+	case MULTICURVETYPE:
+	case MULTISURFACETYPE: {
+		LWGEOM *linear = lwgeom_stroke(geom, 32);
+		int rv;
+		if (!linear)
+			return LW_FAILURE;
+		rv = lwgeom_to_x3d3_sb(linear, precision, opts, defid, sb);
+		lwgeom_free(linear);
+		return rv;
+	}
 
 	default:
 		lwerror("lwgeom_to_x3d3: '%s' geometry type not supported", lwtype_name(type));
@@ -138,32 +158,32 @@ asx3d3_mline_coordindex_sb(const LWMLINE *mgeom, stringbuffer_t *sb)
 	uint32_t np;
 
 	j = 0;
-	for (i=0; i < mgeom->ngeoms; i++)
+	for (i = 0; i < mgeom->ngeoms; i++)
 	{
-		geom = (LWLINE *) mgeom->geoms[i];
+		geom = (LWLINE *)mgeom->geoms[i];
 		pa = geom->points;
 		np = pa->npoints;
-		si = j;  /* start index of first point of linestring */
-		for (k=0; k < np ; k++)
+		si = j; /* start index of first point of linestring */
+		for (k = 0; k < np; k++)
 		{
 			if (k)
 			{
 				stringbuffer_aprintf(sb, " ");
 			}
 			/** if the linestring is closed, we put the start point index
-			*   for the last vertex to denote use first point
-			*    and don't increment the index **/
-			if (!lwline_is_closed(geom) || k < (np -1) )
+			 *   for the last vertex to denote use first point
+			 *    and don't increment the index **/
+			if (!lwline_is_closed(geom) || k < (np - 1))
 			{
 				stringbuffer_aprintf(sb, "%u", j);
 				j += 1;
 			}
 			else
 			{
-				stringbuffer_aprintf(sb,"%u", si);
+				stringbuffer_aprintf(sb, "%u", si);
 			}
 		}
-		if (i < (mgeom->ngeoms - 1) )
+		if (i < (mgeom->ngeoms - 1))
 		{
 			stringbuffer_aprintf(sb, " -1 "); /* separator for each linestring */
 		}
@@ -181,37 +201,40 @@ asx3d3_mpoly_coordindex_sb(const LWMPOLY *psur, stringbuffer_t *sb)
 	uint32_t i, j, k, l;
 	uint32_t np;
 	j = 0;
-	for (i=0; i<psur->ngeoms; i++)
+	for (i = 0; i < psur->ngeoms; i++)
 	{
-		patch = (LWPOLY *) psur->geoms[i];
-		for (l=0; l < patch->nrings; l++)
+		patch = (LWPOLY *)psur->geoms[i];
+		for (l = 0; l < patch->nrings; l++)
 		{
 			np = patch->rings[l]->npoints - 1;
-			for (k=0; k < np ; k++)
+			for (k = 0; k < np; k++)
 			{
 				if (k)
 				{
-					stringbuffer_aprintf(sb,  " ");
+					stringbuffer_aprintf(sb, " ");
 				}
-				stringbuffer_aprintf(sb,  "%d", (j + k));
+				stringbuffer_aprintf(sb, "%d", (j + k));
 			}
 			j += k;
-			if (l < (patch->nrings - 1) )
+			if (l < (patch->nrings - 1))
 			{
 				/** @todo TODO: Decide the best way to render holes
-				*  Evidently according to my X3D expert the X3D consortium doesn't really
-				*  support holes and it's an issue of argument among many that feel it should. He thinks CAD x3d extensions to spec might.
-				*  What he has done and others developing X3D exports to simulate a hole is to cut around it.
-				*  So if you have a donut, you would cut it into half and have 2 solid polygons.  Not really sure the best way to handle this.
-				*  For now will leave it as polygons stacked on top of each other -- which is what we are doing here and perhaps an option
-				*  to color differently.  It's not ideal but the alternative sounds complicated.
-				**/
-				stringbuffer_aprintf(sb,  " -1 "); /* separator for each inner ring. Ideally we should probably triangulate and cut around as others do */
+				 *  Evidently according to my X3D expert the X3D consortium doesn't really
+				 *  support holes and it's an issue of argument among many that feel it should. He
+				 * thinks CAD x3d extensions to spec might. What he has done and others developing X3D
+				 * exports to simulate a hole is to cut around it. So if you have a donut, you would cut
+				 * it into half and have 2 solid polygons.  Not really sure the best way to handle this.
+				 *  For now will leave it as polygons stacked on top of each other -- which is what we
+				 * are doing here and perhaps an option to color differently.  It's not ideal but the
+				 * alternative sounds complicated.
+				 **/
+				stringbuffer_aprintf(sb, " -1 "); /* separator for each inner ring. Ideally we should
+								     probably triangulate and cut around as others do */
 			}
 		}
-		if (i < (psur->ngeoms - 1) )
+		if (i < (psur->ngeoms - 1))
 		{
-			stringbuffer_aprintf(sb,  " -1 "); /* separator for each subgeom */
+			stringbuffer_aprintf(sb, " -1 "); /* separator for each subgeom */
 		}
 	}
 	return LW_SUCCESS;
@@ -225,21 +248,22 @@ asx3d3_line_sb(const LWLINE *line,
 	       __attribute__((__unused__)) const char *defid,
 	       stringbuffer_t *sb)
 {
-
-	/* int dimension=2; */
 	POINTARRAY *pa;
-
-
-	/* if (FLAGS_GET_Z(line->flags)) dimension = 3; */
+	uint32_t npoints;
 
 	pa = line->points;
-	stringbuffer_aprintf(sb, "<LineSet %s vertexCount='%d'>", defid, pa->npoints);
+	npoints = pa->npoints;
 
-	if ( X3D_USE_GEOCOORDS(opts) ) stringbuffer_aprintf(sb, "<GeoCoordinate geoSystem='\"GD\" \"WE\" \"%s\"' point='", ( (opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first") );
+	stringbuffer_aprintf(sb, "<LineSet %s vertexCount='%u'>", defid, npoints);
+
+	if (X3D_USE_GEOCOORDS(opts))
+		stringbuffer_aprintf(sb,
+				     "<GeoCoordinate geoSystem='\"GD\" \"WE\" \"%s\"' point='",
+				     ((opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first"));
 	else
 		stringbuffer_aprintf(sb, "<Coordinate point='");
 
-	ptarray_to_x3d3_sb(line->points, precision, opts, lwline_is_closed((LWLINE *)line), LW_TRUE, sb);
+	ptarray_to_x3d3_sb(line->points, precision, opts, LW_FALSE, LW_TRUE, sb);
 
 	stringbuffer_aprintf(sb, "' />");
 
@@ -256,9 +280,10 @@ asx3d3_poly_sb(const LWPOLY *poly,
 	       stringbuffer_t *sb)
 {
 	uint32_t i;
-	for (i=0; i<poly->nrings; i++)
+	for (i = 0; i < poly->nrings; i++)
 	{
-		if (i) stringbuffer_aprintf(sb, " "); /* inner ring points start */
+		if (i)
+			stringbuffer_aprintf(sb, " "); /* inner ring points start */
 		ptarray_to_x3d3_sb(poly->rings[i], precision, opts, 1, LW_TRUE, sb);
 	}
 	return LW_SUCCESS;
@@ -274,7 +299,6 @@ asx3d3_triangle_sb(const LWTRIANGLE *triangle,
 	return ptarray_to_x3d3_sb(triangle->points, precision, opts, 1, LW_TRUE, sb);
 }
 
-
 /*
  * Don't call this with single-geoms inspected!
  */
@@ -283,13 +307,13 @@ asx3d3_multi_sb(const LWCOLLECTION *col, int precision, int opts, const char *de
 {
 	char *x3dtype;
 	uint32_t i;
-	int dimension=2;
+	int dimension = 2;
 	int has_coordinate_node = LW_FALSE;
 
-	if (FLAGS_GET_Z(col->flags)) dimension = 3;
+	if (FLAGS_GET_Z(col->flags))
+		dimension = 3;
 	LWGEOM *subgeom;
-	x3dtype="";
-
+	x3dtype = "";
 
 	switch (col->type)
 	{
@@ -337,7 +361,7 @@ asx3d3_multi_sb(const LWCOLLECTION *col, int precision, int opts, const char *de
 			stringbuffer_aprintf(sb, "<Coordinate point='");
 	}
 
-	for (i=0; i<col->ngeoms; i++)
+	for (i = 0; i < col->ngeoms; i++)
 	{
 		subgeom = col->geoms[i];
 		if (subgeom->type == POINTTYPE)
@@ -362,9 +386,11 @@ asx3d3_multi_sb(const LWCOLLECTION *col, int precision, int opts, const char *de
 	{
 		stringbuffer_aprintf(sb, "' /></%s>", x3dtype);
 	}
-	else { stringbuffer_aprintf(sb, "' />"); }
+	else
+	{
+		stringbuffer_aprintf(sb, "' />");
+	}
 	return LW_SUCCESS;
-
 }
 
 /*
@@ -380,39 +406,42 @@ asx3d3_psurface_sb(const LWPSURFACE *psur, int precision, int opts, const char *
 	LWPOLY *patch;
 
 	/* Open outmost tag */
-	stringbuffer_aprintf(sb, "<IndexedFaceSet convex='false' %s coordIndex='",defid);
+	stringbuffer_aprintf(sb, "<IndexedFaceSet convex='false' %s coordIndex='", defid);
 
 	j = 0;
-	for (i=0; i<psur->ngeoms; i++)
+	for (i = 0; i < psur->ngeoms; i++)
 	{
-		patch = (LWPOLY *) psur->geoms[i];
+		patch = (LWPOLY *)psur->geoms[i];
 		np = patch->rings[0]->npoints - 1;
-		for (k=0; k < np ; k++)
+		for (k = 0; k < np; k++)
 		{
 			if (k)
 			{
 				stringbuffer_aprintf(sb, " ");
 			}
-			stringbuffer_aprintf(sb,"%d", (j + k));
+			stringbuffer_aprintf(sb, "%d", (j + k));
 		}
-		if (i < (psur->ngeoms - 1) )
+		if (i < (psur->ngeoms - 1))
 		{
 			stringbuffer_aprintf(sb, " -1 "); /* separator for each subgeom */
 		}
 		j += k;
 	}
 
-	if ( X3D_USE_GEOCOORDS(opts) )
-		stringbuffer_aprintf(sb, "'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"%s\"' point='",
-			( (opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first") );
-	else stringbuffer_aprintf(sb, "'><Coordinate point='");
+	if (X3D_USE_GEOCOORDS(opts))
+		stringbuffer_aprintf(sb,
+				     "'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"%s\"' point='",
+				     ((opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first"));
+	else
+		stringbuffer_aprintf(sb, "'><Coordinate point='");
 
-	for (i=0; i<psur->ngeoms; i++)
+	for (i = 0; i < psur->ngeoms; i++)
 	{
 		asx3d3_poly_sb(psur->geoms[i], precision, opts, 1, defid, sb);
-		if (i < (psur->ngeoms - 1) )
+		if (i < (psur->ngeoms - 1))
 		{
-			stringbuffer_aprintf(sb, " "); /* only add a trailing space if its not the last polygon in the set */
+			stringbuffer_aprintf(
+			    sb, " "); /* only add a trailing space if its not the last polygon in the set */
 		}
 	}
 
@@ -430,26 +459,30 @@ asx3d3_tin_sb(const LWTIN *tin, int precision, int opts, const char *defid, stri
 	uint32_t k;
 	/* int dimension=2; */
 
-	stringbuffer_aprintf(sb,"<IndexedTriangleSet %s index='",defid);
+	stringbuffer_aprintf(sb, "<IndexedTriangleSet %s index='", defid);
 	k = 0;
 	/** Fill in triangle index **/
-	for (i=0; i<tin->ngeoms; i++)
+	for (i = 0; i < tin->ngeoms; i++)
 	{
-		stringbuffer_aprintf(sb, "%d %d %d", k, (k+1), (k+2));
-		if (i < (tin->ngeoms - 1) )
+		stringbuffer_aprintf(sb, "%d %d %d", k, (k + 1), (k + 2));
+		if (i < (tin->ngeoms - 1))
 		{
 			stringbuffer_aprintf(sb, " ");
 		}
 		k += 3;
 	}
 
-	if ( X3D_USE_GEOCOORDS(opts) ) stringbuffer_aprintf(sb, "'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"%s\"' point='", ( (opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first") );
-	else stringbuffer_aprintf(sb, "'><Coordinate point='");
+	if (X3D_USE_GEOCOORDS(opts))
+		stringbuffer_aprintf(sb,
+				     "'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"%s\"' point='",
+				     ((opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first"));
+	else
+		stringbuffer_aprintf(sb, "'><Coordinate point='");
 
-	for (i=0; i<tin->ngeoms; i++)
+	for (i = 0; i < tin->ngeoms; i++)
 	{
 		asx3d3_triangle_sb(tin->geoms[i], precision, opts, defid, sb);
-		if (i < (tin->ngeoms - 1) )
+		if (i < (tin->ngeoms - 1))
 		{
 			stringbuffer_aprintf(sb, " ");
 		}
@@ -458,6 +491,53 @@ asx3d3_tin_sb(const LWTIN *tin, int precision, int opts, const char *defid, stri
 	/* Close outmost tag */
 
 	return stringbuffer_aprintf(sb, "'/></IndexedTriangleSet>");
+}
+
+static int
+asx3d3_nurbscurve_sb(const LWNURBSCURVE *curve, int precision, int opts, const char *defid, stringbuffer_t *sb)
+{
+	uint32_t i;
+
+	if (!curve->points || curve->points->npoints == 0)
+		return LW_SUCCESS;
+
+	stringbuffer_aprintf(sb, "<NurbsCurve %s order='%u'", defid, curve->degree + 1);
+
+	if (curve->knots && curve->nknots > 0)
+	{
+		stringbuffer_append_len(sb, " knot='", strlen(" knot='"));
+		for (i = 0; i < curve->nknots; i++)
+		{
+			if (i)
+				stringbuffer_append_len(sb, " ", 1);
+			stringbuffer_append_double(sb, curve->knots[i], precision);
+		}
+		stringbuffer_append_len(sb, "'", 1);
+	}
+
+	if (curve->weights && curve->nweights > 0)
+	{
+		stringbuffer_append_len(sb, " weight='", strlen(" weight='"));
+		for (i = 0; i < curve->nweights; i++)
+		{
+			if (i)
+				stringbuffer_append_len(sb, " ", 1);
+			stringbuffer_append_double(sb, curve->weights[i], precision);
+		}
+		stringbuffer_append_len(sb, "'", 1);
+	}
+
+	if (X3D_USE_GEOCOORDS(opts))
+		stringbuffer_aprintf(
+		    sb,
+		    "><GeoCoordinate containerField='controlPoint' geoSystem='\"GD\" \"WE\" \"%s\"' point='",
+		    ((opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first"));
+	else
+		stringbuffer_append_len(sb,
+					"><Coordinate containerField='controlPoint' point='",
+					strlen("><Coordinate containerField='controlPoint' point='"));
+	ptarray_to_x3d3_sb(curve->points, precision, opts, LW_FALSE, LW_TRUE, sb);
+	return stringbuffer_aprintf(sb, "' /></NurbsCurve>");
 }
 
 static int
@@ -473,48 +553,49 @@ asx3d3_collection_sb(const LWCOLLECTION *col, int precision, int opts, const cha
 	stringbuffer_aprintf(sb, "<%sGroup>", defid);
 #endif
 
-	for (i=0; i<col->ngeoms; i++)
+	for (i = 0; i < col->ngeoms; i++)
 	{
 		subgeom = col->geoms[i];
+
+		if (subgeom->type == COLLECTIONTYPE)
+		{
+			if (asx3d3_collection_sb((LWCOLLECTION *)subgeom, precision, opts, defid, sb) == LW_FAILURE)
+				return LW_FAILURE;
+			continue;
+		}
+
 		stringbuffer_aprintf(sb, "<Shape%s>", defid);
-		if ( subgeom->type == POINTTYPE )
-		{
-			asx3d3_point_sb((LWPOINT *)subgeom, precision, opts, defid, sb);
-		}
-		else if ( subgeom->type == LINETYPE )
-		{
-			asx3d3_line_sb((LWLINE *)subgeom, precision, opts, defid, sb);
-		}
-		else if ( subgeom->type == POLYGONTYPE )
+		if (subgeom->type == POINTTYPE)
 		{
 			LWCOLLECTION *tmp = (LWCOLLECTION *)lwgeom_as_multi(subgeom);
-			asx3d3_multi_sb(tmp, precision, opts, defid, sb);
+			int rv;
+			if (!tmp)
+				return LW_FAILURE;
+			rv = asx3d3_multi_sb(tmp, precision, opts, defid, sb);
 			lwcollection_free(tmp);
+			if (rv == LW_FAILURE)
+				return LW_FAILURE;
 		}
-		else if ( subgeom->type == TINTYPE )
+		else if (subgeom->type == TRIANGLETYPE)
 		{
-			asx3d3_tin_sb((LWTIN *)subgeom, precision, opts, defid, sb);
+			LWTIN *tmp = (LWTIN *)lwgeom_as_multi(subgeom);
+			int rv;
+			if (!tmp)
+				return LW_FAILURE;
+			rv = asx3d3_tin_sb(tmp, precision, opts, defid, sb);
+			lwcollection_free((LWCOLLECTION *)tmp);
+			if (rv == LW_FAILURE)
+				return LW_FAILURE;
 		}
-		else if ( subgeom->type == POLYHEDRALSURFACETYPE )
-		{
-			asx3d3_psurface_sb((LWPSURFACE *)subgeom, precision, opts, defid, sb);
-		}
-		else if ( lwgeom_is_collection(subgeom) )
-		{
-			if ( subgeom->type == COLLECTIONTYPE )
-				asx3d3_collection_sb((LWCOLLECTION *)subgeom, precision, opts, defid, sb);
-			else
-				asx3d3_multi_sb((LWCOLLECTION *)subgeom, precision, opts, defid, sb);
-		}
-		else
-			lwerror("asx3d3_collection_buf: unknown geometry type");
+		else if (lwgeom_to_x3d3_sb(subgeom, precision, opts, defid, sb) == LW_FAILURE)
+			return LW_FAILURE;
 
 		stringbuffer_aprintf(sb, "</Shape>");
 	}
 
 	/* Close outmost tag */
 #ifdef PGIS_X3D_OUTERMOST_TAGS
-	stringbuffer_aprintf(sb,  "</%sGroup>", defid);
+	stringbuffer_aprintf(sb, "</%sGroup>", defid);
 #endif
 
 	return LW_SUCCESS;
@@ -532,10 +613,11 @@ ptarray_to_x3d3_sb(POINTARRAY *pa, int precision, int opts, int is_closed, int f
 
 	if (!FLAGS_GET_Z(pa->flags) && !force_3d)
 	{
-		for (i=0; i<pa->npoints; i++)
+		for (i = 0; i < pa->npoints; i++)
 		{
-			/** Only output the point if it is not the last point of a closed object or it is a non-closed type **/
-			if ( !is_closed || i < (pa->npoints - 1) )
+			/** Only output the point if it is not the last point of a closed object or it is a non-closed
+			 * type **/
+			if (!is_closed || i < (pa->npoints - 1))
 			{
 				POINT2D pt;
 				getPoint2d_p(pa, i, &pt);
@@ -543,9 +625,10 @@ ptarray_to_x3d3_sb(POINTARRAY *pa, int precision, int opts, int is_closed, int f
 				lwprint_double(pt.x, precision, x);
 				lwprint_double(pt.y, precision, y);
 
-				if ( i ) stringbuffer_append_len(sb," ",1);
+				if (i)
+					stringbuffer_append_len(sb, " ", 1);
 
-				if ( ( opts & LW_X3D_FLIP_XY) )
+				if ((opts & LW_X3D_FLIP_XY))
 					stringbuffer_aprintf(sb, "%s %s", y, x);
 				else
 					stringbuffer_aprintf(sb, "%s %s", x, y);
@@ -578,10 +661,11 @@ ptarray_to_x3d3_sb(POINTARRAY *pa, int precision, int opts, int is_closed, int f
 	}
 	else
 	{
-		for (i=0; i<pa->npoints; i++)
+		for (i = 0; i < pa->npoints; i++)
 		{
-			/** Only output the point if it is not the last point of a closed object or it is a non-closed type **/
-			if ( !is_closed || i < (pa->npoints - 1) )
+			/** Only output the point if it is not the last point of a closed object or it is a non-closed
+			 * type **/
+			if (!is_closed || i < (pa->npoints - 1))
 			{
 				POINT4D pt;
 				getPoint4d_p(pa, i, &pt);
@@ -590,9 +674,10 @@ ptarray_to_x3d3_sb(POINTARRAY *pa, int precision, int opts, int is_closed, int f
 				lwprint_double(pt.y, precision, y);
 				lwprint_double(pt.z, precision, z);
 
-				if ( i ) stringbuffer_append_len(sb," ",1);
+				if (i)
+					stringbuffer_append_len(sb, " ", 1);
 
-				if ( ( opts & LW_X3D_FLIP_XY) )
+				if ((opts & LW_X3D_FLIP_XY))
 					stringbuffer_aprintf(sb, "%s %s %s", y, x, z);
 				else
 					stringbuffer_aprintf(sb, "%s %s %s", x, y, z);

--- a/liblwgeom/lwout_x3d.h
+++ b/liblwgeom/lwout_x3d.h
@@ -24,9 +24,9 @@
  **********************************************************************/
 
 /**
-* @file X3D output routines.
-*
-**********************************************************************/
+ * @file X3D output routines.
+ *
+ **********************************************************************/
 #include <string.h>
 #include "liblwgeom_internal.h"
 #include "stringbuffer.h"
@@ -41,6 +41,8 @@ static int
 asx3d3_triangle_sb(const LWTRIANGLE *triangle, int precision, int opts, const char *defid, stringbuffer_t *sb);
 
 static int asx3d3_multi_sb(const LWCOLLECTION *col, int precision, int opts, const char *defid, stringbuffer_t *sb);
+static int
+asx3d3_nurbscurve_sb(const LWNURBSCURVE *curve, int precision, int opts, const char *defid, stringbuffer_t *sb);
 static int asx3d3_psurface_sb(const LWPSURFACE *psur, int precision, int opts, const char *defid, stringbuffer_t *sb);
 static int asx3d3_tin_sb(const LWTIN *tin, int precision, int opts, const char *defid, stringbuffer_t *sb);
 

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1418,7 +1418,8 @@ SELECT '#1416f', ST_AsX3D('GEOMETRYCOLLECTION(CIRCULARSTRING(0 0 1,1 1 1,2 0 1))
 SELECT '#1416g', ST_AsX3D('GEOMETRYCOLLECTION(COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,1 0 1),(1 0 1,0 1 1)))'::geometry, 0) LIKE '<Shape><LineSet%';
 SELECT '#1416h', ST_AsX3D('GEOMETRYCOLLECTION(CURVEPOLYGON(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)))'::geometry, 0) LIKE '<Shape><IndexedFaceSet%';
 SELECT '#1416i', ST_AsX3D('CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)'::geometry, 0) LIKE '<LineSet  vertexCount=''129''><Coordinate point=%';
-SELECT '#1416j', ST_AsX3D('NURBSCURVE(2, (0 0, 1 1, 2 0))'::geometry, 0) LIKE '%<Coordinate containerField=''controlPoint'' point=%';
+SELECT '#1416j', ST_AsX3D('NURBSCURVE(2, (0 0, 1 1, 2 0))'::geometry, 0);
+SELECT '#1416k', ST_AsX3D('NURBSCURVE(2, (0 0, 1 1, 2 0))'::geometry, 0) NOT LIKE '%<LineSet%';
 
 SELECT '#4670-0', ST_AsEWKT(ST_AddPoint('LINESTRING(0 0, 1 1, 3 3, 4 4)'::geometry, 'POINT(2 2)'::geometry, 0));
 SELECT '#4670-1', ST_AsEWKT(ST_AddPoint('LINESTRING(0 0, 1 1, 3 3, 4 4)'::geometry, 'POINT(2 2)'::geometry, 1));

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1012,6 +1012,12 @@ SELECT '#3627b', ST_Equals(geom, ST_LineFromEncodedPolyline(ST_AsEncodedPolyline
 -- #3704
 SELECT '#3704', ST_AsX3D('LINESTRING EMPTY') = '';
 
+-- #3705
+SELECT '#3705a', ST_AsX3D('MULTILINESTRING((2 3,4 5))'::geometry, 0) LIKE '<IndexedLineSet%<Coordinate%';
+SELECT '#3705b', ST_AsX3D('MULTIPOLYGON(((0 0,1 0,0 1,0 0)))'::geometry, 0) LIKE '<IndexedFaceSet%<Coordinate%';
+SELECT '#3705c', ST_AsX3D('GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4))'::geometry, 0) LIKE '<Shape><Polypoint2D%';
+SELECT '#3705d', ST_AsX3D('POINTM(1 2 3)'::geometry, 0);
+
 -- #3709
 select '#3709', ST_SnapToGrid(ST_Project('SRID=4326;POINT(1 1)'::geography, 100000, 20)::geometry, 0.0001) = ST_SnapToGrid(ST_Project('SRID=4326;POINT(1 1)'::geography, -100000, 20+pi())::geometry, 0.0001);
 
@@ -1402,6 +1408,17 @@ select '#4399', 'ST_AsGeoJSON', ST_AsGeoJSON(geom)::text from geom;
 SELECT '#4599-1', ST_AsEWKT(ST_AddPoint(ST_GeomFromEWKT('LINESTRING(0 0 1, 1 1 1)'), ST_MakePoint(1, 2, 3)));
 SELECT '#4599-2', ST_AsEWKT(ST_AddPoint(ST_GeomFromEWKT('LINESTRING(0 0 1, 1 1 1)'), ST_MakePoint(1, 2, 3), 0));
 SELECT '#4599-3', ST_AsEWKT(ST_AddPoint(ST_GeomFromEWKT('LINESTRING(0 0 1, 1 1 1)'), ST_MakePoint(1, 2, 3), -1));
+
+SELECT '#1416a', ST_AsX3D('CIRCULARSTRING(0 0 1,1 1 1,2 0 1)'::geometry, 0) LIKE '<LineSet%';
+SELECT '#1416b', ST_AsX3D('COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,2 0 1),(2 0 1,3 1 1))'::geometry, 0) LIKE '<LineSet%';
+SELECT '#1416c', ST_AsX3D('CURVEPOLYGON(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1))'::geometry, 0) LIKE '<IndexedFaceSet%';
+SELECT '#1416d', ST_AsX3D('MULTICURVE(CIRCULARSTRING(0 0 1,1 1 1,2 0 1))'::geometry, 0) LIKE '<IndexedLineSet%';
+SELECT '#1416e', ST_AsX3D('MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)))'::geometry, 0) LIKE '<IndexedFaceSet%';
+SELECT '#1416f', ST_AsX3D('GEOMETRYCOLLECTION(CIRCULARSTRING(0 0 1,1 1 1,2 0 1))'::geometry, 0) LIKE '<Shape><LineSet%';
+SELECT '#1416g', ST_AsX3D('GEOMETRYCOLLECTION(COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,1 0 1),(1 0 1,0 1 1)))'::geometry, 0) LIKE '<Shape><LineSet%';
+SELECT '#1416h', ST_AsX3D('GEOMETRYCOLLECTION(CURVEPOLYGON(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)))'::geometry, 0) LIKE '<Shape><IndexedFaceSet%';
+SELECT '#1416i', ST_AsX3D('CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)'::geometry, 0) LIKE '<LineSet  vertexCount=''129''><Coordinate point=%';
+SELECT '#1416j', ST_AsX3D('NURBSCURVE(2, (0 0, 1 1, 2 0))'::geometry, 0) LIKE '%<Coordinate containerField=''controlPoint'' point=%';
 
 SELECT '#4670-0', ST_AsEWKT(ST_AddPoint('LINESTRING(0 0, 1 1, 3 3, 4 4)'::geometry, 'POINT(2 2)'::geometry, 0));
 SELECT '#4670-1', ST_AsEWKT(ST_AddPoint('LINESTRING(0 0, 1 1, 3 3, 4 4)'::geometry, 'POINT(2 2)'::geometry, 1));

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -449,7 +449,8 @@ ERROR:  BOX2D_construct: args can not be empty points
 #1416g|t
 #1416h|t
 #1416i|t
-#1416j|t
+#1416j|<NurbsCurve  order='3' knot='0 0 0 1 1 1' weight='1 1 1'><Coordinate containerField='controlPoint' point='0 0 0 1 1 0 2 0 0' /></NurbsCurve>
+#1416k|t
 #4670-0|LINESTRING(2 2,0 0,1 1,3 3,4 4)
 #4670-1|LINESTRING(0 0,2 2,1 1,3 3,4 4)
 #4670-2|LINESTRING(0 0,1 1,2 2,3 3,4 4)

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -306,6 +306,10 @@ ERROR:  invalid KML representation
 #3627a|o}~~|AdshNoSsBgd@eGoBlm@wKhj@~@?
 #3627b|t
 #3704|t
+#3705a|t
+#3705b|t
+#3705c|t
+#3705d|1 2
 #3709|t
 NOTICE:  Hole lies outside shell at or near point 25495368.044100001 6671726.9312000005
 #3719a|f
@@ -436,6 +440,16 @@ ERROR:  BOX2D_construct: args can not be empty points
 #4599-1|LINESTRING(0 0 1,1 1 1,1 2 3)
 #4599-2|LINESTRING(1 2 3,0 0 1,1 1 1)
 #4599-3|LINESTRING(0 0 1,1 1 1,1 2 3)
+#1416a|t
+#1416b|t
+#1416c|t
+#1416d|t
+#1416e|t
+#1416f|t
+#1416g|t
+#1416h|t
+#1416i|t
+#1416j|t
 #4670-0|LINESTRING(2 2,0 0,1 1,3 3,4 4)
 #4670-1|LINESTRING(0 0,2 2,1 1,3 3,4 4)
 #4670-2|LINESTRING(0 0,1 1,2 2,3 3,4 4)


### PR DESCRIPTION
References https://trac.osgeo.org/postgis/ticket/1416
References https://trac.osgeo.org/postgis/ticket/3705

This improves ST_AsX3D output in two related areas:

- adds output for curve geometry types, using native X3D `NurbsCurve` for `NURBSCurve` and stroking other curve types through the existing liblwgeom linearization path before passing them to the current X3D serializers; this covers CIRCULARSTRING, COMPOUNDCURVE, CURVEPOLYGON, MULTICURVE, MULTISURFACE, and NURBSCurve
- fixes invalid XML fragments for 2D MultiLineString/MultiPolygon coordinate output and GeometryCollection children, and documents that M coordinates are not represented in X3D
- keeps closed LineSet output closed by retaining the duplicate closing coordinate, because LineSet has no coordIndex path back to the first vertex

The manual now documents that NURBSCurve maps to X3D `NurbsCurve`, while other curve geometries are linearized before output. Regression coverage checks representative curve, multicurve, multisurface, NURBSCurve, 2D multi-geometry, GeometryCollection point/line/polygon/triangle children, nested GeometryCollections, nested curve members inside GeometryCollections, M-coordinate inputs, and closed LineSet vertex-count/closure cases.

## Review Follow-Up

- route nested curve members through the recursive X3D serializer
- preserve child-rendering failures in GeometryCollection serialization
- keep closed stroked curves closed in LineSet output
- emit NURBSCurve as native X3D `NurbsCurve` with order, weights, explicit knots, and control points instead of stroking it

## Rebase Refresh

- 2026-07-01: rebased over upstream/master `4e470f1534795ae4a4c52ad5ad35b8744af9d708` and force-pushed head `80f194c5a8256e65310b620c48605f7645240e16`

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32 && ./liblwgeom/cunit/cu_tester x3d_output`
- `make postgis_revision.h && make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -B -C extensions/postgis sql/postgis_for_extension.sql sql/postgis--3.7.0dev.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install && sudo -n make -C extensions/postgis install`
- `./config.status --file=regress/dumper/tests.mk:regress/dumper/tests.mk.in --file=regress/core/tests.mk:regress/core/tests.mk.in`
- `dropdb --if-exists postgis_reg || true && PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=$(whoami) PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- liblwgeom/lwout_x3d.c liblwgeom/lwout_x3d.h liblwgeom/cunit/cu_out_x3d.c regress/core/tickets.sql regress/core/tickets_expected doc/reference_output.xml NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`

