### PR TITLE
Export helper APIs for MobilityDB

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -68,6 +68,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           and pass callback call data as actual arguments (Darafei Praliaskouski)
  - #2898, Document SQL function cost tiers for contributors
           (Darafei Praliaskouski)
+ - GH-826, Export selected liblwgeom and libpgcommon helpers for MobilityDB
+          integration (Esteban Zimanyi, Darafei Praliaskouski)
  - #6062, [topology] Stop using recursive snapping, for improved robustness (Sandro Santilli)
  - #6065, Improved winding order computation robustness for rings having collapsed elements
           (Sandro Santilli)

--- a/liblwgeom/Makefile.in
+++ b/liblwgeom/Makefile.in
@@ -84,6 +84,7 @@ SA_OBJS = \
 	lwtin.o \
 	lwout_wkb.o \
 	lwin_geojson.o \
+	lwexports.o \
 	lwin_wkb.o \
 	lwin_twkb.o \
 	lwiterator.o \

--- a/liblwgeom/cunit/cu_in_geojson.c
+++ b/liblwgeom/cunit/cu_in_geojson.c
@@ -18,6 +18,10 @@
 #include "liblwgeom_internal.h"
 #include "cu_tester.h"
 
+#if HAVE_LIBJSON
+#include <json.h>
+#endif
+
 static void do_geojson_test(const char * exp, char * in, char * exp_srs)
 {
 	LWGEOM *g;
@@ -235,6 +239,73 @@ static void in_geojson_test_geoms(void)
 	    NULL);
 }
 
+#if HAVE_LIBJSON
+static void
+in_geojson_test_parse_geojson_public_api(void)
+{
+	json_object *obj = json_tokener_parse("{\"type\":\"Point\",\"coordinates\":[1,2]}");
+	int hasz = LW_FALSE;
+	CU_ASSERT_PTR_NOT_NULL_FATAL(obj);
+	LWGEOM *geom = parse_geojson(obj, &hasz);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(geom);
+	char *wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(wkt);
+
+	ASSERT_STRING_EQUAL(wkt, "POINT(1 2)");
+	CU_ASSERT_EQUAL(hasz, LW_FALSE);
+	CU_ASSERT_FALSE(FLAGS_GET_Z(geom->flags));
+
+	lwfree(wkt);
+	lwgeom_free(geom);
+	json_object_put(obj);
+
+	obj = json_tokener_parse("{\"type\":\"Point\",\"coordinates\":[4,5]}");
+	hasz = LW_TRUE;
+	CU_ASSERT_PTR_NOT_NULL_FATAL(obj);
+	geom = parse_geojson(obj, &hasz);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(geom);
+	wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(wkt);
+
+	ASSERT_STRING_EQUAL(wkt, "POINT(4 5)");
+	CU_ASSERT_EQUAL(hasz, LW_FALSE);
+	CU_ASSERT_FALSE(FLAGS_GET_Z(geom->flags));
+
+	lwfree(wkt);
+	lwgeom_free(geom);
+	json_object_put(obj);
+
+	obj = json_tokener_parse("{\"type\":\"Point\",\"coordinates\":[1,2,3]}");
+	hasz = LW_FALSE;
+	CU_ASSERT_PTR_NOT_NULL_FATAL(obj);
+	geom = parse_geojson(obj, &hasz);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(geom);
+	wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(wkt);
+
+	ASSERT_STRING_EQUAL(wkt, "POINT(1 2 3)");
+	CU_ASSERT_EQUAL(hasz, LW_TRUE);
+	CU_ASSERT_TRUE(FLAGS_GET_Z(geom->flags));
+
+	lwfree(wkt);
+	lwgeom_free(geom);
+	json_object_put(obj);
+
+	obj = json_tokener_parse(
+	    "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[1,2,3]},{\"type\":\"Point\",\"coordinates\":[4,5]}]}");
+	hasz = LW_FALSE;
+	CU_ASSERT_PTR_NOT_NULL_FATAL(obj);
+	geom = parse_geojson(obj, &hasz);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(geom);
+
+	CU_ASSERT_EQUAL(hasz, LW_TRUE);
+	CU_ASSERT_TRUE(FLAGS_GET_Z(geom->flags));
+
+	lwgeom_free(geom);
+	json_object_put(obj);
+}
+#endif
+
 /*
 ** Used by test harness to register the tests in this file.
 */
