### PR TITLE
Expose TopoGeo_AddLineString edge details

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
  - ST_MinimumSpanningTree, window function to calculate MST (Paul Ramsey)
  - #5993, [topology] Add max_edges parameter to TopoGeo_AddLinestring
           (Sandro Santilli)
+ - #5848, [topology] Add TopoGeo_AddLineStringDetails for reporting
+          side-effect edge splits while loading lines (Darafei Praliaskouski)
  - #6001, support MultiLineString in ST_MakeLine (Paul Ramsey)
  - #2858, ST_MMin and ST_MMax (Paul Ramsey)
  - #5941, [raster] Support GDT_Float16 pixel type (Darafei Praliaskouski)

--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -1792,6 +1792,63 @@ up to caller, see <xref linkend="Topology_StatsManagement"/>.
 			</refsection>
 		</refentry>
 
+		<refentry xml:id="TopoGeo_AddLineStringDetails">
+			<refnamediv>
+				<refname>TopoGeo_AddLineStringDetails</refname>
+
+				<refpurpose>
+Adds a linestring to an existing topology and reports inserted line edges
+and side-effect splits of pre-existing edges.
+				</refpurpose>
+			</refnamediv>
+
+			<refsynopsisdiv>
+				<funcsynopsis>
+					<funcprototype>
+						<funcdef>TABLE(event text, old_edge bigint, edge bigint,
+							signed_edge bigint) <function>TopoGeo_AddLineStringDetails</function></funcdef>
+						<paramdef><type>varchar </type> <parameter>atopology</parameter></paramdef>
+						<paramdef><type>geometry </type> <parameter>aline</parameter></paramdef>
+						<paramdef choice="opt"><type>float8 </type> <parameter>tolerance</parameter></paramdef>
+						<paramdef choice="opt"><type>int </type> <parameter>max_edges</parameter></paramdef>
+					</funcprototype>
+				</funcsynopsis>
+			</refsynopsisdiv>
+
+			<refsection>
+				<title>Description</title>
+
+				<para>
+Adds a linestring to an existing topology using <xref linkend="TopoGeo_AddLineString"/>
+and returns detail rows describing the affected edges. Rows with
+<varname>event</varname> set to <varname>input</varname> describe the signed
+edge identifiers forming the input line, in input order. Rows with
+<varname>event</varname> set to <varname>split</varname> describe pieces of a
+pre-existing edge that was split as a side effect; <varname>old_edge</varname>
+contains the edge identifier before the call and <varname>edge</varname>
+contains one of the edge identifiers covering that former edge after the call.
+				</para>
+
+				<para>
+This function is useful when loading multiple source datasets into one topology
+and keeping a source-to-edge mapping after later inserts split edges loaded
+from earlier sources.
+				</para>
+
+				<para role="availability" conformance="3.7.0">Availability: 3.7.0</para>
+			</refsection>
+
+			<refsection>
+				<title>See Also</title>
+				<para>
+<xref linkend="TopoGeo_AddLineString"/>,
+<xref linkend="TopoGeo_AddPoint"/>,
+<xref linkend="TopoGeo_AddPolygon"/>,
+<xref linkend="CreateTopology"/>
+				</para>
+			</refsection>
+		</refentry>
+
 		<refentry xml:id="TopoGeo_AddPolygon">
 			<refnamediv>
 				<refname>TopoGeo_AddPolygon</refname>

