### PR TITLE
Add SFCGAL validity predicate

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,12 @@ These are only changes since 3.7.0alpha1.
             (Bas Couwenberg)
 
 * Enhancements *
+* New Features *
+
+ - #4363, [sfcgal] Add CG_IsValid, CG_IsValidDetail, and SFCGAL 2.3+
+          CG_IsSimple and CG_IsSimpleDetail checks
+          (Darafei Praliaskouski)
+
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)
@@ -162,9 +168,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)
  - #4560, ST_3DInterpolatePoint for M interpolation from XYZ inputs (Paul Ramsey)
- - #4363, [sfcgal] Add CG_IsValid, CG_IsValidDetail, and SFCGAL 2.3+
-          CG_IsSimple and CG_IsSimpleDetail checks
-          (Darafei Praliaskouski)
  - #1291, ST_MakePolygon support for curved rings (Darafei Praliaskouski)
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers

--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,10 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #4363, [sfcgal] Add CG_IsValid, CG_IsValidDetail, and SFCGAL 2.3+
+          CG_IsSimple and CG_IsSimpleDetail checks
+          (Darafei Praliaskouski)
+
 
 PostGIS 3.7.0beta1
 2026/07/20
@@ -90,11 +94,6 @@ These are only changes since 3.7.0alpha1.
 
 * Enhancements *
 * New Features *
-
- - #4363, [sfcgal] Add CG_IsValid, CG_IsValidDetail, and SFCGAL 2.3+
-          CG_IsSimple and CG_IsSimpleDetail checks
-          (Darafei Praliaskouski)
-
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -162,6 +162,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)
  - #4560, ST_3DInterpolatePoint for M interpolation from XYZ inputs (Paul Ramsey)
+ - #4363, [sfcgal] Add CG_IsValid, CG_IsValidDetail, and SFCGAL 2.3+
+          CG_IsSimple and CG_IsSimpleDetail checks
+          (Darafei Praliaskouski)
  - #1291, ST_MakePolygon support for curved rings (Darafei Praliaskouski)
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -43,6 +43,7 @@ htmldir = @htmldir@
 POSTGIS_MAJOR_VERSION=@POSTGIS_MAJOR_VERSION@
 POSTGIS_MINOR_VERSION=@POSTGIS_MINOR_VERSION@
 POSTGIS_MICRO_VERSION=@POSTGIS_MICRO_VERSION@
+POSTGIS_SFCGAL_VERSION=@POSTGIS_SFCGAL_VERSION@
 
 DOCSUFFIX=-en
 
@@ -92,6 +93,9 @@ XSLTPROC_PATH_OPT= \
 XSLTPROC_CUSTOM_VARS = \
 	--stringparam postgis_version $(POSTGIS_MAJOR_VERSION).$(POSTGIS_MINOR_VERSION) \
 	--stringparam postgis_language $(patsubst -%,%,$(DOCSUFFIX))/
+
+XSLTPROC_COMMENT_VARS = \
+	--stringparam postgis_sfcgal_version $(POSTGIS_SFCGAL_VERSION)
 
 XSLTPROC_COMMONOPTS= \
 	$(XSLTPROC_PATH_OPT) \
@@ -432,7 +436,7 @@ $(TAG_GENERATED_SOURCES): xsl/node_by_xpath.xsl xsl-config.xml | Makefile
 endif
 
 $(GENERATED_COMMENT_FILES): %.sql: xsl/%.sql.xsl postgis-out.xml xsl/common_utils.xsl xsl/common_comments.xsl
-	$(XSLTPROC) --novalid $(XSLTPROCFLAGS) $(XSLTPROC_PATH_OPT) -o $@ $< postgis-out.xml
+	$(XSLTPROC) --novalid $(XSLTPROCFLAGS) $(XSLTPROC_PATH_OPT) $(XSLTPROC_COMMENT_VARS) -o $@ $< postgis-out.xml
 
 $(GENERATED_CHEATSHEET_FILES): $(html_builddir)/%$(DOCSUFFIX).html: xsl/%.html.xsl postgis-out.xml xsl/common_cheatsheet.xsl xsl/common_utils.xsl
 	$(XSLTPROC) --novalid $(XSLTPROCFLAGS) $(XSLTPROC_PATH_OPT) $(XSLTPROC_CUSTOM_VARS) -o $@ $< postgis-out.xml

