### PR TITLE
Add raster ST_CreateIndexRaster wrapper

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,8 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #1582, [raster] Add ST_CreateIndexRaster wrapper around map algebra
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta1
 2026/07/20
@@ -107,10 +109,6 @@ These are only changes since 3.7.0alpha1.
           (Darafei Praliaskouski)
 
 * Enhancements *
-
- - #1582, [raster] Add ST_CreateIndexRaster wrapper around map algebra
-          (Darafei Praliaskouski)
-
 
 PostGIS 3.7.0dev
 2026/xx/xx

--- a/NEWS
+++ b/NEWS
@@ -106,6 +106,11 @@ These are only changes since 3.7.0alpha1.
  - #1168, [raster] Support curved geometry inputs in ST_AsRaster
           (Darafei Praliaskouski)
 
+* Enhancements *
+
+ - #1582, [raster] Add ST_CreateIndexRaster wrapper around map algebra
+          (Darafei Praliaskouski)
+
 
 PostGIS 3.7.0dev
 2026/xx/xx
@@ -151,7 +156,7 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)
  - #5992, Optimize GiST index for repeated edge subdivision in topology (Darafei Praliaskouski)
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
- - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)
+- #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)
  - #5950, Document POSTGIS_REGRESS_DB_OWNER for sandboxed regression roles (Darafei Praliaskouski)
  - #4332, Clarify the scope of several Function Reference categories (Darafei Praliaskouski)
  - #4222, [raster] ST_DumpAsPolygons honours PostgreSQL interrupts (Darafei Praliaskouski)
@@ -169,7 +174,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - [fuzzers] Centralize OSS-Fuzz build/dependency logic in PostGIS scripts,
           prefer requested CXX over pg_config --cc for internal C++ checks, and
           make fuzzer linking/runtime dependency packaging portable
-          (Darafei Praliaskouski)
 
 * Enhancements *
 

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,10 @@ These are only changes since 3.7.0beta2.
  - OSSFuzz 6152109301760000, reject overlong encoded polyline coordinate
           varints (Darafei Praliaskouski)
 
+* Enhancements *
 
+ - #1582, [raster] Add ST_CreateIndexRaster wrapper around map algebra
+          (Darafei Praliaskouski)
 
 PostGIS 3.7.0beta2
 2026/08/09

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -10592,6 +10592,72 @@ WHERE t1.rid = 1
                 </refsection>
             </refentry>
 
+            <refentry xml:id="RT_ST_CreateIndexRaster">
+                <refnamediv>
+                    <refname>ST_CreateIndexRaster</refname>
+                    <refpurpose>Creates a one-band raster whose pixel values encode each pixel's traversal index.</refpurpose>
+                </refnamediv>
+
+                <refsynopsisdiv>
+                    <funcsynopsis>
+                        <funcprototype>
+                            <funcdef>raster <function>ST_CreateIndexRaster</function></funcdef>
+                            <paramdef><type>raster </type> <parameter>rast</parameter></paramdef>
+                            <paramdef choice="opt"><type>text </type> <parameter>pixeltype=32BUI</parameter></paramdef>
+                            <paramdef choice="opt"><type>integer </type> <parameter>startvalue=0</parameter></paramdef>
+                            <paramdef choice="opt"><type>boolean </type> <parameter>incwithx=true</parameter></paramdef>
+                            <paramdef choice="opt"><type>boolean </type> <parameter>incwithy=true</parameter></paramdef>
+                            <paramdef choice="opt"><type>boolean </type> <parameter>columnfirst=true</parameter></paramdef>
+                            <paramdef choice="opt"><type>boolean </type> <parameter>rowscanorder=true</parameter></paramdef>
+                            <paramdef choice="opt"><type>integer </type> <parameter>falsecolinc=NULL</parameter></paramdef>
+                            <paramdef choice="opt"><type>integer </type> <parameter>falserowinc=NULL</parameter></paramdef>
+                        </funcprototype>
+                    </funcsynopsis>
+                </refsynopsisdiv>
+
+                <refsection>
+                    <title>Description</title>
+
+                    <para>
+                        Returns a raster with the same georeference, width, and height as <varname>rast</varname> and a single band containing traversal indexes. By default, indexes start at 0 and increase down each column before moving to the next column.
+                    </para>
+
+                    <para>
+                        The traversal direction can be reversed independently for the x and y axes with <varname>incwithx</varname> and <varname>incwithy</varname>. Set <varname>columnfirst</varname> to false to traverse rows before columns. Set <varname>rowscanorder</varname> to false to use alternating row or column direction, also known as boustrophedon order.
+                    </para>
+
+                    <para>
+                        <varname>falsecolinc</varname> and <varname>falserowinc</varname> override the default column and row increments. When columns are traversed first, the column increment must be greater than the number of indexes in one column. When rows are traversed first, the row increment must be greater than the number of indexes in one row.
+                    </para>
+
+                    <para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+                </refsection>
+
+                <refsection>
+                    <title>Examples</title>
+                    <programlisting>
+WITH src AS (
+    SELECT ST_MakeEmptyRaster(3, 2, 0, 0, 1, -1, 0, 0, 0) AS rast
+)
+SELECT (ST_DumpValues(ST_CreateIndexRaster(rast))).valarray
+FROM src;
+
+ valarray
+---------------
+ {{0,2,4},{1,3,5}}
+                    </programlisting>
+                </refsection>
+
+                <refsection>
+                    <title>See Also</title>
+                    <para>
+                        <xref linkend="RT_ST_MapAlgebra"/>,
+                        <xref linkend="RT_ST_MakeEmptyRaster"/>,
+                        <xref linkend="RT_ST_DumpValues"/>
+                    </para>
+                </refsection>
+            </refentry>
+
             <refentry xml:id="RT_ST_MapAlgebraExpr">
                 <refnamediv>
                     <refname>ST_MapAlgebraExpr</refname>

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -10640,12 +10640,8 @@ WITH src AS (
     SELECT ST_MakeEmptyRaster(3, 2, 0, 0, 1, -1, 0, 0, 0) AS rast
 )
 SELECT (ST_DumpValues(ST_CreateIndexRaster(rast))).valarray
