### PR TITLE
raster: preserve missing NODATA in map algebra

### DIFF
--- a/raster/rt_pg/rtpg_mapalgebra.c
+++ b/raster/rt_pg/rtpg_mapalgebra.c
@@ -211,6 +211,10 @@ struct rtpg_nmapalgebra_arg_t {
 	rtpg_nmapalgebra_callback_arg	callback;
 };
 
+static int rtpg_nmapalgebra_missing_band_can_emit_nodata(uint8_t *hasband, int numraster);
+static int
+rtpg_nmapalgebra_source_has_nodata(rt_raster *rasters, uint8_t *hasband, int *nband, int numraster, double *nodataval);
+
 static rtpg_nmapalgebra_arg rtpg_nmapalgebra_arg_init(void) {
 	rtpg_nmapalgebra_arg arg = NULL;
 
@@ -276,6 +280,121 @@ static void rtpg_nmapalgebra_arg_destroy(rtpg_nmapalgebra_arg arg) {
 		pfree(arg->callback.empty_userargs);
 
 	pfree(arg);
+}
+
+static int
+rtpg_nmapalgebra_same_grid_extent(rt_raster rast1, rt_raster rast2)
+{
+	int aligned = 0;
+
+	if (rast1 == NULL || rast2 == NULL || rt_raster_is_empty(rast1) || rt_raster_is_empty(rast2))
+		return 0;
+
+	if (rt_raster_same_alignment(rast1, rast2, &aligned, NULL) != ES_NONE || !aligned)
+		return 0;
+
+	return (rt_raster_get_width(rast1) == rt_raster_get_width(rast2) &&
+		rt_raster_get_height(rast1) == rt_raster_get_height(rast2) &&
+		FLT_EQ(rt_raster_get_x_offset(rast1), rt_raster_get_x_offset(rast2)) &&
+		FLT_EQ(rt_raster_get_y_offset(rast1), rt_raster_get_y_offset(rast2)));
+}
+
+static int
+rtpg_nmapalgebra_covers_grid_extent(rt_raster rast, rt_raster extent)
+{
+	int aligned = 0;
+	int covers = 0;
+
+	if (rast == NULL || extent == NULL || rt_raster_is_empty(rast) || rt_raster_is_empty(extent))
+		return 0;
+
+	if (rt_raster_same_alignment(rast, extent, &aligned, NULL) != ES_NONE || !aligned)
+		return 0;
+
+	if (rt_raster_covers(rast, -1, extent, -1, &covers) != ES_NONE)
+		return 0;
+
+	return covers;
+}
+
+static int
+rtpg_nmapalgebra_extent_can_synthesize_gaps(rt_raster *rasters,
+					    uint8_t *hasband,
+					    int numraster,
+					    rt_extenttype extenttype,
+					    rt_raster customextent)
+{
+	rt_raster ref = NULL;
+	int i = 0;
+
+	if (numraster < 2 || extenttype == ET_INTERSECTION)
+		return 0;
+
+	switch (extenttype)
+	{
+	case ET_CUSTOM:
+		ref = customextent;
+		break;
+	case ET_SECOND:
+		ref = rasters[(numraster > 1) ? 1 : 0];
+		break;
+	case ET_LAST:
+		ref = rasters[numraster - 1];
+		break;
+	case ET_UNION:
+		for (i = 0; i < numraster; i++)
+		{
+			if (hasband[i])
+			{
+				ref = rasters[i];
+				break;
+			}
+		}
+		break;
+	default:
+		ref = rasters[0];
+		break;
+	}
+
+	if (ref == NULL)
+		return 0;
+
+	for (i = 0; i < numraster; i++)
+	{
+		if (!hasband[i])
+			continue;
+		if (extenttype == ET_UNION)
+		{
+			if (!rtpg_nmapalgebra_same_grid_extent(ref, rasters[i]))
+				return 1;
+		}
+		else if (!rtpg_nmapalgebra_covers_grid_extent(rasters[i], ref))
+			return 1;
+	}
+
+	return 0;
+}
+
+static int
+rtpg_nmapalgebra_source_has_nodata(rt_raster *rasters, uint8_t *hasband, int *nband, int numraster, double *nodataval)
+{
+	for (int i = 0; i < numraster; i++)
+	{
+		rt_band band;
+
+		if (!hasband[i])
+			continue;
+
+		band = rt_raster_get_band(rasters[i], nband[i]);
+		if (!rt_band_get_hasnodata_flag(band))
+			continue;
+
+		if (nodataval)
+			rt_band_get_nodata(band, nodataval);
+		return 1;
+	}
+
+	return 0;
 }
 
 static int rtpg_nmapalgebra_rastbandarg_process(rtpg_nmapalgebra_arg arg, ArrayType *array, int *allnull, int *allempty, int *noband) {
@@ -642,6 +761,8 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 	int allnull = 0;
 	int allempty = 0;
 	int noband = 0;
+	int source_has_nodata = 0;
+	double source_nodataval = 0;
 
 	rt_raster raster = NULL;
 	rt_band band = NULL;
@@ -1020,11 +1141,20 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 	if (arg->pixtype == PT_END)
 		arg->pixtype = rt_band_get_pixtype(band);
 
-	/* set hasnodata and nodataval */
-	arg->hasnodata = rt_band_get_hasnodata_flag(band);
+	/* set output hasnodata and nodataval */
+	source_has_nodata = rtpg_nmapalgebra_source_has_nodata(
+	    arg->raster, arg->hasband, arg->nband, arg->numraster, &source_nodataval);
+	arg->hasnodata = source_has_nodata;
+	if (!arg->hasnodata && rtpg_nmapalgebra_missing_band_can_emit_nodata(arg->hasband, arg->numraster))
+		arg->hasnodata = 1;
+	if (!arg->hasnodata && rtpg_nmapalgebra_extent_can_synthesize_gaps(
+				   arg->raster, arg->hasband, arg->numraster, arg->extenttype, arg->cextent))
+		arg->hasnodata = 1;
 	arg->callback.hasnodata = arg->hasnodata;
-	if (arg->hasnodata)
+	if (rt_band_get_hasnodata_flag(band))
 		rt_band_get_nodata(band, &(arg->nodataval));
+	else if (source_has_nodata)
+		arg->nodataval = source_nodataval;
 	else
 		arg->nodataval = rt_band_get_min_value(band);
 
@@ -1171,6 +1301,128 @@ static void rtpg_nmapalgebraexpr_arg_destroy(rtpg_nmapalgebraexpr_arg arg) {
 	}
 
 	pfree(arg);
+}
+
+static int
+rtpg_nmapalgebra_missing_band_can_emit_nodata(uint8_t *hasband, int numraster)
+{
+	/* Missing requested bands are passed to the iterator as NODATA sources,
+	 * even though no source band metadata can advertise that up front. */
+	for (int i = 0; i < numraster; i++)
+	{
+		if (!hasband[i])
+			return 1;
+	}
+
+	return 0;
+}
+
+static int
+rtpg_nmapalgebraexpr_nodata_flags_can_emit(rtpg_nmapalgebraexpr_callback_arg *callback,
+					   int *hasnodata,
+					   int numraster,
+					   int both_can_occur)
+{
+	if (numraster > 1)
+	{
+		if (both_can_occur && hasnodata[0] && hasnodata[1] && !callback->nodatanodata.hasval)
+			return 1;
+		if (hasnodata[0] && !callback->expr[1].hasval && !callback->expr[1].spi_plan)
+			return 1;
+		if (hasnodata[1] && !callback->expr[2].hasval && !callback->expr[2].spi_plan)
+			return 1;
+	}
+	else if (hasnodata[0] && !callback->expr[1].hasval && !callback->expr[1].spi_plan)
+		return 1;
+
+	return 0;
+}
+
+static int
+rtpg_nmapalgebraexpr_source_can_emit_nodata(rtpg_nmapalgebraexpr_callback_arg *callback,
+					    rt_raster *rasters,
+					    uint8_t *hasband,
+					    int *nband,
+					    int numraster)
+{
+	int hasnodata[2] = {0, 0};
+
+	for (int i = 0; i < numraster && i < 2; i++)
+	{
+		rt_band band;
+
+		if (!hasband[i])
+		{
+			hasnodata[i] = 1;
+			continue;
+		}
+
+		band = rt_raster_get_band(rasters[i], nband[i]);
+		hasnodata[i] = rt_band_get_hasnodata_flag(band);
+	}
+
+	return rtpg_nmapalgebraexpr_nodata_flags_can_emit(callback, hasnodata, numraster, 1);
+}
+
+static int
+rtpg_nmapalgebraexpr_extent_can_emit_nodata(rtpg_nmapalgebraexpr_callback_arg *callback,
+					    rt_raster *rasters,
+					    uint8_t *hasband,
+					    int numraster,
+					    rt_extenttype extenttype,
+					    rt_raster customextent)
+{
+	int gap[2] = {0, 0};
+	int both_can_occur = 0;
+	int refindex = 0;
+
+	if (numraster < 2 || extenttype == ET_INTERSECTION)
+		return 0;
+
+	switch (extenttype)
+	{
+	case ET_SECOND:
+		refindex = (numraster > 1) ? 1 : 0;
+		break;
+	case ET_LAST:
+		refindex = numraster - 1;
+		break;
+	default:
+		refindex = 0;
+		break;
+	}
+
+	for (int i = 0; i < numraster && i < 2; i++)
+	{
+		if (!hasband[i])
+			continue;
+
+		if (extenttype == ET_UNION)
+		{
+			for (int j = 0; j < numraster; j++)
+			{
+				if (i == j || !hasband[j])
+					continue;
+				if (!rtpg_nmapalgebra_covers_grid_extent(rasters[i], rasters[j]))
+				{
+					gap[i] = 1;
+					break;
+				}
+			}
+		}
+		else if (extenttype == ET_CUSTOM)
+		{
+			if (!rtpg_nmapalgebra_covers_grid_extent(rasters[i], customextent))
+				gap[i] = 1;
+		}
+		else if (i != refindex && !rtpg_nmapalgebra_covers_grid_extent(rasters[i], rasters[refindex]))
+			gap[i] = 1;
+	}
+
+	if (extenttype == ET_CUSTOM)
+		both_can_occur = 1;
+
+	return rtpg_nmapalgebraexpr_nodata_flags_can_emit(callback, gap, numraster, both_can_occur);
 }
 
 static int rtpg_nmapalgebraexpr_callback(
@@ -1427,6 +1679,9 @@ Datum RASTER_nMapAlgebraExpr(PG_FUNCTION_ARGS)
 	int allempty = 0;
 	int noband = 0;
 	int len = 0;
+	int source_can_emit_nodata = 0;
+	int source_has_nodata = 0;
+	double source_nodataval = 0;
 
 	TupleDesc tupdesc;
 	SPITupleTable *tuptable = NULL;
@@ -1725,11 +1980,24 @@ Datum RASTER_nMapAlgebraExpr(PG_FUNCTION_ARGS)
 	if (arg->bandarg->pixtype == PT_END)
 		arg->bandarg->pixtype = rt_band_get_pixtype(band);
 
-	/* set hasnodata and nodataval */
-	arg->bandarg->hasnodata = rt_band_get_hasnodata_flag(band);
+	/* set output hasnodata and nodataval */
+	source_has_nodata = rtpg_nmapalgebra_source_has_nodata(
+	    arg->bandarg->raster, arg->bandarg->hasband, arg->bandarg->nband, numraster, &source_nodataval);
+	source_can_emit_nodata = rtpg_nmapalgebraexpr_source_can_emit_nodata(
+	    &(arg->callback), arg->bandarg->raster, arg->bandarg->hasband, arg->bandarg->nband, numraster);
+	arg->bandarg->hasnodata = source_can_emit_nodata;
+	if (!arg->bandarg->hasnodata && rtpg_nmapalgebraexpr_extent_can_emit_nodata(&(arg->callback),
+										    arg->bandarg->raster,
+										    arg->bandarg->hasband,
+										    numraster,
+										    arg->bandarg->extenttype,
+										    arg->bandarg->cextent))
+		arg->bandarg->hasnodata = 1;
 	arg->callback.hasnodata = arg->bandarg->hasnodata;
-	if (arg->bandarg->hasnodata)
+	if (rt_band_get_hasnodata_flag(band))
 		rt_band_get_nodata(band, &(arg->bandarg->nodataval));
+	else if (source_can_emit_nodata && source_has_nodata)
+		arg->bandarg->nodataval = source_nodataval;
 	else
 		arg->bandarg->nodataval = rt_band_get_min_value(band);
 

--- a/raster/rt_pg/rtpostgis.sql.in
+++ b/raster/rt_pg/rtpostgis.sql.in
@@ -4444,8 +4444,15 @@ CREATE OR REPLACE FUNCTION st_grayscale(
 		stats @extschema@.summarystats;
 		nodata double precision;
 		nodataval integer;
+		pixtype text;
 		reclassexpr text;
 		hasnodata boolean DEFAULT FALSE;
+		reservenodata boolean;
+		can_synthesize_gaps boolean DEFAULT FALSE;
+		mapalgebra_extenttype text;
+		extenttype_upper text;
+		refidx integer;
+		refrast @extschema@.raster;
 		grayscale @extschema@.raster;
 
 	BEGIN
@@ -4478,9 +4485,59 @@ CREATE OR REPLACE FUNCTION st_grayscale(
 				hasnodata := TRUE;
 			END IF;
 
-			-- check that each band is 8BUI. if not, reclassify to 8BUI
-			IF @extschema@.ST_BandPixelType(rast, nband) != _PIXTYPE THEN
-				stats := @extschema@.ST_SummaryStats(rast, nband);
+		END LOOP;
+
+		extenttype_upper := upper(extenttype);
+		IF extenttype_upper != 'INTERSECTION' THEN
+			refidx := CASE
+				WHEN extenttype_upper = 'SECOND' THEN 2
+				WHEN extenttype_upper = 'LAST' THEN _NBANDS
+				ELSE 1
+			END;
+			refrast := _set[refidx].rast;
+
+			FOR idx IN 1.._NBANDS LOOP
+				IF extenttype_upper = 'UNION' THEN
+					IF NOT @extschema@.ST_SameAlignment(refrast, _set[idx].rast)
+						OR NOT @extschema@.ST_Equals(
+							@extschema@.ST_ConvexHull(refrast),
+							@extschema@.ST_ConvexHull(_set[idx].rast)
+						)
+					THEN
+						can_synthesize_gaps := TRUE;
+						EXIT;
+					END IF;
+				ELSIF NOT @extschema@.ST_SameAlignment(refrast, _set[idx].rast)
+					OR NOT @extschema@.ST_Covers(_set[idx].rast, refrast)
+				THEN
+					can_synthesize_gaps := TRUE;
+					EXIT;
+				END IF;
+			END LOOP;
+		END IF;
+		mapalgebra_extenttype := CASE
+			WHEN can_synthesize_gaps THEN extenttype
+			ELSE 'INTERSECTION'
+		END;
+		reservenodata := hasnodata OR can_synthesize_gaps;
+
+		FOR idx IN 1.._NBANDS LOOP
+
+			rast := _set[idx].rast;
+			nband := _set[idx].nband;
+
+			nodata := @extschema@.ST_BandNoDataValue(rast, nband);
+			pixtype := @extschema@.ST_BandPixelType(rast, nband);
+
+			-- Check that each band is 8BUI and reserve 255 when NULL input
+			-- values must survive as output NODATA.
+			IF pixtype != _PIXTYPE OR reservenodata THEN
+				IF pixtype = _PIXTYPE AND nodata IS NULL AND reservenodata THEN
+					stats.min := 0;
+					stats.max := _NODATA;
+				ELSE
+					stats := @extschema@.ST_SummaryStats(rast, nband);
+				END IF;
 
 				IF nodata IS NOT NULL THEN
 					nodataval := _NODATA;
@@ -4488,6 +4545,9 @@ CREATE OR REPLACE FUNCTION st_grayscale(
 						concat('[', nodata , '-', nodata, ']:', _NODATA, '-', _NODATA, ','),
 						concat('[', stats.min , '-', stats.max , ']:0-', _NODATA - 1)
 					);
+				ELSIF reservenodata THEN
+					nodataval := _NODATA;
+					reclassexpr := concat('[', stats.min , '-', stats.max , ']:0-', _NODATA - 1);
 				ELSE
 					nodataval := NULL;
 					reclassexpr := concat('[', stats.min , '-', stats.max , ']:0-', _NODATA);
@@ -4510,10 +4570,10 @@ CREATE OR REPLACE FUNCTION st_grayscale(
 			_set,
 			'@extschema@._ST_Grayscale4MA(double precision[][][], integer[][], text[])'::regprocedure,
 			'8BUI',
-			extenttype
+			mapalgebra_extenttype
 		);
 
-		IF hasnodata THEN
+		IF hasnodata OR can_synthesize_gaps THEN
 			grayscale := @extschema@.ST_SetBandNoDataValue(grayscale, 1, _NODATA);
 		END IF;
 

--- a/raster/test/regress/rt_grayscale.sql
+++ b/raster/test/regress/rt_grayscale.sql
@@ -160,6 +160,154 @@ SELECT
 	(ST_DumpValues(rast)).valarray
 FROM mixed;
 
+WITH src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 1, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, 0
+		),
+		1, 1, 1, ARRAY[[0, 255]]::double precision[]
+	) AS rast
+), gray AS (
+	SELECT ST_Grayscale(
+		ARRAY[
+			ROW(rast, 1)::rastbandarg,
+			ROW(rast, 1)::rastbandarg,
+			ROW(rast, 1)::rastbandarg
+		]::rastbandarg[]
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.grayscale.8bui-nodata',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM gray;
+
+WITH red AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 255, NULL
+		),
+		1, 1, 1, ARRAY[[255]]::double precision[]
+	) AS rast
+), gb AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 1, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, NULL
+		),
+		1, 1, 1, ARRAY[[0]]::double precision[]
+	) AS rast
+), gray AS (
+	SELECT ST_Grayscale(
+		ARRAY[
+			ROW(red.rast, 1)::rastbandarg,
+			ROW(gb.rast, 1)::rastbandarg,
+			ROW(gb.rast, 1)::rastbandarg
+		]::rastbandarg[],
+		'UNION'
+	) AS rast
+	FROM red CROSS JOIN gb
+)
+SELECT
+	'#2807.grayscale.union-gap',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM gray;
+
+WITH src AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, NULL
+		),
+		1, 1, 1, ARRAY[[255]]::double precision[]
+	) AS rast
+), gray AS (
+	SELECT ST_Grayscale(
+		ARRAY[
+			ROW(rast, 1)::rastbandarg,
+			ROW(rast, 1)::rastbandarg,
+			ROW(rast, 1)::rastbandarg
+		]::rastbandarg[],
+		'UNION'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.grayscale.union-coextensive-white',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM gray;
+
+WITH red AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, NULL
+		),
+		1, 1, 1, ARRAY[[255]]::double precision[]
+	) AS rast
+), gb AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 1, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, NULL
+		),
+		1, 1, 1, ARRAY[[255, 0]]::double precision[]
+	) AS rast
+), gray AS (
+	SELECT ST_Grayscale(
+		ARRAY[
+			ROW(red.rast, 1)::rastbandarg,
+			ROW(gb.rast, 1)::rastbandarg,
+			ROW(gb.rast, 1)::rastbandarg
+		]::rastbandarg[],
+		'FIRST'
+	) AS rast
+	FROM red CROSS JOIN gb
+)
+SELECT
+	'#2807.grayscale.first-covered-white',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM gray;
+
+WITH red AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 1, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, NULL
+		),
+		1, 1, 1, ARRAY[[255, 255]]::double precision[]
+	) AS rast
+), gb AS (
+	SELECT ST_SetValues(
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1, -1, 0, 0, 0),
+			1, '8BUI', 0, NULL
+		),
+		1, 1, 1, ARRAY[[255]]::double precision[]
+	) AS rast
+), gray AS (
+	SELECT ST_Grayscale(
+		ARRAY[
+			ROW(red.rast, 1)::rastbandarg,
+			ROW(gb.rast, 1)::rastbandarg,
+			ROW(gb.rast, 1)::rastbandarg
+		]::rastbandarg[],
+		'FIRST'
+	) AS rast
+	FROM red CROSS JOIN gb
+)
+SELECT
+	'#2807.grayscale.first-gap-white',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM gray;
+
 -- error because of insufficient bands
 BEGIN;
 SELECT

