### PR TITLE
Add raster ST_IsVisible

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -149,6 +149,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)
  - #2858, ST_MMin and ST_MMax (Paul Ramsey)
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)
+ - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
+          using GDAL >= 3.1.1
+          (Darafei Praliaskouski)
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,12 @@ These are only changes since 3.7.0alpha1.
             (Bas Couwenberg)
 
 * Enhancements *
+* New Features *
+
+ - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
+          using GDAL >= 3.1.1
+          (Darafei Praliaskouski)
+
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)
@@ -149,9 +155,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)
  - #2858, ST_MMin and ST_MMax (Paul Ramsey)
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)
- - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
-          using GDAL >= 3.1.1
-          (Darafei Praliaskouski)
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -207,6 +207,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)
  - #2858, ST_MMin and ST_MMax (Paul Ramsey)
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)
+ - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
+          using GDAL >= 3.1.1
+          (Darafei Praliaskouski)
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,11 @@ These are only changes since 3.7.0beta1.
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
 
+ - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
+          using GDAL >= 3.1.1
+          (Darafei Praliaskouski)
+
+
 PostGIS 3.7.0beta1
 2026/07/20
 
@@ -90,11 +95,6 @@ These are only changes since 3.7.0alpha1.
 
 * Enhancements *
 * New Features *
-
- - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
-          using GDAL >= 3.1.1
-          (Darafei Praliaskouski)
-
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -147,6 +147,12 @@ These are only changes since 3.7.0alpha1.
             (Bas Couwenberg)
 
 * Enhancements *
+* New Features *
+
+ - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
+          using GDAL >= 3.1.1
+          (Darafei Praliaskouski)
+
 
  - #1986, ST_GeomFromGML support for GML ArcString and curved polygon rings
           (Darafei Praliaskouski)
@@ -207,9 +213,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)
  - #2858, ST_MMin and ST_MMax (Paul Ramsey)
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)
- - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks
-          using GDAL >= 3.1.1
-          (Darafei Praliaskouski)
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #2596, [raster] Add ST_IsVisible for DEM line-of-sight checks using
+          GDAL >= 3.1.1 (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -4883,6 +4883,99 @@ WHERE
             </refsection>
         </refentry>
 
+        <refentry xml:id="RT_ST_IsVisible">
+            <refnamediv>
+                <refname>ST_IsVisible</refname>
+                <refpurpose>Tests whether one point is visible from another point using a raster band as a digital elevation model.</refpurpose>
+            </refnamediv>
+
+            <refsynopsisdiv>
+                <funcsynopsis>
+                    <funcprototype>
+                        <funcdef>boolean <function>ST_IsVisible</function></funcdef>
+                        <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointa</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointb</parameter></paramdef>
+                        <paramdef choice="opt"><type>boolean </type> <parameter>curvature=false</parameter></paramdef>
+                    </funcprototype>
+                    <funcprototype>
+                        <funcdef>boolean <function>ST_IsVisible</function></funcdef>
+                        <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>band</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointa</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointb</parameter></paramdef>
+                        <paramdef choice="opt"><type>boolean </type> <parameter>curvature=false</parameter></paramdef>
+                    </funcprototype>
+                    <funcprototype>
+                        <funcdef>boolean <function>ST_IsVisible</function></funcdef>
+                        <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointa</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointb</parameter></paramdef>
+                        <paramdef><type>double precision </type> <parameter>curvature_coef</parameter></paramdef>
+                    </funcprototype>
+                    <funcprototype>
+                        <funcdef>boolean <function>ST_IsVisible</function></funcdef>
+                        <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                        <paramdef><type>integer </type> <parameter>band</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointa</parameter></paramdef>
+                        <paramdef><type>geometry </type> <parameter>pointb</parameter></paramdef>
+                        <paramdef><type>double precision </type> <parameter>curvature_coef</parameter></paramdef>
+                    </funcprototype>
+                </funcsynopsis>
+            </refsynopsisdiv>
+
+            <refsection>
+                <title>Description</title>
+
+                <para>Returns true if <varname>pointb</varname> is visible from <varname>pointa</varname> along the surface represented by the raster band. The point coordinates must use the same SRID as the raster. If a point has a Z coordinate, it is used as the observer or target height above the DEM surface; otherwise a height of zero is used.</para>
+                <para>If <varname>curvature</varname> is true, the GDAL viewshed curvature/refraction coefficient is set to 0.85714. The <varname>curvature_coef</varname> overload accepts an explicit coefficient. A coefficient of 0.0 does not adjust for earth curvature.</para>
+                <para>This function uses GDAL's viewshed algorithm, which is intended for projected coordinate reference systems. GDAL does not currently apply special processing for input DEM cells that have a nodata value. The GDAL <varname>GTiff</varname> driver must be enabled in <xref linkend="postgis_gdal_enabled_drivers"/>.</para>
+
+                <para role="availability" conformance="3.7.0">Availability: 3.7.0 - requires GDAL &gt;= 3.1.1.</para>
+            </refsection>
+
+            <refsection>
+                <title>Examples</title>
+
+                <programlisting><![CDATA[
+WITH dem AS (
+    SELECT ST_SetSRID(
+        ST_AddBand(
+            ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+            '32BF'::text, 0, NULL
+        ),
+        3857
+    ) AS rast
+)
+SELECT
+    ST_IsVisible(
+        rast,
+        ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+        ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857)
+    ) AS clear_path,
+    ST_IsVisible(
+        ST_SetValue(rast, 1, 3, 3, 10),
+        ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+        ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857)
+    ) AS blocked_path
+FROM dem;
+
+ clear_path | blocked_path
+------------+--------------
+ t          | f
+                ]]></programlisting>
+            </refsection>
+
+            <refsection>
+                <title>See Also</title>
+                <para>
+                    <xref linkend="RT_ST_Value"/>,
+                    <xref linkend="RT_ST_SetValue"/>,
+                    <xref linkend="RT_ST_MakeEmptyRaster"/>
+                </para>
+            </refsection>
+        </refentry>
+
         <refentry xml:id="RT_ST_NearestValue">
             <refnamediv>
                 <refname>ST_NearestValue</refname>

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -4936,8 +4936,9 @@ WHERE
 
             <refsection>
                 <title>Examples</title>