-FROM src;
-
- valarray
----------------
- {{0,2,4},{1,3,5}}
-                    </programlisting>
+FROM src;</programlisting>
+                    <screen>{{0,2,4},{1,3,5}}</screen>
                 </refsection>
 
                 <refsection>

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -2783,6 +2783,91 @@ CREATE OR REPLACE FUNCTION st_mapalgebra(
 	AS $$ SELECT @extschema@.ST_mapalgebra($1, 1, $2, 1, $3, $4, $5, $6, $7, $8) $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION st_createindexraster(
+	rast raster,
+	pixeltype text DEFAULT '32BUI',
+	startvalue integer DEFAULT 0,
+	incwithx boolean DEFAULT true,
+	incwithy boolean DEFAULT true,
+	columnfirst boolean DEFAULT true,
+	rowscanorder boolean DEFAULT true,
+	falsecolinc integer DEFAULT NULL,
+	falserowinc integer DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+	DECLARE
+		newraster raster;
+		w integer;
+		h integer;
+		rowincx integer;
+		colincx integer;
+		rowincy integer;
+		colincy integer;
+		xdir integer;
+		ydir integer;
+		xdflag integer;
+		ydflag integer;
+		rsflag integer;
+		expr text;
+	BEGIN
+		IF rast IS NULL THEN
+			RETURN NULL;
+		END IF;
+
+		newraster := @extschema@.ST_AddBand(
+			@extschema@.ST_MakeEmptyRaster(rast),
+			COALESCE(pixeltype, '32BUI')
+		);
+
+		w := @extschema@.ST_Width(newraster);
+		h := @extschema@.ST_Height(newraster);
+		rowincx := COALESCE(falserowinc, w);
+		colincx := COALESCE(falsecolinc, h);
+		rowincy := COALESCE(falserowinc, 1);
+		colincy := COALESCE(falsecolinc, 1);
+		xdir := CASE WHEN COALESCE(incwithx, true) THEN 1 ELSE w END;
+		ydir := CASE WHEN COALESCE(incwithy, true) THEN 1 ELSE h END;
+		xdflag := COALESCE(incwithx::integer, 1);
+		ydflag := COALESCE(incwithy::integer, 1);
+		rsflag := COALESCE(rowscanorder::integer, 1);
+
+		IF falsecolinc IS NOT NULL AND falsecolinc <= 0 THEN
+			RAISE EXCEPTION 'Column increment must be greater than zero';
+		END IF;
+		IF falserowinc IS NOT NULL AND falserowinc <= 0 THEN
+			RAISE EXCEPTION 'Row increment must be greater than zero';
+		END IF;
+
+		IF COALESCE(columnfirst, true) THEN
+			IF colincx <= (h - 1) * rowincy THEN
+				RAISE EXCEPTION 'Column increment (now %) must be greater than the number of index on one column (now % pixel x % = %)',
+					colincx, h - 1, rowincy, (h - 1) * rowincy;
+			END IF;
+
+			expr := format(
+				'abs([rast.x] - %s)::numeric * %s::numeric + abs([rast.y] - (%s ^ ((abs([rast.x] - %s + 1) %% 2) | %s # %s))::int)::numeric * %s::numeric + %s::numeric',
+				xdir, colincx, h, xdir, rsflag, ydflag, rowincy, COALESCE(startvalue, 0)
+			);
+		ELSE
+			IF rowincx <= (w - 1) * colincy THEN
+				RAISE EXCEPTION 'Row increment (now %) must be greater than the number of index on one row (now % pixel x % = %)',
+					rowincx, w - 1, colincy, (w - 1) * colincy;
+			END IF;
+
+			expr := format(
+				'abs([rast.x] - (%s ^ ((abs([rast.y] - %s + 1) %% 2) | %s # %s))::int)::numeric * %s::numeric + abs([rast.y] - %s)::numeric * %s::numeric + %s::numeric',
+				w, ydir, rsflag, xdflag, colincy, ydir, rowincx, COALESCE(startvalue, 0)
+			);
+		END IF;
+
+		RETURN @extschema@.ST_SetBandNodataValue(
+			@extschema@.ST_MapAlgebra(newraster, COALESCE(pixeltype, '32BUI'), expr),
+			@extschema@.ST_BandNodataValue(newraster)
+		);
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
+
 -----------------------------------------------------------------------
 -- ST_MapAlgebra callback functions
 -- Should be called with values for distancex and distancey

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -2782,6 +2782,91 @@ CREATE OR REPLACE FUNCTION st_mapalgebra(
 	AS $$ SELECT @extschema@.ST_mapalgebra($1, 1, $2, 1, $3, $4, $5, $6, $7, $8) $$
 	LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION st_createindexraster(
+	rast raster,
+	pixeltype text DEFAULT '32BUI',
+	startvalue integer DEFAULT 0,
+	incwithx boolean DEFAULT true,
+	incwithy boolean DEFAULT true,
+	columnfirst boolean DEFAULT true,
+	rowscanorder boolean DEFAULT true,
+	falsecolinc integer DEFAULT NULL,
+	falserowinc integer DEFAULT NULL
+)
+	RETURNS raster
+	AS $$
+	DECLARE
+		newraster raster;
+		w integer;
+		h integer;
+		rowincx integer;
+		colincx integer;
+		rowincy integer;
+		colincy integer;
+		xdir integer;
+		ydir integer;
+		xdflag integer;
+		ydflag integer;
+		rsflag integer;
+		expr text;
+	BEGIN
+		IF rast IS NULL THEN
+			RETURN NULL;
+		END IF;
+
+		newraster := @extschema@.ST_AddBand(
+			@extschema@.ST_MakeEmptyRaster(rast),
+			COALESCE(pixeltype, '32BUI')
+		);
+
+		w := @extschema@.ST_Width(newraster);
+		h := @extschema@.ST_Height(newraster);
+		rowincx := COALESCE(falserowinc, w);
+		colincx := COALESCE(falsecolinc, h);
+		rowincy := COALESCE(falserowinc, 1);
+		colincy := COALESCE(falsecolinc, 1);
+		xdir := CASE WHEN COALESCE(incwithx, true) THEN 1 ELSE w END;
+		ydir := CASE WHEN COALESCE(incwithy, true) THEN 1 ELSE h END;
+		xdflag := COALESCE(incwithx::integer, 1);
+		ydflag := COALESCE(incwithy::integer, 1);
+		rsflag := COALESCE(rowscanorder::integer, 1);
+
+		IF falsecolinc IS NOT NULL AND falsecolinc <= 0 THEN
+			RAISE EXCEPTION 'Column increment must be greater than zero';
+		END IF;
+		IF falserowinc IS NOT NULL AND falserowinc <= 0 THEN
+			RAISE EXCEPTION 'Row increment must be greater than zero';
+		END IF;
+
+		IF COALESCE(columnfirst, true) THEN
+			IF colincx <= (h - 1) * rowincy THEN
+				RAISE EXCEPTION 'Column increment (now %) must be greater than the number of index on one column (now % pixel x % = %)',
+					colincx, h - 1, rowincy, (h - 1) * rowincy;
+			END IF;
+
+			expr := format(
+				'abs([rast.x] - %s)::numeric * %s::numeric + abs([rast.y] - (%s ^ ((abs([rast.x] - %s + 1) %% 2) | %s # %s))::int)::numeric * %s::numeric + %s::numeric',
+				xdir, colincx, h, xdir, rsflag, ydflag, rowincy, COALESCE(startvalue, 0)
+			);
+		ELSE
+			IF rowincx <= (w - 1) * colincy THEN
+				RAISE EXCEPTION 'Row increment (now %) must be greater than the number of index on one row (now % pixel x % = %)',
+					rowincx, w - 1, colincy, (w - 1) * colincy;
+			END IF;
+
+			expr := format(
+				'abs([rast.x] - (%s ^ ((abs([rast.y] - %s + 1) %% 2) | %s # %s))::int)::numeric * %s::numeric + abs([rast.y] - %s)::numeric * %s::numeric + %s::numeric',
+				w, ydir, rsflag, xdflag, colincy, ydir, rowincx, COALESCE(startvalue, 0)
+			);
+		END IF;
+
+		RETURN @extschema@.ST_SetBandNodataValue(
+			@extschema@.ST_MapAlgebra(newraster, COALESCE(pixeltype, '32BUI'), expr),
+			@extschema@.ST_BandNodataValue(newraster)
+		);
+	END;
+	$$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
+
 -----------------------------------------------------------------------
 -- ST_MapAlgebra callback functions
 -- Should be called with values for distancex and distancey

--- a/raster/test/regress/rt_createindexraster.sql
+++ b/raster/test/regress/rt_createindexraster.sql
@@ -1,0 +1,71 @@
+WITH src AS (
+	SELECT ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326) AS rast
+), idx AS (
+	SELECT ST_CreateIndexRaster(rast) AS rast
+	FROM src
+)
+SELECT
+	'default',
+	(ST_Metadata(rast)).width,
+	(ST_Metadata(rast)).height,
+	(ST_Metadata(rast)).upperleftx,
+	(ST_Metadata(rast)).upperlefty,
+	(ST_Metadata(rast)).scalex,
+	(ST_Metadata(rast)).scaley,
+	(ST_Metadata(rast)).srid,
+	ST_BandPixelType(rast),
+	(ST_DumpValues(rast)).valarray
+FROM idx;
+
+WITH src AS (
+	SELECT ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326) AS rast
+), idx AS (
+	SELECT ST_CreateIndexRaster(rast, '16BUI', 10, false, false, true, false) AS rast
+	FROM src
+)
+SELECT
+	'reverse-column-boustrophedon',
+	ST_BandPixelType(rast),
+	(ST_DumpValues(rast)).valarray
+FROM idx;
+
+WITH src AS (
+	SELECT ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326) AS rast
+), idx AS (
+	SELECT ST_CreateIndexRaster(rast, '16BUI', 5, true, true, false, true, 10, 30) AS rast
+	FROM src
+)
+SELECT
+	'row-first-custom-increments',
+	ST_BandPixelType(rast),
+	(ST_DumpValues(rast)).valarray
+FROM idx;
+
+SELECT 'null-raster', ST_CreateIndexRaster(NULL::raster) IS NULL;
+
+WITH src AS (
+	SELECT ST_MakeEmptyRaster(2, 1, 10, 20, 5, -5, 0, 0, 4326) AS rast
+), idx AS (
+	SELECT ST_CreateIndexRaster(rast, '32BUI', 2147483647) AS rast
+	FROM src
+)
+SELECT
+	'wide-32bui',
+	ST_BandPixelType(rast),
+	(ST_DumpValues(rast)).valarray
+FROM idx;
+
+SELECT 'bad-column-increment', ST_CreateIndexRaster(
+	ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326),
+	'16BUI', 0, true, true, true, true, 1, NULL
+);
+
+SELECT 'zero-row-increment', ST_CreateIndexRaster(
+	ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326),
+	'16BUI', 0, true, true, true, true, NULL, 0
+);
+
+SELECT 'negative-column-increment', ST_CreateIndexRaster(
+	ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326),
+	'16BUI', 0, true, true, true, true, -1, NULL
+);

