### PR TITLE
Add raster focal shape statistics helpers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,8 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #2310, #2311, #2312, [raster] Add ST_Wedge, ST_Annulus, and ST_Circle
+          focal statistics helpers (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta1
 2026/07/20
@@ -170,9 +172,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           prefer requested CXX over pg_config --cc for internal C++ checks, and
           make fuzzer linking/runtime dependency packaging portable
           (Darafei Praliaskouski)
- - #2310, #2311, #2312, [raster] Add ST_Wedge, ST_Annulus, and ST_Circle
-          focal statistics helpers (Darafei Praliaskouski)
-
 * Enhancements *
 
  - #2045, pgsql2shp query dumps no longer require temporary table

--- a/NEWS
+++ b/NEWS
@@ -170,6 +170,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           prefer requested CXX over pg_config --cc for internal C++ checks, and
           make fuzzer linking/runtime dependency packaging portable
           (Darafei Praliaskouski)
+ - #2310, #2311, #2312, [raster] Add ST_Wedge, ST_Annulus, and ST_Circle
+          focal statistics helpers (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #2310, #2311, #2312, [raster] Add ST_Wedge, ST_Annulus, and
+          ST_Circle focal statistics helpers (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -10328,10 +10328,167 @@ WHERE t1.rid = 1
                     <para>
                         <xref linkend="rastbandarg"/>,
                         <xref linkend="RT_ST_Union"/>,
+                        <xref linkend="RT_ST_Circle"/>,
+                        <xref linkend="RT_ST_Annulus"/>,
+                        <xref linkend="RT_ST_Wedge"/>,
                         <xref linkend="RT_ST_MapAlgebra_expr"/>
                     </para>
                 </refsection>
 
+            </refentry>
+
+            <refentry xml:id="RT_ST_Circle">
+                <refnamediv>
+                    <refname>ST_Circle</refname>
+                    <refpurpose>Returns focal statistics over a circular neighborhood.</refpurpose>
+                </refnamediv>
+
+                <refsynopsisdiv>
+                    <funcsynopsis>
+                        <funcprototype>
+                            <funcdef>raster <function>ST_Circle</function></funcdef>
+                            <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>nband</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>radius</parameter></paramdef>
+                            <paramdef><type>text </type> <parameter>operation</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>pixeltype=NULL</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>extenttype=INTERSECTION</parameter></paramdef>
+                            <paramdef choice="opt"><type>raster </type> <parameter>customextent=NULL</parameter></paramdef>
+                        </funcprototype>
+                    </funcsynopsis>
+                </refsynopsisdiv>
+
+                <refsection>
+                    <title>Description</title>
+                    <para>Applies one of the built-in focal-statistics operations to each pixel using a circular mask centered on that pixel. The supported operations are <code>MAX</code>, <code>MEAN</code>, <code>MIN</code>, <code>RANGE</code>, <code>STDDEV</code>, <code>SUM</code>, and <code>DISTINCT</code>.</para>
+                    <para>This is a convenience wrapper around <xref linkend="RT_ST_MapAlgebra"/> using the callback-function variant with a generated mask.</para>
+                    <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                </refsection>
+
+                <refsection>
+                    <title>Examples</title>
+                    <programlisting>
+WITH test AS (
+    SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI', 1, 0) AS rast
+)
+SELECT ST_Value(ST_Circle(rast, 1, 1, 'SUM', '32BF'), 3, 3)
+FROM test;
+-- 5
+                    </programlisting>
+                </refsection>
+
+                <refsection>
+                    <title>See Also</title>
+                    <para>
+                        <xref linkend="RT_ST_Annulus"/>,
+                        <xref linkend="RT_ST_Wedge"/>,
+                        <xref linkend="RT_ST_MapAlgebra"/>
+                    </para>
+                </refsection>
+            </refentry>
+
+            <refentry xml:id="RT_ST_Annulus">
+                <refnamediv>
+                    <refname>ST_Annulus</refname>
+                    <refpurpose>Returns focal statistics over an annular neighborhood.</refpurpose>
+                </refnamediv>
+
+                <refsynopsisdiv>
+                    <funcsynopsis>
+                        <funcprototype>
+                            <funcdef>raster <function>ST_Annulus</function></funcdef>
+                            <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>nband</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>innerradius</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>outerradius</parameter></paramdef>
+                            <paramdef><type>text </type> <parameter>operation</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>pixeltype=NULL</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>extenttype=INTERSECTION</parameter></paramdef>
+                            <paramdef choice="opt"><type>raster </type> <parameter>customextent=NULL</parameter></paramdef>
+                        </funcprototype>
+                    </funcsynopsis>
+                </refsynopsisdiv>
+
+                <refsection>
+                    <title>Description</title>
+                    <para>Applies one of the built-in focal-statistics operations to each pixel using an annulus mask centered on that pixel. Pixels whose distance from the center pixel is between <varname>innerradius</varname> and <varname>outerradius</varname> are included.</para>
+                    <para>Supported operations are <code>MAX</code>, <code>MEAN</code>, <code>MIN</code>, <code>RANGE</code>, <code>STDDEV</code>, <code>SUM</code>, and <code>DISTINCT</code>.</para>
+                    <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                </refsection>
+
+                <refsection>
+                    <title>Examples</title>
+                    <programlisting>
+WITH test AS (
+    SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI', 1, 0) AS rast
+)
+SELECT ST_Value(ST_Annulus(rast, 1, 1, 2, 'SUM', '32BF'), 3, 3)
+FROM test;
+-- 12
+                    </programlisting>
+                </refsection>
+
+                <refsection>
+                    <title>See Also</title>
+                    <para>
+                        <xref linkend="RT_ST_Circle"/>,
+                        <xref linkend="RT_ST_Wedge"/>,
+                        <xref linkend="RT_ST_MapAlgebra"/>
+                    </para>
+                </refsection>
+            </refentry>
+
+            <refentry xml:id="RT_ST_Wedge">
+                <refnamediv>
+                    <refname>ST_Wedge</refname>
+                    <refpurpose>Returns focal statistics over a wedge-shaped neighborhood.</refpurpose>
+                </refnamediv>
+
+                <refsynopsisdiv>
+                    <funcsynopsis>
+                        <funcprototype>
+                            <funcdef>raster <function>ST_Wedge</function></funcdef>
+                            <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>nband</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>innerradius</parameter></paramdef>
+                            <paramdef><type>integer </type> <parameter>outerradius</parameter></paramdef>
+                            <paramdef><type>double precision </type> <parameter>thetastart</parameter></paramdef>
+                            <paramdef><type>double precision </type> <parameter>thetaend</parameter></paramdef>
+                            <paramdef><type>text </type> <parameter>operation</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>pixeltype=NULL</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>extenttype=INTERSECTION</parameter></paramdef>
+                            <paramdef choice="opt"><type>raster </type> <parameter>customextent=NULL</parameter></paramdef>
+                        </funcprototype>
+                    </funcsynopsis>
+                </refsynopsisdiv>
+
+                <refsection>
+                    <title>Description</title>
+                    <para>Applies one of the built-in focal-statistics operations to each pixel using a wedge mask centered on that pixel. Angles are in radians, measured clockwise from the positive Y axis. The start angle is inclusive and <varname>thetaend</varname> must be greater than <varname>thetastart</varname>.</para>
+                    <para>Supported operations are <code>MAX</code>, <code>MEAN</code>, <code>MIN</code>, <code>RANGE</code>, <code>STDDEV</code>, <code>SUM</code>, and <code>DISTINCT</code>.</para>
+                    <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                </refsection>
+
+                <refsection>
+                    <title>Examples</title>
+                    <programlisting>
+WITH test AS (
+    SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI', 1, 0) AS rast
+)
+SELECT ST_Value(ST_Wedge(rast, 1, 0, 1, 0, pi(), 'SUM', '32BF'), 3, 3)
+FROM test;
+-- 4
+                    </programlisting>
+                </refsection>
+
+                <refsection>
+                    <title>See Also</title>
+                    <para>
+                        <xref linkend="RT_ST_Circle"/>,
+                        <xref linkend="RT_ST_Annulus"/>,
+                        <xref linkend="RT_ST_MapAlgebra"/>
+                    </para>
+                </refsection>
             </refentry>
 
             <refentry xml:id="RT_ST_MapAlgebra_expr">

--- a/raster/rt_core/rt_mapalgebra.c
+++ b/raster/rt_core/rt_mapalgebra.c
@@ -1274,7 +1274,8 @@ rt_raster_iterator(
 				/* neighborhood */
 				npixels = NULL;
 				status = 0;
-				if (distancex > 0 && distancey > 0) {
+				if (distancex > 0 || distancey > 0)
+				{
 					RASTER_DEBUG(4, "getting neighborhood");
 
 					status = rt_band_get_nearest_pixel(

--- a/raster/rt_core/rt_mapalgebra.c
+++ b/raster/rt_core/rt_mapalgebra.c
@@ -1273,7 +1273,8 @@ rt_raster_iterator(
 				/* neighborhood */
 				npixels = NULL;
 				status = 0;
-				if (distancex > 0 && distancey > 0) {
+				if (distancex > 0 || distancey > 0)
+				{
 					RASTER_DEBUG(4, "getting neighborhood");
 
 					status = rt_band_get_nearest_pixel(

--- a/raster/rt_pg/rtpg_mapalgebra.c
+++ b/raster/rt_pg/rtpg_mapalgebra.c
@@ -834,16 +834,16 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 			}
 		}
 
-		/*set mask dimensions*/
-		arg->mask->dimx = maskDims[0];
-		arg->mask->dimy = maskDims[1];
+		/* PostgreSQL arrays are row-major: first dimension is Y, second is X. */
+		arg->mask->dimx = maskDims[1];
+		arg->mask->dimy = maskDims[0];
 		if (maskDims[0] == 1 && maskDims[1] == 1) {
 			arg->distance[0] = 0;
 			arg->distance[1] = 0;
 		}
 		else {
-			arg->distance[0] = maskDims[0] % 2;
-			arg->distance[1] = maskDims[1] % 2;
+			arg->distance[0] = (maskDims[1] - 1) / 2;
+			arg->distance[1] = (maskDims[0] - 1) / 2;
 		}
 	}/*end if else argisnull*/
 

--- a/raster/rt_pg/rtpg_mapalgebra.c
+++ b/raster/rt_pg/rtpg_mapalgebra.c
@@ -833,16 +833,16 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 			}
 		}
 
-		/*set mask dimensions*/
-		arg->mask->dimx = maskDims[0];
-		arg->mask->dimy = maskDims[1];
+		/* PostgreSQL arrays are row-major: first dimension is Y, second is X. */
+		arg->mask->dimx = maskDims[1];
+		arg->mask->dimy = maskDims[0];
 		if (maskDims[0] == 1 && maskDims[1] == 1) {
 			arg->distance[0] = 0;
 			arg->distance[1] = 0;
 		}
 		else {
-			arg->distance[0] = maskDims[0] % 2;
-			arg->distance[1] = maskDims[1] % 2;
+			arg->distance[0] = (maskDims[1] - 1) / 2;
+			arg->distance[1] = (maskDims[0] - 1) / 2;
 		}
 	}/*end if else argisnull*/
 

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -3086,6 +3086,168 @@ CREATE OR REPLACE FUNCTION st_stddev4ma(value double precision[][][], pos intege
 	AS $$ SELECT stddev(unnest) FROM unnest($1) $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
 
+-----------------------------------------------------------------------
+-- Focal-statistics mask helpers
+-----------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION _st_focal_mask(
+	fillvalue double precision,
+	innerradius integer,
+	outerradius integer,
+	thetastart double precision DEFAULT 0,
+	thetaend double precision DEFAULT 2 * pi()
+)
+	RETURNS double precision[][]
+	AS $$
+	DECLARE
+		twopi double precision := 2 * pi();
+		width integer;
+		center integer;
+		x integer;
+		y integer;
+		dx integer;
+		dy integer;
+		dist double precision;
+		theta double precision;
+		thetaoffset double precision;
+		startnorm double precision;
+		span double precision;
+		mask double precision[][];
+	BEGIN
+		IF innerradius < 0 THEN
+			RAISE EXCEPTION 'Inner radius must be greater than or equal to zero';
+		END IF;
+
+		IF outerradius < 0 THEN
+			RAISE EXCEPTION 'Outer radius must be greater than or equal to zero';
+		END IF;
+
+		IF innerradius > outerradius THEN
+			RAISE EXCEPTION 'Inner radius cannot be greater than outer radius';
+		END IF;
+
+		IF thetaend <= thetastart THEN
+			RAISE EXCEPTION 'End angle must be greater than start angle';
+		END IF;
+
+		width := 2 * outerradius + 1;
+		center := outerradius + 1;
+		span := thetaend - thetastart;
+		startnorm := thetastart - floor(thetastart / twopi) * twopi;
+		mask := array_fill(0.0::double precision, ARRAY[width, width]);
+
+		FOR y IN 1..width LOOP
+			FOR x IN 1..width LOOP
+				dx := x - center;
+				dy := center - y;
+				dist := sqrt((dx * dx + dy * dy)::double precision);
+
+				IF dist < innerradius OR dist > outerradius THEN
+					CONTINUE;
+				END IF;
+
+				IF dx = 0 AND dy = 0 THEN
+					mask[y][x] := fillvalue;
+					CONTINUE;
+				END IF;
+
+				IF span < twopi THEN
+					theta := atan2(dx::double precision, dy::double precision);
+					IF theta < 0 THEN
+						theta := theta + twopi;
+					END IF;
+
+					thetaoffset := theta - startnorm;
+					IF thetaoffset < 0 THEN
+						thetaoffset := thetaoffset + twopi;
+					END IF;
+
+					IF thetaoffset > span THEN
+						CONTINUE;
+					END IF;
+				END IF;
+
+				mask[y][x] := fillvalue;
+			END LOOP;
+		END LOOP;
+
+		RETURN mask;
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _st_focal_callback(operation text)
+	RETURNS regprocedure
+	AS $$
+	BEGIN
+		CASE upper(operation)
+		WHEN 'MAX' THEN
+			RETURN '@extschema@.st_max4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'MEAN' THEN
+			RETURN '@extschema@.st_mean4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'MIN' THEN
+			RETURN '@extschema@.st_min4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'RANGE' THEN
+			RETURN '@extschema@.st_range4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'STDDEV' THEN
+			RETURN '@extschema@.st_stddev4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'SUM' THEN
+			RETURN '@extschema@.st_sum4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'DISTINCT' THEN
+			RETURN '@extschema@.st_distinct4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		ELSE
+			RAISE EXCEPTION 'Operation "%" is not supported', operation;
+		END CASE;
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_wedge(
+	rast raster, nband integer,
+	innerradius integer, outerradius integer,
+	thetastart double precision, thetaend double precision,
+	operation text,
+	pixeltype text DEFAULT NULL, extenttype text DEFAULT 'INTERSECTION',
+	customextent raster DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+		SELECT CASE
+			WHEN $3 IS NULL OR $4 IS NULL OR $5 IS NULL OR $6 IS NULL OR $7 IS NULL THEN NULL
+			ELSE @extschema@._ST_MapAlgebra(
+				ARRAY[ROW($1, $2)]::@extschema@.rastbandarg[],
+				@extschema@._st_focal_callback($7),
+				$8,
+				$4, $4,
+				$9, $10,
+				@extschema@._st_focal_mask(1.0, $3, $4, $5, $6),
+				false
+			)
+		END
+	$$ LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_annulus(
+	rast raster, nband integer,
+	innerradius integer, outerradius integer,
+	operation text,
+	pixeltype text DEFAULT NULL, extenttype text DEFAULT 'INTERSECTION',
+	customextent raster DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+		SELECT @extschema@.ST_Wedge($1, $2, $3, $4, 0, 2 * pi(), $5, $6, $7, $8)
+	$$ LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_circle(
+	rast raster, nband integer,
+	radius integer,
+	operation text,
+	pixeltype text DEFAULT NULL, extenttype text DEFAULT 'INTERSECTION',
+	customextent raster DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+		SELECT @extschema@.ST_Wedge($1, $2, 0, $3, 0, 2 * pi(), $4, $5, $6, $7)
+	$$ LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
 -- Inverse distance weight equation is based upon Equation 3.51 from the book
 -- Spatial Analysis A Guide for Ecologists
 -- by Marie-Josee Fortin and Mark Dale

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -3085,6 +3085,168 @@ CREATE OR REPLACE FUNCTION st_stddev4ma(value double precision[][][], pos intege
 	AS $$ SELECT stddev(unnest) FROM unnest($1) $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
 
+-----------------------------------------------------------------------
+-- Focal-statistics mask helpers
+-----------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION _st_focal_mask(
+	fillvalue double precision,
+	innerradius integer,
+	outerradius integer,
+	thetastart double precision DEFAULT 0,
+	thetaend double precision DEFAULT 2 * pi()
+)
+	RETURNS double precision[][]
+	AS $$
+	DECLARE
+		twopi double precision := 2 * pi();
+		width integer;
+		center integer;
+		x integer;
+		y integer;
+		dx integer;
+		dy integer;
+		dist double precision;
+		theta double precision;
+		thetaoffset double precision;
+		startnorm double precision;
+		span double precision;
+		mask double precision[][];
+	BEGIN
+		IF innerradius < 0 THEN
+			RAISE EXCEPTION 'Inner radius must be greater than or equal to zero';
+		END IF;
+
+		IF outerradius < 0 THEN
+			RAISE EXCEPTION 'Outer radius must be greater than or equal to zero';
+		END IF;
+
+		IF innerradius > outerradius THEN
+			RAISE EXCEPTION 'Inner radius cannot be greater than outer radius';
+		END IF;
+
+		IF thetaend <= thetastart THEN
+			RAISE EXCEPTION 'End angle must be greater than start angle';
+		END IF;
+
+		width := 2 * outerradius + 1;
+		center := outerradius + 1;
+		span := thetaend - thetastart;
+		startnorm := thetastart - floor(thetastart / twopi) * twopi;
+		mask := array_fill(0.0::double precision, ARRAY[width, width]);
+
+		FOR y IN 1..width LOOP
+			FOR x IN 1..width LOOP
+				dx := x - center;
+				dy := center - y;
+				dist := sqrt((dx * dx + dy * dy)::double precision);
+
+				IF dist < innerradius OR dist > outerradius THEN
+					CONTINUE;
+				END IF;
+
+				IF dx = 0 AND dy = 0 THEN
+					mask[y][x] := fillvalue;
+					CONTINUE;
+				END IF;
+
+				IF span < twopi THEN
+					theta := atan2(dx::double precision, dy::double precision);
+					IF theta < 0 THEN
+						theta := theta + twopi;
+					END IF;
+
+					thetaoffset := theta - startnorm;
+					IF thetaoffset < 0 THEN
+						thetaoffset := thetaoffset + twopi;
+					END IF;
+
+					IF thetaoffset > span THEN
+						CONTINUE;
+					END IF;
+				END IF;
+
+				mask[y][x] := fillvalue;
+			END LOOP;
+		END LOOP;
+
+		RETURN mask;
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _st_focal_callback(operation text)
+	RETURNS regprocedure
+	AS $$
+	BEGIN
+		CASE upper(operation)
+		WHEN 'MAX' THEN
+			RETURN '@extschema@.st_max4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'MEAN' THEN
+			RETURN '@extschema@.st_mean4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'MIN' THEN
+			RETURN '@extschema@.st_min4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'RANGE' THEN
+			RETURN '@extschema@.st_range4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'STDDEV' THEN
+			RETURN '@extschema@.st_stddev4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'SUM' THEN
+			RETURN '@extschema@.st_sum4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		WHEN 'DISTINCT' THEN
+			RETURN '@extschema@.st_distinct4ma(double precision[][][],integer[][],text[])'::regprocedure;
+		ELSE
+			RAISE EXCEPTION 'Operation "%" is not supported', operation;
+		END CASE;
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_wedge(
+	rast raster, nband integer,
+	innerradius integer, outerradius integer,
+	thetastart double precision, thetaend double precision,
+	operation text,
+	pixeltype text DEFAULT NULL, extenttype text DEFAULT 'INTERSECTION',
+	customextent raster DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+		SELECT CASE
+			WHEN $3 IS NULL OR $4 IS NULL OR $5 IS NULL OR $6 IS NULL OR $7 IS NULL THEN NULL
+			ELSE @extschema@._ST_MapAlgebra(
+				ARRAY[ROW($1, $2)]::@extschema@.rastbandarg[],
+				@extschema@._st_focal_callback($7),
+				$8,
+				$4, $4,
+				$9, $10,
+				@extschema@._st_focal_mask(1.0, $3, $4, $5, $6),
+				false
+			)
+		END
+	$$ LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_annulus(
+	rast raster, nband integer,
+	innerradius integer, outerradius integer,
+	operation text,
+	pixeltype text DEFAULT NULL, extenttype text DEFAULT 'INTERSECTION',
+	customextent raster DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+		SELECT @extschema@.ST_Wedge($1, $2, $3, $4, 0, 2 * pi(), $5, $6, $7, $8)
+	$$ LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION st_circle(
+	rast raster, nband integer,
+	radius integer,
+	operation text,
+	pixeltype text DEFAULT NULL, extenttype text DEFAULT 'INTERSECTION',
+	customextent raster DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+		SELECT @extschema@.ST_Wedge($1, $2, 0, $3, 0, 2 * pi(), $4, $5, $6, $7)
+	$$ LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
+
 -- Inverse distance weight equation is based upon Equation 3.51 from the book
 -- Spatial Analysis A Guide for Ecologists
 -- by Marie-Josee Fortin and Mark Dale

--- a/raster/test/regress/rt_mapalgebra_mask.sql
+++ b/raster/test/regress/rt_mapalgebra_mask.sql
@@ -120,5 +120,49 @@ FROM (SELECT rid, st_dumpvalues(st_mapalgebra(rast,1,'raster_nmapalgebra_test(do
     from raster_nmapalgebra_mask_in) AS f
 ORDER BY rid, (dv).nband;
 
-DROP FUNCTION IF EXISTS raster_nmapalgebra_test(double precision[], int[], text[]);
+SET client_min_messages TO warning;
+
+SELECT 'odd-rectangular-mask', (dv).*
+FROM (
+	WITH src AS (
+		SELECT ST_SetValues(
+			ST_AddBand(ST_MakeEmptyRaster(5, 3, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 0, 0),
+			1, 1, 1,
+			ARRAY[[1,2,3,4,5],[10,20,30,40,50],[100,101,102,103,104]]::double precision[][]
+		) AS rast
+	)
+	SELECT st_dumpvalues(st_mapalgebra(rast, 1, 'st_sum4ma(double precision[][][],integer[][],text[])'::regprocedure, ARRAY[[0,0,0,0,0],[0,0,0,0,1],[0,0,0,0,0]]::double precision[], false)) AS dv
+	FROM src
+) AS f
+ORDER BY (dv).nband;
+
+SELECT 'one-dimensional-horizontal-mask', (dv).*
+FROM (
+	WITH src AS (
+		SELECT ST_SetValues(
+			ST_AddBand(ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 0, 0),
+			1, 1, 1,
+			ARRAY[[1,2,3],[10,20,30],[100,200,300]]::double precision[][]
+		) AS rast
+	)
+	SELECT st_dumpvalues(st_mapalgebra(rast, 1, 'st_sum4ma(double precision[][][],integer[][],text[])'::regprocedure, ARRAY[[1,1,1]]::double precision[], false)) AS dv
+	FROM src
+) AS f
+ORDER BY (dv).nband;
+
+SELECT 'one-dimensional-vertical-mask', (dv).*
+FROM (
+	WITH src AS (
+		SELECT ST_SetValues(
+			ST_AddBand(ST_MakeEmptyRaster(3, 3, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 0, 0),
+			1, 1, 1,
+			ARRAY[[1,2,3],[10,20,30],[100,200,300]]::double precision[][]
+		) AS rast
+	)
+	SELECT st_dumpvalues(st_mapalgebra(rast, 1, 'st_sum4ma(double precision[][][],integer[][],text[])'::regprocedure, ARRAY[[1],[1],[1]]::double precision[], false)) AS dv
+	FROM src
+) AS f
+ORDER BY (dv).nband;
+
+DROP FUNCTION IF EXISTS raster_nmapalgebra_test(double precision[][][], int[][], text[]);
 DROP TABLE IF EXISTS raster_nmapalgebra_mask_in;

--- a/raster/test/regress/rt_mapalgebra_mask_expected
+++ b/raster/test/regress/rt_mapalgebra_mask_expected
@@ -593,3 +593,6 @@ NOTICE:  userargs = <NULL>
 2|(1,"{{255,255},{255,255}}")
 3|(1,"{{255,255},{255,255}}")
 4|(1,"{{255,255},{255,255}}")
+odd-rectangular-mask|1|{{3,4,5,NULL,NULL},{30,40,50,NULL,NULL},{102,103,104,NULL,NULL}}
+one-dimensional-horizontal-mask|1|{{3,6,5},{30,60,50},{255,255,255}}
+one-dimensional-vertical-mask|1|{{11,22,33},{111,222,255},{110,220,255}}

--- a/raster/test/regress/tickets.sql
+++ b/raster/test/regress/tickets.sql
@@ -162,3 +162,52 @@ SELECT '#4724.b', ST_SummaryStatsAgg(NULL::raster, NULL::int4, NULL::bool)
  FROM generate_series(1,2) AS e(q);
 
 SELECT '#5854',Round(ST_Rotation(ST_Reskew(ST_AddBand(ST_MakeEmptyRaster(100, 430, 0, 0, 0.001, -0.001, 0, 0, 4269), '8BUI'::text, 1, 0), 0.0015))::numeric,3);
+
+-- #2310, #2311, #2312 focal statistics over wedge/annulus/circle masks
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2312', ST_Value(ST_Circle(rast, 1, 1, 'SUM', '32BF'), 3, 3)
+FROM test;
+
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2311', ST_Value(ST_Annulus(rast, 1, 1, 2, 'SUM', '32BF'), 3, 3)
+FROM test;
+
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2310', ST_Value(ST_Wedge(rast, 1, 0, 1, 0, pi(), 'SUM', '32BF'), 3, 3)
+FROM test;
+
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2310.zero-radius-rotated', ST_Value(ST_Wedge(rast, 1, 0, 0, pi() / 2, 3 * pi() / 2, 'SUM', '32BF'), 3, 3)
+FROM test;
+
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2312.NULL-radius', ST_Circle(rast, 1, NULL, 'SUM', '32BF') IS NULL
+FROM test;
+
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2311.NULL-radius', ST_Annulus(rast, 1, NULL, 2, 'SUM', '32BF') IS NULL
+FROM test;
+
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2310.NULL-angle', ST_Wedge(rast, 1, 0, 1, NULL, pi(), 'SUM', '32BF') IS NULL
+FROM test;
+
+WITH test AS (
+	SELECT ST_AddBand(ST_MakeEmptyRaster(5, 5, 0, 0, 1, -1, 0, 0, 0), '8BUI'::text, 1, 0) AS rast
+)
+SELECT '#2312.NULL-operation', ST_Circle(rast, 1, 1, NULL, '32BF') IS NULL
+FROM test;

--- a/raster/test/regress/tickets_expected
+++ b/raster/test/regress/tickets_expected
@@ -78,3 +78,11 @@ NOTICE:  Adding maximum extent constraint
 #4724.a|(0,,,,,)
 #4724.b|(0,,,,,)
 #5854|-0.983
+#2312|5
+#2311|12
+#2310|4
+#2310.zero-radius-rotated|1
+#2312.NULL-radius|t
+#2311.NULL-radius|t
+#2310.NULL-angle|t
+#2312.NULL-operation|t


### PR DESCRIPTION
## Summary

Implements Trac https://trac.osgeo.org/postgis/ticket/2310, https://trac.osgeo.org/postgis/ticket/2311, and https://trac.osgeo.org/postgis/ticket/2312.

This adds raster focal-statistics helpers for circular, annular, and wedge-shaped neighborhoods:

- `ST_Circle(rast, nband, radius, operation, pixeltype, extenttype, customextent)`
- `ST_Annulus(rast, nband, innerradius, outerradius, operation, pixeltype, extenttype, customextent)`
- `ST_Wedge(rast, nband, innerradius, outerradius, thetastart, thetaend, operation, pixeltype, extenttype, customextent)`

The helpers build masks and dispatch to the existing n-raster `ST_MapAlgebra` callback path for the existing focal operations: `MAX`, `MEAN`, `MIN`, `RANGE`, `STDDEV`, `SUM`, and `DISTINCT`.

While validating the masks, this also fixes mask-derived neighborhood radius inference so PostgreSQL row-major masks map rows to Y and columns to X for rectangular odd-sized masks, so one-dimensional masks still fetch their neighborhoods, and so NULL radius, angle, or operation inputs return NULL instead of invoking unmasked or invalid map algebra calls.

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C raster/rt_pg -j32`
- `sudo -n make -C raster/rt_pg install`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --raster" TESTS="$(pwd)/raster/test/regress/rt_mapalgebra_mask $(pwd)/raster/test/regress/tickets"` (fresh and automatic-upgrade runs passed)
- `make -C raster/test/cunit cu_tester`
- `./raster/test/cunit/cu_tester band_misc`
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- raster/rt_core/rt_mapalgebra.c raster/rt_pg/rtpg_mapalgebra.c raster/rt_pg/rtpostgis.sql.in raster/test/regress/rt_mapalgebra_mask.sql raster/test/regress/rt_mapalgebra_mask_expected raster/test/regress/tickets.sql raster/test/regress/tickets_expected doc/reference_raster.xml NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`

Trac tickets:

- https://trac.osgeo.org/postgis/ticket/2310
- https://trac.osgeo.org/postgis/ticket/2311
- https://trac.osgeo.org/postgis/ticket/2312
