### PR TITLE
Complete ST_AsX3D geometry type coverage

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -55,8 +55,14 @@ jobs:
             gdal geos icu4c json-c libpq libxml2 \
             proj protobuf-c sfcgal cunit \
             docbook docbook-xsl \
-            postgresql@${PG} gettext
+            gettext
           brew link --force gettext
+          HOMEBREW_GITHUB_ACTIONS=1 brew install "postgresql@${PG}"
+          pg_version="$(brew info --json=v2 "postgresql@${PG}" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["formulae"][0]["installed"][0]["version"])')"
+          ln -sfn "${HOMEBREW_PREFIX}/Cellar/postgresql@${PG}/${pg_version}/share/postgresql@${PG}" "${HOMEBREW_PREFIX}/share/postgresql@${PG}"
+          if [ ! -f "${HOMEBREW_PREFIX}/var/postgresql@${PG}/PG_VERSION" ]; then
+            "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/initdb" --locale=en_US.UTF-8 -E UTF-8 "${HOMEBREW_PREFIX}/var/postgresql@${PG}"
+          fi
           ccache --max-size="${CCACHE_MAXSIZE}"
           sudo ln -sfn "${HOMEBREW_PREFIX}/opt/postgresql@${PG}/bin/postgres" /usr/local/bin/postgres
 

--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,9 @@ These are only changes since 3.7.0beta1.
 
  - Add Woodpecker linux/arm64 build and regression coverage under
           QEMU to match the Jenkins Berrie64 platform (Darafei Praliaskouski)
+ - #2838, Complete ST_AsX3D output for curved geometry inputs and
+          mixed geometry collections (Darafei Praliaskouski)
+
 
 PostGIS 3.7.0beta1
 2026/07/20
@@ -204,8 +207,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #6087, Add a repository-owned CI status checker and static dashboard
           generator (Darafei Praliaskouski)
- - #2838, Complete ST_AsX3D output for curved geometry inputs and
-          mixed geometry collections (Darafei Praliaskouski)
  - #2807, [raster] Preserve missing NODATA values in ST_MapAlgebra outputs
           (Darafei Praliaskouski)
  - #2832, [raster] Avoid padding single-tile raster2pgsql overviews

--- a/NEWS
+++ b/NEWS
@@ -204,6 +204,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #6087, Add a repository-owned CI status checker and static dashboard
           generator (Darafei Praliaskouski)
+ - #2838, Complete ST_AsX3D output for curved geometry inputs and
+          mixed geometry collections (Darafei Praliaskouski)
  - #2807, [raster] Preserve missing NODATA values in ST_MapAlgebra outputs
           (Darafei Praliaskouski)
  - #2832, [raster] Avoid padding single-tile raster2pgsql overviews

--- a/doc/reference_output.xml
+++ b/doc/reference_output.xml
@@ -1606,12 +1606,12 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
           <tbody>
             <row>
             <entry>LINESTRING</entry>
-            <entry>not yet implemented - will be PolyLine2D</entry>
+            <entry>LineSet with Z coordinates set to 0</entry>
             <entry>LineSet</entry>
             </row>
             <row>
             <entry>MULTILINESTRING</entry>
-            <entry>not yet implemented - will be PolyLine2D</entry>
+            <entry>IndexedLineSet with Z coordinates set to 0</entry>
             <entry>IndexedLineSet</entry>
             </row>
             <row>
@@ -1626,18 +1626,23 @@ M 7 -8 L 10 -10 6 -14 4 -11 Z</screen>
             </row>
             <row>
             <entry>(MULTI) POLYGON, POLYHEDRALSURFACE</entry>
-            <entry>Invalid X3D markup</entry>
+            <entry>IndexedFaceSet with Z coordinates set to 0</entry>
             <entry>IndexedFaceSet (inner rings currently output as another faceset)</entry>
             </row>
             <row>
             <entry>TIN</entry>
-            <entry>TriangleSet2D (Not Yet Implemented)</entry>
+            <entry>IndexedTriangleSet with Z coordinates set to 0</entry>
             <entry>IndexedTriangleSet</entry>
