### PR TITLE
Document TopoGeo_AddLineString load order

### DIFF
--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1768,6 +1768,15 @@ by the <varname>max_edges</varname> parameter.
                 </para>
 
                 <note><para>
+When adding many lines, the load order can have a large impact on
+performance because each call checks the line against topology elements
+already loaded. In bulk workflows, adding large closed or enclosing
+lines before smaller contained lines can avoid expensive later splits.
+For loading a collection in one call, see
+<xref linkend="TopoGeo_LoadGeometry"/>.
+                </para></note>
+
+                <note><para>
 Updating statistics about topologies being loaded via this function is
 up to caller, see <xref linkend="Topology_StatsManagement"/>.
                 </para></note>


### PR DESCRIPTION
## Summary

Document that `TopoGeo_AddLineString` bulk load performance depends on caller order.

Trac ticket: https://trac.osgeo.org/postgis/ticket/5840

The ticket's testcase shows the same set of lines loading much faster when large closed/enclosing lines are added before smaller contained lines. That ordering is controlled by the caller because each `TopoGeo_AddLineString` call processes exactly one line against topology elements already loaded.

## Changes

- Add a `TopoGeo_AddLineString` documentation note explaining that loading many lines can be order-sensitive.
- Recommend adding large closed or enclosing lines before smaller contained lines in bulk workflows.
- Point users with a geometry collection toward `TopoGeo_LoadGeometry`.

## Validation

- `./autogen.sh`
- `./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check-xml`
- `./utils/check_news.sh .`
- `git diff --check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/306