--- a/doc/reference_sfcgal.xml
+++ b/doc/reference_sfcgal.xml
@@ -201,10 +201,8 @@ FROM data;</programlisting>
             <refsection>
                 <title>Examples</title>
 
-                <programlisting>SELECT CG_IsValid('LINESTRING Z (0 0 0,0 0 1)'::geometry);
- cg_isvalid
---------------
- t</programlisting>
+                <programlisting>SELECT CG_IsValid('LINESTRING Z (0 0 0,0 0 1)'::geometry);</programlisting>
+                <screen>t</screen>
             </refsection>
 
             <refsection>
@@ -248,10 +246,8 @@ FROM data;</programlisting>
                 <title>Examples</title>
 
                 <programlisting>SELECT valid, reason, ST_AsText(location) AS location
-FROM CG_IsValidDetail('POLYGON((0 0,2 2,2 0,0 2,0 0))'::geometry);
- valid |         reason         | location
--------+------------------------+----------
- f     | ring 0 self intersects |</programlisting>
+FROM CG_IsValidDetail('POLYGON((0 0,2 2,2 0,0 2,0 0))'::geometry);</programlisting>
+                <screen>f | ring 0 self intersects |</screen>
             </refsection>
 
             <refsection>
@@ -294,10 +290,8 @@ FROM CG_IsValidDetail('POLYGON((0 0,2 2,2 0,0 2,0 0))'::geometry);
             <refsection>
                 <title>Examples</title>
 
-                <programlisting>SELECT CG_IsSimple('LINESTRING(0 0,2 2,2 0,0 2)'::geometry);
- cg_issimple
--------------
- f</programlisting>
+                <programlisting>SELECT CG_IsSimple('LINESTRING(0 0,2 2,2 0,0 2)'::geometry);</programlisting>
+                <screen>f</screen>
             </refsection>
 
             <refsection>
@@ -339,10 +333,8 @@ FROM CG_IsValidDetail('POLYGON((0 0,2 2,2 0,0 2,0 0))'::geometry);
             <refsection>
                 <title>Examples</title>
 
-                <programlisting>SELECT CG_IsSimpleDetail('LINESTRING(0 0,2 2,2 0,0 2)'::geometry);
-     cg_issimpledetail
----------------------------
- linestring self intersects</programlisting>
+                <programlisting>SELECT CG_IsSimpleDetail('LINESTRING(0 0,2 2,2 0,0 2)'::geometry);</programlisting>
+                <screen>linestring self intersects</screen>
             </refsection>
 
             <refsection>

--- a/doc/reference_sfcgal.xml
+++ b/doc/reference_sfcgal.xml
@@ -169,6 +169,190 @@ FROM data;</programlisting>
 
         </refentry>
 