+				<para>This example requires the <literal>GTiff</literal> driver in <varname>postgis.gdal_enabled_drivers</varname>.</para>
 
-                <programlisting language="sql"><![CDATA[
+                <programlisting language="sql" role="requires-external-state"><![CDATA[
 WITH dem AS (
     SELECT ST_SetSRID(
         ST_AddBand(

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -4937,7 +4937,7 @@ WHERE
             <refsection>
                 <title>Examples</title>
 
-                <programlisting><![CDATA[
+                <programlisting language="sql"><![CDATA[
 WITH dem AS (
     SELECT ST_SetSRID(
         ST_AddBand(
@@ -4959,11 +4959,11 @@ SELECT
         ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857)
     ) AS blocked_path
 FROM dem;
-
- clear_path | blocked_path
+                ]]></programlisting>
+                <screen role="visual-primary text-primary"><![CDATA[ clear_path | blocked_path
 ------------+--------------
  t          | f
-                ]]></programlisting>
+                ]]></screen>
             </refsection>
 
             <refsection>

--- a/raster/rt_pg/rtpg_gdal.c
+++ b/raster/rt_pg/rtpg_gdal.c
@@ -40,6 +40,7 @@
 #include <utils/memutils.h> /* For TopMemoryContext */
 #include <ctype.h>
 #include <strings.h>
+#include <math.h>
 
 #include "../../postgis_config.h"
 
@@ -57,6 +58,9 @@ Datum RASTER_setGDALOpenOptions(PG_FUNCTION_ARGS);
 
 /* warp a raster using GDAL Warp API */
 Datum RASTER_GDALWarp(PG_FUNCTION_ARGS);
+
+/* test raster line of sight using GDAL Viewshed API */
+Datum RASTER_isVisible(PG_FUNCTION_ARGS);
 
 /* ----------------------------------------------------------------
  * Returns raster from GDAL raster
@@ -628,6 +632,312 @@ Datum RASTER_Contour(PG_FUNCTION_ARGS)
 	}
 }
 
+/************************************************************************
+ * ST_IsVisible(
+ *   rast raster,
+ *   bandnumber integer,
+ *   pointa geometry,
+ *   pointb geometry,
+ *   curvature_coef double precision
+ * )
+ ************************************************************************/
+PG_FUNCTION_INFO_V1(RASTER_isVisible);
+Datum
+RASTER_isVisible(PG_FUNCTION_ARGS)
+{
+#if POSTGIS_GDAL_VERSION < 30101
+	elog(ERROR, "%s: ST_IsVisible requires GDAL 3.1.1 or later", __func__);
+	PG_RETURN_NULL();
+#else
+	rt_pgraster *pgraster = NULL;
+	rt_raster raster = NULL;
+	GSERIALIZED *gser_a = NULL;
+	GSERIALIZED *gser_b = NULL;
+	LWGEOM *geom_a = NULL;
+	LWGEOM *geom_b = NULL;
+	LWPOINT *point_a = NULL;
+	LWPOINT *point_b = NULL;
+	POINT4D pa;
+	POINT4D pb;
+	int band_number;
+	int num_bands;
+	int src_srid;
+	char *src_srs = NULL;
+	double curv_coeff;
+	double max_distance;
+	GDALDriverH src_drv = NULL;
+	int destroy_src_drv = 0;
+	GDALDatasetH src_ds = NULL;
+	GDALDatasetH dst_ds = NULL;
+	GDALRasterBandH src_band = NULL;
+	GDALRasterBandH dst_band = NULL;
+	static uint64 dst_file_seq = 0;
+	char dst_filename[64];
+	double src_gt[6] = {0};
+	double dst_gt[6] = {0};
+	double dst_igt[6] = {0};
+	double dst_x = 0.0;
+	double dst_y = 0.0;
+	int dst_col = 0;
+	int dst_row = 0;
+	GByte visibility = 0;
+	CPLErr cplerr;
+
+	band_number = PG_GETARG_INT32(1);
+	if (band_number < 1)
+		elog(ERROR, "%s: Invalid band number %d", __func__, band_number);
+
+	gser_a = (GSERIALIZED *)PG_DETOAST_DATUM(PG_GETARG_DATUM(2));
+	gser_b = (GSERIALIZED *)PG_DETOAST_DATUM(PG_GETARG_DATUM(3));
+
+	if (gserialized_get_type(gser_a) != POINTTYPE || gserialized_is_empty(gser_a))
+		elog(ERROR, "%s: point A must be a non-empty point geometry", __func__);
+	if (gserialized_get_type(gser_b) != POINTTYPE || gserialized_is_empty(gser_b))
+		elog(ERROR, "%s: point B must be a non-empty point geometry", __func__);
+
+	pgraster = (rt_pgraster *)PG_DETOAST_DATUM(PG_GETARG_DATUM(0));
+	raster = rt_raster_deserialize(pgraster, FALSE);
+	if (!raster)
+	{
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not deserialize raster", __func__);
+	}
+
+	src_srid = clamp_srid(rt_raster_get_srid(raster));
+	if (gserialized_get_srid(gser_a) != src_srid || gserialized_get_srid(gser_b) != src_srid)
+	{
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Raster and point geometries do not have the same SRID", __func__);
+	}
+
+	num_bands = rt_raster_get_num_bands(raster);
+	if (band_number > num_bands)
+	{
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: band number must be between 1 and %d inclusive", __func__, num_bands);
+	}
+
+	curv_coeff = PG_GETARG_FLOAT8(4);
+	if (!isfinite(curv_coeff) || curv_coeff < 0.0)
+	{
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: curvature coefficient must be finite and non-negative", __func__);
+	}
+
+	geom_a = lwgeom_from_gserialized(gser_a);
+	geom_b = lwgeom_from_gserialized(gser_b);
+	point_a = lwgeom_as_lwpoint(geom_a);
+	point_b = lwgeom_as_lwpoint(geom_b);
+	lwpoint_getPoint4d_p(point_a, &pa);
+	lwpoint_getPoint4d_p(point_b, &pb);
+
+	if (!isfinite(pa.x) || !isfinite(pa.y) || (gserialized_has_z(gser_a) && !isfinite(pa.z)) || !isfinite(pb.x) ||
+	    !isfinite(pb.y) || (gserialized_has_z(gser_b) && !isfinite(pb.z)))
+	{
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: point coordinates must be finite", __func__);
+	}
+
+	max_distance = hypot(pa.x - pb.x, pa.y - pb.y);
+	if (!isfinite(max_distance))
+	{
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: point distance must be finite", __func__);
+	}
+
+	if (src_srid != SRID_UNKNOWN)
+		src_srs = rtpg_getSR(src_srid);
+
+	rt_util_gdal_register_all(0);
+	src_ds = rt_raster_to_gdal_mem(raster, src_srs, NULL, NULL, 0, &src_drv, &destroy_src_drv);
+	if (!src_ds)
+	{
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not convert raster to GDAL MEM format", __func__);
+	}
+
+	src_band = GDALGetRasterBand(src_ds, band_number);
+	if (!src_band)
+	{
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not get GDAL raster band", __func__);
+	}
+
+	if (GDALGetGeoTransform(src_ds, src_gt) != CE_None)
+	{
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not compute source raster coordinates", __func__);
+	}
+
+	/*
+	 * GDAL uses dfMaxDistance both as a search limit and as an output window
+	 * limit. If point B is not at its pixel center, the sampled pixel center
+	 * can be farther from point A than point B itself.
+	 */
+	max_distance += 0.5 * (hypot(src_gt[1], src_gt[4]) + hypot(src_gt[2], src_gt[5]));
+	if (!isfinite(max_distance) || max_distance <= 0.0)
+	{
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: viewshed distance must be finite and positive", __func__);
+	}
+
+	snprintf(dst_filename,
+		 sizeof(dst_filename),
+		 "/vsimem/postgis_isvisible_%d_%llu.tif",
+		 MyProcPid,
+		 (unsigned long long)dst_file_seq++);
+
+	dst_ds = GDALViewshedGenerate(src_band,
+				      "GTiff",
+				      dst_filename,
+				      NULL,
+				      pa.x,
+				      pa.y,
+				      gserialized_has_z(gser_a) ? pa.z : 0.0,
+				      gserialized_has_z(gser_b) ? pb.z : 0.0,
+				      1.0,
+				      0.0,
+				      0.0,
+				      0.0,
+				      curv_coeff,
+				      GVM_Edge,
+				      max_distance,
+				      rt_util_gdal_progress_func,
+				      (void *)"GDALViewshedGenerate",
+				      GVOT_NORMAL,
+				      NULL);
+
+	if (!dst_ds)
+	{
+		VSIUnlink(dst_filename);
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: GDAL viewshed generation failed: %s", __func__, CPLGetLastErrorMsg());
+	}
+
+	if (GDALGetGeoTransform(dst_ds, dst_gt) != CE_None || GDALInvGeoTransform(dst_gt, dst_igt) == 0)
+	{
+		GDALClose(dst_ds);
+		VSIUnlink(dst_filename);
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not compute output viewshed coordinates", __func__);
+	}
+
+	GDALApplyGeoTransform(dst_igt, pb.x, pb.y, &dst_x, &dst_y);
+	if (!isfinite(dst_x) || !isfinite(dst_y) || dst_x < 0.0 || dst_y < 0.0 || dst_x >= GDALGetRasterXSize(dst_ds) ||
+	    dst_y >= GDALGetRasterYSize(dst_ds))
+	{
+		GDALClose(dst_ds);
+		VSIUnlink(dst_filename);
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		PG_RETURN_BOOL(false);
+	}
+	dst_col = (int)floor(dst_x);
+	dst_row = (int)floor(dst_y);
+
+	dst_band = GDALGetRasterBand(dst_ds, 1);
+	cplerr = GDALRasterIO(dst_band, GF_Read, dst_col, dst_row, 1, 1, &visibility, 1, 1, GDT_Byte, 0, 0);
+
+	GDALClose(dst_ds);
+	VSIUnlink(dst_filename);
+	GDALClose(src_ds);
+	if (src_drv != NULL && destroy_src_drv)
+	{
+		GDALDeregisterDriver(src_drv);
+		GDALDestroyDriver(src_drv);
+	}
+	lwgeom_free(geom_a);
+	lwgeom_free(geom_b);
+	if (src_srs)
+		pfree(src_srs);
+	rt_raster_destroy(raster);
+	PG_FREE_IF_COPY(pgraster, 0);
+
+	if (cplerr != CE_None)
+		elog(ERROR, "%s: Could not read target cell from viewshed raster", __func__);
+
+	PG_RETURN_BOOL(visibility == 1);
+#endif
+}
 
 static int rtpg_util_gdal_progress_func(
 	double dfComplete,

--- a/raster/rt_pg/rtpg_gdal.c
+++ b/raster/rt_pg/rtpg_gdal.c
@@ -39,6 +39,7 @@
 #include <utils/memutils.h> /* For TopMemoryContext */
 #include <ctype.h>
 #include <strings.h>
+#include <math.h>
 
 #include "../../postgis_config.h"
 
@@ -56,6 +57,9 @@ Datum RASTER_setGDALOpenOptions(PG_FUNCTION_ARGS);
 
 /* warp a raster using GDAL Warp API */
 Datum RASTER_GDALWarp(PG_FUNCTION_ARGS);
+
+/* test raster line of sight using GDAL Viewshed API */
+Datum RASTER_isVisible(PG_FUNCTION_ARGS);
 
 /* ----------------------------------------------------------------
  * Returns raster from GDAL raster
@@ -627,6 +631,312 @@ Datum RASTER_Contour(PG_FUNCTION_ARGS)
 	}
 }
 
+/************************************************************************
+ * ST_IsVisible(
+ *   rast raster,
+ *   bandnumber integer,
+ *   pointa geometry,
+ *   pointb geometry,
+ *   curvature_coef double precision
+ * )
+ ************************************************************************/
+PG_FUNCTION_INFO_V1(RASTER_isVisible);
+Datum
+RASTER_isVisible(PG_FUNCTION_ARGS)
+{
+#if POSTGIS_GDAL_VERSION < 30101
+	elog(ERROR, "%s: ST_IsVisible requires GDAL 3.1.1 or later", __func__);
+	PG_RETURN_NULL();
+#else
+	rt_pgraster *pgraster = NULL;
+	rt_raster raster = NULL;
+	GSERIALIZED *gser_a = NULL;
+	GSERIALIZED *gser_b = NULL;
+	LWGEOM *geom_a = NULL;
+	LWGEOM *geom_b = NULL;
+	LWPOINT *point_a = NULL;
+	LWPOINT *point_b = NULL;
+	POINT4D pa;
+	POINT4D pb;
+	int band_number;
+	int num_bands;
+	int src_srid;
+	char *src_srs = NULL;
+	double curv_coeff;
+	double max_distance;
+	GDALDriverH src_drv = NULL;
+	int destroy_src_drv = 0;
+	GDALDatasetH src_ds = NULL;
+	GDALDatasetH dst_ds = NULL;
+	GDALRasterBandH src_band = NULL;
+	GDALRasterBandH dst_band = NULL;
+	static uint64 dst_file_seq = 0;
+	char dst_filename[64];
+	double src_gt[6] = {0};
+	double dst_gt[6] = {0};
+	double dst_igt[6] = {0};
+	double dst_x = 0.0;
+	double dst_y = 0.0;
+	int dst_col = 0;
+	int dst_row = 0;
+	GByte visibility = 0;
+	CPLErr cplerr;
+
+	band_number = PG_GETARG_INT32(1);
+	if (band_number < 1)
+		elog(ERROR, "%s: Invalid band number %d", __func__, band_number);
+
+	gser_a = (GSERIALIZED *)PG_DETOAST_DATUM(PG_GETARG_DATUM(2));
+	gser_b = (GSERIALIZED *)PG_DETOAST_DATUM(PG_GETARG_DATUM(3));
+
+	if (gserialized_get_type(gser_a) != POINTTYPE || gserialized_is_empty(gser_a))
+		elog(ERROR, "%s: point A must be a non-empty point geometry", __func__);
+	if (gserialized_get_type(gser_b) != POINTTYPE || gserialized_is_empty(gser_b))
+		elog(ERROR, "%s: point B must be a non-empty point geometry", __func__);
+
+	pgraster = (rt_pgraster *)PG_DETOAST_DATUM(PG_GETARG_DATUM(0));
+	raster = rt_raster_deserialize(pgraster, FALSE);
+	if (!raster)
+	{
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not deserialize raster", __func__);
+	}
+
+	src_srid = clamp_srid(rt_raster_get_srid(raster));
+	if (gserialized_get_srid(gser_a) != src_srid || gserialized_get_srid(gser_b) != src_srid)
+	{
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Raster and point geometries do not have the same SRID", __func__);
+	}
+
+	num_bands = rt_raster_get_num_bands(raster);
+	if (band_number > num_bands)
+	{
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: band number must be between 1 and %d inclusive", __func__, num_bands);
+	}
+
+	curv_coeff = PG_GETARG_FLOAT8(4);
+	if (!isfinite(curv_coeff) || curv_coeff < 0.0)
+	{
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: curvature coefficient must be finite and non-negative", __func__);
+	}
+
+	geom_a = lwgeom_from_gserialized(gser_a);
+	geom_b = lwgeom_from_gserialized(gser_b);
+	point_a = lwgeom_as_lwpoint(geom_a);
+	point_b = lwgeom_as_lwpoint(geom_b);
+	lwpoint_getPoint4d_p(point_a, &pa);
+	lwpoint_getPoint4d_p(point_b, &pb);
+
+	if (!isfinite(pa.x) || !isfinite(pa.y) || (gserialized_has_z(gser_a) && !isfinite(pa.z)) || !isfinite(pb.x) ||
+	    !isfinite(pb.y) || (gserialized_has_z(gser_b) && !isfinite(pb.z)))
+	{
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: point coordinates must be finite", __func__);
+	}
+
+	max_distance = hypot(pa.x - pb.x, pa.y - pb.y);
+	if (!isfinite(max_distance))
+	{
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: point distance must be finite", __func__);
+	}
+
+	if (src_srid != SRID_UNKNOWN)
+		src_srs = rtpg_getSR(src_srid);
+
+	rt_util_gdal_register_all(0);
+	src_ds = rt_raster_to_gdal_mem(raster, src_srs, NULL, NULL, 0, &src_drv, &destroy_src_drv);
+	if (!src_ds)
+	{
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not convert raster to GDAL MEM format", __func__);
+	}
+
+	src_band = GDALGetRasterBand(src_ds, band_number);
+	if (!src_band)
+	{
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not get GDAL raster band", __func__);
+	}
+
+	if (GDALGetGeoTransform(src_ds, src_gt) != CE_None)
+	{
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not compute source raster coordinates", __func__);
+	}
+
+	/*
+	 * GDAL uses dfMaxDistance both as a search limit and as an output window
+	 * limit. If point B is not at its pixel center, the sampled pixel center
+	 * can be farther from point A than point B itself.
+	 */
+	max_distance += 0.5 * (hypot(src_gt[1], src_gt[4]) + hypot(src_gt[2], src_gt[5]));
+	if (!isfinite(max_distance) || max_distance <= 0.0)
+	{
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: viewshed distance must be finite and positive", __func__);
+	}
+
+	snprintf(dst_filename,
+		 sizeof(dst_filename),
+		 "/vsimem/postgis_isvisible_%d_%llu.tif",
+		 MyProcPid,
+		 (unsigned long long)dst_file_seq++);
+
+	dst_ds = GDALViewshedGenerate(src_band,
+				      "GTiff",
+				      dst_filename,
+				      NULL,
+				      pa.x,
+				      pa.y,
+				      gserialized_has_z(gser_a) ? pa.z : 0.0,
+				      gserialized_has_z(gser_b) ? pb.z : 0.0,
+				      1.0,
+				      0.0,
+				      0.0,
+				      0.0,
+				      curv_coeff,
+				      GVM_Edge,
+				      max_distance,
+				      rt_util_gdal_progress_func,
+				      (void *)"GDALViewshedGenerate",
+				      GVOT_NORMAL,
+				      NULL);
+
+	if (!dst_ds)
+	{
+		VSIUnlink(dst_filename);
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: GDAL viewshed generation failed: %s", __func__, CPLGetLastErrorMsg());
+	}
+
+	if (GDALGetGeoTransform(dst_ds, dst_gt) != CE_None || GDALInvGeoTransform(dst_gt, dst_igt) == 0)
+	{
+		GDALClose(dst_ds);
+		VSIUnlink(dst_filename);
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		elog(ERROR, "%s: Could not compute output viewshed coordinates", __func__);
+	}
+
+	GDALApplyGeoTransform(dst_igt, pb.x, pb.y, &dst_x, &dst_y);
+	if (!isfinite(dst_x) || !isfinite(dst_y) || dst_x < 0.0 || dst_y < 0.0 || dst_x >= GDALGetRasterXSize(dst_ds) ||
+	    dst_y >= GDALGetRasterYSize(dst_ds))
+	{
+		GDALClose(dst_ds);
+		VSIUnlink(dst_filename);
+		GDALClose(src_ds);
+		if (src_drv != NULL && destroy_src_drv)
+		{
+			GDALDeregisterDriver(src_drv);
+			GDALDestroyDriver(src_drv);
+		}
+		lwgeom_free(geom_a);
+		lwgeom_free(geom_b);
+		if (src_srs)
+			pfree(src_srs);
+		rt_raster_destroy(raster);
+		PG_FREE_IF_COPY(pgraster, 0);
+		PG_RETURN_BOOL(false);
+	}
+	dst_col = (int)floor(dst_x);
+	dst_row = (int)floor(dst_y);
+
+	dst_band = GDALGetRasterBand(dst_ds, 1);
+	cplerr = GDALRasterIO(dst_band, GF_Read, dst_col, dst_row, 1, 1, &visibility, 1, 1, GDT_Byte, 0, 0);
+
+	GDALClose(dst_ds);
+	VSIUnlink(dst_filename);
+	GDALClose(src_ds);
+	if (src_drv != NULL && destroy_src_drv)
+	{
+		GDALDeregisterDriver(src_drv);
+		GDALDestroyDriver(src_drv);
+	}
+	lwgeom_free(geom_a);
+	lwgeom_free(geom_b);
+	if (src_srs)
+		pfree(src_srs);
+	rt_raster_destroy(raster);
+	PG_FREE_IF_COPY(pgraster, 0);
+
+	if (cplerr != CE_None)
+		elog(ERROR, "%s: Could not read target cell from viewshed raster", __func__);
+
+	PG_RETURN_BOOL(visibility == 1);
+#endif
+}
 
 static int rtpg_util_gdal_progress_func(
 	double dfComplete,

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -4665,6 +4665,34 @@ CREATE OR REPLACE FUNCTION st_value(rast raster, pt geometry, exclude_nodata_val
     AS $$ SELECT @extschema@.ST_value($1, 1::integer, $2, $3, 'nearest'::text) $$
     LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE _COST_MEDIUM;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, band integer, pointa geometry, pointb geometry, curvature_coef double precision)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'RASTER_isVisible'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, pointa geometry, pointb geometry, curvature_coef double precision)
+	RETURNS boolean
+	AS $$ SELECT @extschema@.ST_IsVisible($1, 1::integer, $2, $3, $4) $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, band integer, pointa geometry, pointb geometry, curvature boolean DEFAULT false)
+	RETURNS boolean
+	AS $$ SELECT @extschema@.ST_IsVisible($1, $2, $3, $4, CASE WHEN $5 THEN 0.85714 ELSE 0.0 END::double precision) $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, pointa geometry, pointb geometry, curvature boolean DEFAULT false)
+	RETURNS boolean
+	AS $$ SELECT @extschema@.ST_IsVisible($1, 1::integer, $2, $3, $4) $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
 -- Availability: 3.2.0 added resample arg
 CREATE OR REPLACE FUNCTION st_setz(rast raster, geom geometry, resample text DEFAULT 'nearest', band integer default 1)
 	RETURNS geometry

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -4664,6 +4664,34 @@ CREATE OR REPLACE FUNCTION st_value(rast raster, pt geometry, exclude_nodata_val
     AS $$ SELECT @extschema@.ST_value($1, 1::integer, $2, $3, 'nearest'::text) $$
     LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE _COST_MEDIUM;
 
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, band integer, pointa geometry, pointb geometry, curvature_coef double precision)
+	RETURNS boolean
+	AS 'MODULE_PATHNAME', 'RASTER_isVisible'
+	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, pointa geometry, pointb geometry, curvature_coef double precision)
+	RETURNS boolean
+	AS $$ SELECT @extschema@.ST_IsVisible($1, 1::integer, $2, $3, $4) $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, band integer, pointa geometry, pointb geometry, curvature boolean DEFAULT false)
+	RETURNS boolean
+	AS $$ SELECT @extschema@.ST_IsVisible($1, $2, $3, $4, CASE WHEN $5 THEN 0.85714 ELSE 0.0 END::double precision) $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
+-- Availability: 3.7.0
+CREATE OR REPLACE FUNCTION ST_IsVisible(rast raster, pointa geometry, pointb geometry, curvature boolean DEFAULT false)
+	RETURNS boolean
+	AS $$ SELECT @extschema@.ST_IsVisible($1, 1::integer, $2, $3, $4) $$
+	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE
+	COST 10000;
+
 -- Availability: 3.2.0 added resample arg
 CREATE OR REPLACE FUNCTION st_setz(rast raster, geom geometry, resample text DEFAULT 'nearest', band integer default 1)
 	RETURNS geometry

--- a/raster/test/regress/rt_isvisible.sql
+++ b/raster/test/regress/rt_isvisible.sql
@@ -1,0 +1,141 @@
+SET postgis.gdal_enabled_drivers = 'GTiff';
+
+WITH dem AS (
+	SELECT ST_SetSRID(
+		ST_AddBand(
+			ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+			'32BF'::text, 0, NULL
+		),
+		3857
+	) AS rast
+)
+SELECT 'isvisible-flat',
+	ST_IsVisible(
+		rast,
+		ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+		ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857)
+	)
+FROM dem;
+
+WITH dem AS (
+	SELECT ST_SetSRID(
+		ST_AddBand(
+			ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+			'32BF'::text, 0, NULL
+		),
+		3857
+	) AS rast
+)
+SELECT 'isvisible-curvature-bool',
+	ST_IsVisible(
+		rast,
+		ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+		ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857),
+		true
+	)
+FROM dem;
+
+WITH dem AS (
+	SELECT ST_SetSRID(
+		ST_AddBand(
+			ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+			'32BF'::text, 0, NULL
+		),
+		3857
+	) AS rast
+)
+SELECT 'isvisible-curvature-coef',
+	ST_IsVisible(
+		rast,
+		ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+		ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857),
+		0.0::double precision
+	)
+FROM dem;
+
+WITH dem AS (
+	SELECT ST_SetSRID(
+		ST_AddBand(
+			ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+			'32BF'::text, 0, NULL
+		),
+		3857
+	) AS rast
+)
+SELECT 'isvisible-target-off-center',
+	ST_IsVisible(
+		rast,
+		ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+		ST_SetSRID(ST_PointZ(4.01, 2.99, 1), 3857)
+	)
+FROM dem;
+
+WITH dem AS (
+	SELECT ST_SetValue(
+		ST_SetSRID(
+			ST_AddBand(
+				ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+				'32BF'::text, 0, NULL
+			),
+			3857
+		),
+		1, 3, 3, 10
+	) AS rast
+)
+SELECT 'isvisible-blocked',
+	ST_IsVisible(
+		rast,
+		ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+		ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857)
+	)
+FROM dem;
+
+WITH dem AS (
+	SELECT ST_SetSRID(
+		ST_AddBand(
+			ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+			'32BF'::text, 0, NULL
+		),
+		3857
+	) AS rast
+)
+SELECT 'isvisible-band2',
+	ST_IsVisible(
+		rast,
+		2,
+		ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+		ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857)
+	)
+FROM dem;
+
+WITH dem AS (
+	SELECT ST_AddBand(
+		ST_MakeEmptyRaster(5, 1, 0, 1, 1, -1, 0, 0, 0),
+		'32BF'::text, 0, NULL
+	) AS rast
+)
+SELECT 'isvisible-srid',
+	ST_IsVisible(
+		rast,
+		ST_SetSRID(ST_PointZ(0.5, 0.5, 1), 4326),
+		ST_PointZ(4.5, 0.5, 1)
+	)
+FROM dem;
+
+WITH dem AS (
+	SELECT ST_SetSRID(
+		ST_AddBand(
+			ST_MakeEmptyRaster(5, 5, 0, 5, 1, -1, 0, 0, 0),
+			'32BF'::text, 0, NULL
+		),
+		3857
+	) AS rast
+)
+SELECT 'isvisible-curvature-nan',
+	ST_IsVisible(
+		rast,
+		ST_SetSRID(ST_PointZ(0.5, 2.5, 1), 3857),
+		ST_SetSRID(ST_PointZ(4.5, 2.5, 1), 3857),
+		'NaN'::double precision
+	)
+FROM dem;