--- a/raster/test/regress/rt_createindexraster.sql
+++ b/raster/test/regress/rt_createindexraster.sql
@@ -60,6 +60,11 @@ SELECT 'bad-column-increment', ST_CreateIndexRaster(
 	'16BUI', 0, true, true, true, true, 1, NULL
 );
 
+SELECT 'zero-column-increment', ST_CreateIndexRaster(
+	ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326),
+	'16BUI', 0, true, true, true, true, 0, NULL
+);
+
 SELECT 'zero-row-increment', ST_CreateIndexRaster(
 	ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326),
 	'16BUI', 0, true, true, true, true, NULL, 0
@@ -68,4 +73,9 @@ SELECT 'zero-row-increment', ST_CreateIndexRaster(
 SELECT 'negative-column-increment', ST_CreateIndexRaster(
 	ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326),
 	'16BUI', 0, true, true, true, true, -1, NULL
+);
+
+SELECT 'negative-row-increment', ST_CreateIndexRaster(
+	ST_MakeEmptyRaster(3, 2, 10, 20, 5, -5, 0, 0, 4326),
+	'16BUI', 0, true, true, true, true, NULL, -1
 );

--- a/raster/test/regress/rt_createindexraster_expected
+++ b/raster/test/regress/rt_createindexraster_expected
@@ -1,0 +1,8 @@
+default|3|2|10|20|5|-5|4326|32BUI|{{0,2,4},{1,3,5}}
+reverse-column-boustrophedon|16BUI|{{15,12,11},{14,13,10}}
+row-first-custom-increments|16BUI|{{5,15,25},{35,45,55}}
+null-raster|t
+wide-32bui|32BUI|{{2147483647,2147483648}}
+ERROR:  Column increment (now 1) must be greater than the number of index on one column (now 1 pixel x 1 = 1)
+ERROR:  Row increment must be greater than zero
+ERROR:  Column increment must be greater than zero