+        <refentry xml:id="CG_IsValid">
+            <refnamediv>
+                <refname>CG_IsValid</refname>
+
+                <refpurpose>Tests whether a geometry is valid according to SFCGAL</refpurpose>
+            </refnamediv>
+
+            <refsynopsisdiv>
+                <funcsynopsis>
+                    <funcprototype>
+                        <funcdef>boolean <function>CG_IsValid</function></funcdef>
+                        <paramdef><type>geometry</type> <parameter>geom</parameter></paramdef>
+                    </funcprototype>
+                </funcsynopsis>
+            </refsynopsisdiv>
+
+            <refsection>
+                <title>Description</title>
+
+                <para>Returns true if the input geometry is valid according to SFCGAL.</para>
+                <para>This differs from <xref linkend="ST_IsValid"/>, which checks OGC validity through GEOS.</para>
+
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                <para>&sfcgal_required;</para>
+                <para>&Z_support;</para>
+                <para>&P_support;</para>
+                <para>&T_support;</para>
+            </refsection>
+
+            <refsection>
+                <title>Examples</title>
+
+                <programlisting>SELECT CG_IsValid('LINESTRING Z (0 0 0,0 0 1)'::geometry);
+ cg_isvalid
+--------------
+ t</programlisting>
+            </refsection>
+
+            <refsection>
+                <title>See Also</title>
+
+                <para><xref linkend="CG_IsValidDetail"/>, <xref linkend="CG_IsSimple"/>, <xref linkend="ST_IsValid"/>, <xref linkend="CG_IsSolid"/></para>
+            </refsection>
+
+        </refentry>
+
+        <refentry xml:id="CG_IsValidDetail">
+            <refnamediv>
+                <refname>CG_IsValidDetail</refname>
+
+                <refpurpose>Returns a <varname>valid_detail</varname> row stating whether a geometry is valid according to SFCGAL, and if not a reason and a location.</refpurpose>
+            </refnamediv>
+
+            <refsynopsisdiv>
+                <funcsynopsis>
+                    <funcprototype>
+                        <funcdef>valid_detail <function>CG_IsValidDetail</function></funcdef>
+                        <paramdef><type>geometry</type> <parameter>geom</parameter></paramdef>
+                    </funcprototype>
+                </funcsynopsis>
+            </refsynopsisdiv>
+
+            <refsection>
+                <title>Description</title>
+
+                <para>Returns a <varname>valid_detail</varname> row with a boolean validity flag, a reason for invalidity, and the invalidity location when SFCGAL reports one.</para>
+                <para>This differs from <xref linkend="ST_IsValidDetail"/>, which checks OGC validity through GEOS.</para>
+
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                <para>&sfcgal_required;</para>
+                <para>&Z_support;</para>
+                <para>&P_support;</para>
+                <para>&T_support;</para>
+            </refsection>
+
+            <refsection>
+                <title>Examples</title>
+
+                <programlisting>SELECT valid, reason, ST_AsText(location) AS location
+FROM CG_IsValidDetail('POLYGON((0 0,2 2,2 0,0 2,0 0))'::geometry);
+ valid |         reason         | location
+-------+------------------------+----------
+ f     | ring 0 self intersects |</programlisting>
+            </refsection>
+
+            <refsection>
+                <title>See Also</title>
+
+                <para><xref linkend="CG_IsValid"/>, <xref linkend="CG_IsSimpleDetail"/>, <xref linkend="ST_IsValidDetail"/></para>
+            </refsection>
+
+        </refentry>
+
+        <refentry xml:id="CG_IsSimple">
+            <refnamediv>
+                <refname>CG_IsSimple</refname>
+
+                <refpurpose>Tests whether a geometry is simple according to SFCGAL</refpurpose>
+            </refnamediv>
+
+            <refsynopsisdiv>
+                <funcsynopsis>
+                    <funcprototype>
+                        <funcdef>boolean <function>CG_IsSimple</function></funcdef>
+                        <paramdef><type>geometry</type> <parameter>geom</parameter></paramdef>
+                    </funcprototype>
+                </funcsynopsis>
+            </refsynopsisdiv>
+
+            <refsection>
+                <title>Description</title>
+
+                <para>Returns true if the input geometry is simple according to SFCGAL.</para>
+                <para>This differs from <xref linkend="ST_IsSimple"/>, which checks simplicity through liblwgeom.</para>
+
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0 - requires SFCGAL &gt;= 2.3.0.</para>
+                <para>&sfcgal_required;</para>
+                <para>&Z_support;</para>
+                <para>&P_support;</para>
+                <para>&T_support;</para>
+            </refsection>
+
+            <refsection>
+                <title>Examples</title>
+
+                <programlisting>SELECT CG_IsSimple('LINESTRING(0 0,2 2,2 0,0 2)'::geometry);
+ cg_issimple
+-------------
+ f</programlisting>
+            </refsection>
+
+            <refsection>
+                <title>See Also</title>
+
+                <para><xref linkend="CG_IsSimpleDetail"/>, <xref linkend="CG_IsValid"/>, <xref linkend="ST_IsSimple"/></para>
+            </refsection>
+
+        </refentry>
+
+        <refentry xml:id="CG_IsSimpleDetail">
+            <refnamediv>
+                <refname>CG_IsSimpleDetail</refname>
+
+                <refpurpose>Returns a reason when a geometry is not simple according to SFCGAL</refpurpose>
+            </refnamediv>
+
+            <refsynopsisdiv>
+                <funcsynopsis>
+                    <funcprototype>
+                        <funcdef>text <function>CG_IsSimpleDetail</function></funcdef>
+                        <paramdef><type>geometry</type> <parameter>geom</parameter></paramdef>
+                    </funcprototype>
+                </funcsynopsis>
+            </refsynopsisdiv>
+
+            <refsection>
+                <title>Description</title>
+
+                <para>Returns SFCGAL's reason when the input geometry is not simple. Returns <varname>NULL</varname> for simple geometries.</para>
+
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0 - requires SFCGAL &gt;= 2.3.0.</para>
+                <para>&sfcgal_required;</para>
+                <para>&Z_support;</para>
+                <para>&P_support;</para>
+                <para>&T_support;</para>
+            </refsection>
+
+            <refsection>
+                <title>Examples</title>
+
+                <programlisting>SELECT CG_IsSimpleDetail('LINESTRING(0 0,2 2,2 0,0 2)'::geometry);
+     cg_issimpledetail
+---------------------------
+ linestring self intersects</programlisting>
+            </refsection>
+
+            <refsection>
+                <title>See Also</title>
+
+                <para><xref linkend="CG_IsSimple"/>, <xref linkend="CG_IsValidDetail"/>, <xref linkend="ST_IsSimple"/></para>
+            </refsection>
+
+        </refentry>
+
         <refentry xml:id="CG_IsSolid">
             <refnamediv>
                 <refname>CG_IsSolid</refname>