+            </row>
+            <row>
+            <entry>CIRCULARSTRING, COMPOUNDCURVE, CURVEPOLYGON, MULTICURVE, MULTISURFACE, NURBSCURVE</entry>
+            <entry>Linearized to the closest supported line or face node</entry>
+            <entry>Linearized to the closest supported line or face node</entry>
             </row>
         </tbody>
       </tgroup>
     </informaltable>
-    <note><para>2D geometry support not yet complete.  Inner rings currently just drawn as separate polygons.  We are working on these.</para></note>
+    <note><para>Inner rings currently output as separate faces.</para></note>
     <para>Lots of advancements happening in 3D space particularly with <link xlink:href="https://www.web3d.org/wiki/index.php/X3D_and_HTML5">X3D Integration with HTML5</link></para>
     <para>There is also a nice open source X3D viewer you can use to view rendered geometries. Free Wrl <link xlink:href="http://freewrl.sourceforge.net/">http://freewrl.sourceforge.net/</link> binaries available for Mac, Linux, and Windows. Use the FreeWRL_Launcher packaged to view the geometries.</para>
     <para>Also check out <link xlink:href="https://git.osgeo.org/gitea/robe/postgis_x3d_viewer">PostGIS minimalist X3D viewer</link>  that utilizes this function and <link xlink:href="http://www.x3dom.org/">x3dDom html/js open source toolkit</link>.</para>

--- a/liblwgeom/cunit/cu_out_x3d.c
+++ b/liblwgeom/cunit/cu_out_x3d.c
@@ -18,7 +18,8 @@
 #include "liblwgeom_internal.h"
 #include "cu_tester.h"
 
-static void do_x3d3_test(char * in, char * out, int precision, int option)
+static void
+do_x3d3_test(char *in, char *out, int precision, int option)
 {
 	LWGEOM *g = lwgeom_from_wkt(in, LW_PARSER_CHECK_NONE);
 	lwvarlena_t *v = lwgeom_to_x3d3(g, precision, option, "");
@@ -29,52 +30,96 @@ static void do_x3d3_test(char * in, char * out, int precision, int option)
 	lwfree(v);
 }
 
+static char *
+x3d3_as_cstring(const lwvarlena_t *v)
+{
+	size_t len = LWSIZE_GET(v->size) - LWVARHDRSZ;
+	char *out = lwalloc(len + 1);
+	memcpy(out, v->data, len);
+	out[len] = '\0';
+	return out;
+}
 
-static void do_x3d3_unsupported(char * in, char * out)
+static void
+do_x3d3_contains(char *in, int precision, int option, const char *expected)
 {
 	LWGEOM *g = lwgeom_from_wkt(in, LW_PARSER_CHECK_NONE);
-	lwvarlena_t *v = lwgeom_to_x3d3(g, 0, 0, "");
+	lwvarlena_t *v = lwgeom_to_x3d3(g, precision, option, "");
+	if (!v)
+	{
+		fprintf(stderr, "[%s:%d]\n Serialization returned NULL for input: %s\n", __FILE__, __LINE__, in);
+		CU_FAIL();
+		lwgeom_free(g);
+		return;
+	}
+	char *out = x3d3_as_cstring(v);
 
-	ASSERT_STRING_EQUAL(out, cu_error_msg);
-	cu_error_msg_reset();
+	if (!strstr(out, expected))
+	{
+		fprintf(stderr, "[%s:%d]\n Expected substring: %s\n Obtained: %s\n", __FILE__, __LINE__, expected, out);
+		CU_FAIL();
+	}
+	else
+		CU_PASS();
 
 	lwfree(v);
+	lwfree(out);
 	lwgeom_free(g);
 }
 