--- a/raster/test/regress/rt_createindexraster_expected
+++ b/raster/test/regress/rt_createindexraster_expected
@@ -4,5 +4,7 @@ row-first-custom-increments|16BUI|{{5,15,25},{35,45,55}}
 null-raster|t
 wide-32bui|32BUI|{{2147483647,2147483648}}
 ERROR:  Column increment (now 1) must be greater than the number of index on one column (now 1 pixel x 1 = 1)
+ERROR:  Column increment must be greater than zero
 ERROR:  Row increment must be greater than zero
 ERROR:  Column increment must be greater than zero
+ERROR:  Row increment must be greater than zero

--- a/raster/test/regress/tests.mk.in
+++ b/raster/test/regress/tests.mk.in
@@ -106,6 +106,7 @@ RASTER_TEST_MAPALGEBRA = \
 	$(top_srcdir)/raster/test/regress/rt_clip \
 	$(top_srcdir)/raster/test/regress/rt_mapalgebra \
 	$(top_srcdir)/raster/test/regress/rt_mapalgebra_expr \
+	$(top_srcdir)/raster/test/regress/rt_createindexraster \
 	$(top_srcdir)/raster/test/regress/rt_mapalgebra_mask \
 	$(top_srcdir)/raster/test/regress/rt_union \
 	$(top_srcdir)/raster/test/regress/rt_invdistweight4ma \