--- a/doc/xsl/sfcgal_comments.sql.xsl
+++ b/doc/xsl/sfcgal_comments.sql.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet version="1.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:db="http://docbook.org/ns/docbook"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
 >
 <!-- ********************************************************************
      ********************************************************************
@@ -15,6 +16,7 @@
 	<xsl:include href="common_comments.xsl" />
 
 	<xsl:output method="text" />
+	<xsl:param name="postgis_sfcgal_version">0</xsl:param>
 
 	<!-- We deal only with the reference chapter -->
         <xsl:template match="/">
@@ -26,6 +28,15 @@
 		<xsl:variable name="apesc"><xsl:text>''</xsl:text></xsl:variable>
 <!-- Pull out the purpose section for each ref entry and strip whitespace and put in a variable to be tagged unto each function comment  -->
 		<xsl:for-each select="db:section[not(contains(@xml:id,'Operator'))]/db:refentry">
+		  <!--
+		    CG_IsSimple and CG_IsSimpleDetail are not declared in sfcgal.sql
+		    when PostGIS is built against SFCGAL before 2.3.0, because the
+		    required SFCGAL C entry points do not exist there. Other documented
+		    SFCGAL 2.3 features keep SQL-visible stubs that raise a version
+		    error at execution time, so their COMMENT statements must remain.
+		  -->
+		  <xsl:variable name="skip-comment" select="number($postgis_sfcgal_version) &lt; 20300 and (@xml:id='CG_IsSimple' or @xml:id='CG_IsSimpleDetail')" />
+		  <xsl:if test="not($skip-comment)">
 		  <xsl:variable name='plaincomment'>
 		  	<xsl:value-of select="normalize-space(translate(translate(db:refnamediv/db:refpurpose,'&#x0d;&#x0a;', ' '), '&#09;', ' '))"/>
 		  </xsl:variable>
@@ -45,6 +56,7 @@ COMMENT ON <xsl:choose><xsl:when test="contains(db:paramdef/db:type,'geometry se
 <xsl:choose><xsl:when test="contains(db:parameter,'OUT')"></xsl:when><xsl:when test="contains(db:type,'geometry set')">geometry</xsl:when><xsl:otherwise><xsl:value-of select="db:type" /></xsl:otherwise></xsl:choose><xsl:if test="position()&lt;last() and not(contains(db:parameter,'OUT')) and not(contains(following-sibling::paramdef[1],'OUT'))"><xsl:text>, </xsl:text></xsl:if></xsl:when>
 </xsl:choose></xsl:for-each>) IS '<xsl:call-template name="listparams"><xsl:with-param name="func" select="." /></xsl:call-template> <xsl:value-of select='$comment' />';
 			</xsl:for-each>
+		  </xsl:if>
 		</xsl:for-each>
 	</xsl:template>
 