+static void
+do_x3d3_not_contains(char *in, int precision, int option, const char *unexpected)
+{
+	LWGEOM *g = lwgeom_from_wkt(in, LW_PARSER_CHECK_NONE);
+	lwvarlena_t *v = lwgeom_to_x3d3(g, precision, option, "");
+	if (!v)
+	{
+		fprintf(stderr, "[%s:%d]\n Serialization returned NULL for input: %s\n", __FILE__, __LINE__, in);
+		CU_FAIL();
+		lwgeom_free(g);
+		return;
+	}
+	char *out = x3d3_as_cstring(v);
 
-static void out_x3d3_test_precision(void)
+	if (strstr(out, unexpected))
+	{
+		fprintf(
+		    stderr, "[%s:%d]\n Unexpected substring: %s\n Obtained: %s\n", __FILE__, __LINE__, unexpected, out);
+		CU_FAIL();
+	}
+	else
+		CU_PASS();
+
+	lwfree(v);
+	lwfree(out);
+	lwgeom_free(g);
+}
+
+static void
+out_x3d3_test_precision(void)
 {
 	/* 0 precision, i.e a round */
-	do_x3d3_test(
-	    "POINT(1.1111111111111 1.1111111111111 2.11111111111111)",
-	    "1 1 2",
-	    0, 0);
+	do_x3d3_test("POINT(1.1111111111111 1.1111111111111 2.11111111111111)", "1 1 2", 0, 0);
 
 	/* 3 digits precision */
-	do_x3d3_test(
-	    "POINT(1.1111111111111 1.1111111111111 2.11111111111111)",
-	    "1.111 1.111 2.111",
-	    3, 0);
+	do_x3d3_test("POINT(1.1111111111111 1.1111111111111 2.11111111111111)", "1.111 1.111 2.111", 3, 0);
 
 	/* 9 digits precision */
 	do_x3d3_test(
-	    "POINT(1.2345678901234 1.2345678901234 4.123456789001)",
-	    "1.23456789 1.23456789 4.123456789",
-	    9, 0);
+	    "POINT(1.2345678901234 1.2345678901234 4.123456789001)", "1.23456789 1.23456789 4.123456789", 9, 0);
 
 	/* huge data */
 	do_x3d3_test("POINT(1E300 -105E-153 4E300)", "1e+300 -1e-151 4e+300", 0, 0);
 }
 