--- a/raster/test/regress/rt_grayscale_expected
+++ b/raster/test/regress/rt_grayscale_expected
@@ -30,6 +30,11 @@ WARNING:  Only the first three elements of 'rastbandargset' will be used
 #2807.grayscale|3|3|255
 #2807.grayscale|3|5|
 #2807.grayscale.mixed|255|{{NULL,38},{254,254}}
+#2807.grayscale.8bui-nodata|255|{{NULL,0}}
+#2807.grayscale.union-gap|255|{{NULL,NULL}}
+#2807.grayscale.union-coextensive-white||{{255}}
+#2807.grayscale.first-covered-white||{{255}}
+#2807.grayscale.first-gap-white|255|{{254,NULL}}
 ERROR:  'rastbandargset' must have three bands for red, green and blue
 ERROR:  Band at index '2' not found for raster '2'
 ERROR:  Band at index '2' not found for raster '2'

--- a/raster/test/regress/rt_mapalgebra.sql
+++ b/raster/test/regress/rt_mapalgebra.sql
@@ -608,6 +608,24 @@ CREATE OR REPLACE FUNCTION raster_nmapalgebra_null(
 	AS $$ SELECT NULL::double precision $$
 	LANGUAGE 'sql' IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION raster_nmapalgebra_zero(
+	value double precision[][][],
+	pos int[][],
+	VARIADIC userargs text[]
+)
+	RETURNS double precision
+	AS $$ SELECT 0::double precision $$
+	LANGUAGE 'sql' IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION raster_nmapalgebra_sum(
+	value double precision[][][],
+	pos int[][],
+	VARIADIC userargs text[]
+)
+	RETURNS double precision
+	AS $$ SELECT value[1][1][1] + value[2][1][1] $$
+	LANGUAGE 'sql' IMMUTABLE;
+
 SET client_min_messages TO warning;
 
 WITH src AS (
@@ -639,6 +657,228 @@ SELECT
 		'raster_nmapalgebra_one(double precision[], int[], text[])'::regprocedure
 	), 1, 1)
 FROM src;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 1.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 2.0, NULL
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, rast2,
+		'[rast1.val] + [rast2.val]',
+		'16BUI', 'UNION'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.union-coextensive',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 1.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 1, 0, 1),
+			'16BUI', 2.0, NULL
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, rast2,
+		'[rast1.val] + [rast2.val]',
+		'16BUI', 'UNION'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.union-gap',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 1.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 1, 0, 0, 1),
+			'16BUI', 2.0, NULL
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, rast2,
+		'[rast1.val] + [rast2.val]',
+		'16BUI', 'FIRST'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.first-covered',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(2, 1, 0, 0, 1),
+			'16BUI', 0.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 1.0, NULL
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, rast2,
+		'[rast1.val] + [rast2.val]',
+		'16BUI', 'FIRST',
+		NULL, '[rast1.val]'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.expr-handled-extent-gap',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 0.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 5.0, 5.0
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, rast2,
+		'[rast1.val] + [rast2.val]',
+		'16BUI', 'INTERSECTION',
+		NULL, '[rast1.val]'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.expr-handled-source-nodata',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 0.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 5.0, 5.0
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, 1,
+		rast2, 1,
+		'raster_nmapalgebra_zero(double precision[][][], int[][], text[])'::regprocedure,
+		'16BUI'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.callback-handled-source-nodata',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 0.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 5.0, 5.0
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, 1,
+		rast2, 1,
+		'raster_nmapalgebra_zero(double precision[][][], int[][], text[])'::regprocedure,
+		'16BUI'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.callback-later-band-nodata',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 1.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 2.0, NULL
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, 1,
+		rast2, 2,
+		'[rast1.val] + [rast2.val]',
+		'16BUI', 'INTERSECTION'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.expr-missing-band-nodata',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
+
+WITH src AS (
+	SELECT
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 1.0, NULL
+		) AS rast1,
+		ST_AddBand(
+			ST_MakeEmptyRaster(1, 1, 0, 0, 1),
+			'16BUI', 2.0, NULL
+		) AS rast2
+), alg AS (
+	SELECT ST_MapAlgebra(
+		rast1, 1,
+		rast2, 2,
+		'raster_nmapalgebra_sum(double precision[][][], int[][], text[])'::regprocedure,
+		'16BUI'
+	) AS rast
+	FROM src
+)
+SELECT
+	'#2807.nmap.callback-missing-band-nodata',
+	(ST_BandMetadata(rast, 1)).nodatavalue,
+	(ST_DumpValues(rast)).valarray
+FROM alg;
 
 WITH src AS (
 	SELECT ST_AddBand(
@@ -695,6 +935,8 @@ WHERE rid IN (2);
 
 DROP FUNCTION IF EXISTS raster_nmapalgebra_one(double precision[], int[], text[]);
 DROP FUNCTION IF EXISTS raster_nmapalgebra_null(double precision[], int[], text[]);
+DROP FUNCTION IF EXISTS raster_nmapalgebra_zero(double precision[][][], int[][], text[]);
+DROP FUNCTION IF EXISTS raster_nmapalgebra_sum(double precision[][][], int[][], text[]);
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test(double precision[], int[], text[]);
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test_no_userargs(double precision[], int[]);
 DROP FUNCTION IF EXISTS raster_nmapalgebra_test_bad_return(double precision[], int[], text[]);

--- a/raster/test/regress/rt_mapalgebra_expected
+++ b/raster/test/regress/rt_mapalgebra_expected
@@ -355,6 +355,15 @@ NOTICE:  userargs = {}
 2|
 #2807.expr|(8BUI,,f,,,,)|0
 #2807.callback|(8BUI,,f,,,,)|1
+#2807.nmap.union-coextensive||{{3}}
+#2807.nmap.union-gap|0|{{NULL,NULL}}
+#2807.nmap.first-covered||{{3}}
+#2807.nmap.expr-handled-extent-gap||{{1,0}}
+#2807.nmap.expr-handled-source-nodata||{{0}}
+#2807.nmap.callback-handled-source-nodata|5|{{0}}
+#2807.nmap.callback-later-band-nodata|5|{{0}}
+#2807.nmap.expr-missing-band-nodata|0|{{NULL}}
+#2807.nmap.callback-missing-band-nodata|0|{{NULL}}
 ERROR:  RASTER_nMapAlgebraExpr: Expression returned NULL but output raster has no NODATA value
 ERROR:  RASTER_nMapAlgebra: Callback returned NULL but output raster has no NODATA value
 ERROR:  RASTER_nMapAlgebra: Function provided must return a double precision, float, int or smallint


### PR DESCRIPTION
## Summary
- keep n-raster map algebra callbacks able to emit output NODATA when source bands, missing requested bands, or selected extents can synthesize missing source pixels
- use an existing source NODATA value as the output sentinel when later participating bands require callback output NODATA, so valid minimum-valued callback results are not hidden
- treat absent requested expression/callback bands as iterator-provided NODATA sources so NULL results become output NODATA instead of raising
- make expression-mode gap detection respect `nodata1expr`, `nodata2expr`, and `nodatanodataval`, so handled extent gaps can return valid minimum-valued pixels without reserving them as NODATA
- make gap detection coverage-aware for `FIRST`, `SECOND`, `LAST`, and custom-style selected extents, while keeping `UNION` gap detection tied to actual source coverage
- reserve the grayscale 255 sentinel only when source bands have NODATA or RGB rasters can actually synthesize gap pixels; covered `FIRST` extents and coextensive `UNION` white pixels remain valid 255 values
- avoid stats-stretching native 8BUI grayscale inputs when a sentinel is reserved, using the full 0..255 domain instead
- add regression coverage for later-band NODATA, missing requested bands, n-raster UNION gap/coextensive behavior, covered `FIRST` extents, handled extent gaps, handled source NODATA, 8BUI white-pixel collisions, and grayscale extent gaps for https://trac.osgeo.org/postgis/ticket/2807

## Current State
- rebased onto `postgis/postgis@4e470f1534795ae4a4c52ad5ad35b8744af9d708`
- current head is `7cccf2a1faf2f4a636cd8001f94972540e510f8a`
- GitHub review threads: 8 total, 0 unresolved current threads

## Validation
- `make -C raster/rt_pg -j32`
- `make -C extensions/postgis_raster all -j1`
- `sudo -n make -C extensions/postgis install`
- `sudo -n make -C extensions/postgis_raster install`
- `sudo -n make -C raster/rt_pg install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C raster/test check RUNTESTFLAGS='--extension --verbose' TESTS="$(pwd)/raster/test/regress/rt_mapalgebra $(pwd)/raster/test/regress/rt_grayscale"`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master -- raster/rt_pg/rtpg_mapalgebra.c`

Closes https://trac.osgeo.org/postgis/ticket/2807

Supersedes closed PR https://github.com/postgis/postgis/pull/1056.