--- a/postgis/uninstall_sfcgal.sql.in
+++ b/postgis/uninstall_sfcgal.sql.in
@@ -20,6 +20,11 @@ DROP FUNCTION IF EXISTS postgis_sfcgal_full_version();
 
 DROP FUNCTION IF EXISTS ST_3DIntersection(geom1 geometry, geom2 geometry);
 
+DROP FUNCTION IF EXISTS CG_IsValid(geometry);
+DROP FUNCTION IF EXISTS CG_IsValidDetail(geometry);
+DROP FUNCTION IF EXISTS CG_IsSimple(geometry);
+DROP FUNCTION IF EXISTS CG_IsSimpleDetail(geometry);
+
 DROP FUNCTION IF EXISTS ST_Tesselate(geometry);
 
 DROP FUNCTION IF EXISTS ST_3DArea(geometry);

--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -26,7 +26,9 @@
 #include "SFCGAL/capi/sfcgal_c.h"
 
 #include "postgres.h"
+#include "access/htup_details.h"
 #include "fmgr.h"
+#include "funcapi.h"
 #include "libpq/pqsignal.h"
 #include "utils/builtins.h"
 #include "utils/elog.h"
@@ -73,6 +75,12 @@ Datum sfcgal_volume(PG_FUNCTION_ARGS);
 Datum sfcgal_extrude(PG_FUNCTION_ARGS);
 Datum sfcgal_straight_skeleton(PG_FUNCTION_ARGS);
 Datum sfcgal_approximate_medial_axis(PG_FUNCTION_ARGS);
+Datum CG_IsValid(PG_FUNCTION_ARGS);
+Datum CG_IsValidDetail(PG_FUNCTION_ARGS);
+#if POSTGIS_SFCGAL_VERSION >= 20300
+Datum CG_IsSimple(PG_FUNCTION_ARGS);
+Datum CG_IsSimpleDetail(PG_FUNCTION_ARGS);
+#endif
 Datum sfcgal_is_planar(PG_FUNCTION_ARGS);
 Datum sfcgal_orientation(PG_FUNCTION_ARGS);
 Datum sfcgal_force_lhr(PG_FUNCTION_ARGS);
@@ -275,6 +283,147 @@ sfcgal_is_planar(PG_FUNCTION_ARGS)
 
 	PG_RETURN_BOOL(result);
 }
