### PR TITLE
topology: avoid face reconstruction for covered MBRs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,6 +71,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           GeometryCollections (Darafei Praliaskouski)
  - #5532, Validate the manual against DocBook XMLSchema in check-xml
           (Darafei Praliaskouski)
+ - #3319, [topology] Avoid full face reconstruction when a polygon covers
+          the candidate face MBR in TopoGeo_AddPolygon (Darafei Praliaskouski)
 
 * Bug Fixes *
 

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7834,8 +7834,37 @@ lwt_AddPolygon(LWT_TOPOLOGY* topo, LWPOLY* poly, double tol, int* nfaces)
     {
       LWT_ISO_FACE *f = &(faces[j]);
       LWGEOM *fg;
-      GEOSGeometry *fgg, *sp;
+      GEOSGeometry *fgg, *sp, *fenv;
       int covers;
+
+      /*
+       * If the input polygon covers the whole face MBR, it necessarily
+       * covers the face itself. This avoids reconstructing full face
+       * geometry for interior faces while preserving the exact fallback
+       * path for boundary and degenerate boxes.
+       */
+      if ( f->mbr && f->mbr->xmin < f->mbr->xmax && f->mbr->ymin < f->mbr->ymax )
+      {
+        fenv = GBOX2GEOS(f->mbr);
+        if ( fenv )
+        {
+          covers = GEOSPreparedCovers( ppoly, fenv );
+          GEOSGeom_destroy(fenv);
+          if (covers == 2)
+          {
+            GEOSPreparedGeom_destroy(ppoly);
+            GEOSGeom_destroy(polyg);
+            _lwt_release_faces(faces, nfacesinbox);
+            lwerror("PreparedCovers error: %s", lwgeom_geos_errmsg);
+            return NULL;
+          }
+          if ( covers )
+          {
+            ids[num++] = f->face_id;
+            continue;
+          }
+        }
+      }
 
       /* check if a point on this face surface is covered by our polygon */
       fg = lwt_GetFaceGeometry( topo, f->face_id );


### PR DESCRIPTION
## Summary
- add a conservative fast path in `lwt_AddPolygon`: if the input polygon covers a candidate face's whole MBR, accept that face without reconstructing the full face polygon and computing `GEOSPointOnSurface`
- keep the existing `lwt_GetFaceGeometry` + `GEOSPointOnSurface` + `GEOSPreparedCovers` path as the fallback for boundary, degenerate, concave, holed, and other non-MBR-covered candidates
- add a NEWS entry for Trac #3319

This avoids the risky shortcut of inventing a face interior point. The fast path only fires when covering the MBR is already enough to prove covering the face.

## Trac
- https://trac.osgeo.org/postgis/ticket/3319

## Validation
- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -j16`
- `sudo -n make install`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres PGPASSWORD=postgres make -C topology/test check-regress RUNTESTFLAGS="--extension --verbose" TESTS="regress/topogeo_addpolygon"`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres PGPASSWORD=postgres make -C topology/test check-regress RUNTESTFLAGS="--extension --verbose" TESTS="regress/st_getfacegeometry"`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres PGPASSWORD=postgres make -C topology/test check-regress RUNTESTFLAGS="--extension --verbose" TESTS="regress/addface regress/getfacecontainingpoint regress/getfacebypoint"`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres PGPASSWORD=postgres psql -X -v ON_ERROR_STOP=1 -f /home/kom/proj/ai_pr/postgis-ticket-2695-topogeo-addpolygon-perf/topology/test/perf/TopoGeo_addPolygon.sql`
- `PGPASSWORD=postgres psql -X -h 127.0.0.1 -p 5432 -U kom -d postgres -Atqc "SELECT count(*) FROM topology.topology WHERE name = 'topoperf';"` returned `0`
- `make check-news`
- `git diff --check`

---

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/302