--- a/raster/test/regress/rt_isvisible_expected
+++ b/raster/test/regress/rt_isvisible_expected
@@ -1,0 +1,8 @@
+isvisible-flat|t
+isvisible-curvature-bool|t
+isvisible-curvature-coef|t
+isvisible-target-off-center|t
+isvisible-blocked|f
+ERROR:  RASTER_isVisible: band number must be between 1 and 1 inclusive
+ERROR:  RASTER_isVisible: Raster and point geometries do not have the same SRID
+ERROR:  RASTER_isVisible: curvature coefficient must be finite and non-negative

--- a/raster/test/regress/tests.mk.in
+++ b/raster/test/regress/tests.mk.in
@@ -11,6 +11,7 @@
 # **********************************************************************
 
 POSTGIS_GEOS_VERSION=@POSTGIS_GEOS_VERSION@
+POSTGIS_GDAL_VERSION=@POSTGIS_GDAL_VERSION@
 
 override RUNTESTFLAGS := $(RUNTESTFLAGS) --raster
 
@@ -158,4 +159,9 @@ TESTS += $(RASTER_TESTS)
 ifeq ($(shell expr "$(POSTGIS_GEOS_VERSION)" ">=" 31400),1)
     TESTS += \
         $(top_srcdir)/raster/test/regress/rt_intersection_fractions
