### PR TITLE
topology: add TopoGeo_AddPolygon perf case

### DIFF
--- a/topology/test/perf/TopoGeo_addPolygon.sql
+++ b/topology/test/perf/TopoGeo_addPolygon.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+SELECT topology.CreateTopology('topoperf');
+
+CREATE TABLE topoperf.case_full_coverage_no_holes AS
+SELECT i, j, geom g
+FROM ST_SquareGrid(4, ST_MakeEnvelope(0, 0, 80, 80));
+
+\timing on
+
+SELECT count(*) FROM (
+  SELECT topology.TopoGeo_addPolygon('topoperf', g)
+  FROM (
+    SELECT g FROM topoperf.case_full_coverage_no_holes
+    ORDER BY i, j
+  ) bar
+) foo;
+
+\timing off
+
+SELECT TopologySummary('topoperf');
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

- add a topology perf harness for `TopoGeo_AddPolygon` on a full square coverage
- mirror the existing `TopoGeo_addLinestring` perf scripts with timing and `TopologySummary` output
- keep the harness repeatable and ephemeral by rolling back the measurement transaction after the summary
- keep this as a measurement slice for the broad topology performance ticket rather than a behavioral change

Trac: https://trac.osgeo.org/postgis/ticket/2695

## Validation

- `git rebase upstream/master`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres psql -v ON_ERROR_STOP=1 -f topology/test/perf/TopoGeo_addPolygon.sql`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres psql -Atqc "SELECT count(*) FROM topology.topology WHERE name = 'topoperf';"` returned `0`
- `git diff --check upstream/master..HEAD`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/304
