### PR TITLE
Move typmod bit helpers into libpgcommon

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Enhancements *
 
+ - #3158, Move geometry and geography typmod bit helpers out of the
+          public liblwgeom header (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks

--- a/liblwgeom/cunit/cu_gserialized1.c
+++ b/liblwgeom/cunit/cu_gserialized1.c
@@ -18,61 +18,6 @@
 #include "gserialized1.c" /* for gserialized_peek_gbox_p */
 #include "cu_tester.h"
 
-static void test_typmod_macros(void)
-{
-	int32_t typmod = 0;
-	int32_t srid = 4326;
-	int type = 6;
-	int z = 1;
-	int rv;
-
-	TYPMOD_SET_SRID(typmod,srid);
-	rv = TYPMOD_GET_SRID(typmod);
-	CU_ASSERT_EQUAL(rv, srid);
-
-	srid = -5005;
-	TYPMOD_SET_SRID(typmod,srid);
-	rv = TYPMOD_GET_SRID(typmod);
-	CU_ASSERT_EQUAL(rv, srid);
-
-        srid = 999999;
-        TYPMOD_SET_SRID(typmod,srid);
-        rv = TYPMOD_GET_SRID(typmod);
-        CU_ASSERT_EQUAL(rv, srid);
-
-        srid = -999999;
-        TYPMOD_SET_SRID(typmod,srid);
-        rv = TYPMOD_GET_SRID(typmod);
-        CU_ASSERT_EQUAL(rv, srid);
-
-	srid = SRID_UNKNOWN;
-	TYPMOD_SET_SRID(typmod,srid);
-	rv = TYPMOD_GET_SRID(typmod);
-	CU_ASSERT_EQUAL(rv, srid);
-
-	srid = 0;
-	TYPMOD_SET_SRID(typmod,srid);
-	rv = TYPMOD_GET_SRID(typmod);
-	CU_ASSERT_EQUAL(rv, srid);
-
-	srid = 1;
-	TYPMOD_SET_SRID(typmod,srid);
-	rv = TYPMOD_GET_SRID(typmod);
-	CU_ASSERT_EQUAL(rv, srid);
-
-	TYPMOD_SET_TYPE(typmod,type);
-	rv = TYPMOD_GET_TYPE(typmod);
-	CU_ASSERT_EQUAL(rv,type);
-
-	TYPMOD_SET_Z(typmod);
-	rv = TYPMOD_GET_Z(typmod);
-	CU_ASSERT_EQUAL(rv,z);
-
-	rv = TYPMOD_GET_M(typmod);
-	CU_ASSERT_EQUAL(rv,0);
-
-}
-
 static void test_flags_macros(void)
 {
 	uint8_t flags = 0;
@@ -1282,7 +1227,6 @@ void gserialized1_suite_setup(void);
 void gserialized1_suite_setup(void)
 {
 	CU_pSuite suite = CU_add_suite("serialization/deserialization v1", NULL, NULL);
-	PG_ADD_TEST(suite, test_typmod_macros);
 	PG_ADD_TEST(suite, test_flags_macros);
 	PG_ADD_TEST(suite, test_serialized1_srid);
 	PG_ADD_TEST(suite, test_gserialized1_from_lwgeom_size);

--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -182,25 +182,6 @@ typedef enum LWORD_T {
 #define FLAGS_NDIMS_BOX(flags) (FLAGS_GET_GEODETIC(flags) ? 3 : FLAGS_NDIMS(flags))
 
 /**
-* Macros for manipulating the 'typemod' int. An int32_t used as follows:
-* Plus/minus = Top bit.
-* Spare bits = Next 2 bits.
-* SRID = Next 21 bits.
-* TYPE = Next 6 bits.
-* ZM Flags = Bottom 2 bits.
-*/
-
-#define TYPMOD_GET_SRID(typmod) ((((typmod) & 0x0FFFFF00) - ((typmod) & 0x10000000)) >> 8)
-#define TYPMOD_SET_SRID(typmod, srid) ((typmod) = (((typmod) & 0xE00000FF) | ((srid & 0x001FFFFF)<<8)))
-#define TYPMOD_GET_TYPE(typmod) ((typmod & 0x000000FC)>>2)
-#define TYPMOD_SET_TYPE(typmod, type) ((typmod) = (typmod & 0xFFFFFF03) | ((type & 0x0000003F)<<2))
-#define TYPMOD_GET_Z(typmod) ((typmod & 0x00000002)>>1)
-#define TYPMOD_SET_Z(typmod) ((typmod) = typmod | 0x00000002)
-#define TYPMOD_GET_M(typmod) (typmod & 0x00000001)
-#define TYPMOD_SET_M(typmod) ((typmod) = typmod | 0x00000001)
-#define TYPMOD_GET_NDIMS(typmod) (2+TYPMOD_GET_Z(typmod)+TYPMOD_GET_M(typmod))
-
-/**
 * Maximum allowed SRID value in serialized geometry.
 * Currently we are using 21 bits (2097152) of storage for SRID.
 */

--- a/libpgcommon/Makefile.in
+++ b/libpgcommon/Makefile.in
@@ -32,6 +32,7 @@ SA_OBJS = \
 
 SA_HEADERS = \
 	lwgeom_pg.h \
+	lwgeom_pg_typmod.h \
 	lwgeom_transform.h \
 	lwgeom_cache.h \
 	gserialized_gist.h
@@ -68,4 +69,3 @@ $(SA_OBJS): %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(SA_OBJS): ../postgis_config.h
-

--- a/libpgcommon/lwgeom_pg_typmod.h
+++ b/libpgcommon/lwgeom_pg_typmod.h
@@ -1,0 +1,50 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * This file is part of PostGIS
+ *
+ * PostGIS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PostGIS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************
+ *
+ * Copyright 2026 Darafei Praliaskouski <me@komzpa.net>
+ *
+ **********************************************************************/
+
+#ifndef LWGEOM_PG_TYPMOD_H
+#define LWGEOM_PG_TYPMOD_H 1
+
+/*
+ * Macros for manipulating the PostgreSQL typmod int32_t used by the
+ * PostGIS geometry and geography types:
+ *
+ * Plus/minus = Top bit.
+ * Spare bits = Next 2 bits.
+ * SRID = Next 21 bits.
+ * TYPE = Next 6 bits.
+ * ZM Flags = Bottom 2 bits.
+ */
+#define TYPMOD_GET_SRID(typmod) ((((typmod) & 0x0FFFFF00) - ((typmod) & 0x10000000)) >> 8)
+#define TYPMOD_SET_SRID(typmod, srid) ((typmod) = (((typmod) & 0xE00000FF) | ((srid & 0x001FFFFF) << 8)))
+#define TYPMOD_GET_TYPE(typmod) (((typmod) & 0x000000FC) >> 2)
+#define TYPMOD_SET_TYPE(typmod, type) ((typmod) = ((typmod) & 0xFFFFFF03) | (((type) & 0x0000003F) << 2))
+#define TYPMOD_GET_Z(typmod) (((typmod) & 0x00000002) >> 1)
+#define TYPMOD_SET_Z(typmod) ((typmod) = (typmod) | 0x00000002)
+#define TYPMOD_GET_M(typmod) ((typmod) & 0x00000001)
+#define TYPMOD_SET_M(typmod) ((typmod) = (typmod) | 0x00000001)
+#define TYPMOD_GET_NDIMS(typmod) (2 + TYPMOD_GET_Z(typmod) + TYPMOD_GET_M(typmod))
+
+#endif /* LWGEOM_PG_TYPMOD_H */

--- a/postgis/Makefile.in
+++ b/postgis/Makefile.in
@@ -273,6 +273,7 @@ distclean: clean
 	if [ -e "cunit/Makefile" ]; then make -C cunit distclean; fi
 
 check-unit:
+	$(MAKE) -C cunit check
 
 check-regress:
 

--- a/postgis/cunit/cu_tester.c
+++ b/postgis/cunit/cu_tester.c
@@ -20,7 +20,7 @@
  *
  **********************************************************************
  *
- * Copyright 2025 (C) Darafei Praliaskouski <me@komzpa.net>
+ * Copyright 2025-2026 (C) Darafei Praliaskouski <me@komzpa.net>
  *
  **********************************************************************/
 
@@ -31,6 +31,8 @@
 #include <math.h>
 #include <string.h>
 
+#include "liblwgeom.h"
+#include "lwgeom_pg_typmod.h"
 #include "../gserialized_estimate_support.h"
 
 static ND_BOX
@@ -48,6 +50,65 @@ make_box(float minx, float miny, float minz, float minm, float maxx, float maxy,
 	box.max[2] = maxz;
 	box.max[3] = maxm;
 	return box;
+}
+
+static void
+typmod_bitfield_roundtrip(void)
+{
+	int32_t typmod = 0;
+	int32_t srid = 4326;
+	int type = 6;
+	int z = 1;
+	int rv;
+
+	TYPMOD_SET_SRID(typmod, srid);
+	rv = TYPMOD_GET_SRID(typmod);
+	CU_ASSERT_EQUAL(rv, srid);
+
+	srid = -5005;
+	TYPMOD_SET_SRID(typmod, srid);
+	rv = TYPMOD_GET_SRID(typmod);
+	CU_ASSERT_EQUAL(rv, srid);
+
+	srid = 999999;
+	TYPMOD_SET_SRID(typmod, srid);
+	rv = TYPMOD_GET_SRID(typmod);
+	CU_ASSERT_EQUAL(rv, srid);
+
+	srid = -999999;
+	TYPMOD_SET_SRID(typmod, srid);
+	rv = TYPMOD_GET_SRID(typmod);
+	CU_ASSERT_EQUAL(rv, srid);
+
+	srid = SRID_UNKNOWN;
+	TYPMOD_SET_SRID(typmod, srid);
+	rv = TYPMOD_GET_SRID(typmod);
+	CU_ASSERT_EQUAL(rv, srid);
+
+	srid = 0;
+	TYPMOD_SET_SRID(typmod, srid);
+	rv = TYPMOD_GET_SRID(typmod);
+	CU_ASSERT_EQUAL(rv, srid);
+
+	srid = 1;
+	TYPMOD_SET_SRID(typmod, srid);
+	rv = TYPMOD_GET_SRID(typmod);
+	CU_ASSERT_EQUAL(rv, srid);
+
+	TYPMOD_SET_TYPE(typmod, type);
+	rv = TYPMOD_GET_TYPE(typmod);
+	CU_ASSERT_EQUAL(rv, type);
+
+	TYPMOD_SET_Z(typmod);
+	rv = TYPMOD_GET_Z(typmod);
+	CU_ASSERT_EQUAL(rv, z);
+
+	rv = TYPMOD_GET_M(typmod);
+	CU_ASSERT_EQUAL(rv, 0);
+
+	TYPMOD_SET_M(typmod);
+	rv = TYPMOD_GET_M(typmod);
+	CU_ASSERT_EQUAL(rv, 1);
 }
 
 static void
@@ -151,11 +212,12 @@ main(void)
 	if (CU_initialize_registry() != CUE_SUCCESS)
 		return CU_get_error();
 
-	suite = CU_add_suite("gserialized_histogram_helpers", NULL, NULL);
+	suite = CU_add_suite("postgis_helpers", NULL, NULL);
 	if (!suite)
 		goto cleanup;
 
-	if (!CU_add_test(suite, "histogram budget clamps", histogram_budget_clamps) ||
+	if (!CU_add_test(suite, "typmod bitfield roundtrip", typmod_bitfield_roundtrip) ||
+	    !CU_add_test(suite, "histogram budget clamps", histogram_budget_clamps) ||
 	    !CU_add_test(suite, "histogram axis guards", histogram_axis_allocation_guards) ||
 	    !CU_add_test(suite, "nd_stats value index guards", nd_stats_indexing_behaviour) ||
 	    !CU_add_test(suite, "nd_box ratio edge cases", nd_box_ratio_cases))

--- a/postgis/gserialized_typmod.c
+++ b/postgis/gserialized_typmod.c
@@ -41,10 +41,10 @@
 #include "catalog/pg_type.h" /* for CSTRINGOID */
 
 #include "liblwgeom.h"         /* For standard geometry types. */
-#include "lwgeom_pg.h"       /* For debugging macros. */
-#include "geography.h"	     /* For utility functions. */
-#include "lwgeom_transform.h" /* for srid_is_latlon */
-
+#include "lwgeom_pg.h"         /* For debugging macros. */
+#include "lwgeom_pg_typmod.h"  /* For typmod bit-field accessors. */
+#include "geography.h"         /* For utility functions. */
+#include "lwgeom_transform.h"  /* for srid_is_latlon */
 
 Datum geography_typmod_in(PG_FUNCTION_ARGS);
 Datum geometry_typmod_in(PG_FUNCTION_ARGS);
@@ -462,4 +462,3 @@ Datum postgis_typmod_srid(PG_FUNCTION_ARGS)
 		PG_RETURN_INT32(0);
 	PG_RETURN_INT32(TYPMOD_GET_SRID(typmod));
 }
-


### PR DESCRIPTION
## Summary
- Move PostGIS typmod bit-field helpers from the public liblwgeom header to libpgcommon.
- Include the helper header explicitly from the geometry/geography typmod implementation.
- Relocate the typmod macro CUnit coverage from liblwgeom to postgis/cunit.

Trac ticket: https://trac.osgeo.org/postgis/ticket/3158

## Validation
- ./autogen.sh
- ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal
- make -C liblwgeom -j8
- make -C libpgcommon -j8
- make -C postgis -j8
- ./liblwgeom/cunit/cu_tester "serialization/deserialization v1"
- make -C postgis/cunit check
- ./utils/check_news.sh .
- git clang-format upstream/master -- libpgcommon/lwgeom_pg_typmod.h postgis/cunit/cu_tester.c postgis/gserialized_typmod.c liblwgeom/cunit/cu_gserialized1.c
- git diff --check