--- a/topology/sql/populate.sql.in
+++ b/topology/sql/populate.sql.in
@@ -750,6 +750,92 @@ CREATE OR REPLACE FUNCTION topology.TopoGeo_AddLinestring(atopology varchar, ali
 --} TopoGeo_addLinestring
 
 --{
+--  TopoGeo_AddLineStringDetails(toponame, linegeom, tolerance)
+--
+--  Add a LineString into a topology and report inserted line edges and split
+--  side effects on pre-existing edges.
+--
+-- Availability: 3.7.0
+--
+CREATE OR REPLACE FUNCTION topology.TopoGeo_AddLineStringDetails(atopology varchar, aline geometry, tolerance float8 DEFAULT -1, max_edges int DEFAULT -1)
+	RETURNS TABLE(event text, old_edge bigint, edge bigint, signed_edge bigint) AS
+$$
+DECLARE
+	sql text;
+	effective_tolerance float8;
+	candidate_tolerance float8;
+BEGIN
+	PERFORM 1 FROM topology.topology WHERE name = atopology;
+	IF NOT FOUND THEN
+		RAISE EXCEPTION
+			'No topology with name "%" in topology.topology', atopology;
+	END IF;
+
+	IF tolerance = -1 THEN
+		effective_tolerance := topology._st_mintolerance(atopology, aline);
+	ELSE
+		effective_tolerance := tolerance;
+	END IF;
+	candidate_tolerance := GREATEST(
+		COALESCE(effective_tolerance, 0),
+		COALESCE(topology._st_mintolerance(ST_StartPoint(aline)), 0),
+		COALESCE(topology._st_mintolerance(ST_EndPoint(aline)), 0));
+
+	EXECUTE format('LOCK TABLE %I.edge_data IN SHARE ROW EXCLUSIVE MODE', atopology);
+
+	IF to_regclass('pg_temp.topogeo_addlinestringdetails_old_edges') IS NOT NULL THEN
+		DROP TABLE pg_temp.topogeo_addlinestringdetails_old_edges;
+	END IF;
+
+	sql := format(
+		'CREATE TEMP TABLE topogeo_addlinestringdetails_old_edges ON COMMIT DROP AS ' ||
+		'SELECT edge_id, geom FROM %I.edge_data ' ||
+		'WHERE geom && ST_Expand($1, $2)',
+		atopology);
+	EXECUTE sql USING aline, candidate_tolerance;
+
+	RETURN QUERY
+	SELECT 'input'::text, NULL::bigint, abs(inserted.edge_id)::bigint, inserted.edge_id::bigint
+	FROM topology.TopoGeo_AddLinestring(atopology, aline, tolerance, max_edges)
+		WITH ORDINALITY AS inserted(edge_id, ord)
+	ORDER BY inserted.ord;
+
+	sql := format($fmt$
+		WITH changed_old AS (
+			SELECT old.edge_id, old.geom
+			FROM pg_temp.topogeo_addlinestringdetails_old_edges old
+			JOIN %1$I.edge_data new USING (edge_id)
+			WHERE NOT ST_Equals(old.geom, new.geom)
+		),
+		split_edges AS (
+			SELECT DISTINCT old.edge_id AS old_edge, new.edge_id AS edge
+			FROM changed_old old
+			JOIN %1$I.edge_data new ON new.geom && ST_Expand(old.geom, $1)
+			                         AND ST_DWithin(new.geom, $2, $1)
+			                         AND (
+			                             ST_Covers(old.geom, new.geom)
+			                             OR ($1 > 0 AND ST_Covers(ST_Buffer(old.geom, $1), new.geom))
+			                         )
+		)
+		SELECT 'split'::text, s.old_edge::bigint, s.edge::bigint, NULL::bigint
+		FROM split_edges s
+		ORDER BY s.old_edge, s.edge
+	$fmt$, atopology);
+
+	RETURN QUERY EXECUTE sql USING candidate_tolerance, aline;
+
+	DROP TABLE pg_temp.topogeo_addlinestringdetails_old_edges;
+EXCEPTION WHEN OTHERS THEN
+	IF to_regclass('pg_temp.topogeo_addlinestringdetails_old_edges') IS NOT NULL THEN
+		DROP TABLE pg_temp.topogeo_addlinestringdetails_old_edges;
+	END IF;
+	RAISE;
+END
+$$
+LANGUAGE 'plpgsql' VOLATILE;
+--} TopoGeo_AddLineStringDetails
+
+--{
 --  TopoGeo_AddPolygon(toponame, polygeom, tolerance)
 --
 --  Add a Polygon into a topology

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -549,6 +549,35 @@ SELECT NULL FROM topology.TopoGeo_addLinestring('t5782',
 SELECT '#5782', 'valid_after', * FROM topology.ValidateTopology('t5782');
 ROLLBACK;
 
+-- See https://trac.osgeo.org/postgis/ticket/5848
+SELECT '#5848.invalid', topology.TopoGeo_AddLineStringDetails('invalid',
+  'LINESTRING(0 0,10 0)');
+SELECT NULL FROM topology.CreateTopology('t5848');
+SELECT '#5848.1', event, old_edge, edge, signed_edge
+FROM topology.TopoGeo_AddLineStringDetails('t5848',
+  'LINESTRING(0 0,10 0)');
+SELECT '#5848.2', event, old_edge, edge, signed_edge
+FROM topology.TopoGeo_AddLineStringDetails('t5848',
+  'LINESTRING(5 -5,5 5)');
+SELECT '#5848.3', 'valid', count(*) FROM topology.ValidateTopology('t5848');
+SELECT NULL FROM topology.DropTopology('t5848');
+SELECT NULL FROM topology.CreateTopology('t5848_endpoint');
+SELECT NULL FROM topology.TopoGeo_AddLineString('t5848_endpoint',
+  'LINESTRING(0 1e-15,10 1e-15)', 0);
+SELECT '#5848.endpoint', event, old_edge, edge, signed_edge
+FROM topology.TopoGeo_AddLineStringDetails('t5848_endpoint',
+  'LINESTRING(5 0,15 0)', 0);
+SELECT NULL FROM topology.DropTopology('t5848_endpoint');
+SELECT NULL FROM topology.CreateTopology('t5848_neighbor');
+SELECT NULL FROM topology.TopoGeo_AddLineString('t5848_neighbor',
+  'LINESTRING(0 0,10 0)', 0);
+SELECT NULL FROM topology.TopoGeo_AddLineString('t5848_neighbor',
+  'LINESTRING(8 0.2,9 0.2)', 0);
+SELECT '#5848.neighbor', event, old_edge, edge, signed_edge
+FROM topology.TopoGeo_AddLineStringDetails('t5848_neighbor',
+  'LINESTRING(1 -1,1 1)', 0.5);
+SELECT NULL FROM topology.DropTopology('t5848_neighbor');
+
 -- See https://trac.osgeo.org/postgis/ticket/5993
 SELECT NULL FROM topology.CreateTopology ('t5993');
 SELECT NULL FROM topology.TopoGeo_addLinestring('t5993',

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -226,6 +226,20 @@ b5234.0|1
 b5234.1|1
 t5568|invalidities at start|
 t5568|invalidities at end|
+ERROR:  No topology with name "invalid" in topology.topology
+#5848.1|input||1|1
+#5848.2|input||3|3
+#5848.2|input||4|4
+#5848.2|split|1|1|
+#5848.2|split|1|2|
+#5848.3|valid|0
+#5848.endpoint|input||3|3
+#5848.endpoint|split|1|1|
+#5848.endpoint|split|1|2|
+#5848.neighbor|input||4|4
+#5848.neighbor|input||5|5
+#5848.neighbor|split|1|1|
+#5848.neighbor|split|1|3|
 #5993.0|existing-data|1
 ERROR:  Adding line to topology requires creating more edges than the requested limit of 0
 ERROR:  Adding line to topology requires creating more edges than the requested limit of 1


### PR DESCRIPTION
## Summary
- add `topology.TopoGeo_AddLineStringDetails` as an additive wrapper around `TopoGeo_AddLineString`
- return `input` rows for the signed edge chain of the inserted line and `split` rows for pre-existing edges divided as a side effect
- bound the pre-insert edge snapshot to candidate edge bboxes around the input line and endpoint min-tolerance envelope, avoiding a full `edge_data` snapshot
- report current replacement edges covering changed old edges, including pre-existing reused edges and tolerance-snapped pieces
- avoid reporting unchanged neighboring edges that merely fall inside the old-edge tolerance corridor but are not near the inserted line
- document the new topology function and cover the https://trac.osgeo.org/postgis/ticket/5848 source-mapping case in `topogeo_addlinestring` regression

Ticket: https://trac.osgeo.org/postgis/ticket/5848

Gitea mirror: https://gitea.osgeo.org/postgis/postgis/pulls/301

## Validation
Rebased on current `master` (`a4ecc46176c3fc0ab3fa69cf117d408bc622e592`) at head `0bdb98908e77226f4a0b32675961b2eab10121d0`:

- `make -C topology topology.sql`
- `make -C topology -j32`
- `sudo -n make -C topology install`
- `make -C extensions/postgis_topology all -j1`
- `sudo -n make -C extensions/postgis_topology install`
- `PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres PGPASSWORD=postgres make -C topology/test check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/topology/test/regress/topogeo_addlinestring"`
- `make -C doc check-xml`
- `./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD`
