### PR TITLE
Use xml2-config for fuzzer libxml links

### DIFF
--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -32,8 +32,10 @@ check:
 	set -- $${cxx}; \
 	if [ "$$#" -eq 0 ] || ! command -v "$$1" >/dev/null 2>&1 || ! "$$@" --version >/dev/null 2>&1; then \
 		echo "C++ compiler '$${cxx}' not available; skipping fuzzer smoke check."; \
-	elif ! command -v pkg-config >/dev/null 2>&1 || ! pkg-config --exists json-c proj libxml-2.0; then \
+	elif ! command -v pkg-config >/dev/null 2>&1 || ! pkg-config --exists json-c proj; then \
 		echo "pkg-config metadata for fuzzer dependencies not found; skipping fuzzer smoke check."; \
+	elif ! command -v xml2-config >/dev/null 2>&1 && ! pkg-config --exists libxml-2.0; then \
+		echo "libxml2 fuzzer dependency helper not found; skipping fuzzer smoke check."; \
 	elif ! command -v geos-config >/dev/null 2>&1 || ! command -v gdal-config >/dev/null 2>&1; then \
 		echo "GEOS/GDAL fuzzer dependency helpers not found; skipping fuzzer smoke check."; \
 	else \

--- a/fuzzers/build_google_oss_fuzzers.sh
+++ b/fuzzers/build_google_oss_fuzzers.sh
@@ -27,10 +27,15 @@ POSTGIS_BUILD_DIR="${POSTGIS_BUILD_DIR:-$POSTGIS_SOURCE_DIR}"
 FUZZERS_DIR="$POSTGIS_SOURCE_DIR/fuzzers"
 JSON_C_LIBS=$(pkg-config --libs json-c)
 GEOS_LIBS=$(geos-config --clibs)
-PROJ_XML2_LIBS=$(pkg-config --libs proj libxml-2.0)
+PROJ_LIBS=$(pkg-config --libs proj)
+if command -v xml2-config >/dev/null 2>&1; then
+    XML2_LIBS=$(xml2-config --libs)
+else
+    XML2_LIBS=$(pkg-config --libs libxml-2.0)
+fi
 GDAL_CFLAGS=$(gdal-config --cflags)
 GDAL_LIBS=$(gdal-config --libs)
-POSTGIS_FUZZER_LIBS="$JSON_C_LIBS $GEOS_LIBS $PROJ_XML2_LIBS"
+POSTGIS_FUZZER_LIBS="$JSON_C_LIBS $GEOS_LIBS $PROJ_LIBS $XML2_LIBS"
 POSTGIS_PACKAGE_RUNTIME_LIBS="${POSTGIS_PACKAGE_RUNTIME_LIBS:-1}"
 
 target_local_cflags()


### PR DESCRIPTION
## Summary

Fix the fuzzer smoke-build libxml2 link flags for Trac https://trac.osgeo.org/postgis/ticket/6084.

Winnie has libxml2 installed in a versioned private prefix and puts the libxml2 `bin` directory on `PATH`, but the fuzzer smoke build only used `pkg-config --libs libxml-2.0`. On that buildbot this can produce a bare `-lxml2` without the matching private library directory, so `geojson_import_fuzzer` fails to link.

This keeps `pkg-config` for json-c and PROJ, but asks `xml2-config --libs` for libxml2 flags when available, with the previous libxml2 pkg-config path as a fallback. The fuzzer Makefile preflight now accepts either libxml2 helper.

## Validation

- `bash -n fuzzers/build_google_oss_fuzzers.sh`
- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j32 -C liblwgeom`
- `make -j32 -C raster/rt_core`
- `make -C fuzzers check`
- `./utils/check_news.sh .`
- `git diff --check`

Note: the first local `make -C fuzzers check` attempt got past `geojson_import_fuzzer` and failed later because this fresh worktree had not built `raster/rt_core/librtcore.a` yet. After building `raster/rt_core`, the fuzzer smoke check passed.
