### PR TITLE
Use next-edge links for face geometry boundaries

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -74,6 +74,9 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - #4680, [topology] Collect ST_GetFaceGeometry boundary edges from
+          next-edge links after using face labels only to find seed edges
+          (Darafei Praliaskouski)
  - #2807, [raster] Preserve missing NODATA values in ST_MapAlgebra outputs
           (Darafei Praliaskouski)
  - #2832, [raster] Avoid padding single-tile raster2pgsql overviews

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -53,6 +53,39 @@ _lwt_describe_point(const LWPOINT *pt, char *buf, size_t bufsize)
 	return true;
 }
 
+static int
+_lwt_compare_elemid(const void *a, const void *b)
+{
+	const LWT_ELEMID *ea = a;
+	const LWT_ELEMID *eb = b;
+
+	if (*ea < *eb)
+		return -1;
+	if (*ea > *eb)
+		return 1;
+	return 0;
+}
+
+static void
+_lwt_sort_unique_elemids(LWT_ELEMID *ids, uint64_t *num_ids)
+{
+	uint64_t i;
+	uint64_t unique_count;
+
+	if (*num_ids < 2)
+		return;
+
+	qsort(ids, *num_ids, sizeof(LWT_ELEMID), _lwt_compare_elemid);
+
+	unique_count = 1;
+	for (i = 1; i < *num_ids; ++i)
+	{
+		if (ids[i] != ids[unique_count - 1])
+			ids[unique_count++] = ids[i];
+	}
+	*num_ids = unique_count;
+}
+
 /*
  * Report a deterministic GEOS-derived location for topology errors.
  * Normalize the intersection geometry so PointOnSurface is stable
@@ -3046,8 +3079,14 @@ lwt_GetFaceGeometry(LWT_TOPOLOGY* topo, LWT_ELEMID faceid)
   LWT_ISO_FACE *face;
   LWPOLY *out;
   LWGEOM *outg;
-  uint64_t i, edgeid;
+  uint64_t i, j, edgeid;
   int fields;
+  LWT_ELEMID *boundary_edge_ids = NULL;
+  uint64_t boundary_edge_count = 0;
+  uint64_t boundary_edge_capacity = 0;
+  LWT_ELEMID *visited = NULL;
+  uint64_t visited_count = 0;
+  int construction_failed = LW_FALSE;
 
   if (faceid == 0)
   {
@@ -3098,7 +3137,139 @@ lwt_GetFaceGeometry(LWT_TOPOLOGY* topo, LWT_ELEMID faceid)
   }
   edgeid = edges[0].edge_id;
 
-  outg = _lwt_FaceByEdges( topo, edges, numfaceedges );
+  for (i = 0; i < numfaceedges; ++i)
+  {
+	  LWT_ELEMID seed_edges[2];
+	  int num_seed_edges = 0;
+
+	  if (edges[i].face_left == faceid)
+		  seed_edges[num_seed_edges++] = edges[i].edge_id;
+	  if (edges[i].face_right == faceid)
+		  seed_edges[num_seed_edges++] = -edges[i].edge_id;
+
+	  for (j = 0; j < (uint64_t)num_seed_edges; ++j)
+	  {
+		  LWT_ELEMID seed_edge = seed_edges[j];
+		  LWT_ELEMID seed_edge_abs = llabs(seed_edge);
+		  LWT_ELEMID *signed_edge_ids;
+		  uint64_t num_signed_edge_ids;
+		  uint64_t k;
+
+		  if (visited && bsearch(&seed_edge_abs, visited, visited_count, sizeof(LWT_ELEMID), _lwt_compare_elemid))
+			  continue;
+
+		  signed_edge_ids = lwt_be_getRingEdges(topo, seed_edge, &num_signed_edge_ids, 0);
+		  if (!signed_edge_ids || num_signed_edge_ids == UINT64_MAX)
+		  {
+			  const char *errmsg = lwt_be_lastErrorMessage(topo->be_iface);
+			  if (errmsg &&
+			      (strncmp(errmsg, "Corrupted topology:", 19) == 0 || strstr(errmsg, "NULL next_")))
+				  construction_failed = LW_TRUE;
+			  else
+			  {
+				  if (boundary_edge_ids)
+					  lwfree(boundary_edge_ids);
+				  if (visited)
+					  lwfree(visited);
+				  _lwt_release_edges(edges, numfaceedges);
+				  PGTOPO_BE_ERROR();
+				  return NULL;
+			  }
+			  break;
+		  }
+
+		  if (visited)
+			  visited = lwrealloc(visited, sizeof(LWT_ELEMID) * (visited_count + num_signed_edge_ids));
+		  else
+			  visited = lwalloc(sizeof(LWT_ELEMID) * num_signed_edge_ids);
+		  for (k = 0; k < num_signed_edge_ids; ++k)
+			  visited[visited_count++] = llabs(signed_edge_ids[k]);
+		  _lwt_sort_unique_elemids(visited, &visited_count);
+
+		  if (boundary_edge_capacity < boundary_edge_count + num_signed_edge_ids)
+		  {
+			  boundary_edge_capacity = boundary_edge_count + num_signed_edge_ids;
+			  if (boundary_edge_ids)
+				  boundary_edge_ids =
+				      lwrealloc(boundary_edge_ids, sizeof(LWT_ELEMID) * boundary_edge_capacity);
+			  else
+				  boundary_edge_ids = lwalloc(sizeof(LWT_ELEMID) * boundary_edge_capacity);
+		  }
+
+		  for (k = 0; k < num_signed_edge_ids; ++k)
+			  boundary_edge_ids[boundary_edge_count++] = llabs(signed_edge_ids[k]);
+
+		  lwfree(signed_edge_ids);
+	  }
+	  if (construction_failed)
+		  break;
+  }
+
+  if (construction_failed)
+  {
+	  if (boundary_edge_ids)
+		  lwfree(boundary_edge_ids);
+	  if (visited)
+		  lwfree(visited);
+	  outg = _lwt_FaceByEdges(topo, edges, numfaceedges);
+  }
+  else if (!boundary_edge_count)
+  {
+	  if (visited)
+		  lwfree(visited);
+	  outg = _lwt_FaceByEdges(topo, edges, numfaceedges);
+  }
+  else
+  {
+	  uint64_t num_boundary_edges = boundary_edge_count;
+	  LWT_ISO_EDGE *boundary_edges;
+	  LWCOLLECTION *bounds;
+	  LWGEOM **geoms;
+
+	  if (boundary_edge_count > 1)
+		  _lwt_sort_unique_elemids(boundary_edge_ids, &boundary_edge_count);
+	  num_boundary_edges = boundary_edge_count;
+
+	  boundary_edges = lwt_be_getEdgeById(
+	      topo, boundary_edge_ids, &num_boundary_edges, LWT_COL_EDGE_EDGE_ID | LWT_COL_EDGE_GEOM);
+	  lwfree(boundary_edge_ids);
+	  if (num_boundary_edges == UINT64_MAX)
+	  {
+		  if (visited)
+			  lwfree(visited);
+		  _lwt_release_edges(edges, numfaceedges);
+		  PGTOPO_BE_ERROR();
+		  return NULL;
+	  }
+	  if (num_boundary_edges != boundary_edge_count)
+	  {
+		  if (visited)
+			  lwfree(visited);
+		  _lwt_release_edges(boundary_edges, num_boundary_edges);
+		  _lwt_release_edges(edges, numfaceedges);
+		  lwerror("Unexpected error: %" PRIu64 " edges found when expecting %" PRIu64,
+			  num_boundary_edges,
+			  boundary_edge_count);
+		  return NULL;
+	  }
+
+	  geoms = lwalloc(sizeof(LWGEOM *) * num_boundary_edges);
+	  for (i = 0; i < num_boundary_edges; ++i)
+		  geoms[i] = lwline_as_lwgeom(boundary_edges[i].geom);
+
+	  bounds = lwcollection_construct(MULTILINETYPE, topo->srid, NULL, num_boundary_edges, geoms);
+	  outg = lwgeom_buildarea(lwcollection_as_lwgeom(bounds));
+	  lwcollection_release(bounds);
+	  lwfree(geoms);
+	  _lwt_release_edges(boundary_edges, num_boundary_edges);
+	  if (outg)
+		  lwgeom_force_clockwise(outg);
+	  else
+		  outg = _lwt_FaceByEdges(topo, edges, numfaceedges);
+	  if (visited)
+		  lwfree(visited);
+  }
+
   _lwt_release_edges(edges, numfaceedges);
 
   if ( ! outg )

--- a/topology/README
+++ b/topology/README
@@ -212,13 +212,12 @@ being input has already been snapped by caller.
 ==ST_GetFaceGeometry() implementation
 
 The ST_GetFaceGeometry() function is currently implemented
-as a call to polygonize() receiving all edges with the
-given Face on the left or right side. This reduces the number
-of SQL queries to 1, but makes it hard to detect any
-inconsistency in the underlying topology.
-Also, the polygonize() function does not use *any* of the
-metadata information in the Edge table, so replacing it
-with a more topology-aware function could speed it up.
+by following next_left_edge/next_right_edge links from an edge
+known to reference the given Face on the left or right side.
+This uses Face labels to find a seed edge for each ring, but
+collects the boundary edge set from the topological linkage
+metadata rather than polygonizing only the edges labelled with
+the Face.
 
 ==ValidateTopology() performance
 
@@ -234,4 +233,3 @@ be slower then overloading the predicates.
 In addition to the constraints defined in SQL/MM specification,
 this implementation adds constraints to enforce Node and Edge
 geometry types to be 'POINT' and 'LINESTRING' respectively.
-

--- a/topology/test/regress/st_getfacegeometry.sql
+++ b/topology/test/regress/st_getfacegeometry.sql
@@ -6,12 +6,19 @@ COPY tt.face(face_id, mbr) FROM STDIN;
 1	POLYGON((0 0,0 10,10 10,10 0,0 0))
 2	POLYGON((2 2,2 8,8 8,8 2,2 2))
 3	POLYGON((12 2,12 8,18 8,18 2,12 2))
+5	POLYGON((20 0,20 10,30 10,30 0,20 0))
 \.
 
 COPY tt.node(node_id, geom) FROM STDIN;
 1	POINT(2 2)
 2	POINT(0 0)
 3	POINT(12 2)
+4	POINT(20 0)
+5	POINT(20 10)
+6	POINT(30 10)
+7	POINT(30 0)
+8	POINT(10 10)
+9	POINT(10 0)
 \.
 
 COPY tt.edge_data(
@@ -22,12 +29,20 @@ COPY tt.edge_data(
 1	1	1	1	1	1	-1	1	2	LINESTRING(2 2, 2  8,  8  8,  8 2, 2 2)
 2	2	2	2	2	2	-2	0	1	LINESTRING(0 0, 0 10, 10 10, 10 0, 0 0)
 3	3	3	3	3	3	-3	0	3	LINESTRING(12 2, 12 8, 18 8, 18 2, 12 2)
+5	4	5	8	11	8	-11	5	5	LINESTRING(20 0, 20 10)
+6	7	4	5	7	5	-7	5	0	LINESTRING(30 0, 20 0)
+7	6	7	6	8	6	-8	5	0	LINESTRING(30 10, 30 0)
+8	5	6	7	5	7	-5	5	0	LINESTRING(20 10, 30 10)
+9	5	8	10	5	10	-5	0	0	LINESTRING(20 10, 10 10)
+10	8	9	11	9	11	-9	0	0	LINESTRING(10 10, 10 0)
+11	9	4	9	10	9	-10	0	0	LINESTRING(10 0, 20 0)
 \.
 
 -- F1 should have an hole !
 -- See http://trac.osgeo.org/postgis/ticket/726
 SELECT 'f1 (with hole)', ST_asText(topology.st_getfacegeometry('tt', 1));
 SELECT 'f2 (fill hole)', ST_asText(topology.st_getfacegeometry('tt', 2));
+SELECT 'f5 (bad labels)', ST_asText(topology.st_getfacegeometry('tt', 5));
 
 -- Universal face has no geometry
 -- See http://trac.osgeo.org/postgis/ticket/973

--- a/topology/test/regress/st_getfacegeometry_expected
+++ b/topology/test/regress/st_getfacegeometry_expected
@@ -1,6 +1,7 @@
 t
 f1 (with hole)|POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,8 2,8 8,2 8,2 2))
 f2 (fill hole)|POLYGON((2 2,2 8,8 8,8 2,2 2))
+f5 (bad labels)|POLYGON((20 0,20 10,30 10,30 0,20 0))
 ERROR:  SQL/MM Spatial exception - universal face has no geometry
 ERROR:  SQL/MM Spatial exception - null argument
 ERROR:  SQL/MM Spatial exception - null argument


### PR DESCRIPTION
## Summary

This updates `ST_GetFaceGeometry` so face labels are used only to find seed edges for each face ring. From each seed it follows `next_left_edge`/`next_right_edge` via the existing `GetRingEdges` backend callback, collects the linked boundary edge set, and then builds the face area from those boundary edges.

This keeps the legacy polygonize/buildarea behavior for area construction, including dangling-edge handling, and falls back to the previous label-only path when ring traversal reports legacy-invalid linkage.

Trac: https://trac.osgeo.org/postgis/ticket/4680
Closes #4680

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j8`
- `sudo -n make install`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/st_getfacegeometry $(pwd)/topology/test/regress/gml $(pwd)/topology/test/regress/legacy_query $(pwd)/topology/test/regress/removeunusedprimitives $(pwd)/topology/test/regress/topo2.5d $(pwd)/topology/test/regress/topogeo_addpoint_merge_edges"`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose"`
- `git diff --check`
- `./utils/check_news.sh .`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/309