+
+PG_FUNCTION_INFO_V1(CG_IsValid);
+Datum
+CG_IsValid(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *input;
+	sfcgal_geometry_t *geom;
+	int result;
+
+	sfcgal_postgis_init();
+
+	input = PG_GETARG_GSERIALIZED_P(0);
+	geom = POSTGIS2SFCGALGeometry(input);
+
+	result = sfcgal_geometry_is_valid(geom);
+	sfcgal_geometry_delete(geom);
+
+	PG_FREE_IF_COPY(input, 0);
+
+	PG_RETURN_BOOL(result);
+}
+
+static void
+sfcgal_detail_reason_free(char *reason)
+{
+	/*
+	 * SFCGAL's detail APIs return reason strings allocated by the C++
+	 * validity/simplicity layer, not by the C API buffer helper. Releasing
+	 * these with lwfree() or sfcgal_free_buffer() corrupts memory with
+	 * SFCGAL 2.3, even after sfcgal_set_alloc_handlers().
+	 */
+	free(reason);
+}
+
+PG_FUNCTION_INFO_V1(CG_IsValidDetail);
+Datum
+CG_IsValidDetail(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *input;
+	GSERIALIZED *location = NULL;
+	sfcgal_geometry_t *geom;
+	sfcgal_geometry_t *invalidity_location = NULL;
+	char *invalidity_reason = NULL;
+	Datum values[3];
+	bool nulls[3] = {false, true, true};
+	int result;
+	HeapTuple tuple;
+	TupleDesc tupdesc;
+
+	sfcgal_postgis_init();
+
+	input = PG_GETARG_GSERIALIZED_P(0);
+	geom = POSTGIS2SFCGALGeometry(input);
+
+	result = sfcgal_geometry_is_valid_detail(geom, &invalidity_reason, &invalidity_location);
+	sfcgal_geometry_delete(geom);
+
+	if (invalidity_reason)
+	{
+		values[1] = CStringGetTextDatum(invalidity_reason);
+		nulls[1] = false;
+		sfcgal_detail_reason_free(invalidity_reason);
+	}
+
+	if (invalidity_location)
+	{
+		location = SFCGALGeometry2POSTGIS(
+		    invalidity_location, FLAGS_GET_Z(input->gflags), gserialized_get_srid(input));
+		sfcgal_geometry_delete(invalidity_location);
+		values[2] = PointerGetDatum(location);
+		nulls[2] = false;
+	}
+
+	PG_FREE_IF_COPY(input, 0);
+
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("function returning record called in context that cannot accept type record")));
+	BlessTupleDesc(tupdesc);
+
+	values[0] = BoolGetDatum(result);
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+
+	PG_RETURN_DATUM(HeapTupleGetDatum(tuple));
+}
+
+#if POSTGIS_SFCGAL_VERSION >= 20300
+PG_FUNCTION_INFO_V1(CG_IsSimple);
+Datum
+CG_IsSimple(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *input;
+	sfcgal_geometry_t *geom;
+	int result;
+
+	sfcgal_postgis_init();
+
+	input = PG_GETARG_GSERIALIZED_P(0);
+	geom = POSTGIS2SFCGALGeometry(input);
+
+	result = sfcgal_geometry_is_simple(geom);
+	sfcgal_geometry_delete(geom);
+
+	PG_FREE_IF_COPY(input, 0);
+
+	PG_RETURN_BOOL(result);
+}
+
+PG_FUNCTION_INFO_V1(CG_IsSimpleDetail);
+Datum
+CG_IsSimpleDetail(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *input;
+	sfcgal_geometry_t *geom;
+	char *complexity_reason = NULL;
+	int result;
+	text *text_result;
+
+	sfcgal_postgis_init();
+
+	input = PG_GETARG_GSERIALIZED_P(0);
+	geom = POSTGIS2SFCGALGeometry(input);
+
+	result = sfcgal_geometry_is_simple_detail(geom, &complexity_reason);
+	sfcgal_geometry_delete(geom);
+
+	PG_FREE_IF_COPY(input, 0);
+
+	if (result || !complexity_reason)
+	{
+		if (complexity_reason)
+			sfcgal_detail_reason_free(complexity_reason);
+		PG_RETURN_NULL();
+	}
+
+	text_result = cstring_to_text(complexity_reason);
+	sfcgal_detail_reason_free(complexity_reason);
+	PG_RETURN_TEXT_P(text_result);
+}
+#endif
 
 PG_FUNCTION_INFO_V1(sfcgal_orientation);
 Datum

--- a/sfcgal/regress/is_simple.sql
+++ b/sfcgal/regress/is_simple.sql
@@ -1,0 +1,4 @@
+SELECT 'CG_IsSimple.simple_line', CG_IsSimple('LINESTRING(0 0,1 1)');
+SELECT 'CG_IsSimple.crossing_line', CG_IsSimple('LINESTRING(0 0,2 2,2 0,0 2)');
+SELECT 'CG_IsSimpleDetail.simple_line', CG_IsSimpleDetail('LINESTRING(0 0,1 1)') IS NULL;
+SELECT 'CG_IsSimpleDetail.crossing_line', CG_IsSimpleDetail('LINESTRING(0 0,2 2,2 0,0 2)') IS NOT NULL;

--- a/sfcgal/regress/is_simple_expected
+++ b/sfcgal/regress/is_simple_expected
@@ -1,0 +1,4 @@
+CG_IsSimple.simple_line|t
+CG_IsSimple.crossing_line|f
+CG_IsSimpleDetail.simple_line|t
+CG_IsSimpleDetail.crossing_line|t

--- a/sfcgal/regress/regress_sfcgal.sql
+++ b/sfcgal/regress/regress_sfcgal.sql
@@ -9,6 +9,13 @@ SELECT 'postgis_sfcgal_version', count(*) FROM (SELECT postgis_sfcgal_version())
 SELECT 'postgis_sfcgal_noop', ST_NPoints(postgis_sfcgal_noop(ST_Buffer('POINT(0 0)', 5)));
 SELECT 'CG_Tesselate', ST_AsText(CG_Tesselate('GEOMETRYCOLLECTION(POINT(4 4),POLYGON((0 0,1 0,1 1,0 1,0 0)))'));
 SELECT 'CG_3DArea', CG_3DArea('POLYGON((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0))');
