### PR TITLE
Add shp2pgsql TopoGeometry loading mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           both loaders accept long aliases for existing options, and
           --if-not-exists makes creation actions idempotent
           (Darafei Praliaskouski)
+ - #2103, shp2pgsql can load Shapefiles directly into TopoGeometry columns
+          (Darafei Praliaskouski)
  - #4208, Add single-geometry variants of ST_MaxDistance and ST_LongestLine
           (Darafei Praliaskouski)
  - [topology] FindVertexSegmentPairsBelowDistance function (Sandro Santilli)

--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -1883,7 +1883,7 @@ COMMIT;</programlisting>
 
   <para>
     The <filename>shp2pgsql</filename> data loader converts Shapefiles into SQL suitable for
-    insertion into a PostGIS/PostgreSQL database either in geometry or geography format.
+    insertion into a PostGIS/PostgreSQL database in geometry, geography, or TopoGeometry format.
     The loader has several operating modes selected by command line flags.
   </para>
   <para>
@@ -1988,6 +1988,18 @@ COMMIT;</programlisting>
           Optionally specifies that the input shapefile uses the given
           FROM_SRID, in which case the geometries will be reprojected to the
           target SRID.
+        </para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term><option>-g &lt;column&gt;</option></term>
+      <listitem>
+        <para>
+          Specify the name of the geometry, geography, or TopoGeometry column.
+          This is mostly useful in append mode, or with
+          <option>--topology</option> when choosing the TopoGeometry column
+          name.
         </para>
       </listitem>
     </varlistentry>
@@ -2132,6 +2144,19 @@ AVERYLONGCOLUMNNAME DBFFIELD2</programlisting>
 		</para>
 	  </listitem>
 	</varlistentry>
+    <varlistentry>
+      <term><option>--topology &lt;topology&gt;</option></term>
+      <listitem>
+        <para>
+          Load shapes as TopoGeometry values in the named topology. The topology
+          must already exist in the target database and the
+          <filename>postgis_topology</filename> extension must be installed. Use
+          <option>-g</option> to set the TopoGeometry column name. This mode is
+          not compatible with <option>-D</option>, <option>-G</option>,
+          <option>-I</option>, or <option>-n</option>.
+        </para>
+      </listitem>
+    </varlistentry>
     <varlistentry>
       <term><option>-T &lt;tablespace&gt;</option></term>
       <listitem>

--- a/loader/README.shp2pgsql
+++ b/loader/README.shp2pgsql
@@ -75,8 +75,15 @@ OPTIONS
 
 
        -g <geometry_column>
-              Specify the name of the geometry column (mostly useful in append
-              mode).
+              Specify the name of the geometry, geography, or TopoGeometry
+              column (mostly useful in append mode).
+
+       --topology <topology>
+              Load shapes as TopoGeometry values in the named topology.  The
+              topology must already exist in the target database and the
+              postgis_topology extension must be installed. Use -g to set the
+              TopoGeometry column name. This mode is not compatible with -D,
+              -G, -I, or -n.
 
        -f, --feature-id-column <fid_column>
               Specify the name of the feature id column. The default is gid.

--- a/loader/cunit/cu_shp2pgsql.c
+++ b/loader/cunit/cu_shp2pgsql.c
@@ -13,6 +13,7 @@
 #include "cu_tester.h"
 #include "../shp2pgsql-core.h"
 #include <string.h>
+#include <unistd.h>
 
 /* Test functions */
 void test_ShpLoaderCreate(void);
@@ -23,9 +24,25 @@ void test_ShpLoaderGetSQLFooter_if_not_exists_index_modifier(void);
 void test_ShpLoaderFIDColumnSQL(void);
 void test_ShpLoaderRejectsInvalidFIDColumn(void);
 void test_ShpLoaderOpenShapeRejectsZip(void);
+void test_ShpLoaderTopoGeometryDefaults(void);
+void test_ShpLoaderTopoGeometrySQLHeader(void);
+void test_ShpLoaderTopoGeometryIfNotExistsSQLHeader(void);
+void test_ShpLoaderTopoGeometrySQLDrop(void);
+void test_ShpLoaderTopoGeometrySQLAppend(void);
+void test_ShpLoaderTopoGeometrySQLAppendRow(void);
+void test_ShpLoaderTopoGeometryLineFeatureType(void);
+void test_ShpLoaderTopoGeometryMOnlyReject(void);
+void test_ShpLoaderTopoGeometryRejectsDBFOnlyFallback(void);
+void test_ShpLoaderTopoGeometrySQLFooter(void);
 
 SHPLOADERCONFIG *loader_config;
 SHPLOADERSTATE *loader_state;
