### PR TITLE
Replace topology edge insert rule with trigger

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           GeometryCollections (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
           (Darafei Praliaskouski)
+ - #5334, [topology] Replace edge view insert rule with edge_data trigger
+          (Darafei Praliaskouski)
 
 * Bug Fixes *
 

--- a/topology/sql/manage/CreateTopology.sql.in
+++ b/topology/sql/manage/CreateTopology.sql.in
@@ -24,6 +24,18 @@
 -- Availability: 3.6.0
 -- Replaces CreateTopology(varchar, integer, float8, boolean) deprecated in 3.6.0
 --
+CREATE OR REPLACE FUNCTION topology._update_edge_data_abs_next_edges()
+RETURNS trigger
+AS
+$BODY$
+BEGIN
+  NEW.abs_next_left_edge := abs(NEW.next_left_edge);
+  NEW.abs_next_right_edge := abs(NEW.next_right_edge);
+  RETURN NEW;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
 CREATE OR REPLACE FUNCTION topology.CreateTopology(atopology name, srid integer DEFAULT 0, prec float8 DEFAULT 0, hasZ boolean DEFAULT false, topoid integer default 0, usesLargeIDs boolean default false)
 RETURNS integer
 AS
@@ -200,16 +212,11 @@ BEGIN
       COMMENT ON COLUMN %1$I.edge.geom IS
       'The geometry of the edge';
 
-      -- edge standard view (insert rule)
-      CREATE RULE edge_insert_rule AS
-      ON INSERT TO %1$I.edge
-      DO INSTEAD INSERT into %1$I.edge_data
-      VALUES (
-        NEW.edge_id, NEW.start_node, NEW.end_node,
-        NEW.next_left_edge, abs(NEW.next_left_edge),
-        NEW.next_right_edge, abs(NEW.next_right_edge),
-        NEW.left_face, NEW.right_face, NEW.geom
-      );
+      CREATE TRIGGER edge_data_abs_next_edges
+      BEFORE INSERT OR UPDATE OF next_left_edge, next_right_edge
+      ON %1$I.edge_data
+      FOR EACH ROW
+      EXECUTE FUNCTION topology._update_edge_data_abs_next_edges();
 
       ------- Add support indices supporting edge linking foreign keys
       ------- See https://trac.osgeo.org/postgis/ticket/2083#comment:20

--- a/topology/sql/manage/UpgradeTopology.sql.in
+++ b/topology/sql/manage/UpgradeTopology.sql.in
@@ -85,6 +85,7 @@ BEGIN
 		-- Upgrade the edge_data table
   	-- Drop the edge view
     DROP VIEW IF EXISTS %1$I.edge;
+    DROP TRIGGER IF EXISTS edge_data_abs_next_edges ON %1$I.edge_data;
 
 		ALTER TABLE %1$I.edge_data
     	ALTER COLUMN edge_id TYPE BIGINT;
@@ -152,16 +153,11 @@ BEGIN
 		COMMENT ON COLUMN %1$I.edge.geom IS
 		'The geometry of the edge';
 
-		-- edge standard view (insert rule)
-		CREATE RULE edge_insert_rule AS
-		ON INSERT TO %1$I.edge
-		DO INSTEAD INSERT into %1$I.edge_data
-		VALUES (
-			NEW.edge_id, NEW.start_node, NEW.end_node,
-			NEW.next_left_edge, abs(NEW.next_left_edge),
-			NEW.next_right_edge, abs(NEW.next_right_edge),
-			NEW.left_face, NEW.right_face, NEW.geom
-		);
+		CREATE TRIGGER edge_data_abs_next_edges
+		BEFORE INSERT OR UPDATE OF next_left_edge, next_right_edge
+		ON %1$I.edge_data
+		FOR EACH ROW
+		EXECUTE FUNCTION topology._update_edge_data_abs_next_edges();
 
 		-- Upgrade the node table
 	  ALTER TABLE %1$I.node
@@ -205,4 +201,3 @@ BEGIN
   EXECUTE sql;
 END;
 $BODY$ LANGUAGE 'plpgsql' VOLATILE;
-

--- a/topology/test/regress/createtopology.sql
+++ b/topology/test/regress/createtopology.sql
@@ -3,6 +3,43 @@ set client_min_messages to WARNING;
 
 SELECT topology.CreateTopology('2d') > 0;
 SELECT topology.CreateTopology('2dLarge', 0, 0, false, 0, true) > 0;
+SELECT topology.CreateTopology('edgeTrigger') > 0;
+
+SELECT 'edge-insert-rule', count(*)
+FROM pg_rewrite
+WHERE ev_class = '"edgeTrigger".edge'::regclass
+AND rulename = 'edge_insert_rule';
+
+INSERT INTO "edgeTrigger".node(node_id, containing_face, geom)
+VALUES
+  (100, NULL, 'POINT(0 0)'::geometry),
+  (101, NULL, 'POINT(1 0)'::geometry),
+  (102, NULL, 'POINT(2 0)'::geometry);
+
+INSERT INTO "edgeTrigger".edge(edge_id, start_node, end_node, next_left_edge, next_right_edge, left_face, right_face, geom)
+VALUES (100, 100, 101, 100, -100, 0, 0, 'LINESTRING(0 0, 1 0)'::geometry);
+
+SELECT 'edge-view-insert', edge_id, next_left_edge, abs_next_left_edge, next_right_edge, abs_next_right_edge
+FROM "edgeTrigger".edge_data
+WHERE edge_id = 100;
+
+INSERT INTO "edgeTrigger".edge_data(edge_id, start_node, end_node, next_left_edge, abs_next_left_edge, next_right_edge, abs_next_right_edge, left_face, right_face, geom)
+VALUES (101, 101, 102, -101, 0, 101, 0, 0, 0, 'LINESTRING(1 0, 2 0)'::geometry);
+
+SELECT 'edge-data-insert', edge_id, next_left_edge, abs_next_left_edge, next_right_edge, abs_next_right_edge
+FROM "edgeTrigger".edge_data
+WHERE edge_id = 101;
+
+UPDATE "edgeTrigger".edge_data
+SET next_left_edge = -100,
+  next_right_edge = 100
+WHERE edge_id = 101;
+
+SELECT 'edge-data-update', edge_id, next_left_edge, abs_next_left_edge, next_right_edge, abs_next_right_edge
+FROM "edgeTrigger".edge_data
+WHERE edge_id = 101;
+
+SELECT topology.DropTopology('edgeTrigger');
 
 SELECT topology.CreateTopology('2dAgain', -1, 0, false) > 0;
 SELECT topology.CreateTopology('2dLarge.2', -1, 0, false, 0, true) > 0;
@@ -49,4 +86,3 @@ SELECT topology.DropTopology('3dLarge.2');
 -- Exceptions
 SELECT topology.CreateTopology('public');
 SELECT topology.CreateTopology('topology');
-

--- a/topology/test/regress/createtopology_expected
+++ b/topology/test/regress/createtopology_expected
@@ -1,6 +1,12 @@
 t
 t
 t
+edge-insert-rule|0
+edge-view-insert|100|100|100|-100|100
+edge-data-insert|101|-101|101|101|101
+edge-data-update|101|-100|100|100|100
+Topology 'edgeTrigger' dropped
+t
 t
 t
 t

--- a/topology/topology_after_upgrade.sql.in
+++ b/topology/topology_after_upgrade.sql.in
@@ -26,9 +26,29 @@ BEGIN
       RETURNING *
     )
     SELECT * FROM updated