@@ -245,4 +316,7 @@ void in_geojson_suite_setup(void)
 	PG_ADD_TEST(suite, in_geojson_test_srid);
 	PG_ADD_TEST(suite, in_geojson_test_bbox);
 	PG_ADD_TEST(suite, in_geojson_test_geoms);
+#if HAVE_LIBJSON
+	PG_ADD_TEST(suite, in_geojson_test_parse_geojson_public_api);
+#endif
 }

--- a/liblwgeom/cunit/cu_out_wkb.c
+++ b/liblwgeom/cunit/cu_out_wkb.c
@@ -3,6 +3,7 @@
  * PostGIS - Spatial Types for PostgreSQL
  * http://postgis.net
  * Copyright 2010 Paul Ramsey <pramsey@cleverelephant.ca>
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU General Public Licence. See the COPYING file.
@@ -72,6 +73,31 @@ static void cu_wkb_empty_point_check(char *hex)
 	CU_ASSERT(g != NULL);
 	CU_ASSERT(lwgeom_is_empty(g));
 	CU_ASSERT(g->type == POINTTYPE);
+	lwgeom_free(g);
+}
+
+static void
+test_wkb_out_hex_size_matches_buf(void)
+{
+	const uint8_t variant = WKB_HEX | WKB_XDR | WKB_EXTENDED;
+	LWGEOM *g = lwgeom_from_wkt("SRID=4;POINT(1 2)", LW_PARSER_CHECK_NONE);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(g);
+	size_t hex_size = lwgeom_to_wkb_size(g, variant);
+	size_t binary_size = lwgeom_to_wkb_size(g, variant & ~WKB_HEX);
+	uint8_t *buf = lwalloc(hex_size);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(buf);
+	uint8_t *end = lwgeom_to_wkb_buf(g, buf, variant);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(end);
+	char *owned = (char *)lwgeom_to_wkb_buffer(g, variant);
+	CU_ASSERT_PTR_NOT_NULL_FATAL(owned);
+
+	CU_ASSERT_EQUAL(end - buf, hex_size);
+	CU_ASSERT_EQUAL(hex_size, 2 * binary_size);
+	CU_ASSERT_EQUAL(strlen(owned), hex_size);
+	CU_ASSERT_EQUAL(strncmp((char *)buf, owned, hex_size), 0);
+
+	lwfree(owned);
+	lwfree(buf);
 	lwgeom_free(g);
 }
 
@@ -214,6 +240,7 @@ void wkb_out_suite_setup(void);
 void wkb_out_suite_setup(void)
 {
 	CU_pSuite suite = CU_add_suite("wkb_output", init_wkb_out_suite, clean_wkb_out_suite);
+	PG_ADD_TEST(suite, test_wkb_out_hex_size_matches_buf);
 	PG_ADD_TEST(suite, test_wkb_out_point);
 	PG_ADD_TEST(suite, test_wkb_out_linestring);
 	PG_ADD_TEST(suite, test_wkb_out_polygon);

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -20,6 +20,7 @@
  *
  * Copyright 2011 Sandro Santilli <strk@kbt.io>
  * Copyright 2011 Paul Ramsey <pramsey@cleverelephant.ca>
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  * Copyright 2007-2008 Mark Cave-Ayland
  * Copyright 2001-2006 Refractions Research Inc.
  *
@@ -28,6 +29,16 @@
 
 #ifndef _LIBLWGEOM_H
 #define _LIBLWGEOM_H 1
+
+#ifndef PGDLLEXPORT
+#  ifdef _WIN32
+#    define PGDLLEXPORT __declspec(dllexport)
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define PGDLLEXPORT __attribute__ ((visibility("default")))
+#  else
+#    define PGDLLEXPORT
+#  endif
+#endif
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -1777,6 +1788,12 @@ extern lwvarlena_t* lwgeom_to_encoded_polyline(const LWGEOM *geom, int precision
  */
 extern LWGEOM* lwgeom_from_geojson(const char *geojson, char **srs);
 
+#if defined(HAVE_LIBJSON)
+/* Forward-declare to avoid exposing json-c headers in a public API */
+struct json_object;
+PGDLLEXPORT LWGEOM *parse_geojson(struct json_object *geojson, int *hasz);
+#endif /* HAVE_LIBJSON */
+
 /**
  * Create an LWGEOM object from an Encoded Polyline representation
  *
@@ -2281,6 +2298,8 @@ extern lwvarlena_t* lwgeom_to_wkt_varlena(const LWGEOM *geom, uint8_t variant, i
 */
 extern uint8_t* lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant);
 extern lwvarlena_t* lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant);
