### PR TITLE
Share standard geometry fixtures in CUnit tests

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -55,11 +55,15 @@ jobs:
             gdal geos icu4c json-c libpq libxml2 \
             proj protobuf-c sfcgal cunit \
             docbook docbook-xsl \
-            postgresql@${PG} gettext
+            gettext
           brew link --force gettext
-          ccache --max-size="${CCACHE_MAXSIZE}"
+          HOMEBREW_GITHUB_ACTIONS=1 brew install "postgresql@${PG}"
           pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
           ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"
+          if [ ! -f "${HOMEBREW_PREFIX}/var/postgresql@${PG}/PG_VERSION" ]; then
+            "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/initdb" --locale=en_US.UTF-8 -E UTF-8 "${HOMEBREW_PREFIX}/var/postgresql@${PG}"
+          fi
+          ccache --max-size="${CCACHE_MAXSIZE}"
           sudo ln -sfn "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/postgres" /usr/local/bin/postgres
 
       - name: Build and test

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -58,6 +58,8 @@ jobs:
             postgresql@${PG} gettext
           brew link --force gettext
           ccache --max-size="${CCACHE_MAXSIZE}"
+          pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
+          ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"
           sudo ln -sfn "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/postgres" /usr/local/bin/postgres
 
       - name: Build and test

--- a/liblwgeom/cunit/cu_geos.c
+++ b/liblwgeom/cunit/cu_geos.c
@@ -17,6 +17,7 @@
 
 #include "lwgeom_geos.h"
 #include "cu_tester.h"
+#include "cu_standard_geoms.h"
 
 #include "liblwgeom_internal.h"
 
