### PR TITLE
Add curve constructor functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,11 @@ These are only changes since 3.7.0alpha1.
             (Bas Couwenberg)
 
 * Enhancements *
+* New Features *
+
+ - #1291, Add ST_MakeCurveLine and ST_MakeCompoundCurve constructors
+          for curve geometries (Darafei Praliaskouski)
+
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)
@@ -162,8 +167,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)
  - #4560, ST_3DInterpolatePoint for M interpolation from XYZ inputs (Paul Ramsey)
- - #1291, Add ST_MakeCurveLine and ST_MakeCompoundCurve constructors
-          for curve geometries (Darafei Praliaskouski)
+ - #1291, ST_MakePolygon support for curved rings (Darafei Praliaskouski)
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,9 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #1291, Add ST_MakeCurveLine and ST_MakeCompoundCurve constructors
+          for curve geometries (Darafei Praliaskouski)
+
 
 PostGIS 3.7.0beta1
 2026/07/20
@@ -90,10 +93,6 @@ These are only changes since 3.7.0alpha1.
 
 * Enhancements *
 * New Features *
-
- - #1291, Add ST_MakeCurveLine and ST_MakeCompoundCurve constructors
-          for curve geometries (Darafei Praliaskouski)
-
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -162,7 +162,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GH-839, ST_Multi support for TIN and surfaces (Loïc Bartoletti)
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)
  - #4560, ST_3DInterpolatePoint for M interpolation from XYZ inputs (Paul Ramsey)
- - #1291, ST_MakePolygon support for curved rings (Darafei Praliaskouski)
+ - #1291, Add ST_MakeCurveLine and ST_MakeCompoundCurve constructors
+          for curve geometries (Darafei Praliaskouski)
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)

--- a/doc/reference_constructor.xml
+++ b/doc/reference_constructor.xml
@@ -451,6 +451,119 @@ GROUP BY gps.track_id;</programlisting>
         </refsection>
     </refentry>
 
+    <refentry xml:id="ST_MakeCurveLine">
+        <refnamediv>
+        <refname>ST_MakeCurveLine</refname>
+
+        <refpurpose>Creates a CircularString from Point inputs.</refpurpose>
+        </refnamediv>
+
+        <refsynopsisdiv>
+        <funcsynopsis>
+          <funcprototype>
+            <funcdef>geometry <function>ST_MakeCurveLine</function></funcdef>
+            <paramdef><type>geometry[]</type> <parameter>point_array</parameter></paramdef>
+          </funcprototype>
+        </funcsynopsis>
+        <funcsynopsis>
+          <funcprototype>
+            <funcdef>geometry <function>ST_MakeCurveLine</function></funcdef>
+            <paramdef><type>geometry</type> <parameter>point1</parameter></paramdef>
+            <paramdef><type>geometry</type> <parameter>point2</parameter></paramdef>
+            <paramdef><type>geometry</type> <parameter>point3</parameter></paramdef>
+          </funcprototype>
+        </funcsynopsis>
+        </refsynopsisdiv>
+
+        <refsection>
+            <title>Description</title>
+
+            <para>Creates a CircularString from an array of Point inputs, or from three Point inputs.
+            CircularStrings require at least three points and an odd number of points.
+            The inputs must have the same SRID. NULL array entries are ignored; an empty array
+            or an array containing only NULL values returns NULL.</para>
+
+            <para>&Z_support;</para>
+            <para>&M_support;</para>
+            <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+        </refsection>
+
+        <refsection>
+        <title>Examples</title>
+<programlisting>
+SELECT ST_AsText( ST_MakeCurveLine(ST_MakePoint(1,2), ST_MakePoint(3,4), ST_MakePoint(5,6)) );
+
+       st_astext
+------------------------
+ CIRCULARSTRING(1 2,3 4,5 6)
+</programlisting>
+<programlisting>
+SELECT ST_AsText( ST_MakeCurveLine(ARRAY[
+  ST_MakePoint(1,2), ST_MakePoint(3,4), ST_MakePoint(5,6),
+  ST_MakePoint(7,8), ST_MakePoint(9,10)]));
+
+               st_astext
+---------------------------------------
+ CIRCULARSTRING(1 2,3 4,5 6,7 8,9 10)
+</programlisting>
+        </refsection>
+
+        <refsection>
+            <title>See Also</title>
+            <para><xref linkend="ST_MakeLine"/>, <xref linkend="ST_MakePoint"/>,
+            <xref linkend="ST_MakeCompoundCurve"/></para>
+        </refsection>
+    </refentry>
+
+    <refentry xml:id="ST_MakeCompoundCurve">
+        <refnamediv>
+        <refname>ST_MakeCompoundCurve</refname>
+
+        <refpurpose>Creates a CompoundCurve from curve components.</refpurpose>
+        </refnamediv>
+
+        <refsynopsisdiv>
+        <funcsynopsis>
+          <funcprototype>
+            <funcdef>geometry <function>ST_MakeCompoundCurve</function></funcdef>
+            <paramdef><type>geometry[]</type> <parameter>curve_array</parameter></paramdef>
+          </funcprototype>
+        </funcsynopsis>
+        </refsynopsisdiv>
+
+        <refsection>
+            <title>Description</title>
+
+            <para>Creates a CompoundCurve from an array of continuous LineString, CircularString,
+            or NURBSCurve components. Components must have the same SRID and dimensionality,
+            and must join end-to-end. NULL array entries are ignored; an empty array or an array
+            containing only NULL values returns NULL.</para>
+
+            <para>&Z_support;</para>
+            <para>&M_support;</para>
+            <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+        </refsection>
+
+        <refsection>
+        <title>Examples</title>
+<programlisting>
+SELECT ST_AsText( ST_MakeCompoundCurve(ARRAY[
+  'CIRCULARSTRING(0 0,2 0,2 1,2 3,4 3)'::geometry,
+  'LINESTRING(4 3,4 5,1 4,0 0)'::geometry]));
+
+                                st_astext
+----------------------------------------------------------------------
+ COMPOUNDCURVE(CIRCULARSTRING(0 0,2 0,2 1,2 3,4 3),(4 3,4 5,1 4,0 0))
+</programlisting>
+        </refsection>
+
+        <refsection>
+            <title>See Also</title>
+            <para><xref linkend="ST_MakeCurveLine"/>, <xref linkend="ST_MakeLine"/>,
+            <xref linkend="ST_MakePolygon"/></para>
+        </refsection>
+    </refentry>
+
     <refentry xml:id="ST_MakePolygon">
         <refnamediv>
         <refname>ST_MakePolygon</refname>

