### PR TITLE
Clarify shp2pgsql zip archive input

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Enhancements *
 
+ - #1577, [loader] Report unsupported .zip archive input before trying
+          to open shapefile sidecar files (Darafei Praliaskouski)
  - #2116, [raster] Add ST_Value nearest-neighbor boundary options
           (Darafei Praliaskouski)
  - #2804, #4315, [raster] Support two-argument ST_MapAlgebra callbacks

--- a/doc/man/shp2pgsql.1
+++ b/doc/man/shp2pgsql.1
@@ -19,6 +19,8 @@ Version: 1.1.5 (2006/10/06)
 The <shapefile> is the name of the shape file, without any extension
 information. For example, 'roads' would be the name of the shapefile 
 comprising the 'roads.shp', 'roads.shx', and 'roads.dbf' files.
+Compressed archives are not read directly; unpack .zip packages before
+loading the shapefile components.
 
 The <tablename> is the (optionally schema-qualified) name of the database 
 table you want the data stored in in the database. Within that table, 

--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -1877,6 +1877,11 @@ COMMIT;</programlisting>
     insertion into a PostGIS/PostgreSQL database either in geometry or geography format.
     The loader has several operating modes selected by command line flags.
   </para>
+  <para>
+    The input must be an unpacked shapefile path. The loader does not read
+    <filename>.zip</filename> archives directly; unpack the <filename>.shp</filename>,
+    <filename>.shx</filename>, and <filename>.dbf</filename> files before loading.
+  </para>
   <para>There is also a <filename>shp2pgsql-gui</filename> graphical interface with most
 	of the options as the command-line loader.
     This may be easier to use for one-off non-scripted loading or if you are new to PostGIS.

--- a/loader/cunit/cu_shp2pgsql.c
+++ b/loader/cunit/cu_shp2pgsql.c
@@ -16,6 +16,7 @@
 /* Test functions */
 void test_ShpLoaderCreate(void);
 void test_ShpLoaderDestroy(void);
+void test_ShpLoaderOpenShapeRejectsZip(void);
 
 SHPLOADERCONFIG *loader_config;
 SHPLOADERSTATE *loader_state;
@@ -33,10 +34,9 @@ CU_pSuite register_shp2pgsql_suite(void)
 		return NULL;
 	}
 
-	if (
-	    (NULL == CU_add_test(pSuite, "test_ShpLoaderCreate()", test_ShpLoaderCreate)) ||
-	    (NULL == CU_add_test(pSuite, "test_ShpLoaderDestroy()", test_ShpLoaderDestroy))
-	)
+	if ((NULL == CU_add_test(pSuite, "test_ShpLoaderCreate()", test_ShpLoaderCreate)) ||
+	    (NULL == CU_add_test(pSuite, "test_ShpLoaderDestroy()", test_ShpLoaderDestroy)) ||
+	    (NULL == CU_add_test(pSuite, "test_ShpLoaderOpenShapeRejectsZip()", test_ShpLoaderOpenShapeRejectsZip)))
 	{
 		CU_cleanup_registry();
 		return NULL;
@@ -73,5 +73,30 @@ void test_ShpLoaderCreate(void)
 
 void test_ShpLoaderDestroy(void)
 {
+	ShpLoaderDestroy(loader_state);
+}
+
+void
+test_ShpLoaderOpenShapeRejectsZip(void)
+{
+	int ret;
+
+	loader_config = (SHPLOADERCONFIG *)calloc(1, sizeof(SHPLOADERCONFIG));
+	set_loader_config_defaults(loader_config);
+	loader_config->shp_file = "fixtures/parcel.ZIP";
+	loader_state = ShpLoaderCreate(loader_config);
+	ret = ShpLoaderOpenShape(loader_state);
+	CU_ASSERT_EQUAL(ret, SHPLOADERERR);
+	CU_ASSERT_PTR_NOT_NULL(strstr(loader_state->message, "does not read .zip archives"));
+	ShpLoaderDestroy(loader_state);
+
+	loader_config = (SHPLOADERCONFIG *)calloc(1, sizeof(SHPLOADERCONFIG));
+	set_loader_config_defaults(loader_config);
+	loader_config->shp_file = "fixtures.zip/parcel";
+	loader_config->readshape = 0;
+	loader_state = ShpLoaderCreate(loader_config);
+	ret = ShpLoaderOpenShape(loader_state);
+	CU_ASSERT_EQUAL(ret, SHPLOADERERR);
+	CU_ASSERT_PTR_NULL(strstr(loader_state->message, "does not read .zip archives"));
 	ShpLoaderDestroy(loader_state);
 }

--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -16,6 +16,7 @@
 #include "../postgis_config.h"
 
 #include <math.h> /* for isnan */
+#include <strings.h>
 
 #include "shp2pgsql-core.h"
 #include "../liblwgeom/liblwgeom.h"
@@ -55,7 +56,25 @@ int PIP(Point P, Point *V, int n);
 int FindPolygons(SHPObject *obj, Ring ***Out);
 void ReleasePolygons(Ring **polys, int npolys);
 int GeneratePolygonGeometry(SHPLOADERSTATE *state, SHPObject *obj, char **geometry);
+static int shp_loader_is_zip_archive(const char *filename);
 
+static int
+shp_loader_is_zip_archive(const char *filename)
+{
+	const char *basename;
+	const char *ext;
+
+	if (!filename)
+		return 0;
+
+	basename = strrchr(filename, '/');
+	if (!basename)
+		basename = strrchr(filename, '\\');
+	basename = basename ? basename + 1 : filename;
+
+	ext = strrchr(basename, '.');
+	return ext && strcasecmp(ext, ".zip") == 0;
+}
 
 /* Return allocated string containing UTF8 string converted from encoding fromcode */
 static int
@@ -852,6 +871,15 @@ ShpLoaderOpenShape(SHPLOADERSTATE *state)
 	char name[MAXFIELDNAMELEN];
 	DBFFieldType type = FTInvalid;
 	char *utf8str;
+
+	if (shp_loader_is_zip_archive(state->config->shp_file))
+	{
+		snprintf(state->message,
+			 SHPLOADERMSGLEN,
+			 _("%s: shp2pgsql does not read .zip archives; unpack the .shp, .shx, and .dbf files first."),
+			 state->config->shp_file);
+		return SHPLOADERERR;
+	}
 
 	/* If we are reading the entire shapefile, open it */
 	if (state->config->readshape == 1)


### PR DESCRIPTION
## Summary

This is a bounded loader UX/docs follow-up for https://trac.osgeo.org/postgis/ticket/1577. It does not implement direct archive extraction; it makes the current unsupported case explicit.

Changes:
- reject `.zip` input early in the shared `ShpLoaderOpenShape` path before trying shapefile sidecar files
- keep the check basename-aware and case-insensitive, so parent directories containing `.zip` are not treated as archives
- add CUnit coverage for the archive rejection and basename guard
- document that `shp2pgsql` expects unpacked `.shp`, `.shx`, and `.dbf` files

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make postgis_revision.h`
- `make -C loader/cunit check`
- `./loader/shp2pgsql /tmp/sample.zip public.sample` returns 1 with the new archive-specific error
- `make -C doc check`
- `make check-news`
- `git diff --check`
