### PR TITLE
topology: let CopyTopology skip layers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,6 +67,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           public liblwgeom header (Darafei Praliaskouski)
  - #4678, [raster] Move st_sum4ma neighborhood callback to C
           (Darafei Praliaskouski)
+ - #1195, [topology] Add CopyTopology option to skip layer copies
+          (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1499,7 +1499,7 @@ topoid
 		<refentry xml:id="CopyTopology">
 			<refnamediv>
 				<refname>CopyTopology</refname>
-				<refpurpose>Makes a copy of a topology (nodes, edges, faces, layers and TopoGeometries) into a new schema</refpurpose>
+				<refpurpose>Makes a copy of a topology into a new schema, optionally without layers and TopoGeometries</refpurpose>
 			</refnamediv>
 
 			<refsynopsisdiv>
@@ -1508,6 +1508,7 @@ topoid
 						<funcdef>integer <function>CopyTopology</function></funcdef>
 						<paramdef><type>varchar </type> <parameter>existing_topology_name</parameter></paramdef>
 						<paramdef><type>varchar </type> <parameter>new_name</parameter></paramdef>
+						<paramdef choice="opt"><type>boolean </type> <parameter>copy_layers=true</parameter></paramdef>
 					</funcprototype>
 				</funcsynopsis>
 			</refsynopsisdiv>
@@ -1518,7 +1519,7 @@ topoid
                 <para>
 Creates a new topology with name <varname>new_name</varname>, with SRID and precision copied from <varname>existing_topology_name</varname>
 The nodes, edges and faces in <varname>existing_topology_name</varname> are copied into the new topology,
-as well as Layers and their associated TopoGeometries.
+as well as Layers and their associated TopoGeometries, unless <varname>copy_layers</varname> is false.
 		</para>
 
                 <note><para>
@@ -1537,6 +1538,10 @@ This is because the TopoGeometry objects exist only as a definition and are not 
 Make a backup of a topology called <varname>ma_topo</varname>.
 				</para>
 				<programlisting>SELECT topology.CopyTopology('ma_topo', 'ma_topo_backup');</programlisting>
+				<para>
+Copy only the topology primitives, leaving layer metadata and TopoGeometry definitions out of the new topology.
+				</para>
+				<programlisting>SELECT topology.CopyTopology('ma_topo', 'ma_topo_primitives', false);</programlisting>
 
 			</refsection>
 

--- a/topology/sql/manage/CopyTopology.sql.in
+++ b/topology/sql/manage/CopyTopology.sql.in
@@ -11,12 +11,13 @@
 -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 --{
--- CopyTopology(name_source, name_target)
+-- CopyTopology(name_source, name_target, copy_layers)
 --
--- Makes a copy of a topology (primitives + topogeometry collections) .
+-- Makes a copy of a topology.
+-- Optionally copies layer metadata and TopoGeometry definitions.
 -- Returns the new topology id.
 --
-CREATE OR REPLACE FUNCTION topology.CopyTopology(atopology varchar, newtopo varchar)
+CREATE OR REPLACE FUNCTION topology.CopyTopology(atopology varchar, newtopo varchar, copy_layers boolean DEFAULT true)
 RETURNS int
 AS
 $BODY$
@@ -82,46 +83,48 @@ BEGIN
   );
   EXECUTE sql;
 
-  -- Copy layers and their TopoGeometry sequences
-  -- and their TopoGeometry definitions, from primitives
-  -- to hierarchical
-  FOR rec IN
-    SELECT * FROM topology.layer
-    WHERE topology_id = oldtopo_id
-    ORDER BY COALESCE(child_id, 0), layer_id
-  LOOP
-    INSERT INTO topology.layer (topology_id, layer_id, feature_type,
-      level, child_id, schema_name, table_name, feature_column)
-      VALUES (newtopo_id, rec.layer_id, rec.feature_type,
-              rec.level, rec.child_id, newtopo,
-              'LAYER' ||  rec.layer_id, '');
+  IF copy_layers THEN
+    -- Copy layers and their TopoGeometry sequences
+    -- and their TopoGeometry definitions, from primitives
+    -- to hierarchical
+    FOR rec IN
+      SELECT * FROM topology.layer
+      WHERE topology_id = oldtopo_id
+      ORDER BY COALESCE(child_id, 0), layer_id
+    LOOP
+      INSERT INTO topology.layer (topology_id, layer_id, feature_type,
+        level, child_id, schema_name, table_name, feature_column)
+        VALUES (newtopo_id, rec.layer_id, rec.feature_type,
+                rec.level, rec.child_id, newtopo,
+                'LAYER' ||  rec.layer_id, '');
 
-    -- Create layer's TopoGeometry sequences
-    EXECUTE format(
-      $$
-        CREATE SEQUENCE %1$I.topogeo_s_%2$s;
-        SELECT setval(
-          '%1$I.topogeo_s_%2$s',
-          (SELECT last_value FROM %3$I.topogeo_s_%2$s)
-        );
-      $$,
-      newtopo,
-      rec.layer_id,
-      atopology
-    );
+      -- Create layer's TopoGeometry sequences
+      EXECUTE format(
+        $$
+          CREATE SEQUENCE %1$I.topogeo_s_%2$s;
+          SELECT setval(
+            '%1$I.topogeo_s_%2$s',
+            (SELECT last_value FROM %3$I.topogeo_s_%2$s)
+          );
+        $$,
+        newtopo,
+        rec.layer_id,
+        atopology
+      );
 
-    -- Copy TopoGeometry definitions
-    EXECUTE format(
-      $$
-        INSERT INTO %1$I.relation
-        SELECT * FROM %2$I.relation
-        WHERE layer_id = $1
-      $$,
-      newtopo,
-      atopology
-    ) USING rec.layer_id;
+      -- Copy TopoGeometry definitions
+      EXECUTE format(
+        $$
+          INSERT INTO %1$I.relation
+          SELECT * FROM %2$I.relation
+          WHERE layer_id = $1
+        $$,
+        newtopo,
+        atopology
+      ) USING rec.layer_id;
 
-  END LOOP;
+    END LOOP;
+  END IF;
 
   RETURN newtopo_id;
 END

--- a/topology/test/regress/copytopology.sql
+++ b/topology/test/regress/copytopology.sql
@@ -38,6 +38,14 @@ FROM topology.layer l, topology.topology t
 WHERE l.topology_id = t.id and t.name = 'CITY_data_UP_down'
 ORDER BY l.layer_id;
 
+SELECT '#1195', topology.CopyTopology('city_data', 'city_data_primitives', false) > 0;
+SELECT '#1195.nodes', count(node_id) FROM "city_data_primitives".node;
+SELECT '#1195.edges', count(edge_id) FROM "city_data_primitives".edge_data;
+SELECT '#1195.faces', count(face_id) FROM "city_data_primitives".face;
+SELECT '#1195.relations', count(*) FROM "city_data_primitives".relation;
+SELECT '#1195.layers', count(l.*) FROM topology.layer l, topology.topology t
+WHERE l.topology_id = t.id and t.name = 'city_data_primitives';
+
 -- Check sequences
 SELECT tableoid::regclass AS sequence_name, last_value,  is_called from "CITY_data_UP_down".node_node_id_seq;
 SELECT tableoid::regclass AS sequence_name, last_value,  is_called from "CITY_data_UP_down".edge_data_edge_id_seq;
@@ -61,6 +69,7 @@ select '#2184.4', length(topology.dropTopology('t3d')) > 0, length(topology.drop
 
 -- Cleanup
 
+SELECT topology.DropTopology('city_data_primitives');
 SELECT topology.DropTopology('CITY_data_UP_down');
 SELECT topology.DropTopology('city_data');
 DROP SCHEMA features CASCADE;

--- a/topology/test/regress/copytopology_expected
+++ b/topology/test/regress/copytopology_expected
@@ -11,6 +11,12 @@ layers|6
 4|CITY_data_UP_down|LAYER4|
 5|CITY_data_UP_down|LAYER5|
 6|CITY_data_UP_down|LAYER6|
+#1195|t
+#1195.nodes|22
+#1195.edges|24
+#1195.faces|10
+#1195.relations|0
+#1195.layers|0
 "CITY_data_UP_down".node_node_id_seq|22|t
 "CITY_data_UP_down".edge_data_edge_id_seq|26|t
 "CITY_data_UP_down".face_face_id_seq|9|t
@@ -23,5 +29,6 @@ layers|6
 #2184.2|1
 #2184.3|t
 #2184.4|t|t
+Topology 'city_data_primitives' dropped
 Topology 'CITY_data_UP_down' dropped
 Topology 'city_data' dropped

--- a/topology/topology_before_upgrade.sql.in
+++ b/topology/topology_before_upgrade.sql.in
@@ -40,9 +40,12 @@ SELECT _postgis_drop_function_by_signature('topology.CreateTopology(varchar, int
 SELECT _postgis_drop_function_by_signature('topology.CreateTopology(varchar, integer, float8)', '3.6.0');
 SELECT _postgis_drop_function_by_signature('topology.CreateTopology(varchar, integer)', '3.6.0');
 SELECT _postgis_drop_function_by_signature('topology.CreateTopology(varchar)', '3.6.0');
+
+-- Added optional copy_layers parameter in 3.7.0
+SELECT _postgis_drop_function_by_signature('topology.CopyTopology(varchar, varchar)', '3.7.0');
+
 -- Upgrade casts, domains, and types from integer to bigint
 SELECT _postgis_drop_cast_by_types('topogeometry', 'integer[]', '3.6.0');
 SELECT _postgis_topology_upgrade_domain_type('topoelement','integer[]','bigint[]','3.6.0');
 SELECT _postgis_topology_upgrade_domain_type('topoelementarray','integer[][]','bigint[][]','3.6.0');
 SELECT _postgis_add_column_to_table('topology.topology', 'useslargeids', 'BOOLEAN', true, 'false','3.6.0');
-


### PR DESCRIPTION
Trac ticket: https://trac.osgeo.org/postgis/ticket/1195

Summary:
- add an optional `copy_layers` boolean argument to `topology.CopyTopology`, defaulting to true
- when false, copy primitives only and leave `topology.layer`, relation rows, and `topogeo_*` sequences out of the target topology

Validation:
- `make -j32`
- `make -C topology -j32`
- `make -C extensions/postgis_topology -j32`
- `sudo -n make -C topology install`
- `sudo -n make -C extensions/postgis_topology install`
- `make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/copytopology"`
- `make -C doc check-xml`
- `./utils/check_news.sh .`
- `git diff --check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/303