--- a/doc/reference_constructor.xml
+++ b/doc/reference_constructor.xml
@@ -490,22 +490,20 @@ GROUP BY gps.track_id;</programlisting>
 
         <refsection>
         <title>Examples</title>
-<programlisting>
+<programlisting language="sql">
 SELECT ST_AsText( ST_MakeCurveLine(ST_MakePoint(1,2), ST_MakePoint(3,4), ST_MakePoint(5,6)) );
-
-       st_astext
-------------------------
- CIRCULARSTRING(1 2,3 4,5 6)
 </programlisting>
-<programlisting>
+<screen role="visual-primary text-primary">       st_astext
+------------------------
+ CIRCULARSTRING(1 2,3 4,5 6)</screen>
+<programlisting language="sql">
 SELECT ST_AsText( ST_MakeCurveLine(ARRAY[
   ST_MakePoint(1,2), ST_MakePoint(3,4), ST_MakePoint(5,6),
   ST_MakePoint(7,8), ST_MakePoint(9,10)]));
-
-               st_astext
----------------------------------------
- CIRCULARSTRING(1 2,3 4,5 6,7 8,9 10)
 </programlisting>
+<screen role="visual-primary text-primary">               st_astext
+---------------------------------------
+ CIRCULARSTRING(1 2,3 4,5 6,7 8,9 10)</screen>
         </refsection>
 
         <refsection>