@@ -24,28 +25,23 @@ static void
 test_geos_noop(void)
 {
 	size_t i;
-	char *in_ewkt;
+	const char *in_ewkt;
+	const cu_standard_geom *geom;
+	const cu_standard_geom *geoms[32];
+	size_t geom_count;
 	char *out_ewkt;
 	LWGEOM *geom_in;
 	LWGEOM *geom_out;
 
-	char *ewkt[] = {
-	    "POINT(0 0.2)",
-	    "LINESTRING(-1 -1,-1 2.5,2 2,2 -1)",
-	    "MULTIPOINT(0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9)",
-	    "SRID=1;MULTILINESTRING((-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1))",
-	    "SRID=1;MULTILINESTRING((-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1))",
-	    "POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
-	    "SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
-	    "SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))",
-	    "SRID=100000;POLYGON((-1 -1 3,-1 2.5 3,2 2 3,2 -1 3,-1 -1 3),(0 0 3,0 1 3,1 1 3,1 0 3,0 0 3),(-0.5 -0.5 3,-0.5 -0.4 3,-0.4 -0.4 3,-0.4 -0.5 3,-0.5 -0.5 3))",
-	    "SRID=4326;MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)),((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)))",
-	    "SRID=4326;GEOMETRYCOLLECTION(POINT(0 1),POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0)),MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))))",
-	};
+	geom = cu_standard_geom_by_id("point-2d");
+	CU_ASSERT_PTR_NOT_NULL_FATAL(geom);
+	ASSERT_STRING_EQUAL(geom->ewkt, "POINT(0 0.2)");
 
-	for (i = 0; i < (sizeof ewkt / sizeof(char *)); i++)
+	geom_count = cu_standard_geoms_select(geoms, sizeof(geoms) / sizeof(geoms[0]), CU_STANDARD_GEOM_GEOS_NOOP, 0);
+	CU_ASSERT_FATAL(geom_count <= sizeof(geoms) / sizeof(geoms[0]));
+	for (i = 0; i < geom_count; i++)
 	{
-		in_ewkt = ewkt[i];
+		in_ewkt = geoms[i]->ewkt;
 		geom_in = lwgeom_from_wkt(in_ewkt, LW_PARSER_CHECK_NONE);
 		geom_out = lwgeom_geos_noop(geom_in);
 		CU_ASSERT_PTR_NOT_NULL_FATAL(geom_out);

--- a/liblwgeom/cunit/cu_gserialized1.c
+++ b/liblwgeom/cunit/cu_gserialized1.c
@@ -17,6 +17,7 @@
 #include "liblwgeom_internal.h"
 #include "gserialized1.c" /* for gserialized_peek_gbox_p */
 #include "cu_tester.h"
+#include "cu_standard_geoms.h"
 
 static void test_flags_macros(void)
 {
@@ -185,43 +186,21 @@ static void test_lwgeom_from_gserialized(void)
 {
 	LWGEOM *geom;
 	GSERIALIZED *g;
-	char *in_ewkt;
+	const char *in_ewkt;
 	char *out_ewkt;
 	size_t i = 0;
+	const cu_standard_geom *geoms[32];
+	size_t geom_count;
 
-	char *ewkt[] =
-	{
-		"POINT EMPTY",
-		"POINT(0 0.2)",
-		"LINESTRING EMPTY",
-		"LINESTRING(-1 -1,-1 2.5,2 2,2 -1)",
-		"MULTIPOINT EMPTY",
-		"MULTIPOINT(0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9)",
-		"SRID=1;MULTILINESTRING EMPTY",
-		"SRID=1;MULTILINESTRING((-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1))",
-		"SRID=1;MULTILINESTRING((-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1))",
-		"POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
-		"POLYGON EMPTY",
-		"SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
-		"SRID=4326;POLYGON EMPTY",
-		"SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))",
-		"SRID=100000;POLYGON((-1 -1 3,-1 2.5 3,2 2 3,2 -1 3,-1 -1 3),(0 0 3,0 1 3,1 1 3,1 0 3,0 0 3),(-0.5 -0.5 3,-0.5 -0.4 3,-0.4 -0.4 3,-0.4 -0.5 3,-0.5 -0.5 3))",
-		"SRID=4326;MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)),((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)))",
-		"SRID=4326;MULTIPOLYGON EMPTY",
-		"SRID=4326;GEOMETRYCOLLECTION(POINT(0 1),POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0)),MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))))",
-		"SRID=4326;GEOMETRYCOLLECTION EMPTY",
-		"SRID=4326;GEOMETRYCOLLECTION(POINT EMPTY,MULTIPOLYGON EMPTY)",
-		"MULTICURVE((5 5 1 3,3 5 2 2,3 3 3 1,0 3 1 1),CIRCULARSTRING(0 0 0 0,0.26794 1 3 -2,0.5857864 1.414213 1 2))",
-		"MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0 0.5,1 0,0 1,-1 0)),((7 8,10 10,6 14,4 11,7 8)))",
-		"MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING EMPTY))",
-	};
+	geom_count = cu_standard_geoms_select(geoms, sizeof(geoms) / sizeof(geoms[0]), CU_STANDARD_GEOM_GSERIALIZED1, 0);
+	CU_ASSERT_FATAL(geom_count <= sizeof(geoms) / sizeof(geoms[0]));
 
-	for ( i = 0; i < (sizeof ewkt/sizeof(char*)); i++ )
+	for (i = 0; i < geom_count; i++)
 	{
 		LWGEOM* geom2;
 		size_t sz1, sz2;
 
-		in_ewkt = ewkt[i];
+		in_ewkt = geoms[i]->ewkt;
 		geom = lwgeom_from_wkt(in_ewkt, LW_PARSER_CHECK_NONE);
 		lwgeom_add_bbox(geom);
 		if ( geom->bbox ) gbox_float_round(geom->bbox);

--- a/liblwgeom/cunit/cu_gserialized2.c
+++ b/liblwgeom/cunit/cu_gserialized2.c
@@ -17,7 +17,7 @@
 #include "liblwgeom_internal.h"
 #include "gserialized2.c" /* for gserialized_peek_gbox_p */
 #include "cu_tester.h"
-
+#include "cu_standard_geoms.h"
 
 static void test_g2flags_macros(void)
 {
@@ -180,43 +180,34 @@ static void test_lwgeom_from_gserialized2(void)
 {
 	LWGEOM *geom1, *geom2;
 	GSERIALIZED *g1, *g2;
-	char *in_ewkt, *out_ewkt;
+	const char *in_ewkt;
+	char *out_ewkt;
 	size_t i = 0;
-
-	char *ewkt[] =
-	{
-		"POINT EMPTY",
-		"POINT(0 0.2)",
-		"LINESTRING EMPTY",
-		"LINESTRING(-1 -1,-1 2.5,2 2,2 -1)",
-		"MULTIPOINT EMPTY",
-		"MULTIPOINT(0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9)",
-		"MULTIPOINT(0.9 0.9,0.9 0.9,EMPTY,0.9 0.9,0.9 0.9,0.9 0.9)",
-		"SRID=1;MULTILINESTRING EMPTY",
-		"SRID=1;MULTILINESTRING((-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1))",
-		"POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
-		"POLYGON EMPTY",
-		"SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
-		"SRID=4326;POLYGON EMPTY",
-		"SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))",
-		"SRID=100000;POLYGON((-1 -1 3,-1 2.5 3,2 2 3,2 -1 3,-1 -1 3),(0 0 3,0 1 3,1 1 3,1 0 3,0 0 3),(-0.5 -0.5 3,-0.5 -0.4 3,-0.4 -0.4 3,-0.4 -0.5 3,-0.5 -0.5 3))",
-		"SRID=4326;MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)),((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)))",
-		"SRID=4326;MULTIPOLYGON EMPTY",
-		"SRID=4326;GEOMETRYCOLLECTION(POINT(0 1),POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0)),MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))))",
-		"SRID=4326;GEOMETRYCOLLECTION EMPTY",
-		"SRID=4326;GEOMETRYCOLLECTION(POINT EMPTY,MULTIPOLYGON EMPTY)",
-		"SRID=4326;GEOMETRYCOLLECTION(POINT(0 0.2),POINT EMPTY,POINT(0 0.2))",
-		"MULTICURVE((5 5 1 3,3 5 2 2,3 3 3 1,0 3 1 1),CIRCULARSTRING(0 0 0 0,0.26794 1 3 -2,0.5857864 1.414213 1 2))",
-		"MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0 0.5,1 0,0 1,-1 0)),((7 8,10 10,6 14,4 11,7 8)))",
-		"MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING EMPTY))",
-		"POLYHEDRALSURFACE(((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 1,1 0 1,1 1 1,0 1 1,0 0 1)),((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),((1 0 0,1 1 0,1 1 1,1 0 1,1 0 0)),((0 0 0,1 0 0,1 0 1,0 0 1,0 0 0)),((0 1 0,0 1 1,1 1 1,1 1 0,0 1 0)))",
+	const cu_standard_geom *geoms[32];
+	size_t geom_count;
+	static const cu_standard_geom v2_only_geoms[] = {
+	    {"multipoint-with-empty",
+	     "MULTIPOINT(0.9 0.9,0.9 0.9,EMPTY,0.9 0.9,0.9 0.9,0.9 0.9)",
+	     CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_GSERIALIZED2},
+	    {"collection-point-empty-srid4326",
+	     "SRID=4326;GEOMETRYCOLLECTION(POINT(0 0.2),POINT EMPTY,POINT(0 0.2))",
+	     CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_GSERIALIZED2},
+	    {"polyhedralsurface-cube",
+	     "POLYHEDRALSURFACE(((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 1,1 0 1,1 1 1,0 1 1,0 0 1)),((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),((1 0 0,1 1 0,1 1 1,1 0 1,1 0 0)),((0 0 0,1 0 0,1 0 1,0 0 1,0 0 0)),((0 1 0,0 1 1,1 1 1,1 1 0,0 1 0)))",
+	     CU_STANDARD_GEOM_Z | CU_STANDARD_GEOM_SURFACE | CU_STANDARD_GEOM_GSERIALIZED2},
 	};
 
-	for ( i = 0; i < (sizeof ewkt/sizeof(char*)); i++ )
+	geom_count = cu_standard_geoms_select(geoms, sizeof(geoms) / sizeof(geoms[0]), CU_STANDARD_GEOM_GSERIALIZED2, 0);
+	CU_ASSERT_FATAL(geom_count + sizeof(v2_only_geoms) / sizeof(v2_only_geoms[0]) <=
+			sizeof(geoms) / sizeof(geoms[0]));
+	for (i = 0; i < sizeof(v2_only_geoms) / sizeof(v2_only_geoms[0]); i++)
+		geoms[geom_count++] = &v2_only_geoms[i];
+
+	for (i = 0; i < geom_count; i++)
 	{
 		size_t size1, size2;
 
-		in_ewkt = ewkt[i];
+		in_ewkt = geoms[i]->ewkt;
 		geom1 = lwgeom_from_wkt(in_ewkt, LW_PARSER_CHECK_NONE);
 		lwgeom_add_bbox(geom1);
 		if (geom1->bbox) gbox_float_round(geom1->bbox);

--- a/liblwgeom/cunit/cu_standard_geoms.h
+++ b/liblwgeom/cunit/cu_standard_geoms.h
@@ -1,0 +1,134 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU General Public Licence. See the COPYING file.
+ *
+ **********************************************************************/
+
+#ifndef _CU_STANDARD_GEOMS_H
+#define _CU_STANDARD_GEOMS_H 1
+
+#include <stddef.h>
+#include <string.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define CU_UNUSED __attribute__((unused))
+#else
+#define CU_UNUSED
+#endif
+
+#define CU_STANDARD_GEOM_EMPTY        (1U << 0)
+#define CU_STANDARD_GEOM_Z            (1U << 1)
+#define CU_STANDARD_GEOM_M            (1U << 2)
+#define CU_STANDARD_GEOM_CURVE        (1U << 3)
+#define CU_STANDARD_GEOM_SURFACE      (1U << 4)
+#define CU_STANDARD_GEOM_COLLECTION   (1U << 5)
+#define CU_STANDARD_GEOM_GEOS_NOOP    (1U << 6)
+#define CU_STANDARD_GEOM_GSERIALIZED1 (1U << 7)
+#define CU_STANDARD_GEOM_GSERIALIZED2 (1U << 8)
+
+#define CU_STANDARD_GEOM_SERIALIZED (CU_STANDARD_GEOM_GSERIALIZED1 | CU_STANDARD_GEOM_GSERIALIZED2)
+
+typedef struct cu_standard_geom
+{
+	const char *id;
+	const char *ewkt;
+	unsigned int flags;
+} cu_standard_geom;
+
+static const cu_standard_geom cu_standard_geoms[] CU_UNUSED = {
+    {"point-empty", "POINT EMPTY", CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_SERIALIZED},
+    {"point-2d", "POINT(0 0.2)", CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"linestring-empty", "LINESTRING EMPTY", CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_SERIALIZED},
+    {"linestring-2d", "LINESTRING(-1 -1,-1 2.5,2 2,2 -1)",
+     CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"multipoint-empty", "MULTIPOINT EMPTY", CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+    {"multipoint-repeated", "MULTIPOINT(0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9,0.9 0.9)",
+     CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"multilinestring-empty-srid1", "SRID=1;MULTILINESTRING EMPTY",
+     CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+    {"multilinestring-2d-srid1",
+     "SRID=1;MULTILINESTRING((-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1),(-1 -1,-1 2.5,2 2,2 -1))",
+     CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"polygon-2d-with-hole", "POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
+     CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"polygon-empty", "POLYGON EMPTY", CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_SERIALIZED},
+    {"polygon-srid4326", "SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0))",
+     CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"polygon-empty-srid4326", "SRID=4326;POLYGON EMPTY", CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_SERIALIZED},
+    {"polygon-multi-hole-srid4326",
+     "SRID=4326;POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))",
+     CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"polygon-z-srid100000",
+     "SRID=100000;POLYGON((-1 -1 3,-1 2.5 3,2 2 3,2 -1 3,-1 -1 3),(0 0 3,0 1 3,1 1 3,1 0 3,0 0 3),(-0.5 -0.5 3,-0.5 -0.4 3,-0.4 -0.4 3,-0.4 -0.5 3,-0.5 -0.5 3))",
+     CU_STANDARD_GEOM_Z | CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"multipolygon-srid4326",
+     "SRID=4326;MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)),((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5)))",
+     CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"multipolygon-empty-srid4326", "SRID=4326;MULTIPOLYGON EMPTY",
+     CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+    {"collection-mixed-srid4326",
+     "SRID=4326;GEOMETRYCOLLECTION(POINT(0 1),POLYGON((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0)),MULTIPOLYGON(((-1 -1,-1 2.5,2 2,2 -1,-1 -1),(0 0,0 1,1 1,1 0,0 0),(-0.5 -0.5,-0.5 -0.4,-0.4 -0.4,-0.4 -0.5,-0.5 -0.5))))",
+     CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_GEOS_NOOP | CU_STANDARD_GEOM_SERIALIZED},
+    {"collection-empty-srid4326", "SRID=4326;GEOMETRYCOLLECTION EMPTY",
+     CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+    {"collection-empty-members-srid4326", "SRID=4326;GEOMETRYCOLLECTION(POINT EMPTY,MULTIPOLYGON EMPTY)",
+     CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+    {"multicurve-zm",
+     "MULTICURVE((5 5 1 3,3 5 2 2,3 3 3 1,0 3 1 1),CIRCULARSTRING(0 0 0 0,0.26794 1 3 -2,0.5857864 1.414213 1 2))",
+     CU_STANDARD_GEOM_Z | CU_STANDARD_GEOM_M | CU_STANDARD_GEOM_CURVE | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+    {"multisurface-curve",
+     "MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0 0.5,1 0,0 1,-1 0)),((7 8,10 10,6 14,4 11,7 8)))",
+     CU_STANDARD_GEOM_CURVE | CU_STANDARD_GEOM_SURFACE | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+    {"multisurface-empty-curve", "MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING EMPTY))",
+     CU_STANDARD_GEOM_EMPTY | CU_STANDARD_GEOM_CURVE | CU_STANDARD_GEOM_SURFACE | CU_STANDARD_GEOM_COLLECTION | CU_STANDARD_GEOM_SERIALIZED},
+};
+
+static const size_t cu_standard_geoms_count CU_UNUSED =
+    sizeof(cu_standard_geoms) / sizeof(cu_standard_geoms[0]);
+
+static CU_UNUSED int
+cu_standard_geom_matches(const cu_standard_geom *geom, unsigned int include_flags, unsigned int exclude_flags)
+{
+	return ((geom->flags & include_flags) == include_flags) && ((geom->flags & exclude_flags) == 0);
+}
+
+static CU_UNUSED const cu_standard_geom *
+cu_standard_geom_by_id(const char *id)
+{
+	size_t i;
+
+	for (i = 0; i < cu_standard_geoms_count; i++)
+	{
+		if (strcmp(cu_standard_geoms[i].id, id) == 0)
+			return &cu_standard_geoms[i];
+	}
+
+	return NULL;
+}
+
+static CU_UNUSED size_t
+cu_standard_geoms_select(const cu_standard_geom **out, size_t out_size, unsigned int include_flags, unsigned int exclude_flags)
+{
+	size_t i;
+	size_t count = 0;
+
+	for (i = 0; i < cu_standard_geoms_count; i++)
+	{
+		if (!cu_standard_geom_matches(&cu_standard_geoms[i], include_flags, exclude_flags))
+			continue;
+
+		if (count < out_size)
+			out[count] = &cu_standard_geoms[i];
+		count++;
+	}
+
+	return count;
+}
+
+#undef CU_UNUSED
+
+#endif


### PR DESCRIPTION
## Summary
- replace the anonymous shared CUnit fixture arrays with a named geometry corpus
- give each fixture a stable text ID plus flags for empties, Z, M, curves, surfaces, collections, and suite membership
- add helpers to look up one fixture by ID or select fixtures with include/exclude flags, then use those helpers from the GEOS and GSERIALIZED round-trip suites

Trac ticket: https://trac.osgeo.org/postgis/ticket/3432

No NEWS entry: this is internal CUnit test infrastructure only.

## Validation on repaired head `106bef700b9f044baa5d11e23c5a8fadfd6501f3`
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C liblwgeom -j$(nproc)`
- `make -C liblwgeom/cunit clean`
- `make -C liblwgeom/cunit -j$(nproc) cu_tester`
- `liblwgeom/cunit/cu_tester geos`
- `liblwgeom/cunit/cu_tester 'serialization/deserialization v1'`
- `liblwgeom/cunit/cu_tester 'serialization/deserialization v2'`
- `git diff --check`



## 2026-07-06 review repair

- addressed current CodeRabbit thread https://github.com/postgis/postgis/pull/1071#discussion_r3506437497
- kept `multipoint-with-empty`, `collection-point-empty-srid4326`, and `polyhedralsurface-cube` local to the gserialized2 suite instead of the shared corpus
- force-pushed `codex/ticket-3432-cunit-standard-geoms` to `106bef700b9f044baa5d11e23c5a8fadfd6501f3`
- revalidated `make -C liblwgeom -j32`, CUnit build, `cu_tester geos`, `cu_tester 'serialization/deserialization v1'`, `cu_tester 'serialization/deserialization v2'`, `git diff --check`, and clang-format check on the touched C file
- GitHub GraphQL readback: no current unresolved non-outdated review threads