+PGDLLEXPORT size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+PGDLLEXPORT uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
 
 /**
 * @param geom geometry to convert to HEXWKB

--- a/liblwgeom/liblwgeom_internal.h
+++ b/liblwgeom/liblwgeom_internal.h
@@ -20,11 +20,11 @@
  *
  * Copyright (C) 2011-2021 Sandro Santilli <strk@kbt.io>
  * Copyright (C) 2011 Paul Ramsey <pramsey@cleverelephant.ca>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  * Copyright (C) 2007-2008 Mark Cave-Ayland
  * Copyright (C) 2001-2006 Refractions Research Inc.
  *
  **********************************************************************/
-
 
 #ifndef _LIBLWGEOM_INTERNAL_H
 #define _LIBLWGEOM_INTERNAL_H 1
@@ -528,5 +528,13 @@ int lwpoly_contains_point(const LWPOLY *poly, const POINT2D *pt);
 POINT4D* lwmpoint_extract_points_4d(const LWMPOINT* g, uint32_t* npoints, int* input_empty);
 char* lwstrdup(const char* a);
 void* lwalloc0(size_t sz);
+
+#if defined(HAVE_LIBJSON)
+struct json_object;
+LWGEOM *lwgeom_parse_geojson(struct json_object *geojson, int *hasz);
+#endif
+
+size_t lwgeom_to_wkb_size_internal(const LWGEOM *geom, uint8_t variant);
+uint8_t *lwgeom_to_wkb_buf_internal(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
 
 #endif /* _LIBLWGEOM_INTERNAL_H */

--- a/liblwgeom/lwexports.c
+++ b/liblwgeom/lwexports.c
@@ -1,0 +1,52 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * PostGIS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PostGIS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************
+ *
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
+ *
+ **********************************************************************/
+
+#include "liblwgeom_internal.h"
+
+/*
+ * Keep public helper wrappers separate from their implementation objects. The
+ * PostGIS SQL module links liblwgeom as a hidden static archive and provides
+ * its own exported shims for these names, while ordinary liblwgeom users still
+ * get the public API from this object.
+ */
+
+#if defined(HAVE_LIBJSON)
+PGDLLEXPORT LWGEOM *
+parse_geojson(struct json_object *geojson, int *hasz)
+{
+	return lwgeom_parse_geojson(geojson, hasz);
+}
+#endif
+
+PGDLLEXPORT size_t
+lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
+{
+	return lwgeom_to_wkb_size_internal(geom, variant);
+}
+
+PGDLLEXPORT uint8_t *
+lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+{
+	return lwgeom_to_wkb_buf_internal(geom, buf, variant);
+}

--- a/liblwgeom/lwin_geojson.c
+++ b/liblwgeom/lwin_geojson.c
@@ -18,7 +18,7 @@
  *
  **********************************************************************
  *
- * Copyright 2019 Darafei Praliaskouski <me@komzpa.net>
+ * Copyright 2019-2026 Darafei Praliaskouski <me@komzpa.net>
  * Copyright 2013 Sandro Santilli <strk@kbt.io>
  * Copyright 2011 Kashif Rasul <kashif.rasul@gmail.com>
  *
@@ -46,7 +46,7 @@
 #include <string.h>
 
 /* Prototype */
-static LWGEOM *parse_geojson(json_object *geojson, int *hasz);
+static LWGEOM *parse_geojson_internal(json_object *geojson, int *hasz);
 
 static inline json_object *
 findMemberByName(json_object *poObj, const char *pszName)
@@ -345,7 +345,7 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 		for (int i = 0; i < nGeoms; ++i)
 		{
 			json_object *poObjGeom = json_object_array_get_idx(poObjGeoms, i);
-			LWGEOM *t = parse_geojson(poObjGeom, hasz);
+			LWGEOM *t = parse_geojson_internal(poObjGeom, hasz);
 			if (t)
 				geom = (LWGEOM *)lwcollection_add_lwgeom((LWCOLLECTION *)geom, t);
 			else
@@ -359,8 +359,8 @@ parse_geojson_geometrycollection(json_object *geojson, int *hasz)
 	return geom;
 }
 
-static inline LWGEOM *
-parse_geojson(json_object *geojson, int *hasz)
+static LWGEOM *
+parse_geojson_internal(json_object *geojson, int *hasz)
 {
 	json_object *type = NULL;
 	const char *name;
@@ -403,6 +403,27 @@ parse_geojson(json_object *geojson, int *hasz)
 
 	lwerror("invalid GeoJson representation");
 	return NULL; /* Never reach */
+}
+
+LWGEOM *
+lwgeom_parse_geojson(json_object *geojson, int *hasz)
+{
+	int local_hasz = LW_FALSE;
+	LWGEOM *geom;
+
+	if (hasz)
+		*hasz = LW_FALSE;
+
+	geom = parse_geojson_internal(geojson, hasz ? hasz : &local_hasz);
+
+	if (geom && !*(hasz ? hasz : &local_hasz))
+	{
+		LWGEOM *tmp = lwgeom_force_2d(geom);
+		lwgeom_free(geom);
+		geom = tmp;
+	}
+
+	return geom;
 }
 
 #endif /* HAVE_LIBJSON */
@@ -455,17 +476,11 @@ lwgeom_from_geojson(const char *geojson, char **srs)
 	}
 
 	int hasz = LW_FALSE;
