### PR TITLE
Preserve geography expansion across serialization

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -87,6 +87,8 @@ These are only changes since 3.7.0alpha1.
           safely (Darafei Praliaskouski)
  - #6092, [fuzzingengine] fuzzingengine doesn't use hardening CPPFLAGS
             (Bas Couwenberg)
+ - #4122, Preserve geography _ST_Expand index filtering across text and
+          binary serialization round trips (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/postgis/geography.sql.in
+++ b/postgis/geography.sql.in
@@ -504,7 +504,7 @@ CREATE OR REPLACE FUNCTION ST_Distance(text, text)
 	$$ SELECT @extschema@.ST_Distance($1::@extschema@.geometry, $2::@extschema@.geometry);  $$
 	LANGUAGE 'sql' IMMUTABLE STRICT PARALLEL SAFE;
 
--- Only expands the bounding box, the actual geometry will remain unchanged, use with care.
+-- Expands the geocentric bounding box and returns a geography carrier for index filtering, use with care.
 -- Availability: 1.5.0
 CREATE OR REPLACE FUNCTION _ST_Expand(geography, float8)
 	RETURNS geography

--- a/postgis/geography_measurement.c
+++ b/postgis/geography_measurement.c
@@ -441,21 +441,212 @@ Datum geography_dwithin_uncached(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(distance <= tolerance);
 }
 
-
 /*
 ** geography_expand(GSERIALIZED *g) returns *GSERIALIZED
 **
-** warning, this tricky little function does not expand the
-** geometry at all, just re-writes bounding box value to be
-** a bit bigger. only useful when passing the result along to
-** an index operator (&&)
+** This internal helper expands the geocentric bounds used by geography indexes.
+** The returned geography is a multipoint surrogate whose calculated geocentric
+** box matches the expanded bounds so text and binary datum serialization keep
+** the same index-filter behavior after a round trip.
 */
+static double
+geography_expand_clamp(double v, double min, double max)
+{
+	if (v < min)
+		return min;
+	if (v > max)
+		return max;
+	return v;
+}
+
+static int
+geography_expand_try_axis_pair(double a, double radius2, double bmin, double bmax, double *b)
+{
+	double b_abs;
+
+	if (fabs(a) > 1.0 || a * a > radius2)
+		return LW_FALSE;
+
+	b_abs = sqrt(radius2 - a * a);
+	if (b_abs >= bmin && b_abs <= bmax)
+	{
+		*b = b_abs;
+		return LW_TRUE;
+	}
+
+	if (-b_abs >= bmin && -b_abs <= bmax)
+	{
+		*b = -b_abs;
+		return LW_TRUE;
+	}
+
+	return LW_FALSE;
+}
+
+static double
+geography_expand_interval_delta(double v, double min, double max)
+{
+	if (v < min)
+		return min - v;
+	if (v > max)
+		return v - max;
+	return 0.0;
+}
+
+static void
+geography_expand_box_axis_pair(double radius2, double amin, double amax, double bmin, double bmax, double *a, double *b)
+{
+	double candidates[10];
+	int candidate_count = 0;
+	double best_a = 0.0;
+	double best_b = 0.0;
+	double best_score = DBL_MAX;
+	int i;
+
+	candidates[candidate_count++] = geography_expand_clamp(0.0, amin, amax);
+	candidates[candidate_count++] = amin;
+	candidates[candidate_count++] = amax;
+
+	if (radius2 >= bmin * bmin)
+	{
+		double v = sqrt(radius2 - bmin * bmin);
+		candidates[candidate_count++] = v;
+		candidates[candidate_count++] = -v;
+	}
+
+	if (radius2 >= bmax * bmax)
+	{
+		double v = sqrt(radius2 - bmax * bmax);
+		candidates[candidate_count++] = v;
+		candidates[candidate_count++] = -v;
+	}
+
+	candidates[candidate_count++] = sqrt(radius2);
+	candidates[candidate_count++] = -sqrt(radius2);
+
+	for (i = 0; i < candidate_count; i++)
+	{
+		double candidate = candidates[i];
+		if (candidate < amin || candidate > amax)
+			continue;
+		if (geography_expand_try_axis_pair(candidate, radius2, bmin, bmax, b))
+		{
+			*a = candidate;
+			return;
+		}
+	}
+
+	/*
+	 * There may be no unit-circle point with both coordinates inside the
+	 * independently expanded off-axis intervals.  Keep the target-axis
+	 * extremum exact and choose the nearest unit-circle point rather than
+	 * clamping to a non-unit vector that cart2geog() would normalize inward.
+	 */
+	for (i = 0; i < candidate_count; i++)
+	{
+		double candidate = candidates[i];
+		double b_abs;
+		int sign;
+
+		if (fabs(candidate) > 1.0 || candidate * candidate > radius2)
+			continue;
+
+		b_abs = sqrt(radius2 - candidate * candidate);
+		for (sign = -1; sign <= 1; sign += 2)
+		{
+			double b_candidate = sign * b_abs;
+			double a_delta = geography_expand_interval_delta(candidate, amin, amax);
+			double b_delta = geography_expand_interval_delta(b_candidate, bmin, bmax);
+			double score = a_delta * a_delta + b_delta * b_delta;
+
+			if (score < best_score)
+			{
+				best_score = score;
+				best_a = candidate;
+				best_b = b_candidate;
+			}
+		}
+	}
+
+	*a = best_a;
+	*b = best_b;
+}
+
+static POINT3D
+geography_expand_box_axis_point(const GBOX *gbox, double v, int axis)
+{
+	POINT3D p = {0.0, 0.0, 0.0};
+	double radius2;
+
+	v = geography_expand_clamp(v, -1.0, 1.0);
+	radius2 = 1.0 - v * v;
+
+	switch (axis)
+	{
+	case 0:
+		p.x = v;
+		geography_expand_box_axis_pair(radius2, gbox->ymin, gbox->ymax, gbox->zmin, gbox->zmax, &p.y, &p.z);
+		break;
+	case 1:
+		p.y = v;
+		geography_expand_box_axis_pair(radius2, gbox->xmin, gbox->xmax, gbox->zmin, gbox->zmax, &p.x, &p.z);
+		break;
+	default:
+		p.z = v;
+		geography_expand_box_axis_pair(radius2, gbox->xmin, gbox->xmax, gbox->ymin, gbox->ymax, &p.x, &p.y);
+		break;
+	}
+
+	return p;
+}
+
+static LWPOINT *
+geography_expand_box_lwpoint(const GBOX *gbox, double v, int axis, int32_t srid)
+{
+	POINT3D cart = geography_expand_box_axis_point(gbox, v, axis);
+	GEOGRAPHIC_POINT geog;
+	POINT4D point = {0.0, 0.0, 0.0, 0.0};
+
+	cart2geog(&cart, &geog);
+	point.x = rad2deg(geog.lon);
+	point.y = rad2deg(geog.lat);
+
+	return lwpoint_make(srid, LW_FALSE, LW_FALSE, &point);
+}
+
+static GSERIALIZED *
+geography_expand_box_to_multipoint(const GBOX *gbox, int32_t srid)
+{
+	enum
+	{
+		NUM_AXIS_EXTREMES = 6
+	};
+	LWGEOM **points = lwalloc(sizeof(LWGEOM *) * NUM_AXIS_EXTREMES);
+	LWCOLLECTION *mpoint;
+	GSERIALIZED *g_out;
+
+	points[0] = lwpoint_as_lwgeom(geography_expand_box_lwpoint(gbox, gbox->xmin, 0, srid));
+	points[1] = lwpoint_as_lwgeom(geography_expand_box_lwpoint(gbox, gbox->xmax, 0, srid));
+	points[2] = lwpoint_as_lwgeom(geography_expand_box_lwpoint(gbox, gbox->ymin, 1, srid));
+	points[3] = lwpoint_as_lwgeom(geography_expand_box_lwpoint(gbox, gbox->ymax, 1, srid));
+	points[4] = lwpoint_as_lwgeom(geography_expand_box_lwpoint(gbox, gbox->zmin, 2, srid));
+	points[5] = lwpoint_as_lwgeom(geography_expand_box_lwpoint(gbox, gbox->zmax, 2, srid));
+
+	mpoint = lwcollection_construct(MULTIPOINTTYPE, srid, NULL, NUM_AXIS_EXTREMES, points);
+	lwgeom_set_geodetic(lwcollection_as_lwgeom(mpoint), true);
+	g_out = geography_serialize(lwcollection_as_lwgeom(mpoint));
+	lwcollection_free(mpoint);
+
+	return g_out;
+}
+
 PG_FUNCTION_INFO_V1(geography_expand);
 Datum geography_expand(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *g = NULL;
-	GSERIALIZED *g_out = NULL;
+	GBOX gbox;
 	double unit_distance, distance;
+	int32_t srid;
 
 	/* Get a wholly-owned pointer to the geography */
 	g = PG_GETARG_GSERIALIZED_P_COPY(0);
@@ -467,21 +658,19 @@ Datum geography_expand(PG_FUNCTION_ARGS)
 	/* calculated on sphere */
 	unit_distance = 1.01 * distance / WGS84_RADIUS;
 
-	/* Try the expansion */
-	g_out = gserialized_expand(g, unit_distance);
-
-	/* If the expansion fails, the return our input */
-	if ( g_out == NULL )
+	if (gserialized_get_gbox_p(g, &gbox) == LW_FAILURE)
 	{
 		PG_RETURN_POINTER(g);
 	}
 
-	if ( g_out != g )
-	{
-		pfree(g);
-	}
+	if (unit_distance <= 0.0)
+		PG_RETURN_POINTER(g);
 
-	PG_RETURN_POINTER(g_out);
+	gbox_expand(&gbox, unit_distance);
+	srid = gserialized_get_srid(g);
+	pfree(g);
+
+	PG_RETURN_POINTER(geography_expand_box_to_multipoint(&gbox, srid));
 }
 
 /*

--- a/regress/core/geography.sql
+++ b/regress/core/geography.sql
@@ -125,6 +125,31 @@ select 'dwithin_poly_poly_1', ST_DWithin('POLYGON((0 0, -2 -2, -3 0, 0 0))'::geo
 select 'dwithin_poly_poly_2', ST_DWithin('POLYGON((0 0, -2 -2, -3 0, 0 0))'::geography, 'POLYGON((1 1, 2 2, 3 0, 1 1))'::geography, 300000);
 select 'dwithin_poly_poly_3', ST_DWithin('POLYGON((1 1, -2 -2, -3 0, 1 1))'::geography, 'POLYGON((1 1, 2 2, 3 0, 1 1))'::geography, 300000);
 
+WITH expanded AS (
+	SELECT _ST_Expand('POINT(-74.028349 40.737980)'::geography, 10000) AS geog
+)
+SELECT '#4122',
+       pg_typeof(geog),
+       near_probe && geog,
+       near_probe && geog::text::geography,
+       near_probe && geog::bytea::geography,
+       far_probe && geog,
+       far_probe && geog::text::geography,
+       far_probe && geog::bytea::geography
+FROM expanded,
+     (SELECT 'POINT(-73.95 40.737980)'::geography AS near_probe,
+             'POINT(-10 0)'::geography AS far_probe) AS p;
+
+WITH expanded AS (
+	SELECT _ST_Expand('POINT(112.43006556 -20.55138435)'::geography, 496381) AS geog
+)
+SELECT '#4122-expanded-carrier',
+       probe && geog,
+       probe && geog::text::geography,
+       probe && geog::bytea::geography
+FROM expanded,
+     (SELECT 'POINT(116.13433622 -23.40307415)'::geography AS probe) AS p;
+
 
 -- Linear Referencing functions
 -- #5456 garden crash

--- a/regress/core/geography_expected
+++ b/regress/core/geography_expected
@@ -49,6 +49,8 @@ dwithin_poly_line_1|t
 dwithin_poly_poly_1|f
 dwithin_poly_poly_2|t
 dwithin_poly_poly_3|t
+#4122|geography|t|t|t|f|f|f
+#4122-expanded-carrier|t|t|t
 #5456|0
 lrs_empty_1|
 lrs_empty_2|


### PR DESCRIPTION
## Summary

- make geography `_ST_Expand` return a serialization-stable multipoint carrier for expanded geocentric index bounds
- choose carrier points whose off-axis coordinates stay inside the expanded bounds when possible, preserving index selectivity
- keep the fallback carrier points on the unit sphere so `cart2geog()` does not normalize requested extrema inward
- keep non-positive expansions as the original geography
- add regression coverage for text and binary geography round trips, including far probes that must stay outside the expanded box and the shrinking case from the review

Closes https://trac.osgeo.org/postgis/ticket/4122

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `/usr/bin/perl ./utils/repo_revision.pl`
- `make postgis_revision.h`
- `make -C postgis -j32`
- `sudo -n make -C postgis install`
- `make -C extensions postgis_extension_helper.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C extensions/postgis install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/geography"`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/geography"`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- postgis/geography_measurement.c postgis/geography.sql.in regress/core/geography.sql regress/core/geography_expected NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
