### PR TITLE
postgis: fast-path point collection ST_Disjoint

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,8 +23,13 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - GH-1153, [topology] Preserve large ids from edge wrappers
           (Darafei Praliaskouski)
 
+* Enhancements *
 
-PostGIS 3.7.0beta1
+ - #4749, Use point-in-polygon predicate fast paths for point-only
+          GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
+
+
+PostGIS 3.7.0alpha1
 2026/07/05
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.
@@ -112,7 +117,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #2137, [raster] Reuse matching source raster overviews in raster2pgsql -l
           (Darafei Praliaskouski)
  - #4749, Use point-in-polygon predicate fast paths for point-only
-          GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
+          GeometryCollections (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
           (Darafei Praliaskouski)
  - #6087, Add a repository-owned CI status checker and static dashboard

--- a/NEWS
+++ b/NEWS
@@ -112,7 +112,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #2137, [raster] Reuse matching source raster overviews in raster2pgsql -l
           (Darafei Praliaskouski)
  - #4749, Use point-in-polygon predicate fast paths for point-only
-          GeometryCollections (Darafei Praliaskouski)
+          GeometryCollections, including ST_Disjoint (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
           (Darafei Praliaskouski)
  - #6087, Add a repository-owned CI status checker and static dashboard

--- a/NEWS
+++ b/NEWS
@@ -24,7 +24,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
 
 
-PostGIS 3.7.0alpha1
+PostGIS 3.7.0beta1
 2026/07/05
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.

--- a/postgis/lwgeom_geos_predicates.c
+++ b/postgis/lwgeom_geos_predicates.c
@@ -378,6 +378,7 @@ Datum disjoint(PG_FUNCTION_ARGS)
 	int8_t result;
 	GBOX box1, box2;
 	PrepGeomCache *prep_cache;
+	bool pip_result;
 
 	gserialized_error_if_srid_mismatch(geom1, geom2, __func__);
 
@@ -396,6 +397,21 @@ Datum disjoint(PG_FUNCTION_ARGS)
 		{
 			PG_RETURN_BOOL(true);
 		}
+	}
+
+	/*
+	 * Short-circuit 2: if one geometry is polygonal and the other is a
+	 * point or point-only collection, use the IntervalTree PIP fast path.
+	 */
+	if (is_point_or_collection(geom1) && is_poly(geom2) &&
+	    try_itree_pointlike_pip(fcinfo, geom1, shared_geom2, itree_pip_intersects, &pip_result))
+	{
+		PG_RETURN_BOOL(!pip_result);
+	}
+	else if (is_point_or_collection(geom2) && is_poly(geom1) &&
+		 try_itree_pointlike_pip(fcinfo, geom2, shared_geom1, itree_pip_intersects, &pip_result))
+	{
+		PG_RETURN_BOOL(!pip_result);
 	}
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1313,6 +1313,21 @@ SELECT '#4749.intersects',
 	ST_Intersects(poly, pts_outside)
 FROM g;
 
+WITH g AS (
+	SELECT
+		'POLYGON((0 0,0 10,10 10,10 0,0 0))'::geometry AS poly,
+		'GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(5 5)),MULTIPOINT((7 7),(8 8)))'::geometry AS pts_inside,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(0 0))'::geometry AS pts_boundary,
+		'GEOMETRYCOLLECTION(POINT(5 5),POINT(11 11))'::geometry AS pts_outside,
+		'GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(-1 -1)),MULTIPOINT((11 11),(12 12)))'::geometry AS pts_disjoint
+)
+SELECT '#4749.disjoint',
+	ST_Disjoint(poly, pts_inside),
+	ST_Disjoint(pts_boundary, poly),
+	ST_Disjoint(poly, pts_outside),
+	ST_Disjoint(pts_disjoint, poly)
+FROM g;
+
 -- #4299
 SELECT '#4299', ST_Disjoint(ST_GeneratePoints(g, 1000), ST_GeneratePoints(g, 1000))
 FROM (SELECT 'POLYGON((0 0,1 0,1 1,0 1,0 0))'::geometry AS g) AS f;

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -392,6 +392,7 @@ equals213|t
 #4749.covers|t|t|f
 #4749.coveredby|t|t|f
 #4749.intersects|t|t|t
+#4749.disjoint|f|f|f|t
 #4299|t
 #4304|t|t|t
 ERROR:  BOX3D_construct: args can not be empty points


### PR DESCRIPTION
## Summary

This extends the point-only `GeometryCollection` predicate fast path from Trac ticket 4749 to `ST_Disjoint`.

`ST_Disjoint` now reuses the existing point-in-polygon interval tree path for polygonal inputs against points, multipoints, and point-only nested `GeometryCollection`s, returning the complement of the existing `ST_Intersects` PIP result. Mixed collections still fall through to GEOS.

Trac ticket: https://trac.osgeo.org/postgis/ticket/4749

## Validation on rebased head `6dc503f7dfbe23845c998ed181ed340d5e844835`

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C deps/flatgeobuf all V=1` after the first fresh-worktree parallel build hit a dependency race
- `make -C postgis -j32`
- `sudo -n make -C postgis install`
- `make -C raster/rt_pg sql_objs`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C extensions/postgis install`
- `make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"` (fresh and upgrade: `Run tests: 3`, `Failed: 0`)
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/lwgeom_geos_predicates.c regress/core/tickets.sql regress/core/tickets_expected NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