+
+static void free_loader_config(SHPLOADERCONFIG *config);
+static char *loader_fixture_base_path(const char *name, const char *required_suffix);
+static char *loader_fixture_path(const char *name);
+static SHPLOADERCONFIG *make_topogeometry_config(void);
+static SHPLOADERSTATE *make_topogeometry_state(SHPLOADERCONFIG *config);
 
 /*
 ** Called from test harness to register the tests in this file.
@@ -54,7 +71,27 @@ CU_pSuite register_shp2pgsql_suite(void)
 	    (NULL == CU_add_test(pSuite, "test_ShpLoaderFIDColumnSQL()", test_ShpLoaderFIDColumnSQL)) ||
 	    (NULL ==
 	     CU_add_test(pSuite, "test_ShpLoaderRejectsInvalidFIDColumn()", test_ShpLoaderRejectsInvalidFIDColumn)) ||
-	    (NULL == CU_add_test(pSuite, "test_ShpLoaderOpenShapeRejectsZip()", test_ShpLoaderOpenShapeRejectsZip)))
+	    (NULL == CU_add_test(pSuite, "test_ShpLoaderOpenShapeRejectsZip()", test_ShpLoaderOpenShapeRejectsZip)) ||
+	    (NULL == CU_add_test(pSuite, "test_ShpLoaderTopoGeometryDefaults()", test_ShpLoaderTopoGeometryDefaults)) ||
+	    (NULL ==
+	     CU_add_test(pSuite, "test_ShpLoaderTopoGeometrySQLHeader()", test_ShpLoaderTopoGeometrySQLHeader)) ||
+	    (NULL == CU_add_test(pSuite,
+				 "test_ShpLoaderTopoGeometryIfNotExistsSQLHeader()",
+				 test_ShpLoaderTopoGeometryIfNotExistsSQLHeader)) ||
+	    (NULL == CU_add_test(pSuite, "test_ShpLoaderTopoGeometrySQLDrop()", test_ShpLoaderTopoGeometrySQLDrop)) ||
+	    (NULL ==
+	     CU_add_test(pSuite, "test_ShpLoaderTopoGeometrySQLAppend()", test_ShpLoaderTopoGeometrySQLAppend)) ||
+	    (NULL ==
+	     CU_add_test(pSuite, "test_ShpLoaderTopoGeometrySQLAppendRow()", test_ShpLoaderTopoGeometrySQLAppendRow)) ||
+	    (NULL == CU_add_test(pSuite,
+				 "test_ShpLoaderTopoGeometryLineFeatureType()",
+				 test_ShpLoaderTopoGeometryLineFeatureType)) ||
+	    (NULL ==
+	     CU_add_test(pSuite, "test_ShpLoaderTopoGeometryMOnlyReject()", test_ShpLoaderTopoGeometryMOnlyReject)) ||
+	    (NULL == CU_add_test(pSuite,
+				 "test_ShpLoaderTopoGeometryRejectsDBFOnlyFallback()",
+				 test_ShpLoaderTopoGeometryRejectsDBFOnlyFallback)) ||
+	    (NULL == CU_add_test(pSuite, "test_ShpLoaderTopoGeometrySQLFooter()", test_ShpLoaderTopoGeometrySQLFooter)))
 	{
 		CU_cleanup_registry();
 		return NULL;
@@ -78,6 +115,109 @@ int init_shp2pgsql_suite(void)
 int clean_shp2pgsql_suite(void)
 {
 	return 0;
+}
+
+static void
+free_loader_config(SHPLOADERCONFIG *config)
+{
+	if (!config)
+		return;
+
+	free(config->topology);
+	free(config->schema);
+	free(config->table);
+	free(config->geo_col);
+	free(config->shp_file);
+	free(config->encoding);
+	free(config);
+}
+
+static char *
+loader_fixture_base_path(const char *name, const char *required_suffix)
+{
+	static const char *prefixes[] = {"regress/loader/", "../../regress/loader/"};
+	size_t i;
+
+	for (i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++)
+	{
+		char *path;
+		char *required_path;
+		size_t suffix_len = strlen(required_suffix);
+		int len = snprintf(NULL, 0, "%s%s", prefixes[i], name);
+		if (len < 0)
+			continue;
+
+		path = malloc((size_t)len + 1);
+		required_path = malloc((size_t)len + suffix_len + 1);
+		if (!path || !required_path)
+		{
+			free(path);
+			free(required_path);
+			return NULL;
+		}
+
+		snprintf(path, (size_t)len + 1, "%s%s", prefixes[i], name);
+		snprintf(required_path, (size_t)len + suffix_len + 1, "%s%s", path, required_suffix);
+		if (access(required_path, R_OK) == 0)
+		{
+			free(required_path);
+			return path;
+		}
+		free(path);
+		free(required_path);
+	}
+
+	return NULL;
+}
+
+static char *
+loader_fixture_path(const char *name)
+{
+	return loader_fixture_base_path(name, ".shp");
+}
+
+static SHPLOADERCONFIG *
+make_topogeometry_config(void)
+{
+	SHPLOADERCONFIG *config = (SHPLOADERCONFIG *)calloc(1, sizeof(SHPLOADERCONFIG));
+	if (!config)
+		return NULL;
+
+	set_loader_config_defaults(config);
+	config->topology = strdup("city_topo");
+	config->schema = strdup("public");
+	config->table = strdup("blocks");
+	config->geo_col = strdup("topogeom");
+	if (!config->encoding || !config->topology || !config->schema || !config->table || !config->geo_col)
+	{
+		free_loader_config(config);
+		return NULL;
+	}
+
+	return config;
+}
+
+static SHPLOADERSTATE *
+make_topogeometry_state(SHPLOADERCONFIG *config)
+{
+	SHPLOADERSTATE *state;
+	if (!config)
+		return NULL;
+
+	state = ShpLoaderCreate(config);
+	if (!state)
+		return NULL;
+
+	state->pgtype = "POLYGON";
+	state->pgdims = 2;
+	state->col_names = strdup("topogeom");
+	if (!state->col_names)
+	{
+		ShpLoaderDestroy(state);
+		return NULL;
+	}
+
+	return state;
 }
 
 void test_ShpLoaderCreate(void)
@@ -266,4 +406,251 @@ test_ShpLoaderOpenShapeRejectsZip(void)
 	CU_ASSERT_EQUAL(ret, SHPLOADERERR);
 	CU_ASSERT_PTR_NULL(strstr(loader_state->message, "does not read .zip archives"));
 	ShpLoaderDestroy(loader_state);
+}
+
+void
+test_ShpLoaderTopoGeometryDefaults(void)
+{
+	SHPLOADERCONFIG *config = (SHPLOADERCONFIG *)calloc(1, sizeof(SHPLOADERCONFIG));
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	set_loader_config_defaults(config);
+	CU_ASSERT_FATAL(config->encoding != NULL);
+	config->topology = strdup("city_topo");
+	CU_ASSERT_FATAL(config->topology != NULL);
+	state = ShpLoaderCreate(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_STRING_EQUAL(state->geo_col, TOPOGEOMETRY_DEFAULT);
+
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometrySQLHeader(void)
+{
+	char *header = NULL;
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	state = make_topogeometry_state(config);
+	CU_ASSERT_FATAL(state != NULL);
+	CU_ASSERT_EQUAL(ShpLoaderGetSQLHeader(state, &header), SHPLOADEROK);
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "CREATE TABLE \"public\".\"blocks\" (\"gid\" serial);"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "SELECT topology.AddTopoGeometryColumn('city_topo', '\"public\".\"blocks\"'::regclass, 'topogeom', NULL, 'POLYGON');"));
+	CU_ASSERT_PTR_NULL(strstr(header, "AddGeometryColumn"));
+	CU_ASSERT_PTR_NULL(strstr(header, "geometry(POLYGON"));
+
+	free(header);
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometryIfNotExistsSQLHeader(void)
+{
+	char *header = NULL;
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	config->actions.if_not_exists = 1;
+	state = make_topogeometry_state(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderGetSQLHeader(state, &header), SHPLOADEROK);
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "CREATE TABLE IF NOT EXISTS \"public\".\"blocks\""));
+	CU_ASSERT_PTR_NOT_NULL(
+	    strstr(header, "IF topology.FindLayer('\"public\".\"blocks\"'::regclass, 'topogeom'::name) IS NULL THEN"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "PERFORM topology.AddTopoGeometryColumn('city_topo', '\"public\".\"blocks\"'::regclass, 'topogeom', NULL, 'POLYGON');"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "CREATE OR REPLACE FUNCTION pg_temp.shp2pgsql_topogeometry_layer_id(toponame name, tab regclass, col name)"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "PERFORM pg_temp.shp2pgsql_topogeometry_layer_id('city_topo'::name, '\"public\".\"blocks\"'::regclass, 'topogeom'::name);"));
+
+	free(header);
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometrySQLDrop(void)
+{
+	char *header = NULL;
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	config->actions.mode = 'd';
+	state = make_topogeometry_state(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderGetSQLHeader(state, &header), SHPLOADEROK);
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "target_table regclass := to_regclass('\"public\".\"blocks\"');"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "schema_name = target_schema AND table_name = target_name"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "PERFORM topology.DropTopoGeometryColumn(target_schema::varchar, target_name::varchar, lyr.feature_column);"));
+	CU_ASSERT_PTR_NULL(strstr(header, "AND feature_column = 'topogeom'"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "DROP TABLE IF EXISTS \"public\".\"blocks\";"));
+
+	free(header);
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometrySQLAppend(void)
+{
+	char *header = NULL;
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	config->actions.mode = 'a';
+	state = make_topogeometry_state(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderGetSQLHeader(state, &header), SHPLOADEROK);
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "CREATE OR REPLACE FUNCTION pg_temp.shp2pgsql_topogeometry_layer_id(toponame name, tab regclass, col name)"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "topoid := topology.GetTopologyID(toponame::varchar);"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "lyr := topology.FindLayer(tab, col);"));
+	CU_ASSERT_PTR_NOT_NULL(
+	    strstr(header, "RAISE EXCEPTION 'TopoGeometry column %.% is not registered in topology.layer'"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "IF lyr.topology_id != topoid THEN"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(header, "RETURN lyr.layer_id;"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "PERFORM pg_temp.shp2pgsql_topogeometry_layer_id('city_topo'::name, '\"public\".\"blocks\"'::regclass, 'topogeom'::name);"));
+	CU_ASSERT_PTR_NULL(strstr(header, "CREATE TABLE"));
+	CU_ASSERT_PTR_NULL(strstr(header, "AddTopoGeometryColumn"));
+
+	free(header);
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometrySQLAppendRow(void)
+{
+	char *record = NULL;
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	config->actions.mode = 'a';
+	config->shp_file = loader_fixture_path("ReprojectPts");
+	CU_ASSERT_FATAL(config->shp_file != NULL);
+	state = ShpLoaderCreate(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderOpenShape(state), SHPLOADEROK);
+	CU_ASSERT_EQUAL(ShpLoaderGenerateSQLRowStatement(state, 0, &record), SHPLOADEROK);
+	CU_ASSERT_PTR_NOT_NULL(strstr(record, "topology.toTopoGeom("));
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    record,
+	    "pg_temp.shp2pgsql_topogeometry_layer_id('city_topo'::name, '\"public\".\"blocks\"'::regclass, 'topogeom'::name)"));
+	CU_ASSERT_PTR_NULL(strstr(record, "layer_id(topology.FindLayer"));
+
+	free(record);
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometryLineFeatureType(void)
+{
+	char *header = NULL;
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	config->shp_file = loader_fixture_path("Arc");
+	CU_ASSERT_FATAL(config->shp_file != NULL);
+	state = ShpLoaderCreate(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderOpenShape(state), SHPLOADEROK);
+	CU_ASSERT_STRING_EQUAL(state->pgtype, "MULTILINE");
+	CU_ASSERT_EQUAL(ShpLoaderGetSQLHeader(state, &header), SHPLOADEROK);
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    header,
+	    "SELECT topology.AddTopoGeometryColumn('city_topo', '\"public\".\"blocks\"'::regclass, 'topogeom', NULL, 'MULTILINE');"));
+
+	free(header);
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometryMOnlyReject(void)
+{
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	config->force_output = FORCE_OUTPUT_3DM;
+	config->shp_file = loader_fixture_path("PointM");
+	CU_ASSERT_FATAL(config->shp_file != NULL);
+	state = ShpLoaderCreate(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderOpenShape(state), SHPLOADERERR);
+	CU_ASSERT_PTR_NOT_NULL(strstr(
+	    state->message,
+	    "Topology loading does not support M-only geometries; use -t 2D or -t 3DZ to drop the measure dimension."));
+
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometryRejectsDBFOnlyFallback(void)
+{
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	config->shp_file = loader_fixture_base_path("CharNoWidth", ".dbf");
+	CU_ASSERT_FATAL(config->shp_file != NULL);
+	state = ShpLoaderCreate(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderOpenShape(state), SHPLOADERERR);
+	CU_ASSERT_PTR_NOT_NULL(strstr(state->message, "topology loading requires readable shape"));
+	CU_ASSERT_EQUAL(config->readshape, 1);
+
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
+}
+
+void
+test_ShpLoaderTopoGeometrySQLFooter(void)
+{
+	char *footer = NULL;
+	SHPLOADERCONFIG *config = make_topogeometry_config();
+	SHPLOADERSTATE *state;
+
+	CU_ASSERT_FATAL(config != NULL);
+	state = make_topogeometry_state(config);
+	CU_ASSERT_FATAL(state != NULL);
+
+	CU_ASSERT_EQUAL(ShpLoaderGetSQLFooter(state, &footer), SHPLOADEROK);
+	CU_ASSERT_PTR_NULL(strstr(footer, "USING GIST"));
+	CU_ASSERT_PTR_NOT_NULL(strstr(footer, "ANALYZE \"public\".\"blocks\";"));
+
+	free(footer);
+	ShpLoaderDestroy(state);
+	free_loader_config(config);
 }

--- a/loader/shp2pgsql-cli.c
+++ b/loader/shp2pgsql-cli.c
@@ -133,6 +133,9 @@ usage()
 	printf(_( "  -e  Execute each statement individually, do not use a transaction.\n"
 	          "      Not compatible with -D.\n" ));
 	printf(_("  -G, --geography  Use geography type (requires lon/lat data or -s to reproject).\n"));
+	printf(
+	    _("  --topology <topology> Load shapes as TopoGeometry in the named topology.\n"
+	      "      Use -g to set the TopoGeometry column name.\n"));
 	printf(_("  -k, --keep-case  Keep postgresql identifiers case.\n"));
 	printf(_("  -i, --force-int4  Use int4 type for all integer dbf fields.\n"));
 	printf(_( "  -I  Create a spatial index on the geocolumn.\n" ));
@@ -273,6 +276,26 @@ main (int argc, char **argv)
 		if (strcmp(argv[pgis_optind], "--no-transaction") == 0)
 		{
 			config->usetransaction = 0;
+			pgis_optind++;
+			continue;
+		}
+		if (strcmp(argv[pgis_optind], "--topology") == 0)
+		{
+			pgis_optind++;
+			if (pgis_optind >= argc)
+			{
+				fprintf(stderr, "The --topology parameter requires a topology name\n");
+				exit(1);
+			}
+			free(config->topology);
+			config->topology = strdup(argv[pgis_optind]);
+			pgis_optind++;
+			continue;
+		}
+		if (strncmp(argv[pgis_optind], "--topology=", 11) == 0)
+		{
+			free(config->topology);
+			config->topology = strdup(argv[pgis_optind] + 11);
 			pgis_optind++;
 			continue;
 		}
@@ -459,6 +482,35 @@ main (int argc, char **argv)
 	{
 		fprintf(stderr, "Invalid argument combination - cannot use both -D and -e\n");
 		exit(1);
+	}
+
+	if (config->topology)
+	{
+		if (config->topology[0] == '\0')
+		{
+			fprintf(stderr, "The --topology parameter requires a non-empty topology name\n");
+			exit(1);
+		}
+		if (config->geography)
+		{
+			fprintf(stderr, "Invalid argument combination - cannot use both --topology and -G\n");
+			exit(1);
+		}
+		if (config->dump_format)
+		{
+			fprintf(stderr, "Invalid argument combination - cannot use both --topology and -D\n");
+			exit(1);
+		}
+		if (!config->readshape)
+		{
+			fprintf(stderr, "Invalid argument combination - cannot use both --topology and -n\n");
+			exit(1);
+		}
+		if (config->actions.create_index_set && config->actions.create_index != LOADER_CREATE_NONE)
+		{
+			fprintf(stderr, "Invalid argument combination - cannot use both --topology and -I\n");
+			exit(1);
+		}
 	}
 
 	{
@@ -685,6 +737,7 @@ main (int argc, char **argv)
 	free(config->schema);
 	free(config->table);
 	free(config->encoding);
+	free(config->topology);
 	free(config);
 
 	return 0;

--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -873,6 +873,133 @@ append_qualified_table(stringbuffer_t *sb, const char *schema, const char *table
 }
 
 static void
+append_sql_literal(stringbuffer_t *sb, char *str)
+{
+	char *escval = escape_insert_string(str);
+	stringbuffer_aprintf(sb, "'%s'", escval);
+	if (str != escval)
+		free(escval);
+}
+
+static void
+append_quoted_identifier_component(stringbuffer_t *sb, char *identifier)
+{
+	char *ptr = identifier;
+	stringbuffer_append(sb, "\"");
+	while (*ptr)
+	{
+		if (*ptr == '"')
+			stringbuffer_append(sb, "\"\"");
+		else
+			stringbuffer_append_len(sb, ptr, 1);
+		ptr++;
+	}
+	stringbuffer_append(sb, "\"");
+}
+
+static void
+append_table_identifier_literal(stringbuffer_t *sb, SHPLOADERSTATE *state)
+{
+	stringbuffer_t *identifier = stringbuffer_create();
+	if (state->config->schema)
+	{
+		append_quoted_identifier_component(identifier, state->config->schema);
+		stringbuffer_append(identifier, ".");
+	}
+	append_quoted_identifier_component(identifier, state->config->table);
+	append_sql_literal(sb, (char *)stringbuffer_getstring(identifier));
+	stringbuffer_destroy(identifier);
+}
+
+static void
+append_table_regclass(stringbuffer_t *sb, SHPLOADERSTATE *state)
+{
+	append_table_identifier_literal(sb, state);
+	stringbuffer_aprintf(sb, "::regclass");
+}
+
+static void
+append_topology_layer_id(stringbuffer_t *sb, SHPLOADERSTATE *state)
+{
+	stringbuffer_aprintf(sb, "pg_temp.shp2pgsql_topogeometry_layer_id(");
+	append_sql_literal(sb, state->config->topology);
+	stringbuffer_aprintf(sb, "::name, ");
+	append_table_regclass(sb, state);
+	stringbuffer_aprintf(sb, ", ");
+	append_sql_literal(sb, state->geo_col);
+	stringbuffer_aprintf(sb, "::name)");
+}
+
+static void
+append_validate_topology_layer(stringbuffer_t *sb, SHPLOADERSTATE *state)
+{
+	stringbuffer_aprintf(
+	    sb,
+	    "CREATE OR REPLACE FUNCTION pg_temp.shp2pgsql_topogeometry_layer_id(toponame name, tab regclass, col name)\n"
+	    "RETURNS integer AS $$\n"
+	    "DECLARE\n"
+	    "  lyr topology.layer;\n"
+	    "  topoid integer;\n"
+	    "BEGIN\n"
+	    "  topoid := topology.GetTopologyID(toponame::varchar);\n"
+	    "  lyr := topology.FindLayer(tab, col);\n"
+	    "  IF lyr IS NULL THEN\n"
+	    "    RAISE EXCEPTION ");
+	append_sql_literal(sb, "TopoGeometry column %.% is not registered in topology.layer");
+	stringbuffer_aprintf(sb,
+			     ", tab::text, col;\n"
+			     "  END IF;\n"
+			     "  IF lyr.topology_id != topoid THEN\n"
+			     "    RAISE EXCEPTION ");
+	append_sql_literal(sb, "TopoGeometry column %.% belongs to topology id %, not topology \"%\"");
+	stringbuffer_aprintf(sb,
+			     ", tab::text, col, lyr.topology_id, toponame;\n"
+			     "  END IF;\n"
+			     "  RETURN lyr.layer_id;\n"
+			     "END\n"
+			     "$$ LANGUAGE plpgsql STABLE;\n"
+			     "DO $$ BEGIN\n"
+			     "  PERFORM pg_temp.shp2pgsql_topogeometry_layer_id(");
+	append_sql_literal(sb, state->config->topology);
+	stringbuffer_aprintf(sb, "::name, ");
+	append_table_regclass(sb, state);
+	stringbuffer_aprintf(sb, ", ");
+	append_sql_literal(sb, state->geo_col);
+	stringbuffer_aprintf(sb,
+			     "::name);\n"
+			     "END $$;\n");
+}
+
+static void
+append_drop_topogeometry_column(stringbuffer_t *sb, SHPLOADERSTATE *state)
+{
+	stringbuffer_aprintf(sb,
+			     "DO $$ DECLARE\n"
+			     "  lyr record;\n"
+			     "  target_table regclass := to_regclass(");
+	append_table_identifier_literal(sb, state);
+	stringbuffer_aprintf(sb,
+			     ");\n"
+			     "  target_schema name;\n"
+			     "  target_name name;\n"
+			     "BEGIN\n"
+			     "  IF target_table IS NULL THEN\n"
+			     "    RETURN;\n"
+			     "  END IF;\n"
+			     "  SELECT n.nspname, c.relname INTO target_schema, target_name\n"
+			     "    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace\n"
+			     "    WHERE c.oid = target_table;\n"
+			     "  FOR lyr IN SELECT feature_column FROM topology.layer\n"
+			     "    WHERE schema_name = target_schema AND table_name = target_name"
+			     " LOOP\n"
+			     "    PERFORM topology.DropTopoGeometryColumn(");
+	stringbuffer_aprintf(sb,
+			     "target_schema::varchar, target_name::varchar, lyr.feature_column);\n"
+			     "  END LOOP;\n"
+			     "END $$;\n");
+}
+
+static void
 append_primary_key_ddl(const SHPLOADERSTATE *state, stringbuffer_t *sb)
 {
 	const char *fid_col = ShpLoaderFIDColumn(state);
@@ -911,6 +1038,7 @@ set_loader_config_defaults(SHPLOADERCONFIG *config)
 	config->dump_format = 0;
 	config->simple_geometries = 0;
 	config->geography = 0;
+	config->topology = NULL;
 	config->quoteidentifiers = 0;
 	config->forceint4 = 0;
 	config->createindex = LOADER_CREATE_NONE;
@@ -1041,7 +1169,10 @@ ShpLoaderCreate(SHPLOADERCONFIG *config)
 
 	if (!state->geo_col)
 	{
-		state->geo_col = config->geography ? GEOGRAPHY_DEFAULT : GEOMETRY_DEFAULT;
+		if (config->topology)
+			state->geo_col = TOPOGEOMETRY_DEFAULT;
+		else
+			state->geo_col = config->geography ? GEOGRAPHY_DEFAULT : GEOMETRY_DEFAULT;
 	}
 
 	colmap_init(&state->column_map);
@@ -1079,6 +1210,16 @@ ShpLoaderOpenShape(SHPLOADERSTATE *state)
 
 		if (state->hSHPHandle == NULL)
 		{
+			if (state->config->topology)
+			{
+				snprintf(
+				    state->message,
+				    SHPLOADERMSGLEN,
+				    _("%s: topology loading requires readable shape (.shp) and index files (.shx)."),
+				    state->config->shp_file);
+				return SHPLOADERERR;
+			}
+
 			snprintf(state->message, SHPLOADERMSGLEN, _("%s: shape (.shp) or index files (.shx) can not be opened, will just import attribute data."), state->config->shp_file);
 			state->config->readshape = 0;
 
@@ -1291,6 +1432,37 @@ ShpLoaderOpenShape(SHPLOADERSTATE *state)
 		default:
 			/* Simply use the auto-detected values above */
 			break;