+    LOOP
+      -- NOTE: these notices will not be shown during extension upgrade
+      RAISE NOTICE 'Topology % had SRID<0, updated to the officially unknown SRID value 0', rec.name;
+    END LOOP;
+
+  FOR rec IN
+    SELECT name
+    FROM topology.topology
   LOOP
-    -- NOTE: these notices will not be shown during extension upgrade
-    RAISE NOTICE 'Topology % had SRID<0, updated to the officially unknown SRID value 0', rec.name;
+    IF to_regclass(format('%I.edge_data', rec.name)) IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('DROP RULE IF EXISTS edge_insert_rule ON %I.edge', rec.name);
+    EXECUTE format('DROP TRIGGER IF EXISTS edge_data_abs_next_edges ON %I.edge_data', rec.name);
+    EXECUTE format(
+      'CREATE TRIGGER edge_data_abs_next_edges
+       BEFORE INSERT OR UPDATE OF next_left_edge, next_right_edge
+       ON %I.edge_data
+       FOR EACH ROW
+       EXECUTE FUNCTION topology._update_edge_data_abs_next_edges()',
+      rec.name
+    );
   END LOOP;
 END;
 $BODY$ LANGUAGE 'plpgsql';


### PR DESCRIPTION
## Summary
- remove the per-topology `edge_insert_rule` and let the simple `edge` view remain auto-updatable
- add an `edge_data` trigger that keeps `abs_next_left_edge` and `abs_next_right_edge` synchronized for view inserts, direct table inserts, and updates
- retrofit existing topology schemas during extension upgrade and keep explicit `UpgradeTopology()` recreating the trigger after bigint conversion

## Ticket
- https://trac.osgeo.org/postgis/ticket/5334

Closes #5334

## Current branch state
- Base: `a4ecc46176c3fc0ab3fa69cf117d408bc622e592`
- Head: `1f27e1a0209f345f7bbc8cd6e96a2775297a7a3c`

## Validation
- `make -C topology topology.sql topology_upgrade.sql`
- `make -C extensions/postgis_topology -j1`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology check-regress RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/createtopology.sql"`
- `make -C topology check-regress RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/upgradetopology.sql"`
- `make -C topology check-regress RUNTESTFLAGS="--extension --verbose --after-create-db-script $(pwd)/regress/hooks/standard-conforming-strings-off.sql" TESTS="$(pwd)/topology/test/regress/createtopology.sql $(pwd)/topology/test/regress/upgradetopology.sql"`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/308
