### PR TITLE
Add two-raster ST_Union variant

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,10 @@ These are only changes since 3.7.0alpha1.
             (Bas Couwenberg)
 
 * Enhancements *
+* New Features *
+
+ - #2474, [raster] Add two-raster ST_Union variant (Darafei Praliaskouski)
+
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)
@@ -163,7 +167,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)
  - #4560, ST_3DInterpolatePoint for M interpolation from XYZ inputs (Paul Ramsey)
  - #1291, ST_MakePolygon support for curved rings (Darafei Praliaskouski)
- - #2474, [raster] Add two-raster ST_Union variant (Darafei Praliaskouski)
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,7 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #2474, [raster] Add two-raster ST_Union variant (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta1
 2026/07/20
@@ -90,9 +91,6 @@ These are only changes since 3.7.0alpha1.
 
 * Enhancements *
 * New Features *
-
- - #2474, [raster] Add two-raster ST_Union variant (Darafei Praliaskouski)
-
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -163,6 +163,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #4398, Add ST_CatmullSmoothing smoothes but retains original vertices (Paul Ramsey)
  - #4560, ST_3DInterpolatePoint for M interpolation from XYZ inputs (Paul Ramsey)
  - #1291, ST_MakePolygon support for curved rings (Darafei Praliaskouski)