--- a/raster/test/regress/tests.mk.in
+++ b/raster/test/regress/tests.mk.in
@@ -108,6 +108,7 @@ RASTER_TEST_MAPALGEBRA = \
 	$(top_srcdir)/raster/test/regress/rt_clip \
 	$(top_srcdir)/raster/test/regress/rt_mapalgebra \
 	$(top_srcdir)/raster/test/regress/rt_mapalgebra_expr \
+	$(top_srcdir)/raster/test/regress/rt_createindexraster \
 	$(top_srcdir)/raster/test/regress/rt_mapalgebra_mask \
 	$(top_srcdir)/raster/test/regress/rt_union \
 	$(top_srcdir)/raster/test/regress/rt_invdistweight4ma \


### PR DESCRIPTION
## Summary

Adds the missing shipped `ST_CreateIndexRaster` wrapper requested in Trac https://trac.osgeo.org/postgis/ticket/1582.

The implementation promotes the existing experimental helper idea into canonical raster SQL by building the index band through the current `ST_MapAlgebra` expression wrapper. It keeps the old traversal knobs, documents the function, adds a NEWS entry, and covers default, reversed/boustrophedon, custom increment, NULL-raster, wide `32BUI`, and increment guard behavior in raster regressions.

The generated expression casts index arithmetic to `numeric` before addition so valid `32BUI` values beyond signed `int4` do not overflow in PostgreSQL expression evaluation.

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C raster/rt_pg -j32`
- `sudo -n make -C raster/rt_pg install`
- `make -C extensions/postgis_raster -j1`
- `sudo -n make -C extensions/postgis_raster install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C raster/test/regress check RUNTESTFLAGS="--extension --verbose --raster" TESTS="$(pwd)/raster/test/regress/rt_createindexraster"` (fresh and automatic-upgrade runs passed)
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git clang-format --diff upstream/master -- raster/rt_pg/rtpostgis.sql.in raster/test/regress/rt_createindexraster.sql raster/test/regress/rt_createindexraster_expected raster/test/regress/tests.mk.in doc/reference_raster.xml NEWS`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