-
-static void out_x3d3_test_geoms(void)
+static void
+out_x3d3_test_geoms(void)
 {
 	/* Linestring */
-	do_x3d3_test(
-	    "LINESTRING(0 1 5,2 3 6,4 5 7)",
-	    "<LineSet  vertexCount='3'><Coordinate point='0 1 5 2 3 6 4 5 7' /></LineSet>",
-	    0, 0);
+	do_x3d3_test("LINESTRING(0 1 5,2 3 6,4 5 7)",
+		     "<LineSet  vertexCount='3'><Coordinate point='0 1 5 2 3 6 4 5 7' /></LineSet>",
+		     0,
+		     0);
 
 	/* 2D Linestring */
 	do_x3d3_test("LINESTRING(0 1,2 3,4 5)",
@@ -82,11 +127,18 @@ static void out_x3d3_test_geoms(void)
 		     0,
 		     0);
 
+	/* Closed linestring keeps the closing coordinate because LineSet has no index to close the path. */
+	do_x3d3_test("LINESTRING(0 0,1 0,0 0)",
+		     "<LineSet  vertexCount='3'><Coordinate point='0 0 0 1 0 0 0 0 0' /></LineSet>",
+		     0,
+		     0);
+
 	/* Polygon **/
 	do_x3d3_test(
 	    "POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><Coordinate point='15 10 3 13.536 6.464 3 10 5 3 6.464 6.464 3 5 10 3 6.464 13.536 3 10 15 3 13.536 13.536 3 ' /></IndexedFaceSet>",
-	    3, 0);
+	    3,
+	    0);
 
 	/* 2D Polygon */
 	do_x3d3_test(
@@ -98,25 +150,21 @@ static void out_x3d3_test_geoms(void)
 	/* TODO: Polygon - with internal ring - the answer is clearly wrong */
 	/** do_x3d3_test(
 	    "POLYGON((0 1 3,2 3 3,4 5 3,0 1 3),(6 7 3,8 9 3,10 11 3,6 7 3))",
-	        "",
+		"",
 	    NULL, 0); **/
 
 	/* 2D MultiPoint */
-	do_x3d3_test(
-	    "MULTIPOINT(0 1,2 3,4 5)",
-	    "<Polypoint2D  point='0 1 2 3 4 5 ' />",
-	    0, 0);
+	do_x3d3_test("MULTIPOINT(0 1,2 3,4 5)", "<Polypoint2D  point='0 1 2 3 4 5 ' />", 0, 0);
 
 	/* 3D MultiPoint */
 	do_x3d3_test(
-	    "MULTIPOINT Z(0 1 1,2 3 4,4 5 5)",
-	    "<PointSet ><Coordinate point='0 1 1 2 3 4 4 5 5 ' /></PointSet>",
-	    0, 0);
+	    "MULTIPOINT Z(0 1 1,2 3 4,4 5 5)", "<PointSet ><Coordinate point='0 1 1 2 3 4 4 5 5 ' /></PointSet>", 0, 0);
 	/* 3D Multiline */
 	do_x3d3_test(
 	    "MULTILINESTRING Z((0 1 1,2 3 4,4 5 5),(6 7 5,8 9 8,10 11 5))",
 	    "<IndexedLineSet  coordIndex='0 1 2 -1 3 4 5'><Coordinate point='0 1 1 2 3 4 4 5 5 6 7 5 8 9 8 10 11 5 ' /></IndexedLineSet>",
-	    0, 0);
+	    0,
+	    0);
 
 	/* 2D Multiline */
 	do_x3d3_test(
@@ -129,7 +177,8 @@ static void out_x3d3_test_geoms(void)
 	do_x3d3_test(
 	    "MULTIPOLYGON(((0 1 1,2 3 1,4 5 1,0 1 1)),((6 7 1,8 9 1,10 11 1,6 7 1)))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 -1 3 4 5'><Coordinate point='0 1 1 2 3 1 4 5 1 6 7 1 8 9 1 10 11 1 ' /></IndexedFaceSet>",
-	    0, 0);
+	    0,
+	    0);
 
 	/* 2D MultiPolygon */
 	do_x3d3_test(
@@ -142,7 +191,8 @@ static void out_x3d3_test_geoms(void)
 	do_x3d3_test(
 	    "POLYHEDRALSURFACE( ((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)), ((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)), ((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)), ((1 1 0, 1 1 1, 1 0 1, 1 0 0, 1 1 0)), ((0 1 0, 0 1 1, 1 1 1, 1 1 0, 0 1 0)), ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1)) )",
 	    "<IndexedFaceSet convex='false'  coordIndex='0 1 2 3 -1 4 5 6 7 -1 8 9 10 11 -1 12 13 14 15 -1 16 17 18 19 -1 20 21 22 23'><Coordinate point='0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 1 0 0 1 0 1 0 0 1 1 1 0 1 1 1 1 0 1 1 0 0 0 1 0 0 1 1 1 1 1 1 1 0 0 0 1 1 0 1 1 1 1 0 1 1' /></IndexedFaceSet>",
-	    0, 0);
+	    0,
+	    0);
 
 	/* GeometryCollection with 2D Polygon */
 	do_x3d3_test(
@@ -157,45 +207,89 @@ static void out_x3d3_test_geoms(void)
 	    "",
 	    NULL, 0); **/
 
-	/* CircularString */
-	do_x3d3_unsupported(
-	    "CIRCULARSTRING(-2 0 1,0 2 1,2 0 1,0 2 1,2 4 1)",
-	    "lwgeom_to_x3d3: 'CircularString' geometry type not supported");
+	/* Curved inputs are linearized before X3D serialization.  These checks
+	 * avoid depending on the full stroked coordinate list while still proving
+	 * that each curved family reaches the expected X3D node type. */
+	do_x3d3_contains(
+	    "CIRCULARSTRING(0 0 1,1 1 1,2 0 1)", 3, 0, "<LineSet  vertexCount='65'><Coordinate point='0 0 1");
 
-	/* CompoundCurve */
-	do_x3d3_unsupported(
-	    "COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,1 0 1),(1 0 1,0 1 1))",
-	    "lwgeom_to_x3d3: 'CompoundCurve' geometry type not supported");
+	do_x3d3_contains("CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)",
+			 0,
+			 0,
+			 "<LineSet  vertexCount='129'><Coordinate point='0 0 1");
+	do_x3d3_contains("CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)", 3, 0, "0 0 1' /></LineSet>");
+	do_x3d3_contains("COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1))", 3, 0, "0 0 1' /></LineSet>");
+	do_x3d3_contains(
+	    "GEOMETRYCOLLECTION(CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1))", 3, 0, "0 0 1' /></LineSet></Shape>");
 