-	LWGEOM *lwgeom = parse_geojson(poObj, &hasz);
+	LWGEOM *lwgeom = lwgeom_parse_geojson(poObj, &hasz);
 	json_object_put(poObj);
 	if (!lwgeom)
 		return NULL;
 
-	if (!hasz)
-	{
-		LWGEOM *tmp = lwgeom_force_2d(lwgeom);
-		lwgeom_free(lwgeom);
-		lwgeom = tmp;
-	}
 	lwgeom_add_bbox(lwgeom);
 	return lwgeom;
 #endif /* HAVE_LIBJSON */

--- a/liblwgeom/lwout_wkb.c
+++ b/liblwgeom/lwout_wkb.c
@@ -19,9 +19,9 @@
  **********************************************************************
  *
  * Copyright (C) 2009 Paul Ramsey <pramsey@cleverelephant.ca>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
-
 
 #include <math.h>
 #include <stddef.h> // for ptrdiff_t
@@ -29,8 +29,8 @@
 #include "liblwgeom_internal.h"
 #include "lwgeom_log.h"
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
-static size_t lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant);
+uint8_t *lwgeom_to_wkb_buf_internal(const LWGEOM *geom, uint8_t *buf, uint8_t variant);
+static size_t lwgeom_to_wkb_binary_size(const LWGEOM *geom, uint8_t variant);
 
 /*
 * Look-up table for hex writer
@@ -43,9 +43,11 @@ char* hexbytes_from_bytes(const uint8_t *bytes, size_t size)
 	uint32_t i;
 	if ( ! bytes || ! size )
 	{
-		lwerror("hexbutes_from_bytes: invalid input");
+		lwerror("%s: invalid input", __func__);
 		return NULL;
 	}
+	if (size > (SIZE_MAX - 1) / 2)
+		lwerror("%s: hex output size overflow", __func__);
 	hex = lwalloc(size * 2 + 1);
 	hex[2*size] = '\0';
 	for( i = 0; i < size; i++ )
@@ -724,7 +726,7 @@ static size_t lwcollection_to_wkb_size(const LWCOLLECTION *col, uint8_t variant)
 	for ( i = 0; i < col->ngeoms; i++ )
 	{
 		/* size of subgeom */