+SELECT 'CG_IsValid.2d_polygon', CG_IsValid('POLYGON((0 0,1 0,1 1,0 0))');
+SELECT 'CG_IsValid.invalid_polygon', CG_IsValid('POLYGON((0 0,2 2,2 0,0 2,0 0))');
+SELECT 'CG_IsValid.3d_vertical_line', CG_IsValid('LINESTRING Z (0 0 0,0 0 1)');
+SELECT 'CG_IsValid.polyhedralsurface', CG_IsValid('POLYHEDRALSURFACE Z (((0 0 0,0 0 1,0 1 0,0 0 0)),((0 0 0,0 1 0,1 0 0,0 0 0)),((0 0 0,1 0 0,0 0 1,0 0 0)),((1 0 0,0 1 0,0 0 1,1 0 0)))');
+SELECT 'CG_IsValid.solid', CG_IsValid(CG_MakeSolid('POLYHEDRALSURFACE Z (((0 0 0,0 0 1,0 1 0,0 0 0)),((0 0 0,0 1 0,1 0 0,0 0 0)),((0 0 0,1 0 0,0 0 1,0 0 0)),((1 0 0,0 1 0,0 0 1,1 0 0)))'));
+SELECT 'CG_IsValidDetail.valid_polygon', valid, reason IS NULL, location IS NULL FROM CG_IsValidDetail('POLYGON((0 0,1 0,1 1,0 0))');
+SELECT 'CG_IsValidDetail.invalid_polygon', valid, reason IS NOT NULL, location IS NULL FROM CG_IsValidDetail('POLYGON((0 0,2 2,2 0,0 2,0 0))');
 SELECT 'CG_Extrude_point', ST_AsText(CG_Extrude('POINT(0 0)', 1, 0, 0));
 SELECT 'CG_Extrude_line', ST_AsText(CG_Extrude(CG_Extrude('POINT(0 0)', 1, 0, 0), 0, 1, 0));
 -- In the first SFCGAL versions, the extruded face was wrongly oriented

--- a/sfcgal/regress/regress_sfcgal_expected
+++ b/sfcgal/regress/regress_sfcgal_expected
@@ -2,6 +2,13 @@ postgis_sfcgal_version|1
 postgis_sfcgal_noop|33
 CG_Tesselate|GEOMETRYCOLLECTION(POINT(4 4),TIN(((0 1,1 0,1 1,0 1)),((0 1,0 0,1 0,0 1))))
 CG_3DArea|1
+CG_IsValid.2d_polygon|t
+CG_IsValid.invalid_polygon|f
+CG_IsValid.3d_vertical_line|t
+CG_IsValid.polyhedralsurface|t
+CG_IsValid.solid|t
+CG_IsValidDetail.valid_polygon|t|t|t
+CG_IsValidDetail.invalid_polygon|f|t|t
 CG_Extrude_point|LINESTRING Z (0 0 0,1 0 0)
 CG_Extrude_line|POLYHEDRALSURFACE Z (((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0)))
 CG_Extrude_surface|POLYHEDRALSURFACE Z (((1 1 0,1 0 0,0 1 0,1 1 0)),((0 1 1,1 0 1,1 1 1,0 1 1)),((1 0 0,0 0 0,0 1 0,1 0 0)),((0 1 1,0 0 1,1 0 1,0 1 1)),((1 0 0,1 1 0,1 1 1,1 0 1,1 0 0)),((1 1 0,0 1 0,0 1 1,1 1 1,1 1 0)),((0 1 0,0 0 0,0 0 1,0 1 1,0 1 0)),((0 0 0,1 0 0,1 0 1,0 0 1,0 0 0)))

--- a/sfcgal/regress/tests.mk.in
+++ b/sfcgal/regress/tests.mk.in
@@ -50,6 +50,7 @@ ifeq ($(shell expr "$(POSTGIS_SFCGAL_VERSION)" ">=" 20300),1)
 		$(top_srcdir)/sfcgal/regress/alphashape_components.sql \
 		$(top_srcdir)/sfcgal/regress/roofgeneration.sql \
 		$(top_srcdir)/sfcgal/regress/approximatemedialaxis_projected.sql \