+ - #2474, [raster] Add two-raster ST_Union variant (Darafei Praliaskouski)
  - GT-270, Add NURBSCurve (Loïc Bartoletti)
  - #2863, Add ST_XSize, ST_YSize, ST_ZSize, and ST_MSize dimension helpers
           (Darafei Praliaskouski)

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -12251,11 +12251,8 @@ SELECT ST_Union(rast, ARRAY[ROW(2, 'LAST'), ROW(1, 'LAST'), ROW(3, 'LAST')]::uni
 FROM aerials.boston
 WHERE ST_Intersects(rast, ST_GeomFromText('LINESTRING(230486 887771,230500 88772)', 26986) );
                     </programlisting>
-                </refsection>
-                <refsection>
-                    <title>Examples: Union two raster values</title>
-                    <programlisting>
--- this unions a generated raster with an existing raster without a subquery aggregate
+                    <para>Union a generated raster with an existing raster without a subquery aggregate.</para>
+                    <programlisting language="sql">
 SELECT ST_Union(rast, ST_AsRaster(geom, rast), 'LAST')
 FROM raster_table
 JOIN geometry_table

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -12166,7 +12166,7 @@ FROM rc;
             <refentry xml:id="RT_ST_Union">
                 <refnamediv>
                     <refname>ST_Union</refname>
-                    <refpurpose>Returns the union of a set of raster tiles into a single raster composed of 1 or more bands.</refpurpose>
+                    <refpurpose>Returns the union of a set of raster tiles, or two raster values, into a single raster composed of 1 or more bands.</refpurpose>
                 </refnamediv>
 
                 <refsynopsisdiv>
@@ -12200,13 +12200,20 @@ FROM rc;
                             <paramdef><type>integer</type> <parameter>nband</parameter></paramdef>
                             <paramdef><type>text</type> <parameter>uniontype</parameter></paramdef>
                         </funcprototype>
+
+                        <funcprototype>
+                            <funcdef>raster <function>ST_Union</function></funcdef>
+                            <paramdef><type>raster</type> <parameter>rast1</parameter></paramdef>
+                            <paramdef><type>raster</type> <parameter>rast2</parameter></paramdef>
+                            <paramdef choice="opt"><type>text</type> <parameter>uniontype=LAST</parameter></paramdef>
+                        </funcprototype>
                     </funcsynopsis>
                 </refsynopsisdiv>
 
                 <refsection>
                     <title>Description</title>
 
-                    <para>Returns the union of a set of raster tiles into a single raster composed of at least one band.  The resulting raster's extent is the extent of the whole set.  In the case of intersection, the resulting value is defined by <varname>uniontype</varname> which is one of the following: LAST (default), FIRST, MIN, MAX, COUNT, SUM, MEAN, RANGE.</para>
+                    <para>Returns the union of a set of raster tiles, or the union of two raster values, into a single raster composed of at least one band.  The resulting raster's extent is the extent of all input rasters.  In the case of intersection, the resulting value is defined by <varname>uniontype</varname> which is one of the following: LAST (default), FIRST, MIN, MAX, COUNT, SUM, MEAN, RANGE.</para>
 
                     <note>
                       <para>In order for rasters to be unioned, they must all have the same alignment.  Use <xref linkend="RT_ST_SameAlignment"/> and <xref linkend="RT_ST_NotSameAlignmentReason"/> for more details and help. One way to fix alignment issues is to use <xref linkend="RT_ST_Resample"/> and use the same reference raster for alignment.</para>
@@ -12217,6 +12224,7 @@ FROM rc;
                     <para role="availability" conformance="2.1.0">Availability: 2.1.0 ST_Union(rast, unionarg) variant was introduced.</para>
                     <para role="enhanced" conformance="2.1.0">Enhanced: 2.1.0 ST_Union(rast) (variant 1) unions all bands of all input rasters.  Prior versions of PostGIS assumed the first band.</para>
                     <para role="enhanced" conformance="2.1.0">Enhanced: 2.1.0 ST_Union(rast, uniontype) (variant 4) unions all bands of all input rasters.</para>
+                    <para role="availability" conformance="3.7.0">Availability: 3.7.0 ST_Union(rast1, rast2, uniontype) variant was introduced.</para>
                 </refsection>
                 <refsection>
                     <title>Examples</title>
@@ -12242,6 +12250,16 @@ WHERE ST_Intersects(rast, ST_GeomFromText('LINESTRING(230486 887771,230500 88772
 SELECT ST_Union(rast, ARRAY[ROW(2, 'LAST'), ROW(1, 'LAST'), ROW(3, 'LAST')]::unionarg[])
 FROM aerials.boston
 WHERE ST_Intersects(rast, ST_GeomFromText('LINESTRING(230486 887771,230500 88772)', 26986) );
+                    </programlisting>
+                </refsection>
+                <refsection>
+                    <title>Examples: Union two raster values</title>
+                    <programlisting>
+-- this unions a generated raster with an existing raster without a subquery aggregate
+SELECT ST_Union(rast, ST_AsRaster(geom, rast), 'LAST')
+FROM raster_table
+JOIN geometry_table
+  ON ST_Intersects(rast, geom);
                     </programlisting>
                 </refsection>
 

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -6583,6 +6583,15 @@ CREATE AGGREGATE st_union(raster, text) (
 	FINALFUNC = _st_union_finalfn
 );
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION st_union(rast1 raster, rast2 raster, uniontype text DEFAULT 'LAST')
+	RETURNS raster
+	AS $$
+		SELECT @extschema@.ST_Union(rast, uniontype ORDER BY ord)
+		FROM (VALUES (1, $1), (2, $2)) AS foo(ord, rast)
+	$$
+	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
 -----------------------------------------------------------------------
 -- ST_AsRasterAgg aggregate
 ----------------------------------------------------------------------{

--- a/raster/test/regress/rt_union.sql
+++ b/raster/test/regress/rt_union.sql
@@ -505,3 +505,27 @@ SELECT 'none', ST_Union(r) from ( select null::raster r where false ) f;
 SELECT 'null', ST_Union(null::raster);
 --#4699 crash
 SELECT 'null-1', ST_Union(null::raster,1);
+
+WITH r AS (
+	SELECT
+		ST_AddBand(ST_MakeEmptyRaster(2, 2, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 1, 0) AS rast1,
+		ST_AddBand(ST_MakeEmptyRaster(2, 2, 1, -1, 1, -1, 0, 0, 0), 1, '8BUI', 2, 0) AS rast2
+),
+u AS (
+	SELECT 'two-raster-last' AS label, ST_Union(rast1, rast2) AS rast FROM r UNION ALL
+	SELECT 'two-raster-first', ST_Union(rast1, rast2, 'FIRST') FROM r UNION ALL
+	SELECT 'two-raster-sum', ST_Union(rast1, rast2, 'SUM') FROM r
+)
+SELECT label, (ST_Metadata(rast)).width, (ST_Metadata(rast)).height, (ST_DumpValues(rast)).valarray
+FROM u
+ORDER BY label;
+
+WITH r AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(2, 2, 0, 0, 1, -1, 0, 0, 0), 1, '8BUI', 7, 0) AS rast
+)
+SELECT 'two-raster-null-left', (ST_Metadata(ST_Union(NULL::raster, rast))).width, (ST_DumpValues(ST_Union(NULL::raster, rast))).valarray FROM r
+UNION ALL
+SELECT 'two-raster-null-right', (ST_Metadata(ST_Union(rast, NULL::raster))).width, (ST_DumpValues(ST_Union(rast, NULL::raster))).valarray FROM r
+UNION ALL
+SELECT 'two-raster-null-both', NULL::integer, NULL::double precision[][] WHERE ST_Union(NULL::raster, NULL::raster) IS NULL
+ORDER BY 1;

--- a/raster/test/regress/rt_union_expected
+++ b/raster/test/regress/rt_union_expected
@@ -630,3 +630,9 @@ LAST|3|9|4
 none|
 null|
 null-1|
+two-raster-first|3|3|{{1,1,NULL},{1,1,2},{NULL,2,2}}
+two-raster-last|3|3|{{1,1,NULL},{1,2,2},{NULL,2,2}}
+two-raster-sum|3|3|{{1,1,NULL},{1,3,2},{NULL,2,2}}
+two-raster-null-both||
+two-raster-null-left|2|{{7,7},{7,7}}
+two-raster-null-right|2|{{7,7},{7,7}}


### PR DESCRIPTION
## Summary

- add `ST_Union(rast1 raster, rast2 raster, uniontype text DEFAULT 'LAST')`
- reuse the existing raster union aggregate semantics for all bands, union types, and NULL raster handling
- preserve input order for `FIRST` and `LAST` modes with an explicit aggregate `ORDER BY`
- document the scalar form and add focused raster regression coverage

Trac ticket: https://trac.osgeo.org/postgis/ticket/2474

Note: ticket comment 2 mentions a possible future `raster[]` variant. This PR implements the original requested two-raster form and leaves array support as follow-up design scope.

## Validation

Validation performed on current head `d451a8617c22f9114c12c506af74b2666bccb8d8`:

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C raster/rt_pg -j32`
- `sudo -n make -C raster/rt_pg install`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --raster" TESTS="$(pwd)/raster/test/regress/rt_union"` (fresh and automatic-upgrade runs passed, 2 tests, Failed 0)
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