-		size += lwgeom_to_wkb_size((LWGEOM*)col->geoms[i], variant | WKB_NO_SRID);
+		size += lwgeom_to_wkb_binary_size((LWGEOM *)col->geoms[i], variant | WKB_NO_SRID);
 	}
 
 	return size;
@@ -762,7 +764,7 @@ static uint8_t* lwcollection_to_wkb_buf(const LWCOLLECTION *col, uint8_t *buf, u
 	   inherit from their parents. */
 	for ( i = 0; i < col->ngeoms; i++ )
 	{
-		buf = lwgeom_to_wkb_buf(col->geoms[i], buf, variant | WKB_NO_SRID);
+		buf = lwgeom_to_wkb_buf_internal(col->geoms[i], buf, variant | WKB_NO_SRID);
 	}
 
 	return buf;
@@ -945,7 +947,7 @@ static uint8_t* lwnurbscurve_to_wkb_buf(const LWNURBSCURVE *curve, uint8_t *buf,
  * @return Number of bytes required to encode `geom` under `variant`, or 0 on error.
  */
 static size_t
-lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
+lwgeom_to_wkb_binary_size(const LWGEOM *geom, uint8_t variant)
 {
 	size_t size = 0;
 
@@ -1008,6 +1010,19 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
 	return size;
 }
 
+size_t
+lwgeom_to_wkb_size_internal(const LWGEOM *geom, uint8_t variant)
+{
+	size_t size = lwgeom_to_wkb_binary_size(geom, variant);
+	if (variant & WKB_HEX)
+	{
+		if (size > SIZE_MAX / 2)
+			lwerror("%s: WKB size overflow", __func__);
+		size *= 2;
+	}
+	return size;
+}
+
 /**
  * Serialize a LWGEOM into WKB format, writing into the provided buffer.
  *
@@ -1027,7 +1042,8 @@ lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
  *         success; NULL (0) on unsupported/unknown geometry type or other error.
  */
 
-static uint8_t* lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+uint8_t *
+lwgeom_to_wkb_buf_internal(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
 {
 
 	/* Do not simplify empties when outputting to canonical form */
@@ -1099,7 +1115,7 @@ lwgeom_to_wkb_write_buf(const LWGEOM *geom, uint8_t variant, uint8_t *buffer)
 	}
 
 	/* Write the WKB into the output buffer */
-	int written_bytes = (lwgeom_to_wkb_buf(geom, buffer, variant) - buffer);
+	ptrdiff_t written_bytes = (lwgeom_to_wkb_buf_internal(geom, buffer, variant) - buffer);
 
 	return written_bytes;
 }
@@ -1107,14 +1123,17 @@ lwgeom_to_wkb_write_buf(const LWGEOM *geom, uint8_t variant, uint8_t *buffer)
 uint8_t *
 lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size(geom, variant);
+	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
+	size_t alloc_size = b_size;
 	/* Hex string takes twice as much space as binary + a null character */
 	if (variant & WKB_HEX)
 	{
-		b_size = 2 * b_size + 1;
+		if (alloc_size == SIZE_MAX)
+			lwerror("%s: WKB allocation size overflow", __func__);
+		alloc_size++;
 	}
 
-	uint8_t *buffer = (uint8_t *)lwalloc(b_size);
+	uint8_t *buffer = (uint8_t *)lwalloc(alloc_size);
 	ptrdiff_t written_size = lwgeom_to_wkb_write_buf(geom, variant, buffer);
 	if (variant & WKB_HEX)
 	{
@@ -1122,7 +1141,7 @@ lwgeom_to_wkb_buffer(const LWGEOM *geom, uint8_t variant)
 		written_size++;
 	}
 
-	if (written_size != (ptrdiff_t)b_size)
+	if (written_size != (ptrdiff_t)alloc_size)
 	{
 		char *wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
 		lwerror("Output WKB is not the same size as the allocated buffer. Variant: %u, Geom: %s", variant, wkt);
@@ -1143,15 +1162,16 @@ lwgeom_to_hexwkb_buffer(const LWGEOM *geom, uint8_t variant)
 lwvarlena_t *
 lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant)
 {
-	size_t b_size = lwgeom_to_wkb_size(geom, variant);
-	/* Hex string takes twice as much space as binary, but No NULL ending in varlena */
-	if (variant & WKB_HEX)
-	{
-		b_size = 2 * b_size;
-	}
+	size_t b_size = lwgeom_to_wkb_size_internal(geom, variant);
+	size_t varlena_size;
+	if (b_size > SIZE_MAX - LWVARHDRSZ)
+		lwerror("%s: WKB varlena size overflow", __func__);
+	varlena_size = b_size + LWVARHDRSZ;
+	if (varlena_size > 0x3FFFFFFF)
+		lwerror("%s: WKB varlena size overflow", __func__);
 
-	lwvarlena_t *buffer = (lwvarlena_t *)lwalloc(b_size + LWVARHDRSZ);
-	int written_size = lwgeom_to_wkb_write_buf(geom, variant, (uint8_t *)buffer->data);
+	lwvarlena_t *buffer = (lwvarlena_t *)lwalloc(varlena_size);
+	ptrdiff_t written_size = lwgeom_to_wkb_write_buf(geom, variant, (uint8_t *)buffer->data);
 	if (written_size != (ptrdiff_t)b_size)
 	{
 		char *wkt = lwgeom_to_wkt(geom, WKT_EXTENDED, 15, NULL);
@@ -1160,7 +1180,7 @@ lwgeom_to_wkb_varlena(const LWGEOM *geom, uint8_t variant)
 		lwfree(buffer);
 		return NULL;
 	}
-	LWSIZE_SET(buffer->size, written_size + LWVARHDRSZ);
+	LWSIZE_SET(buffer->size, varlena_size);
 	return buffer;
 }
 

--- a/libpgcommon/lwgeom_cache.c
+++ b/libpgcommon/lwgeom_cache.c
@@ -4,6 +4,7 @@
  * http://postgis.net
  *
  * Copyright (C) 2012 Sandro Santilli <strk@kbt.io>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU General Public Licence. See the COPYING file.
@@ -262,8 +263,8 @@ ToastCacheGetGeometry(FunctionCallInfo fcinfo, uint32_t argnum)
  * Could return SRS as short one (i.e EPSG:4326)
  * or as long one: (i.e urn:ogc:def:crs:EPSG::4326)
  */
-static char *
-getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
+const char *
+LookupSRSBySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
 {
 	static const uint16_t max_query_size = 512;
 	char query[512];
@@ -352,11 +353,12 @@ GetSRSCacheBySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
 
 	if (arg->srid != srid || arg->short_mode != short_crs || !arg->srs)
 	{
+		const char *srs = LookupSRSBySRID(fcinfo, srid, short_crs);
 		arg->srid = srid;
 		arg->short_mode = short_crs;
 		if (arg->srs)
 			pfree(arg->srs);
-		arg->srs = getSRSbySRID(fcinfo, srid, short_crs);
+		arg->srs = (char *)srs;
 	}
 	return arg->srs;
 }

--- a/libpgcommon/lwgeom_cache.h
+++ b/libpgcommon/lwgeom_cache.h
@@ -4,6 +4,7 @@
  * http://postgis.net
  *
  * Copyright (C) 2012 Sandro Santilli <strk@kbt.io>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  *
  * This is free software; you can redistribute and/or modify it under
  * the terms of the GNU General Public Licence. See the COPYING file.
@@ -18,6 +19,16 @@
 #include "liblwgeom.h"
 #include "lwgeodetic_tree.h"
 #include "lwgeom_pg.h"
+
+#ifndef POSTGIS_HELPER_EXPORT
+#ifdef _WIN32
+#define POSTGIS_HELPER_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define POSTGIS_HELPER_EXPORT __attribute__((visibility("default")))
+#else
+#define POSTGIS_HELPER_EXPORT
+#endif
+#endif
 
 enum CacheEntryEnum {
 	TOAST_CACHE_ENTRY   = 0,
@@ -120,6 +131,7 @@ typedef struct {
 } SRSDescCache;
 
 const char *GetSRSCacheBySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);
+const char *LookupSRSBySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);
 
 /******************************************************************************/
 
@@ -136,3 +148,5 @@ typedef struct {
 
 int32_t GetSRIDCacheBySRS(FunctionCallInfo fcinfo, const char *srs);
 
+POSTGIS_HELPER_EXPORT
+const char *getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs);

--- a/postgis/lwgeom_export.c
+++ b/postgis/lwgeom_export.c
@@ -18,11 +18,10 @@
  *
  **********************************************************************
  *
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
  * Copyright 2009-2011 Olivier Courtin <olivier.courtin@oslandia.com>
  *
  **********************************************************************/
-
-
 
 /** @file
  *  Commons functions for all export functions
@@ -32,7 +31,9 @@
 #include "catalog/pg_type.h" /* for INT4OID */
 #include "executor/spi.h"
 #include "utils/builtins.h"
+#include "utils/hsearch.h"
 #include "utils/jsonb.h"
+#include "utils/memutils.h"
 
 #include "../postgis_config.h"
 #include "lwgeom_cache.h"
@@ -48,6 +49,124 @@ Datum LWGEOM_asX3D(PG_FUNCTION_ARGS);
 Datum LWGEOM_asEncodedPolyline(PG_FUNCTION_ARGS);
 Datum geometry_to_json(PG_FUNCTION_ARGS);
 Datum geometry_to_jsonb(PG_FUNCTION_ARGS);
+
+typedef struct {
+	FmgrInfo *flinfo;
+	SRSDescCacheArgument arg;
+} ExportSRSCacheEntry;
+
+typedef struct {
+	FmgrInfo *flinfo;
+} ExportSRSCacheCallbackArg;
+
+static HTAB *ExportSRSCache = NULL;
+
+static void
+export_srs_cache_delete(void *ptr)
+{
+	ExportSRSCacheCallbackArg *arg = (ExportSRSCacheCallbackArg *)ptr;
+	FmgrInfo *flinfo = arg->flinfo;
+
+	if (ExportSRSCache)
+		hash_search(ExportSRSCache, &flinfo, HASH_REMOVE, NULL);
+}
+
+static ExportSRSCacheEntry *
+export_srs_cache_get(FunctionCallInfo fcinfo)
+{
+	HASHCTL ctl;
+	bool found;
+	FmgrInfo *flinfo;
+	MemoryContext context;
+	ExportSRSCacheEntry *entry;
+
+	if (!fcinfo || !fcinfo->flinfo)
+		elog(ERROR, "%s: Could not find upper context", __func__);
+
+	if (!ExportSRSCache)
+	{
+		memset(&ctl, 0, sizeof(ctl));
+		ctl.keysize = sizeof(FmgrInfo *);
+		ctl.entrysize = sizeof(ExportSRSCacheEntry);
+		ctl.hcxt = TopMemoryContext;
+		ExportSRSCache =
+		    hash_create("PostGIS exported SRS cache", 128, &ctl, HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+	}
+
+	flinfo = fcinfo->flinfo;
+	entry = (ExportSRSCacheEntry *)hash_search(ExportSRSCache, &flinfo, HASH_FIND, NULL);
+	if (!entry)
+	{
+		MemoryContextCallback *callback;
+		ExportSRSCacheCallbackArg *callback_arg;
+
+		context = PostgisCacheContext(fcinfo);
+
+		/* Arm cleanup before publishing a TopMemoryContext hash entry. */
+		callback = MemoryContextAlloc(context, sizeof(MemoryContextCallback));
+		callback_arg = MemoryContextAlloc(context, sizeof(ExportSRSCacheCallbackArg));
+		callback_arg->flinfo = flinfo;
+		callback->arg = callback_arg;
+		callback->func = export_srs_cache_delete;
+		MemoryContextRegisterResetCallback(context, callback);
+
+		entry = (ExportSRSCacheEntry *)hash_search(ExportSRSCache, &flinfo, HASH_ENTER, &found);
+		if (!found)
+		{
+			entry->flinfo = flinfo;
+			memset(&(entry->arg), 0, sizeof(entry->arg));
+		}
+	}
+	return entry;
+}
+
+POSTGIS_HELPER_EXPORT const char *
+getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
+{
+	ExportSRSCacheEntry *entry = export_srs_cache_get(fcinfo);
+	SRSDescCacheArgument *arg = &(entry->arg);
+
+	/*
+	 * Downstream callers may already own fcinfo->flinfo->fn_extra. Keep this
+	 * exported API's cache separate from PostGIS' generic fn_extra cache.
+	 */
+	if (arg->srid != srid || arg->short_mode != short_crs || !arg->srs)
+	{
+		const char *srs = LookupSRSBySRID(fcinfo, srid, short_crs);
+		arg->srid = srid;
+		arg->short_mode = short_crs;
+		if (arg->srs)
+			pfree(arg->srs);
+		arg->srs = (char *)srs;
+	}
+	return arg->srs;
+}
+
+/*
+ * liblwgeom is linked into postgis-3.so as a static archive hidden by
+ * --exclude-libs,ALL. Publish strong module-local shims for the helper API so
+ * downstream extensions can resolve these names from the loaded PostGIS module
+ * without exposing the whole liblwgeom archive.
+ */
+#if defined(HAVE_LIBJSON)
+POSTGIS_HELPER_EXPORT LWGEOM *
+parse_geojson(struct json_object *geojson, int *hasz)
+{
+	return lwgeom_parse_geojson(geojson, hasz);
+}
+#endif
+
+POSTGIS_HELPER_EXPORT size_t
+lwgeom_to_wkb_size(const LWGEOM *geom, uint8_t variant)
+{
+	return lwgeom_to_wkb_size_internal(geom, variant);
+}
+
+POSTGIS_HELPER_EXPORT uint8_t *
+lwgeom_to_wkb_buf(const LWGEOM *geom, uint8_t *buf, uint8_t variant)
+{
+	return lwgeom_to_wkb_buf_internal(geom, buf, variant);
+}
 
 /**
  * Encode feature in GML


### PR DESCRIPTION
## Summary

Export helper APIs needed by MobilityDB for Trac https://trac.osgeo.org/postgis/ticket/5975.

This exposes selected GeoJSON parsing, WKB buffer, and SRS lookup helpers from the layers where downstream extensions need to resolve them:

- `parse_geojson`, `lwgeom_to_wkb_size`, and `lwgeom_to_wkb_buf` are exported from liblwgeom through public wrappers around the internal implementation names.
- `postgis-3.so` publishes explicit shims for those liblwgeom helpers because the liblwgeom archive is linked into the module with hidden archive symbols.
- `getSRSbySRID` is exported from `postgis-3.so` with a separate cache, so downstream callers do not have their `fcinfo->flinfo->fn_extra` storage overwritten.

## Notes

The Trac ticket also mentioned union-find initialization for skipped ids. That part is already covered on current master by PR-974 / commit `5f207dbe`, so this PR focuses on the remaining MobilityDB helper-export surface.

## Validation

- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C liblwgeom -j32`
- `make -C libpgcommon -j32`
- `make -C postgis -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `./liblwgeom/cunit/cu_tester geojson_input`
- `./liblwgeom/cunit/cu_tester wkb_output`
- `nm -D --defined-only postgis/postgis-3.so | rg ' (getSRSbySRID|parse_geojson|lwgeom_to_wkb_size|lwgeom_to_wkb_buf)$'`
- `nm -g --defined-only liblwgeom/.libs/liblwgeom.a | rg ' parse_geojson$| lwgeom_to_wkb_size$| lwgeom_to_wkb_buf$'`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git diff --cached --check`
- `git clang-format --diff upstream/master`

## Review follow-up

Addressed CodeRabbit feedback on the original head by:

- swapping SRS cache entries only after replacement lookup succeeds;
- adding fatal NULL assertions around the new public GeoJSON CUnit checks;
- checking the `lwgeom_to_wkb_buf` return pointer before pointer arithmetic.

## Rebase refresh

- 2026-06-21: rebased over upstream/master `c4bae99fc25aabfc512dd0c14f1474b66b3e7730` and force-pushed head `5a4a65627b0a68232a03987d3413169b72237afb`.
