### PR TITLE
Add geography support for ST_AddMeasure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,7 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #4565, Add geography support for ST_AddMeasure (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta1
 2026/07/20
@@ -95,9 +96,6 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
- - #4565, Add geography support for ST_AddMeasure (Darafei Praliaskouski)
-
-
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions

--- a/NEWS
+++ b/NEWS
@@ -95,6 +95,9 @@ These are only changes since 3.7.0alpha1.
 
  - GH-1161, Render manual geometry examples as build-time SVG in HTML
           and PDF (Darafei Praliaskouski)
+ - #4565, Add geography support for ST_AddMeasure (Darafei Praliaskouski)
+
+
  - #4749, Use point-in-polygon predicate fast paths for point-only
           GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #3676, Mark geometry and geography btree comparison support functions
@@ -181,7 +184,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           public liblwgeom header (Darafei Praliaskouski)
  - #4678, [raster] Move st_sum4ma neighborhood callback to C
           (Darafei Praliaskouski)
- - #4565, Add geography support for ST_AddMeasure (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks

--- a/NEWS
+++ b/NEWS
@@ -181,6 +181,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           public liblwgeom header (Darafei Praliaskouski)
  - #4678, [raster] Move st_sum4ma neighborhood callback to C
           (Darafei Praliaskouski)
+ - #4565, Add geography support for ST_AddMeasure (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks

--- a/doc/reference_lrs.xml
+++ b/doc/reference_lrs.xml
@@ -845,7 +845,7 @@ ST_AddMeasure(
 	  <refnamediv>
 		<refname>ST_AddMeasure</refname>
 
-		<refpurpose>Interpolates measures along a linear geometry.</refpurpose>
+		<refpurpose>Interpolates measures along a linear geometry or geography.</refpurpose>
 	  </refnamediv>
 
 	  <refsynopsisdiv>
@@ -856,6 +856,12 @@ ST_AddMeasure(
 			<paramdef><type>float8 </type> <parameter>measure_start</parameter></paramdef>
 			<paramdef><type>float8 </type> <parameter>measure_end</parameter></paramdef>
 		  </funcprototype>
+		  <funcprototype>
+			<funcdef>geography <function>ST_AddMeasure</function></funcdef>
+			<paramdef><type>geography </type> <parameter>geog_mline</parameter></paramdef>
+			<paramdef><type>float8 </type> <parameter>measure_start</parameter></paramdef>
+			<paramdef><type>float8 </type> <parameter>measure_end</parameter></paramdef>
+		  </funcprototype>
 
 		</funcsynopsis>
 	  </refsynopsisdiv>
@@ -863,9 +869,12 @@ ST_AddMeasure(
 	  <refsection>
 		<title>Description</title>
 
-		   <para>Return a derived geometry with measure values linearly interpolated between the start and end points. If the geometry has no measure dimension, one is added. If the geometry has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported.</para>
+		   <para>Return a derived geometry or geography with measure values linearly interpolated between the start and end points. If the input has no measure dimension, one is added. If the input has a measure dimension, it is over-written with new values. Only LINESTRINGS and MULTILINESTRINGS are supported.</para>
+
+		   <para>For geography inputs, measures are interpolated using spheroidal segment lengths.</para>
 
 			<para role="availability" conformance="1.5.0">Availability: 1.5.0</para>
+			<para role="enhanced" conformance="3.7.0">Enhanced: 3.7.0 - Support for geography was introduced.</para>
 
 		<para>&Z_support;</para>
 	  </refsection>

--- a/postgis/geography.sql.in
+++ b/postgis/geography.sql.in
@@ -939,4 +939,16 @@ CREATE OR REPLACE FUNCTION ST_LineInterpolatePoint(text, float8)
 	$$ SELECT @extschema@.ST_LineInterpolatePoint($1::@extschema@.geometry, $2);  $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_AddMeasure(geography, float8, float8)
+	RETURNS geography
+	AS 'MODULE_PATHNAME', 'geography_add_measure'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_AddMeasure(text, float8, float8)
+	RETURNS geometry AS
+	$$ SELECT @extschema@.ST_AddMeasure($1::@extschema@.geometry, $2, $3);  $$
+	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
 ----------------------------------------------------------------

--- a/postgis/geography_measurement.c
+++ b/postgis/geography_measurement.c
@@ -35,6 +35,7 @@
 
 #include "liblwgeom.h"                  /* For standard geometry types. */
 #include "liblwgeom_internal.h"         /* For FP comparators. */
+#include "lwgeodetic.h"                 /* For geodetic length helpers. */
 #include "lwgeom_pg.h"                  /* For debugging macros. */
 #include "geography.h"                  /* For utility functions. */
 #include "geography_measurement_trees.h" /* For circ_tree caching */
@@ -69,6 +70,7 @@ Datum geography_segmentize(PG_FUNCTION_ARGS);
 Datum geography_line_locate_point(PG_FUNCTION_ARGS);
 Datum geography_line_interpolate_point(PG_FUNCTION_ARGS);
 Datum geography_line_substring(PG_FUNCTION_ARGS);
+Datum geography_add_measure(PG_FUNCTION_ARGS);
 Datum geography_closestpoint(PG_FUNCTION_ARGS);
 Datum geography_shortestline(PG_FUNCTION_ARGS);
 
@@ -1337,6 +1339,179 @@ Datum geography_line_interpolate_point(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(result);
 }
 
+static double
+geography_segment_length_spheroid(const POINT4D *p1, const POINT4D *p2, const SPHEROID *s, int hasz)
+{
+	GEOGRAPHIC_POINT g1, g2;
+	double length;
+
+	geographic_point_init(p1->x, p1->y, &g1);
+	geographic_point_init(p2->x, p2->y, &g2);
+
+	if (s->a == s->b)
+		length = s->radius * sphere_distance(&g1, &g2);
+	else
+		length = spheroid_distance(&g1, &g2, s);
+
+	if (hasz)
+		length = sqrt((p2->z - p1->z) * (p2->z - p1->z) + length * length);
+
+	return length;
+}
+
+static LWLINE *
+geography_line_add_measure(const LWLINE *lwline, double m_start, double m_end, const SPHEROID *s)
+{
+	POINTARRAY *pa;
+	POINT4D p1, p2;
+	uint32_t i;
+	uint32_t npoints = 0;
+	int hasz = FLAGS_GET_Z(lwline->flags);
+	double length = 0.0;
+	double length_so_far = 0.0;
+	double m_range = m_end - m_start;
+
+	if (lwline->points)
+		npoints = lwline->points->npoints;
+
+	pa = ptarray_construct(hasz, LW_TRUE, npoints);
+
+	if (npoints == 0)
+		return lwline_construct(lwline->srid, NULL, pa);
+
+	length = ptarray_length_spheroid(lwline->points, s);
+	getPoint4d_p(lwline->points, 0, &p1);
+
+	for (i = 0; i < npoints; i++)
+	{
+		POINT4D q;
+		double m;
+
+		getPoint4d_p(lwline->points, i, &p2);
+		length_so_far += geography_segment_length_spheroid(&p1, &p2, s, hasz);
+
+		if (length > 0.0)
+			m = m_start + m_range * length_so_far / length;
+		else if (npoints > 1)
+			m = m_start + m_range * i / (npoints - 1);
+		else
+			m = 0.0;
+
+		q = p2;
+		q.m = m;
+		ptarray_set_point4d(pa, i, &q);
+		p1 = p2;
+	}
+
+	return lwline_construct(lwline->srid, NULL, pa);
+}
+
+static LWMLINE *
+geography_multiline_add_measure(const LWMLINE *lwmline, double m_start, double m_end, const SPHEROID *s)
+{
+	LWGEOM **geoms;
+	uint32_t i;
+	uint32_t total_steps = 0;
+	uint32_t steps_so_far = 0;
+	int hasz = FLAGS_GET_Z(lwmline->flags);
+	double length = 0.0;
+	double length_so_far = 0.0;
+	double m_range = m_end - m_start;
+
+	if (lwgeom_is_empty(lwmline_as_lwgeom(lwmline)))
+		return (LWMLINE *)lwcollection_construct_empty(MULTILINETYPE, lwmline->srid, hasz, LW_TRUE);
+
+	geoms = lwalloc(sizeof(LWGEOM *) * lwmline->ngeoms);
+
+	for (i = 0; i < lwmline->ngeoms; i++)
+	{
+		const LWLINE *lwline = (const LWLINE *)lwmline->geoms[i];
+		if (lwline->points && lwline->points->npoints > 1)
+		{
+			length += ptarray_length_spheroid(lwline->points, s);
+			total_steps += lwline->points->npoints - 1;
+		}
+	}
+
+	for (i = 0; i < lwmline->ngeoms; i++)
+	{
+		const LWLINE *lwline = (const LWLINE *)lwmline->geoms[i];
+		double sub_length = 0.0;
+		double sub_m_start = m_start;
+		double sub_m_end = m_start;
+
+		if (lwline->points && lwline->points->npoints > 1)
+			sub_length = ptarray_length_spheroid(lwline->points, s);
+
+		if (length > 0.0)
+		{
+			sub_m_start = m_start + m_range * length_so_far / length;
+			sub_m_end = m_start + m_range * (length_so_far + sub_length) / length;
+		}
+		else if (total_steps > 0)
+		{
+			uint32_t line_steps =
+			    (lwline->points && lwline->points->npoints > 1) ? lwline->points->npoints - 1 : 0;
+			sub_m_start = m_start + m_range * steps_so_far / total_steps;
+			sub_m_end = m_start + m_range * (steps_so_far + line_steps) / total_steps;
+			steps_so_far += line_steps;
+		}
+
+		geoms[i] = (LWGEOM *)geography_line_add_measure(lwline, sub_m_start, sub_m_end, s);
+		length_so_far += sub_length;
+	}
+
+	return (LWMLINE *)lwcollection_construct(MULTILINETYPE, lwmline->srid, NULL, lwmline->ngeoms, geoms);
+}
+
+/**
+ * ST_AddMeasure(geography line, float start_measure, float end_measure)
+ * Add a measure coordinate using spheroidal segment lengths.
+ */
+PG_FUNCTION_INFO_V1(geography_add_measure);
+Datum
+geography_add_measure(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+	double start_measure = PG_GETARG_FLOAT8(1);
+	double end_measure = PG_GETARG_FLOAT8(2);
+	LWGEOM *lwgeom, *lwresult;
+	GSERIALIZED *result;
+	SPHEROID s;
+	int type = gserialized_get_type(gs);
+
+	if (gserialized_is_empty(gs))
+	{
+		PG_FREE_IF_COPY(gs, 0);
+		PG_RETURN_NULL();
+	}
+
+	if (type != LINETYPE && type != MULTILINETYPE)
+	{
+		elog(ERROR, "%s: only LINESTRING and MULTILINESTRING are supported", __func__);
+		PG_FREE_IF_COPY(gs, 0);
+		PG_RETURN_NULL();
+	}
+
+	spheroid_init_from_srid(gserialized_get_srid(gs), &s);
+
+	lwgeom = lwgeom_from_gserialized(gs);
+	if (type == LINETYPE)
+		lwresult = lwline_as_lwgeom(
+		    geography_line_add_measure(lwgeom_as_lwline(lwgeom), start_measure, end_measure, &s));
+	else
+		lwresult = lwmline_as_lwgeom(
+		    geography_multiline_add_measure(lwgeom_as_lwmline(lwgeom), start_measure, end_measure, &s));
+
+	lwgeom_free(lwgeom);
+	PG_FREE_IF_COPY(gs, 0);
+
+	lwgeom_set_geodetic(lwresult, true);
+	result = geography_serialize(lwresult);
+	lwgeom_free(lwresult);
+
+	PG_RETURN_POINTER(result);
+}
 
 /**
  * ST_LineLocatePoint(geography line, geography point, bool use_spheroid)

--- a/postgis/uninstall_geography.sql.in
+++ b/postgis/uninstall_geography.sql.in
@@ -51,6 +51,7 @@ DROP FUNCTION IF EXISTS ST_CoveredBy(text, text);
 DROP FUNCTION IF EXISTS ST_Intersects(text, text);
 DROP FUNCTION IF EXISTS ST_Buffer(text, float8);
 DROP FUNCTION IF EXISTS ST_Intersection(text, text);
+DROP FUNCTION IF EXISTS ST_AddMeasure(text, float8, float8);
 
 -- functions
 DROP FUNCTION IF EXISTS ST_AsText(geography);
@@ -127,6 +128,7 @@ DROP FUNCTION IF EXISTS _ST_BestSRID(geography, geography);
 DROP FUNCTION IF EXISTS _ST_BestSRID(geography);
 DROP FUNCTION IF EXISTS ST_Buffer(geography, float8);
 DROP FUNCTION IF EXISTS ST_Intersection(geography, geography);
+DROP FUNCTION IF EXISTS ST_AddMeasure(geography, float8, float8);
 DROP FUNCTION IF EXISTS geography(geography, integer, boolean);
 
 --DROP FUNCTION IF EXISTS geography_in(cstring, oid, integer);
@@ -139,4 +141,3 @@ DROP FUNCTION IF EXISTS geography_analyze(internal);
 -- DROP FUNCTION IF EXISTS gidx_in(cstring);
 -- DROP FUNCTION IF EXISTS gidx_out(gidx);
 DROP TYPE gidx CASCADE;
-

--- a/regress/core/geography.sql
+++ b/regress/core/geography.sql
@@ -156,6 +156,12 @@ SELECT 'lrs_llp_3', round(ST_LineLocatePoint(geography 'linestring(0 1, 50 1)', 
 SELECT 'lrs_llp_4', round(ST_LineLocatePoint(geography 'linestring(0 1, 50 1)', geography 'Linestring(25 0,26 1)')::numeric, 2);
 
 SELECT 'lrs_substr_1', ST_AsText(ST_LineSubstring(geography 'linestring(0 20, 100 20)', 0.1, 0.2),2);
+SELECT 'lrs_addmeasure_empty', ST_AddMeasure(geography 'Linestring empty', 1, 2);
+SELECT 'lrs_addmeasure_geog_1', round(ST_M(ST_PointN(ST_AddMeasure(geography 'LINESTRING(0 0,0 60,60 60)', 0, 100)::geometry, 2))::numeric, 2);
+SELECT 'lrs_addmeasure_geog_2', ST_AsEWKT(ST_AddMeasure(geography 'MULTILINESTRING((0 0,0 10),(0 10,10 10))', 10, 30)::geometry, 2);
+SELECT 'lrs_addmeasure_geog_3', ST_AsEWKT(ST_AddMeasure(geography 'LINESTRING ZM(0 0 1 99,0 0 3 99)', 5, 9)::geometry, 2);
+SELECT 'lrs_addmeasure_geog_4', ST_AsEWKT(ST_AddMeasure(geography 'MULTILINESTRING((0 0,0 0),(0 0,0 0))', 10, 30)::geometry, 2);
+SELECT 'lrs_addmeasure_text_literal', ST_AsEWKT(ST_AddMeasure('LINESTRING(0 0,1 0)', 7, 9));
 
 -- Ticket #6076
 SELECT 'ticket_6076_length', round(ST_Length(ST_GeogFromText('GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1), POLYGON ((0 0, 0 1, 1 0, 0 0)))'))::numeric, 3);

--- a/regress/core/geography_expected
+++ b/regress/core/geography_expected
@@ -68,6 +68,12 @@ lrs_llp_2|0.00
 lrs_llp_3|1.00
 ERROR:  geography_line_locate_point: 2nd arg is not a point
 lrs_substr_1|LINESTRING(9.28 23.25,18.97 25.93)
+lrs_addmeasure_empty|
+lrs_addmeasure_geog_1|67.31
+lrs_addmeasure_geog_2|SRID=4326;MULTILINESTRINGM((0 0 10,0 10 20.04),(0 10 20.04,10 10 30))
+lrs_addmeasure_geog_3|SRID=4326;LINESTRING(0 0 1 5,0 0 3 9)
+lrs_addmeasure_geog_4|SRID=4326;MULTILINESTRINGM((0 0 10,0 0 20),(0 0 20,0 0 30))
+lrs_addmeasure_text_literal|LINESTRINGM(0 0 7,1 0 9)
 ticket_6076_length|110574.389
 ticket_6076_perimeter|378793.448
 lrs_sl_1|LINESTRING(25 42.79,25 40)


### PR DESCRIPTION
## Summary

Trac: https://trac.osgeo.org/postgis/ticket/4565

This adds `ST_AddMeasure(geography, float8, float8)` so geography line and multiline inputs distribute measures by spheroidal segment length instead of planar degree distance. The existing `ST_AddMeasure(geometry, ...)` behavior remains planar, and a text shim keeps bare WKT literals dispatched through geometry.

The regression covers spheroidal distribution, multiline continuity, Z/M overwrite, zero-length fallback, empty input, and text literal dispatch.

## Validation on rebased head `655c1e23135a2c864464cfae72d4c3ec2743913b`

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `./config.status --file=regress/dumper/tests.mk:regress/dumper/tests.mk.in --file=regress/core/tests.mk:regress/core/tests.mk.in`
- `make postgis_revision.h`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -B -C extensions/postgis sql/postgis_for_extension.sql sql/postgis--3.7.0dev.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/geography $(pwd)/regress/core/regress_lrs"` (fresh and upgrade: `Run tests: 4`, `Failed: 0`)
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/geography_measurement.c postgis/geography.sql.in postgis/uninstall_geography.sql.in doc/reference_lrs.xml regress/core/geography.sql regress/core/geography_expected NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
- `find . \! -user $(id -u) -print | head -20`