+	do_x3d3_contains("COMPOUNDCURVE(CIRCULARSTRING(0 0 1,1 1 1,2 0 1),(2 0 1,3 0 1))", 3, 0, "3 0 1' /></LineSet>");
+
+	do_x3d3_contains(
+	    "CURVEPOLYGON(CIRCULARSTRING(0 0,1 1,2 0,1 -1,0 0))", 3, 0, "<IndexedFaceSet  convex='false' coordIndex='");
+
+	do_x3d3_contains("MULTICURVE((0 0,1 1),CIRCULARSTRING(1 1,2 2,3 1))", 3, 0, "<IndexedLineSet  coordIndex='");
+
+	do_x3d3_contains("MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 0,1 1,2 0,1 -1,0 0)))",
+			 3,
+			 0,
+			 "<IndexedFaceSet  convex='false' coordIndex='");
+
+	do_x3d3_contains(
+	    "NURBSCURVE(2, (0 0, 5 10, 10 0))", 3, 0, "<LineSet  vertexCount='129'><Coordinate point='0 0 0");
+
+	/* A general GeometryCollection must wrap each renderable child in Shape,
+	 * including curved children and 3D surface families. Nested collections
+	 * are flattened to sibling Shapes, because X3D Shape nodes cannot contain
+	 * other Shape nodes as geometry. */
+	do_x3d3_contains(
+	    "GEOMETRYCOLLECTION(CIRCULARSTRING(0 0,1 1,2 0),POLYHEDRALSURFACE(((0 0 0,0 1 0,1 1 0,0 0 0))),TIN(((0 0,1 1,0 1,0 0))))",
+	    3,
+	    0,
+	    "<Shape><LineSet");
+
+	do_x3d3_contains(
+	    "GEOMETRYCOLLECTION(CIRCULARSTRING(0 0,1 1,2 0),POLYHEDRALSURFACE(((0 0 0,0 1 0,1 1 0,0 0 0))),TIN(((0 0,1 1,0 1,0 0))))",
+	    3,
+	    0,
+	    "</IndexedTriangleSet></Shape>");
+
+	do_x3d3_test(
+	    "GEOMETRYCOLLECTION(TRIANGLE((0 0,1 1,0 1,0 0)))",
+	    "<Shape><IndexedTriangleSet  index='0 1 2'><Coordinate point='0 0 0 1 1 0 0 1 0'/></IndexedTriangleSet></Shape>",
+	    0,
+	    0);
+
+	do_x3d3_not_contains(
+	    "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(0 0,1 1)))", 0, 0, "<Shape><Shape>");
 }
 
-static void out_x3d3_test_option(void)
+static void
+out_x3d3_test_option(void)
 {
 	/* 0 precision, flip coordinates*/
-	do_x3d3_test(
-	    "POINT(3.1111111111111 1.1111111111111 2.11111111111111)",
-	    "1 3 2",
-	    0, 1);
+	do_x3d3_test("POINT(3.1111111111111 1.1111111111111 2.11111111111111)", "1 3 2", 0, 1);
 
 	/* geocoordinate long,lat*/
 	do_x3d3_test(
 	    "SRID=4326;POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"longitude_first\"' point='15 10 3 13.536 6.464 3 10 5 3 6.464 6.464 3 5 10 3 6.464 13.536 3 10 15 3 13.536 13.536 3 ' /></IndexedFaceSet>",
-	    3, 2);
+	    3,
+	    2);
 
 	/* geocoordinate lat long*/
 	do_x3d3_test(
 	    "SRID=4326;POLYGON((15 10 3,13.536 6.464 3,10 5 3,6.464 6.464 3,5 10 3,6.464 13.536 3,10 15 3,13.536 13.536 3,15 10 3))",
 	    "<IndexedFaceSet  convex='false' coordIndex='0 1 2 3 4 5 6 7'><GeoCoordinate geoSystem='\"GD\" \"WE\" \"latitude_first\"' point='10 15 3 6.464 13.536 3 5 10 3 6.464 6.464 3 10 5 3 13.536 6.464 3 15 10 3 13.536 13.536 3 ' /></IndexedFaceSet>",
-	    3, 3);
+	    3,
+	    3);
 }