@@ -546,15 +544,14 @@ SELECT ST_AsText( ST_MakeCurveLine(ARRAY[
 
         <refsection>
         <title>Examples</title>
-<programlisting>
+<programlisting language="sql">
 SELECT ST_AsText( ST_MakeCompoundCurve(ARRAY[
   'CIRCULARSTRING(0 0,2 0,2 1,2 3,4 3)'::geometry,
   'LINESTRING(4 3,4 5,1 4,0 0)'::geometry]));
-
-                                st_astext
-----------------------------------------------------------------------
- COMPOUNDCURVE(CIRCULARSTRING(0 0,2 0,2 1,2 3,4 3),(4 3,4 5,1 4,0 0))
 </programlisting>
+<screen role="visual-primary text-primary">                                st_astext
+----------------------------------------------------------------------
+ COMPOUNDCURVE(CIRCULARSTRING(0 0,2 0,2 1,2 3,4 3),(4 3,4 5,1 4,0 0))</screen>
         </refsection>
 
         <refsection>

--- a/postgis/lwgeom_functions_basic.c
+++ b/postgis/lwgeom_functions_basic.c
@@ -97,6 +97,8 @@ Datum LWGEOM_makepoint(PG_FUNCTION_ARGS);
 Datum LWGEOM_makepoint3dm(PG_FUNCTION_ARGS);
 Datum LWGEOM_makeline_garray(PG_FUNCTION_ARGS);
 Datum LWGEOM_makeline(PG_FUNCTION_ARGS);
+Datum LWGEOM_makecurveline_garray(PG_FUNCTION_ARGS);
+Datum LWGEOM_makecompoundcurve_garray(PG_FUNCTION_ARGS);
 Datum LWGEOM_makepoly(PG_FUNCTION_ARGS);
 Datum LWGEOM_line_from_mpoint(PG_FUNCTION_ARGS);
 Datum LWGEOM_addpoint(PG_FUNCTION_ARGS);
@@ -1563,6 +1565,184 @@ Datum LWGEOM_makeline(PG_FUNCTION_ARGS)
 	PG_FREE_IF_COPY(pglwg2, 1);
 	lwgeom_free(lwgeoms[0]);
 	lwgeom_free(lwgeoms[1]);
+
+	PG_RETURN_POINTER(result);
+}
+
+/**
+ * makecurveline ( GEOMETRY[] ) returns a CIRCULARSTRING formed by
+ * the given point geometries.
+ */
+PG_FUNCTION_INFO_V1(LWGEOM_makecurveline_garray);
+Datum
+LWGEOM_makecurveline_garray(PG_FUNCTION_ARGS)
+{
+	ArrayType *array;
+	int nelems;
+	GSERIALIZED *result = NULL;
+	LWGEOM **geoms;
+	uint32 npoints = 0;
+	int32_t srid = SRID_UNKNOWN;
+	int has_z = 0;
+	int has_m = 0;
+	POINTARRAY *pa;
+	LWCIRCSTRING *outcurve;
+
+	ArrayIterator iterator;
+	Datum value;
+	bool isnull;
+
+	POSTGIS_DEBUGF(2, "%s called", __func__);
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	array = PG_GETARG_ARRAYTYPE_P(0);
+	nelems = ArrayGetNItems(ARR_NDIM(array), ARR_DIMS(array));
+	if (nelems == 0)
+		PG_RETURN_NULL();
+
+	geoms = palloc(sizeof(LWGEOM *) * nelems);
+
+	iterator = array_create_iterator(array, 0, NULL);
+	while (array_iterate(iterator, &value, &isnull))
+	{
+		GSERIALIZED *geom;
+		LWGEOM *lwgeom;
+
+		if (isnull)
+			continue;
+
+		geom = (GSERIALIZED *)DatumGetPointer(value);
+		if (gserialized_get_type(geom) != POINTTYPE)
+			elog(ERROR, "ST_MakeCurveLine: input geometries must be points");
+
+		if (npoints == 0)
+			srid = gserialized_get_srid(geom);
+		else
+			gserialized_error_if_srid_mismatch_reference(geom, srid, __func__);
+
+		lwgeom = lwgeom_from_gserialized(geom);
+		if (lwgeom_is_empty(lwgeom))
+			elog(ERROR, "ST_MakeCurveLine: empty points are not allowed");
+
+		geoms[npoints] = lwgeom;
+		has_z |= FLAGS_GET_Z(lwgeom->flags);
+		has_m |= FLAGS_GET_M(lwgeom->flags);
+		npoints++;
+	}
+	array_free_iterator(iterator);
+
+	if (npoints == 0)
+		PG_RETURN_NULL();
+	if (npoints < 3)
+		elog(ERROR, "ST_MakeCurveLine: circular strings require at least 3 points");
+	if ((npoints % 2) == 0)
+		elog(ERROR, "ST_MakeCurveLine: circular strings require an odd number of points");
+
+	pa = ptarray_construct(has_z, has_m, npoints);
+	for (uint32 i = 0; i < npoints; i++)
+	{
+		POINT4D pt;
+		if (!getPoint4d_p(lwgeom_as_lwpoint(geoms[i])->point, 0, &pt))
+			elog(ERROR, "ST_MakeCurveLine: could not read input point");
+		ptarray_set_point4d(pa, i, &pt);
+	}
+
+	outcurve = lwcircstring_construct(srid, NULL, pa);
+	result = geometry_serialize(lwcircstring_as_lwgeom(outcurve));
+
+	for (uint32 i = 0; i < npoints; i++)
+		lwgeom_free(geoms[i]);
+	lwcircstring_free(outcurve);
+
+	PG_RETURN_POINTER(result);
+}
+
+/**
+ * makecompoundcurve ( GEOMETRY[] ) returns a COMPOUNDCURVE formed by
+ * continuous line, circular string, or NURBS curve components.
+ */
+PG_FUNCTION_INFO_V1(LWGEOM_makecompoundcurve_garray);
+Datum
+LWGEOM_makecompoundcurve_garray(PG_FUNCTION_ARGS)
+{
+	ArrayType *array;
+	int nelems;
+	GSERIALIZED *result = NULL;
+	LWCOMPOUND *outcurve = NULL;
+	int32_t srid = SRID_UNKNOWN;
+	int has_z = 0;
+	int has_m = 0;
+	uint32 ngeoms = 0;
+
+	ArrayIterator iterator;
+	Datum value;
+	bool isnull;
+
+	POSTGIS_DEBUGF(2, "%s called", __func__);
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	array = PG_GETARG_ARRAYTYPE_P(0);
+	nelems = ArrayGetNItems(ARR_NDIM(array), ARR_DIMS(array));
+	if (nelems == 0)
+		PG_RETURN_NULL();
+
+	iterator = array_create_iterator(array, 0, NULL);
+	while (array_iterate(iterator, &value, &isnull))
+	{
+		GSERIALIZED *geom;
+		LWGEOM *lwgeom;
+		int geom_type;
+
+		if (isnull)
+			continue;
+
+		geom = (GSERIALIZED *)DatumGetPointer(value);
+		geom_type = gserialized_get_type(geom);
+		if (!lwcollection_allows_subtype(COMPOUNDTYPE, geom_type))
+			elog(ERROR, "ST_MakeCompoundCurve: input geometries must be curve components");
+
+		lwgeom = lwgeom_from_gserialized(geom);
+		if (lwgeom_is_empty(lwgeom))
+			elog(ERROR, "ST_MakeCompoundCurve: empty components are not allowed");
+
+		if (ngeoms == 0)
+		{
+			srid = lwgeom->srid;
+			has_z = FLAGS_GET_Z(lwgeom->flags);
+			has_m = FLAGS_GET_M(lwgeom->flags);
+			outcurve = lwcompound_construct_empty(srid, has_z, has_m);
+		}
+		else
+		{
+			gserialized_error_if_srid_mismatch_reference(geom, srid, __func__);
+			if (FLAGS_GET_Z(lwgeom->flags) != has_z || FLAGS_GET_M(lwgeom->flags) != has_m)
+				elog(ERROR, "ST_MakeCompoundCurve: mixed dimensioned components");
+		}
+
+		if (LW_FAILURE == lwcompound_add_lwgeom(outcurve, lwgeom))
+		{
+			lwgeom_free(lwgeom);
+			lwgeom_free(lwcompound_as_lwgeom(outcurve));
+			elog(ERROR, "ST_MakeCompoundCurve: components must join end-to-end");
+		}
+		ngeoms++;
+	}
+	array_free_iterator(iterator);
+
+	if (ngeoms == 0)
+		PG_RETURN_NULL();
+	if (!lwcompound_is_valid(outcurve))
+	{
+		lwgeom_free(lwcompound_as_lwgeom(outcurve));
+		elog(ERROR, "ST_MakeCompoundCurve: components must join end-to-end");
+	}
+
+	result = geometry_serialize(lwcompound_as_lwgeom(outcurve));
+	lwgeom_free(lwcompound_as_lwgeom(outcurve));
 
 	PG_RETURN_POINTER(result);
 }

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -1968,6 +1968,27 @@ CREATE OR REPLACE FUNCTION ST_MakeLine(geom1 geometry, geom2 geometry)
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
 	_COST_LOW;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_MakeCurveLine (geometry[])
+	RETURNS geometry
+	AS 'MODULE_PATHNAME', 'LWGEOM_makecurveline_garray'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_LOW;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_MakeCurveLine(geom1 geometry, geom2 geometry, geom3 geometry)
+	RETURNS geometry
+	AS 'SELECT @extschema@.ST_MakeCurveLine(ARRAY[$1, $2, $3])'
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_LOW;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_MakeCompoundCurve (geometry[])
+	RETURNS geometry
+	AS 'MODULE_PATHNAME', 'LWGEOM_makecompoundcurve_garray'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	_COST_LOW;
+
 -- Availability: 1.2.2
 CREATE OR REPLACE FUNCTION ST_AddPoint(geom1 geometry, geom2 geometry)
 	RETURNS geometry

--- a/regress/core/ctors.sql
+++ b/regress/core/ctors.sql
@@ -30,6 +30,51 @@ select 'ST_MakeLine_agg2', ST_AsText(ST_MakeLine(g)) from (
         ('POINT(1 0)')
 ) as foo(g);
 
+SELECT 'ST_MakeCurveLine1', ST_AsText(ST_MakeCurveLine(
+  ST_MakePoint(1, 2), ST_MakePoint(3, 4), ST_MakePoint(5, 6)));
+
+SELECT 'ST_MakeCurveLine2', ST_AsText(ST_MakeCurveLine(ARRAY[
+  ST_MakePoint(1, 2), ST_MakePoint(3, 4), ST_MakePoint(5, 6),
+  ST_MakePoint(7, 8), ST_MakePoint(9, 10)]));
+
+SELECT 'ST_MakeCurveLineZM', ST_AsEWKT(ST_MakeCurveLine(ARRAY[
+  'POINT ZM (0 0 1 5)'::geometry,
+  'POINT ZM (1 1 2 6)'::geometry,
+  'POINT ZM (2 0 3 7)'::geometry]));
+
+SELECT 'ST_MakeCurveLineNullArray', ST_MakeCurveLine(ARRAY[NULL]::geometry[]) IS NULL;
+SELECT ST_MakeCurveLine(ARRAY['POINT(0 0)'::geometry, 'POINT(1 1)'::geometry]);
+SELECT ST_MakeCurveLine(ARRAY[
+  'POINT(0 0)'::geometry, 'POINT(1 1)'::geometry,
+  'POINT(2 0)'::geometry, 'POINT(3 1)'::geometry]);
+SELECT ST_MakeCurveLine(ARRAY['POINT(0 0)'::geometry, 'LINESTRING(1 1, 2 2)'::geometry, 'POINT(3 3)'::geometry]);
+SELECT ST_MakeCurveLine(ARRAY['POINT(0 0)'::geometry, 'SRID=3;POINT(1 1)'::geometry, 'POINT(2 0)'::geometry]);
+
+SELECT 'ST_MakeCompoundCurve1', ST_AsText(ST_MakeCompoundCurve(ARRAY[
+  'CIRCULARSTRING(0 0,2 0,2 1,2 3,4 3)'::geometry,
+  'LINESTRING(4 3,4 5,1 4,0 0)'::geometry]));
+
+SELECT 'ST_MakeCompoundCurveNurbs', ST_AsText(ST_MakeCompoundCurve(ARRAY[
+  'LINESTRING(0 0,1 1)'::geometry,
+  'NURBSCURVE(2, (1 1, 2 3, 4 1))'::geometry]));
+
+SELECT 'ST_MakeCompoundCurveEmptyArray', ST_MakeCompoundCurve(ARRAY[]::geometry[]) IS NULL;
+SELECT ST_MakeCompoundCurve(ARRAY[
+  'LINESTRING(0 0,1 1)'::geometry,
+  'LINESTRING(2 2,3 3)'::geometry]);
+SELECT ST_MakeCompoundCurve(ARRAY[
+  'LINESTRING Z (0 0 0,1 1 0)'::geometry,
+  'LINESTRING M (1 1 0,2 2 0)'::geometry]);
+SELECT ST_MakeCompoundCurve(ARRAY[
+  'LINESTRING Z (0 0 0,1 1 0)'::geometry,
+  'LINESTRING Z (1 1 1,2 2 0)'::geometry]);
+SELECT ST_MakeCompoundCurve(ARRAY[
+  'LINESTRING(0 0,1 1)'::geometry,
+  'SRID=3;LINESTRING(1 1,2 2)'::geometry]);
+SELECT ST_MakeCompoundCurve(ARRAY['POINT(0 0)'::geometry]);
+SELECT ST_MakeCompoundCurve(ARRAY[
+  'COMPOUNDCURVE((0 0,1 1),(1 1,2 2))'::geometry]);
+
 -- postgis-users/2006-July/012788.html
 select ST_makebox2d('SRID=3;POINT(0 0)', 'SRID=3;POINT(1 1)');
 select ST_makebox2d('POINT(0 0)', 'SRID=3;POINT(1 1)');

--- a/regress/core/ctors_expected
+++ b/regress/core/ctors_expected
@@ -5,6 +5,23 @@ ERROR:  LWGEOM_makeline: Operation on mixed SRID geometries (Point, 0) != (Point
 ST_MakeLine1|LINESTRING(0 0,1 1,10 0)
 ST_MakeLine_agg1|LINESTRING(0 0,1 1,10 0,20 20,40 4,40 4,40 5,40 5,40 6,40 6,40 7,40 8)
 ST_MakeLine_agg2|LINESTRING(0 0,1 0,1 0)
+ST_MakeCurveLine1|CIRCULARSTRING(1 2,3 4,5 6)
+ST_MakeCurveLine2|CIRCULARSTRING(1 2,3 4,5 6,7 8,9 10)
+ST_MakeCurveLineZM|CIRCULARSTRING(0 0 1 5,1 1 2 6,2 0 3 7)
+ST_MakeCurveLineNullArray|t
+ERROR:  ST_MakeCurveLine: circular strings require at least 3 points
+ERROR:  ST_MakeCurveLine: circular strings require an odd number of points
+ERROR:  ST_MakeCurveLine: input geometries must be points
+ERROR:  LWGEOM_makecurveline_garray: Operation on mixed SRID geometries Point 3 != 0
+ST_MakeCompoundCurve1|COMPOUNDCURVE(CIRCULARSTRING(0 0,2 0,2 1,2 3,4 3),(4 3,4 5,1 4,0 0))
+ST_MakeCompoundCurveNurbs|COMPOUNDCURVE((0 0,1 1),NURBSCURVE(DEGREE 2,CONTROLPOINTS(NURBSPOINT(WEIGHTEDPOINT(1 1),WEIGHT 1),NURBSPOINT(WEIGHTEDPOINT(2 3),WEIGHT 1),NURBSPOINT(WEIGHTEDPOINT(4 1),WEIGHT 1)),KNOTS (KNOT(0,3),KNOT(1,3))))
+ST_MakeCompoundCurveEmptyArray|t
+ERROR:  ST_MakeCompoundCurve: components must join end-to-end
+ERROR:  ST_MakeCompoundCurve: mixed dimensioned components
+ERROR:  ST_MakeCompoundCurve: components must join end-to-end
+ERROR:  LWGEOM_makecompoundcurve_garray: Operation on mixed SRID geometries LineString 3 != 0
+ERROR:  ST_MakeCompoundCurve: input geometries must be curve components
+ERROR:  ST_MakeCompoundCurve: input geometries must be curve components
 BOX(0 0,1 1)
 ERROR:  BOX2D_construct: Operation on mixed SRID geometries (Point, 0) != (Point, 3)
 BOX3D(0 0 0,1 1 0)


### PR DESCRIPTION
## Summary
- add `ST_MakeCurveLine` constructors for three points and point arrays
- add `ST_MakeCompoundCurve` for continuous LineString, CircularString, and NURBSCurve arrays
- document and regress constructor success and validation/error cases
- clarify NEWS wording so the entry describes the new curve constructors without implying unrelated `ST_MakePolygon` scope

Trac ticket: https://trac.osgeo.org/postgis/ticket/1291

## Validation on rebased head `5cf192375509fd1fd11299c26913781046cb2710`
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make postgis_revision.h`
- `make -C postgis -j32`
- `make -C extensions postgis_extension_helper.sql`
- `make -B -C extensions/postgis sql/postgis_for_extension.sql sql/postgis--3.7.0dev.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C postgis install`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/ctors"` (fresh and upgrade: `Run tests: 3`, `Failed: 0`)
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/lwgeom_functions_basic.c postgis/postgis.sql.in doc/reference_constructor.xml regress/core/ctors.sql regress/core/ctors_expected NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
