### PR TITLE
doc: explain repeated ring point validity

### DIFF
--- a/doc/using_postgis_dataman.xml
+++ b/doc/using_postgis_dataman.xml
@@ -1091,10 +1091,12 @@ SELECT
         </orderedlist>
 
       <para>
-        Consecutive repeated points in a polygon boundary ring are treated as
-        redundant vertices, and do not make the polygon invalid. Repeated points
-        that cause the boundary to self-intersect, self-touch, or collapse
-        still violate the validity rules.
+        Consecutive repeated points in a polygon boundary ring do not make the
+        ring non-simple. Under the SFS curve model, a curve is interpreted by a
+        continuous parameterization; consecutive equal coordinates are
+        topologically indistinguishable from a single vertex. PostGIS therefore
+        treats them as redundant vertices, so they do not make an otherwise valid
+        polygon invalid.
       </para>
 
 	  <informaltable frame="none">


### PR DESCRIPTION
## Summary

This follows up on https://github.com/postgis/postgis/pull/1017#discussion_r3448971304.

The docs now explain why consecutive repeated points in a polygon boundary ring do not make the polygon invalid: under the SFS curve model, consecutive equal coordinates are topologically indistinguishable from a single vertex.

References https://trac.osgeo.org/postgis/ticket/3425.

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C doc check-xml`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