-
 
 /*
 ** Used by test harness to register the tests in this file.
 */
 void out_x3d_suite_setup(void);
-void out_x3d_suite_setup(void)
+void
+out_x3d_suite_setup(void)
 {
 	CU_pSuite suite = CU_add_suite("x3d_output", NULL, NULL);
 	PG_ADD_TEST(suite, out_x3d3_test_precision);

--- a/liblwgeom/lwout_x3d.c
+++ b/liblwgeom/lwout_x3d.c
@@ -68,6 +68,25 @@ lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid
 {
 	int type = geom->type;
 
+	if (lwgeom_type_needs_stroke(type))
+	{
+		LWGEOM *linear = lwgeom_stroke(geom, 32);
+		int rv;
+
+		if (!linear)
+			return LW_FAILURE;
+
+		/* X3D has native curved nodes, but the existing ST_AsX3D contract
+		 * emits broadly supported line and face nodes. Linearize curved
+		 * inputs here so collections and single curved geometries share the
+		 * same serialization paths. Closed stroked curves rely on
+		 * asx3d3_line_sb retaining the duplicate endpoint because LineSet has
+		 * no coordinate index with which to close the path. */
+		rv = lwgeom_to_x3d3_sb(linear, precision, opts, defid, sb);
+		lwgeom_free(linear);
+		return rv;
+	}
+
 	switch (type)
 	{
 	case POINTTYPE:
@@ -82,9 +101,9 @@ lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid
 		* seems like the simplest way to go so treat just like a mulitpolygon
 		*/
 		LWCOLLECTION *tmp = (LWCOLLECTION*)lwgeom_as_multi(geom);
-		asx3d3_multi_sb(tmp, precision, opts, defid, sb);
+		int rv = asx3d3_multi_sb(tmp, precision, opts, defid, sb);
 		lwcollection_free(tmp);
-		return LW_SUCCESS;
+		return rv;
 	}
 
 	case TRIANGLETYPE:
@@ -107,6 +126,23 @@ lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid
 	default:
 		lwerror("lwgeom_to_x3d3: '%s' geometry type not supported", lwtype_name(type));
 		return LW_FAILURE;
+	}
+}
+
+static int
+lwgeom_type_needs_stroke(uint8_t type)
+{
+	switch (type)
+	{
+	case CIRCSTRINGTYPE:
+	case COMPOUNDTYPE:
+	case CURVEPOLYTYPE:
+	case MULTICURVETYPE:
+	case MULTISURFACETYPE:
+	case NURBSCURVETYPE:
+		return LW_TRUE;
+	default:
+		return LW_FALSE;
 	}
 }
 