+endif
+
+ifeq ($(shell expr "$(POSTGIS_GDAL_VERSION)" ">=" 30101),1)
+    TESTS += \
+        $(top_srcdir)/raster/test/regress/rt_isvisible
 endif

--- a/raster/test/regress/tests.mk.in
+++ b/raster/test/regress/tests.mk.in
@@ -11,6 +11,7 @@
 # **********************************************************************
 
 POSTGIS_GEOS_VERSION=@POSTGIS_GEOS_VERSION@
+POSTGIS_GDAL_VERSION=@POSTGIS_GDAL_VERSION@
 
 override RUNTESTFLAGS := $(RUNTESTFLAGS) --raster
 
@@ -160,4 +161,9 @@ TESTS += $(RASTER_TESTS)
 ifeq ($(shell expr "$(POSTGIS_GEOS_VERSION)" ">=" 31400),1)
     TESTS += \
         $(top_srcdir)/raster/test/regress/rt_intersection_fractions
+endif
+
+ifeq ($(shell expr "$(POSTGIS_GDAL_VERSION)" ">=" 30101),1)
+    TESTS += \
+        $(top_srcdir)/raster/test/regress/rt_isvisible
 endif


### PR DESCRIPTION
## Summary

Adds `ST_IsVisible` for raster DEM line-of-sight checks, closing https://trac.osgeo.org/postgis/ticket/2596.