+		$(top_srcdir)/sfcgal/regress/is_simple.sql \
 		$(top_srcdir)/sfcgal/regress/nurbs.sql
 	ifeq ($(shell expr "$(POSTGIS_CGAL_VERSION)" ">=" 600),1)
 		TESTS += $(top_srcdir)/sfcgal/regress/polygonrepair.sql

--- a/sfcgal/sfcgal.sql.in
+++ b/sfcgal/sfcgal.sql.in
@@ -334,6 +334,36 @@ CREATE OR REPLACE FUNCTION CG_IsPlanar(geometry)
        LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
        COST 100;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION CG_IsValid(geometry)
+       RETURNS boolean
+       AS 'MODULE_PATHNAME','CG_IsValid'
+       LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+       COST 100;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION CG_IsValidDetail(geometry)
+       RETURNS valid_detail
+       AS 'MODULE_PATHNAME','CG_IsValidDetail'
+       LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+       COST 100;
+
+-- Availability: 3.7.0 - requires SFCGAL >= 2.3.0
+#if POSTGIS_SFCGAL_VERSION >= 20300
+CREATE OR REPLACE FUNCTION CG_IsSimple(geometry)
+       RETURNS boolean
+       AS 'MODULE_PATHNAME','CG_IsSimple'
+       LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+       COST 100;
+
+-- Availability: 3.7.0 - requires SFCGAL >= 2.3.0
+CREATE OR REPLACE FUNCTION CG_IsSimpleDetail(geometry)
+       RETURNS text
+       AS 'MODULE_PATHNAME','CG_IsSimpleDetail'
+       LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+       COST 100;
+#endif
+
 -- Availability: 2.2.0
 -- Deprecation in 3.5.0
 CREATE OR REPLACE FUNCTION ST_IsPlanar(geometry)


### PR DESCRIPTION
Adds SFCGAL-backed validity and simplicity predicates for https://trac.osgeo.org/postgis/ticket/4363.

Changes:
- expose `CG_IsValid(geometry)` through `postgis_sfcgal` using `sfcgal_geometry_is_valid`
- expose `CG_IsValidDetail(geometry)` using SFCGAL validity detail, returning the existing `valid_detail` row type
- expose `CG_IsSimple(geometry)` and `CG_IsSimpleDetail(geometry)` on SFCGAL 2.3+ builds, where the needed SFCGAL C APIs are available
- keep generated SFCGAL function comments aligned with the configured SFCGAL version, so older SFCGAL builds do not comment on SQL functions they cannot declare
- keep PostgreSQL C entry-point symbols aligned with their `CG_` SQL function names
- avoid adding an `ST_3DIsValid` alias only to deprecate it; the SFCGAL predicate applies to both 2D and 3D inputs, so the canonical `CG_` name is the new surface
- document the new predicates and cover them in SFCGAL regression, upgrade, and uninstall tests
- add regression coverage for valid 2D polygon, invalid polygon, valid/invalid detail paths, 3D line, polyhedral surface, solid, and simple/non-simple line inputs

Validation on rebased head `39892d2b4876d5c7c03c43639212bed4039e179a`:
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make postgis_revision.h && make -C sfcgal -j32 && make -C extensions/postgis_sfcgal -j1`
- `make -C postgis -j32 && make -C extensions/postgis -j1`
- `sudo -n make -C postgis install && sudo -n make -C extensions/postgis install && sudo -n make -C sfcgal install && sudo -n make -C extensions/postgis_sfcgal install`
- `make -C sfcgal/regress check RUNTESTFLAGS="--extension --verbose"` (fresh and upgrade: `Run tests: 18`, `Failed: 0`)
- `make -C doc check-xml`
- `xsltproc --novalid --nonet --path ".:doc" --stringparam postgis_sfcgal_version 20100 doc/xsl/sfcgal_comments.sql.xsl doc/postgis-out.xml > /tmp/postgis-pr1070-sfcgal-comments-20100.sql`
- `xsltproc --novalid --nonet --path ".:doc" --stringparam postgis_sfcgal_version 20300 doc/xsl/sfcgal_comments.sql.xsl doc/postgis-out.xml > /tmp/postgis-pr1070-sfcgal-comments-20300.sql`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- sfcgal/lwgeom_sfcgal.c`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