@@ -229,17 +265,17 @@ asx3d3_line_sb(const LWLINE *line,
 	/* int dimension=2; */
 	POINTARRAY *pa;
 
-
 	/* if (FLAGS_GET_Z(line->flags)) dimension = 3; */
 
 	pa = line->points;
-	stringbuffer_aprintf(sb, "<LineSet %s vertexCount='%d'>", defid, pa->npoints);
+
+	stringbuffer_aprintf(sb, "<LineSet %s vertexCount='%u'>", defid, pa->npoints);
 
 	if ( X3D_USE_GEOCOORDS(opts) ) stringbuffer_aprintf(sb, "<GeoCoordinate geoSystem='\"GD\" \"WE\" \"%s\"' point='", ( (opts & LW_X3D_FLIP_XY) ? "latitude_first" : "longitude_first") );
 	else
 		stringbuffer_aprintf(sb, "<Coordinate point='");
 
-	ptarray_to_x3d3_sb(line->points, precision, opts, lwline_is_closed((LWLINE *)line), LW_TRUE, sb);
+	ptarray_to_x3d3_sb(line->points, precision, opts, LW_FALSE, LW_TRUE, sb);
 
 	stringbuffer_aprintf(sb, "' />");
 
@@ -476,39 +512,24 @@ asx3d3_collection_sb(const LWCOLLECTION *col, int precision, int opts, const cha
 	for (i=0; i<col->ngeoms; i++)
 	{
 		subgeom = col->geoms[i];
-		stringbuffer_aprintf(sb, "<Shape%s>", defid);
-		if ( subgeom->type == POINTTYPE )
+		if (subgeom->type == COLLECTIONTYPE)
 		{
-			asx3d3_point_sb((LWPOINT *)subgeom, precision, opts, defid, sb);
+			if (asx3d3_collection_sb((LWCOLLECTION *)subgeom, precision, opts, defid, sb) == LW_FAILURE)
+				return LW_FAILURE;
+			continue;
 		}
-		else if ( subgeom->type == LINETYPE )
-		{
-			asx3d3_line_sb((LWLINE *)subgeom, precision, opts, defid, sb);
-		}
-		else if ( subgeom->type == POLYGONTYPE )
-		{
-			LWCOLLECTION *tmp = (LWCOLLECTION *)lwgeom_as_multi(subgeom);
-			asx3d3_multi_sb(tmp, precision, opts, defid, sb);
-			lwcollection_free(tmp);
-		}
-		else if ( subgeom->type == TINTYPE )
-		{
-			asx3d3_tin_sb((LWTIN *)subgeom, precision, opts, defid, sb);
-		}
-		else if ( subgeom->type == POLYHEDRALSURFACETYPE )
-		{
-			asx3d3_psurface_sb((LWPSURFACE *)subgeom, precision, opts, defid, sb);
-		}
-		else if ( lwgeom_is_collection(subgeom) )
-		{
-			if ( subgeom->type == COLLECTIONTYPE )
-				asx3d3_collection_sb((LWCOLLECTION *)subgeom, precision, opts, defid, sb);
-			else
-				asx3d3_multi_sb((LWCOLLECTION *)subgeom, precision, opts, defid, sb);
-		}
-		else
-			lwerror("asx3d3_collection_buf: unknown geometry type");
 
+		stringbuffer_aprintf(sb, "<Shape%s>", defid);
+		if (subgeom->type == TRIANGLETYPE)
+		{
+			LWTIN *tmp = (LWTIN *)lwgeom_as_multi(subgeom);
+			int rv = asx3d3_tin_sb(tmp, precision, opts, defid, sb);
+			lwcollection_free((LWCOLLECTION *)tmp);
+			if (rv == LW_FAILURE)
+				return LW_FAILURE;
+		}
+		else if (lwgeom_to_x3d3_sb(subgeom, precision, opts, defid, sb) == LW_FAILURE)
+			return LW_FAILURE;
 		stringbuffer_aprintf(sb, "</Shape>");
 	}
 

--- a/liblwgeom/lwout_x3d.h
+++ b/liblwgeom/lwout_x3d.h
@@ -33,6 +33,7 @@
 
 /** defid is the id of the coordinate can be used to hold other elements DEF='abc' transform='' etc. **/
 static int lwgeom_to_x3d3_sb(const LWGEOM *geom, int precision, int opts, const char *defid, stringbuffer_t *sb);
+static int lwgeom_type_needs_stroke(uint8_t type);
 
 static int asx3d3_point_sb(const LWPOINT *point, int precision, int opts, const char *defid, stringbuffer_t *sb);
 static int asx3d3_line_sb(const LWLINE *line, int precision, int opts, const char *defid, stringbuffer_t *sb);

--- a/regress/core/tickets.sql
+++ b/regress/core/tickets.sql
@@ -1399,6 +1399,9 @@ select '#4399', 'ST_GeoHash', ST_GeoHash(geom)::text from geom
 union all
 select '#4399', 'ST_AsGeoJSON', ST_AsGeoJSON(geom)::text from geom;
 
+SELECT '#2838-triangle-collection', ST_AsX3D('GEOMETRYCOLLECTION(TRIANGLE((0 0,1 1,0 1,0 0)))'::geometry);
+SELECT '#2838-closed-curve-x3d', strpos(ST_AsX3D('CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)'::geometry), '<LineSet  vertexCount=''129''>') > 0 AND strpos(ST_AsX3D('CIRCULARSTRING(0 0 1,1 1 1,2 0 1,1 -1 1,0 0 1)'::geometry), '0 0 1'' /></LineSet>') > 0;
+
 SELECT '#4599-1', ST_AsEWKT(ST_AddPoint(ST_GeomFromEWKT('LINESTRING(0 0 1, 1 1 1)'), ST_MakePoint(1, 2, 3)));
 SELECT '#4599-2', ST_AsEWKT(ST_AddPoint(ST_GeomFromEWKT('LINESTRING(0 0 1, 1 1 1)'), ST_MakePoint(1, 2, 3), 0));
 SELECT '#4599-3', ST_AsEWKT(ST_AddPoint(ST_GeomFromEWKT('LINESTRING(0 0 1, 1 1 1)'), ST_MakePoint(1, 2, 3), -1));

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -433,6 +433,8 @@ ERROR:  BOX2D_construct: args can not be empty points
 #4399|ST_AsGeoJSON|{"type":"Polygon","coordinates":[[[0,0],[1,1],[0,1],[0,0]]]}
 #4399|ST_AsGeoJSON|{"type":"GeometryCollection","geometries":[{"type":"Polygon","coordinates":[[[0,0],[1,1],[0,1],[0,0]]]}]}
 #4399|ST_AsGeoJSON|{"type":"Polygon","coordinates":[[]]}
+#2838-triangle-collection|<Shape><IndexedTriangleSet  index='0 1 2'><Coordinate point='0 0 0 1 1 0 0 1 0'/></IndexedTriangleSet></Shape>
+#2838-closed-curve-x3d|t
 #4599-1|LINESTRING(0 0 1,1 1 1,1 2 3)
 #4599-2|LINESTRING(1 2 3,0 0 1,1 1 1)
 #4599-3|LINESTRING(0 0 1,1 1 1,1 2 3)


### PR DESCRIPTION
## Summary

This follows up the earlier ST_AsX3D 2D Coordinate-node fix and completes the broader scope of https://trac.osgeo.org/postgis/ticket/2838.

The patch:

- linearizes curved inputs through the existing `lwgeom_stroke` path before X3D serialization
- supports `CIRCULARSTRING`, `COMPOUNDCURVE`, `CURVEPOLYGON`, `MULTICURVE`, `MULTISURFACE`, and `NURBSCURVE` in ST_AsX3D
- routes `GEOMETRYCOLLECTION` children through the common serializer so curved children, TINs, triangles, and polyhedral surfaces share valid X3D node output paths
- avoids nested `<Shape><Shape>...` output for nested collections
- propagates polygon serialization failures from the stroked recursion path
- hardens the X3D CUnit substring helpers against NULL serialization results
- keeps closed single-line `LineSet` output closed by retaining the duplicate closing coordinate and matching `vertexCount`
- adds explicit CUnit and SQL coverage for closed stroked curves and triangle collection output
- updates the ST_AsX3D docs for current 2D and curved-type behavior

Closes https://trac.osgeo.org/postgis/ticket/2838

## Validation

- `./autogen.sh && ./configure --with-jsondir=/usr --with-projdir=/usr --with-raster --with-topology --with-sfcgal`
- `make -C liblwgeom -j32`
- `make -C liblwgeom/cunit cu_tester -j32`
- `./liblwgeom/cunit/cu_tester x3d_output`
- `git clang-format upstream/master -- liblwgeom/cunit/cu_out_x3d.c liblwgeom/lwout_x3d.c liblwgeom/lwout_x3d.h` (no changes)
- `make -C postgis -j32`
- `sudo -n make -C postgis install`
- `make -C extensions postgis_extension_helper.sql`
- `make -B -C extensions/postgis sql/postgis_for_extension.sql sql/postgis--3.7.0dev.sql`
- `make -C extensions/postgis -j1`
- `sudo -n make -C extensions/postgis install`
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--extension --verbose" TESTS="$(pwd)/regress/core/tickets"` (fresh and automatic-upgrade runs passed)
- `PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=5432 PGUSER=kom PGDATABASE=postgres make -C regress check RUNTESTFLAGS="--upgrade --extension --verbose" TESTS="$(pwd)/regress/core/tickets"`
- `make -C doc check-xml`
- `make check-news && ./utils/check_news.sh .`
- `git diff --check upstream/master..HEAD && git diff --check && git diff --cached --check`