The new raster function:
- tests whether point B is visible from point A using a raster band as DEM input
- supports the ticket-shaped `curvature boolean DEFAULT false` overload
- also exposes an explicit `curvature_coef double precision` overload for callers who need GDAL's coefficient directly
- uses point Z values as observer/target heights above the DEM surface
- documents GDAL viewshed caveats: projected CRS behavior, no special input nodata handling, and `GTiff` driver requirement

## Notes

Implementation uses GDAL `GDALViewshedGenerate`, writing the temporary viewshed raster to `/vsimem` via the `GTiff` driver. The implementation is gated to GDAL 3.1.1 and newer to avoid GDAL 3.1.0 viewshed coordinate snapping behavior; the `rt_isvisible` regression is gated the same way.

The viewshed range is padded by a half-cell reach so a target point away from its pixel center still includes the sampled target cell.

## Validation

- `/usr/bin/perl ./utils/repo_revision.pl`
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `git clang-format --diff upstream/master -- raster/rt_pg/rtpg_gdal.c`
- `make -C raster/rt_pg -j32`
- `sudo -n make -C raster/rt_pg install`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --raster" TESTS="$(pwd)/raster/test/regress/rt_isvisible"` (fresh and automatic-upgrade runs passed)
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`

Trac: https://trac.osgeo.org/postgis/ticket/2596