+		}
+
+		if (state->config->topology)
+		{
+			if (state->has_m && !state->has_z)
+			{
+				snprintf(
+				    state->message,
+				    SHPLOADERMSGLEN,
+				    _("Topology loading does not support M-only geometries; use -t 2D or -t 3DZ to drop the measure dimension."));
+				return SHPLOADERERR;
+			}
+
+			switch (geomtype)
+			{
+			case POINTTYPE:
+				state->pgtype = "POINT";
+				break;
+			case MULTIPOINTTYPE:
+				state->pgtype = "MULTIPOINT";
+				break;
+			case MULTILINETYPE:
+				state->pgtype = "MULTILINE";
+				break;
+			case MULTIPOLYGONTYPE:
+				state->pgtype = "MULTIPOLYGON";
+				break;
+			default:
+				state->pgtype = "GEOMETRY";
+				break;
+			}
 		}
 
 		/* If in simple geometry mode, alter names for CREATE TABLE by skipping MULTI */
@@ -1521,6 +1693,9 @@ ShpLoaderGetSQLHeader(SHPLOADERSTATE *state, char **strheader)
 	/* Drop table if requested */
 	if (state->config->plan.drop_table)
 	{
+		if (state->config->readshape == 1 && state->config->topology)
+			append_drop_topogeometry_column(sb, state);
+
 		if (state->config->schema)
 		{
 			stringbuffer_aprintf(sb, "DROP TABLE IF EXISTS \"%s\".\"%s\";\n", state->config->schema,
@@ -1584,7 +1759,7 @@ ShpLoaderGetSQLHeader(SHPLOADERSTATE *state, char **strheader)
 		 * geometry_columns is a view in current PostGIS, so typmod column
 		 * DDL is equivalent to the default AddGeometryColumn path.
 		 */
-		if (state->config->readshape == 1)
+		if (state->config->readshape == 1 && !state->config->topology)
 		{
 			const char *coltype = state->config->geography ? "geography" : "geometry";
 			char typmod_type[64];
@@ -1608,6 +1783,40 @@ ShpLoaderGetSQLHeader(SHPLOADERSTATE *state, char **strheader)
 
 		if (!if_not_exists)
 			append_primary_key_ddl(state, sb);
+
+		if (state->config->readshape == 1 && state->config->topology)
+		{
+			if (if_not_exists)
+			{
+				stringbuffer_aprintf(sb, "DO $$ BEGIN\n");
+				stringbuffer_aprintf(sb, "  IF topology.FindLayer(");
+				append_table_regclass(sb, state);
+				stringbuffer_aprintf(sb, ", ");
+				append_sql_literal(sb, state->geo_col);
+				stringbuffer_aprintf(
+				    sb, "::name) IS NULL THEN\n    PERFORM topology.AddTopoGeometryColumn(");
+			}
+			else
+			{
+				stringbuffer_aprintf(sb, "SELECT topology.AddTopoGeometryColumn(");
+			}
+			append_sql_literal(sb, state->config->topology);
+			stringbuffer_aprintf(sb, ", ");
+			append_table_regclass(sb, state);
+			stringbuffer_aprintf(sb, ", ");
+			append_sql_literal(sb, state->geo_col);
+			stringbuffer_aprintf(sb, ", NULL, ");
+			append_sql_literal(sb, state->pgtype);
+			if (if_not_exists)
+				stringbuffer_aprintf(sb, ");\n  END IF;\nEND $$;\n");
+			else
+				stringbuffer_aprintf(sb, ");\n");
+		}
+	}
+
+	if (state->config->plan.load_data && state->config->readshape == 1 && state->config->topology)
+	{
+		append_validate_topology_layer(sb, state);
 	}
 
 	/**If we are in dump mode and a transform was asked for need to create a temp table to store original data
@@ -1956,6 +2165,10 @@ done_cell:
 			/* Now generate the geometry string according to the current configuration */
 			if (!state->config->dump_format)
 			{
+				if (state->config->topology)
+				{
+					stringbuffer_aprintf(sb, "topology.toTopoGeom(");
+				}
 				if (state->to_srid != state->from_srid)
 				{
 					stringbuffer_aprintf(sb, "ST_Transform(");
@@ -1979,6 +2192,19 @@ done_cell:
 						stringbuffer_aprintf(sb, "::geometry, %d)::geography", state->to_srid);
 					else
 						stringbuffer_aprintf(sb, "::geometry, %d)", state->to_srid);
+				}
+				else if (state->config->topology)
+				{
+					stringbuffer_aprintf(sb, "::geometry");
+				}
+
+				if (state->config->topology)
+				{
+					stringbuffer_aprintf(sb, ", ");
+					append_sql_literal(sb, state->config->topology);
+					stringbuffer_aprintf(sb, ", ");
+					append_topology_layer_id(sb, state);
+					stringbuffer_aprintf(sb, ")");
 				}
 			}
 
@@ -2054,7 +2280,8 @@ ShpLoaderGetSQLFooter(SHPLOADERSTATE *state, char **strfooter)
 	}
 
 	/* Create gist index if specified and not in "prepare" mode */
-	if (state->config->readshape && state->config->plan.create_index != LOADER_CREATE_NONE)
+	if (state->config->readshape && !state->config->topology &&
+	    state->config->plan.create_index != LOADER_CREATE_NONE)
 	{
 		stringbuffer_aprintf(sb, "CREATE INDEX ");
 		if (state->config->plan.create_index == LOADER_CREATE_IF_NOT_EXISTS)

--- a/loader/shp2pgsql-core.h
+++ b/loader/shp2pgsql-core.h
@@ -71,6 +71,7 @@
  */
 #define GEOMETRY_DEFAULT "geom"
 #define GEOGRAPHY_DEFAULT "geog"
+#define TOPOGEOMETRY_DEFAULT "topogeom"
 #define FID_DEFAULT "gid"
 
 /*
@@ -109,6 +110,9 @@ typedef struct shp_loader_config
 
 	/* 0 = geometry, 1 = geography */
 	int geography;
+
+	/* Topology name for loading directly into a TopoGeometry column, may be null. */
+	char *topology;
 
 	/* 0 = columnname, 1 = "columnName" */
 	int quoteidentifiers;


### PR DESCRIPTION
## Summary

This adds a `shp2pgsql --topology <topology>` mode for loading Shapefiles directly into a TopoGeometry column.

The generated SQL now:

- creates the regular feature table,
- registers the target column with `topology.AddTopoGeometryColumn(...)`,
- skips duplicate TopoGeometry registration when `--if-not-exists` finds an existing layer,
- inserts each shape through `topology.toTopoGeom(...)`, resolving the layer through a fail-fast helper,
- validates append-mode topology layer ownership before loading,
- keeps the per-row helper in append mode so ignored header errors cannot become NULL TopoGeometry inserts,
- rejects implicit DBF-only fallback in topology mode,
- rejects M-only topology loads with a clear error,
- uses `-g` as the TopoGeometry column name override.

The mode rejects combinations that do not fit this SQL path yet: `-D`, `-G`, `-I`, and `-n`.

Closes https://trac.osgeo.org/postgis/ticket/2103

## Validation

- `make -C loader -j16`
- `make -C loader/cunit cu_tester -j16`
- `./loader/cunit/cu_tester shp2pgsql`
- live topology smoke: repeat `./loader/shp2pgsql -s 4326 --if-not-exists --topology city_topo regress/loader/Point public.blocks | psql -v ON_ERROR_STOP=1 ...`
- live topology smoke: `./loader/shp2pgsql --topology city_topo regress/loader/CharNoWidth public.dbf_only` rejects missing `.shp/.shx`
- live topology smoke: `./loader/shp2pgsql -a -e -s 4326 --topology city_topo regress/loader/Point public.ordinary_blocks | psql ...` leaves `0|0` rows and raises per-row `not registered in topology.layer`
- `make -C doc check-xml`
- `./utils/check_news.sh .`
- `git diff --check`
- `git clang-format --diff upstream/master -- loader/shp2pgsql-core.c loader/cunit/cu_shp2pgsql.c loader/shp2pgsql-cli.c loader/shp2pgsql-core.h`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/307
