### PR TITLE
Rasterize curved geometry inputs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,8 +62,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           rasterization (Darafei Praliaskouski)
 
 
-PostGIS 3.7.0alpha1
-2026/07/05
+PostGIS 3.7.0dev
+2026/xx/xx
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.
 To take advantage of all features postgis extension features, GEOS 3.15+ is needed.

--- a/NEWS
+++ b/NEWS
@@ -58,10 +58,12 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2557, #2805, Document ST_MapAlgebra callback argument
           signatures and return semantics (Darafei Praliaskouski)
+ - #1168, [raster] Linearize curved geometry inputs with GDAL for ST_AsRaster
+          rasterization (Darafei Praliaskouski)
 
 
-PostGIS 3.7.0dev
-2026/xx/xx
+PostGIS 3.7.0alpha1
+2026/07/05
 
 This version requires GEOS 3.10+, PostgreSQL 14-19beta1, Proj 6.1+, libgmp.
 To take advantage of all features postgis extension features, GEOS 3.15+ is needed.
@@ -126,8 +128,6 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Enhancements *
 
- - #1168, [raster] Linearize curved geometry inputs before ST_AsRaster
-          rasterization (Darafei Praliaskouski)
  - #2045, pgsql2shp query dumps no longer require temporary table
           privileges (Darafei Praliaskouski)
  - #1577, [loader] Report unsupported .zip archive input before trying

--- a/NEWS
+++ b/NEWS
@@ -58,8 +58,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2557, #2805, Document ST_MapAlgebra callback argument
           signatures and return semantics (Darafei Praliaskouski)
- - #1168, [raster] Linearize curved geometry inputs with GDAL for ST_AsRaster
-          rasterization (Darafei Praliaskouski)
+ - #1168, [raster] Linearize curved geometry inputs with the PostGIS
+          curve linearizer for ST_AsRaster (Darafei Praliaskouski)
 
 
 PostGIS 3.7.0dev

--- a/NEWS
+++ b/NEWS
@@ -58,8 +58,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
           (Darafei Praliaskouski)
  - #2557, #2805, Document ST_MapAlgebra callback argument
           signatures and return semantics (Darafei Praliaskouski)
- - #1168, [raster] Linearize curved geometry inputs with the PostGIS
-          curve linearizer for ST_AsRaster (Darafei Praliaskouski)
+ - #1168, [raster] Support curved geometry inputs in ST_AsRaster
+          (Darafei Praliaskouski)
 
 
 PostGIS 3.7.0dev

--- a/NEWS
+++ b/NEWS
@@ -126,6 +126,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Enhancements *
 
+ - #1168, [raster] Linearize curved geometry inputs before ST_AsRaster
+          rasterization (Darafei Praliaskouski)
  - #2045, pgsql2shp query dumps no longer require temporary table
           privileges (Darafei Praliaskouski)
  - #1577, [loader] Report unsupported .zip archive input before trying

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -1728,8 +1728,7 @@ FROM ST_BandMetaData(ST_AddBand(ST_MakeEmptyRaster(10, 10, 0, 0, 1, -1, 0, 0, 0)
                     with <xref linkend="RT_ST_AsPNG"/> and other <xref linkend="RT_ST_AsGDALRaster"/> family of functions.</para>
                  <para role="availability" conformance="2.0.0">Availability: 2.0.0 - requires GDAL &gt;= 1.6.0. </para>
 
-                 <note><para>Not yet capable of rendering complex geometry types such as curves, TINS, and PolyhedralSurfaces, but should be
-                 able too once GDAL can.</para></note>
+                 <para>Curved geometry inputs are linearized before rasterization. TIN and PolyhedralSurface inputs are not supported.</para>
             </refsection>
 
             <refsection>

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -1728,7 +1728,7 @@ FROM ST_BandMetaData(ST_AddBand(ST_MakeEmptyRaster(10, 10, 0, 0, 1, -1, 0, 0, 0)
                     with <xref linkend="RT_ST_AsPNG"/> and other <xref linkend="RT_ST_AsGDALRaster"/> family of functions.</para>
                  <para role="availability" conformance="2.0.0">Availability: 2.0.0 - requires GDAL &gt;= 1.6.0. </para>
 
-                 <para>Curved geometry inputs are linearized before rasterization. TIN and PolyhedralSurface inputs are not supported.</para>
+                 <para>Curved geometry inputs are linearized with GDAL before rasterization. TIN and PolyhedralSurface inputs are not supported.</para>
             </refsection>
 
             <refsection>

--- a/doc/reference_raster.xml
+++ b/doc/reference_raster.xml
@@ -1728,7 +1728,7 @@ FROM ST_BandMetaData(ST_AddBand(ST_MakeEmptyRaster(10, 10, 0, 0, 1, -1, 0, 0, 0)
                     with <xref linkend="RT_ST_AsPNG"/> and other <xref linkend="RT_ST_AsGDALRaster"/> family of functions.</para>
                  <para role="availability" conformance="2.0.0">Availability: 2.0.0 - requires GDAL &gt;= 1.6.0. </para>
 
-                 <para>Curved geometry inputs are linearized with GDAL before rasterization. TIN and PolyhedralSurface inputs are not supported.</para>
+                 <para>Curved geometry inputs are linearized before rasterization, including NURBSCurve inputs handled by PostGIS. TIN and PolyhedralSurface inputs are not supported.</para>
             </refsection>
 
             <refsection>

--- a/raster/rt_core/rt_raster.c
+++ b/raster/rt_core/rt_raster.c
@@ -4,6 +4,7 @@
  * http://trac.osgeo.org/postgis/wiki/WKTRaster
  *
  * Copyright (C) 2013 Bborie Park <dustymugs@gmail.com>
+ * Copyright (C) 2026 Darafei Praliaskouski <me@komzpa.net>
  * Copyright (C) 2011-2013 Regents of the University of California
  *   <bkpark@ucdavis.edu>
  * Copyright (C) 2010-2011 Jorge Arevalo <jorge.arevalo@deimos-space.com>
@@ -2414,6 +2415,14 @@ rt_raster_gdal_rasterize(
 		compatibility with GDAL 1.6, 1.7 and 1.8.  1.9+ works fine with half-pixel.
 	*/
 	wkbtype = wkbFlatten(OGR_G_GetGeometryType(src_geom));
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 14, 0)
+	/*
+	 * GDAL 3.14 rasterizes curve line types as their linear counterparts. Use
+	 * the same type mapping for extent padding so native and pre-linearized
+	 * curves receive identical bounds.
+	 */
+	wkbtype = wkbFlatten(OGR_GT_GetLinear(wkbtype));
+#endif
 	if ((
 			(wkbtype == wkbPoint) ||
 			(wkbtype == wkbMultiPoint) ||

--- a/raster/rt_core/rt_raster.c
+++ b/raster/rt_core/rt_raster.c
@@ -2319,23 +2319,6 @@ rt_raster_gdal_rasterize(
 		return NULL;
 	}
 
-	if (OGR_G_HasCurveGeometry(src_geom, FALSE)) {
-		/*
-		 * GDAL can read curved OGR geometries, but GDALRasterizeGeometries()
-		 * does not burn direct curve inputs reliably without an explicit
-		 * linearization step.
-		 */
-		OGRGeometryH linearized_geom = OGR_G_GetLinearGeometry(src_geom, 0.0, NULL);
-		if (linearized_geom == NULL) {
-			OGR_G_DestroyGeometry(src_geom);
-			_rti_rasterize_arg_destroy(arg);
-			rterror("rt_raster_gdal_rasterize: Could not linearize OGR Geometry");
-			return NULL;
-		}
-		OGR_G_DestroyGeometry(src_geom);
-		src_geom = linearized_geom;
-	}
-
 	/* OGR Geometry is empty */
 	if (OGR_G_IsEmpty(src_geom)) {
 		rtinfo("Geometry provided is empty. Returning empty raster");

--- a/raster/rt_core/rt_raster.c
+++ b/raster/rt_core/rt_raster.c
@@ -2319,6 +2319,23 @@ rt_raster_gdal_rasterize(
 		return NULL;
 	}
 
+	if (OGR_G_HasCurveGeometry(src_geom, FALSE)) {
+		/*
+		 * GDAL can read curved OGR geometries, but GDALRasterizeGeometries()
+		 * does not burn direct curve inputs reliably without an explicit
+		 * linearization step.
+		 */
+		OGRGeometryH linearized_geom = OGR_G_GetLinearGeometry(src_geom, 0.0, NULL);
+		if (linearized_geom == NULL) {
+			OGR_G_DestroyGeometry(src_geom);
+			_rti_rasterize_arg_destroy(arg);
+			rterror("rt_raster_gdal_rasterize: Could not linearize OGR Geometry");
+			return NULL;
+		}
+		OGR_G_DestroyGeometry(src_geom);
+		src_geom = linearized_geom;
+	}
+
 	/* OGR Geometry is empty */
 	if (OGR_G_IsEmpty(src_geom)) {
 		rtinfo("Geometry provided is empty. Returning empty raster");

--- a/raster/rt_pg/rtpg_geometry.c
+++ b/raster/rt_pg/rtpg_geometry.c
@@ -59,6 +59,34 @@ Datum RASTER_getPolygon(PG_FUNCTION_ARGS);
 /* rasterize a geometry */
 Datum RASTER_asRaster(PG_FUNCTION_ARGS);
 
+static bool
+rtpg_lwgeom_is_curve_type(const LWGEOM *geom)
+{
+	uint32_t i;
+
+	switch (geom->type)
+	{
+	case CIRCSTRINGTYPE:
+	case COMPOUNDTYPE:
+	case CURVEPOLYTYPE:
+	case MULTICURVETYPE:
+	case MULTISURFACETYPE:
+	case NURBSCURVETYPE:
+		return true;
+	case COLLECTIONTYPE: {
+		const LWCOLLECTION *collection = (const LWCOLLECTION *)geom;
+		for (i = 0; i < collection->ngeoms; i++)
+		{
+			if (rtpg_lwgeom_is_curve_type(collection->geoms[i]))
+				return true;
+		}
+		return false;
+	}
+	default:
+		return false;
+	}
+}
+
 /* ---------------------------------------------------------------- */
 /*  Raster envelope                                                 */
 /* ---------------------------------------------------------------- */
@@ -1051,7 +1079,7 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 	rt_pgraster *pgrast = NULL;
 
 	lwvarlena_t *wkb;
-	unsigned char variant = WKB_ISO;
+	unsigned char variant = WKB_SFSQL;
 
 	double scale[2] = {0};
 	double *scale_x = NULL;
@@ -1122,6 +1150,20 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 		LWGEOM *geom2d = lwgeom_force_2d(geom);
 		lwgeom_free(geom);
 		geom = geom2d;
+	}
+
+	if (lwgeom_has_arc(geom) || rtpg_lwgeom_is_curve_type(geom))
+	{
+		LWGEOM *linearized = lwcurve_linearize(geom, 32, LW_LINEARIZE_TOLERANCE_TYPE_SEGS_PER_QUAD, 0);
+		if (linearized == NULL)
+		{
+			lwgeom_free(geom);
+			PG_FREE_IF_COPY(gser, 0);
+			elog(ERROR, "RASTER_asRaster: Could not linearize geometry");
+			PG_RETURN_NULL();
+		}
+		lwgeom_free(geom);
+		geom = linearized;
 	}
 
 	/* empty geometry, return empty raster */

--- a/raster/rt_pg/rtpg_geometry.c
+++ b/raster/rt_pg/rtpg_geometry.c
@@ -59,34 +59,6 @@ Datum RASTER_getPolygon(PG_FUNCTION_ARGS);
 /* rasterize a geometry */
 Datum RASTER_asRaster(PG_FUNCTION_ARGS);
 
-static bool
-rtpg_lwgeom_is_curve_type(const LWGEOM *geom)
-{
-	uint32_t i;
-
-	switch (geom->type)
-	{
-	case CIRCSTRINGTYPE:
-	case COMPOUNDTYPE:
-	case CURVEPOLYTYPE:
-	case MULTICURVETYPE:
-	case MULTISURFACETYPE:
-	case NURBSCURVETYPE:
-		return true;
-	case COLLECTIONTYPE: {
-		const LWCOLLECTION *collection = (const LWCOLLECTION *)geom;
-		for (i = 0; i < collection->ngeoms; i++)
-		{
-			if (rtpg_lwgeom_is_curve_type(collection->geoms[i]))
-				return true;
-		}
-		return false;
-	}
-	default:
-		return false;
-	}
-}
-
 /* ---------------------------------------------------------------- */
 /*  Raster envelope                                                 */
 /* ---------------------------------------------------------------- */
@@ -1079,7 +1051,7 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 	rt_pgraster *pgrast = NULL;
 
 	lwvarlena_t *wkb;
-	unsigned char variant = WKB_SFSQL;
+	unsigned char variant = WKB_ISO;
 
 	double scale[2] = {0};
 	double *scale_x = NULL;
@@ -1150,20 +1122,6 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 		LWGEOM *geom2d = lwgeom_force_2d(geom);
 		lwgeom_free(geom);
 		geom = geom2d;
-	}
-
-	if (lwgeom_has_arc(geom) || rtpg_lwgeom_is_curve_type(geom))
-	{
-		LWGEOM *linearized = lwgeom_stroke(geom, 32);
-		if (!linearized)
-		{
-			lwgeom_free(geom);
-			PG_FREE_IF_COPY(gser, 0);
-			elog(ERROR, "RASTER_asRaster: Could not linearize geometry");
-			PG_RETURN_NULL();
-		}
-		lwgeom_free(geom);
-		geom = linearized;
 	}
 
 	/* empty geometry, return empty raster */

--- a/raster/rt_pg/rtpg_geometry.c
+++ b/raster/rt_pg/rtpg_geometry.c
@@ -65,7 +65,16 @@ rtpg_lwgeom_needs_curve_linearize(const LWGEOM *geom)
 	uint32_t i;
 	const LWCOLLECTION *collection;
 
+	/*
+	 * GDAL 3.14 linearizes OGR curve geometries in
+	 * GDALRasterizeGeometries(). Older versions ignore them. NURBSCURVE is
+	 * not an OGR geometry type, so it must always be linearized here.
+	 */
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 14, 0)
+	if (geom->type == NURBSCURVETYPE)
+#else
 	if (lwgeom_type_arc(geom))
+#endif
 		return LW_TRUE;
 
 	if (!lwgeom_is_collection(geom))

--- a/raster/rt_pg/rtpg_geometry.c
+++ b/raster/rt_pg/rtpg_geometry.c
@@ -59,6 +59,34 @@ Datum RASTER_getPolygon(PG_FUNCTION_ARGS);
 /* rasterize a geometry */
 Datum RASTER_asRaster(PG_FUNCTION_ARGS);
 
+static bool
+rtpg_lwgeom_is_curve_type(const LWGEOM *geom)
+{
+	uint32_t i;
+
+	switch (geom->type)
+	{
+	case CIRCSTRINGTYPE:
+	case COMPOUNDTYPE:
+	case CURVEPOLYTYPE:
+	case MULTICURVETYPE:
+	case MULTISURFACETYPE:
+	case NURBSCURVETYPE:
+		return true;
+	case COLLECTIONTYPE: {
+		const LWCOLLECTION *collection = (const LWCOLLECTION *)geom;
+		for (i = 0; i < collection->ngeoms; i++)
+		{
+			if (rtpg_lwgeom_is_curve_type(collection->geoms[i]))
+				return true;
+		}
+		return false;
+	}
+	default:
+		return false;
+	}
+}
+
 /* ---------------------------------------------------------------- */
 /*  Raster envelope                                                 */
 /* ---------------------------------------------------------------- */
@@ -1122,6 +1150,20 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 		LWGEOM *geom2d = lwgeom_force_2d(geom);
 		lwgeom_free(geom);
 		geom = geom2d;
+	}
+
+	if (lwgeom_has_arc(geom) || rtpg_lwgeom_is_curve_type(geom))
+	{
+		LWGEOM *linearized = lwgeom_stroke(geom, 32);
+		if (!linearized)
+		{
+			lwgeom_free(geom);
+			PG_FREE_IF_COPY(gser, 0);
+			elog(ERROR, "RASTER_asRaster: Could not linearize geometry");
+			PG_RETURN_NULL();
+		}
+		lwgeom_free(geom);
+		geom = linearized;
 	}
 
 	/* empty geometry, return empty raster */

--- a/raster/rt_pg/rtpg_geometry.c
+++ b/raster/rt_pg/rtpg_geometry.c
@@ -59,6 +59,28 @@ Datum RASTER_getPolygon(PG_FUNCTION_ARGS);
 /* rasterize a geometry */
 Datum RASTER_asRaster(PG_FUNCTION_ARGS);
 
+static int
+rtpg_lwgeom_needs_curve_linearize(const LWGEOM *geom)
+{
+	uint32_t i;
+	const LWCOLLECTION *collection;
+
+	if (lwgeom_type_arc(geom))
+		return LW_TRUE;
+
+	if (!lwgeom_is_collection(geom))
+		return LW_FALSE;
+
+	collection = (const LWCOLLECTION *)geom;
+	for (i = 0; i < collection->ngeoms; i++)
+	{
+		if (rtpg_lwgeom_needs_curve_linearize(collection->geoms[i]))
+			return LW_TRUE;
+	}
+
+	return LW_FALSE;
+}
+
 /* ---------------------------------------------------------------- */
 /*  Raster envelope                                                 */
 /* ---------------------------------------------------------------- */
@@ -1124,11 +1146,7 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 		geom = geom2d;
 	}
 
-	/*
-	 * Follow the same liblwgeom path as ST_CurveToLine. It returns a
-	 * cloned geometry for already-linear inputs, and recursively handles
-	 * curved members inside geometry collections before WKB serialization.
-	 */
+	if (rtpg_lwgeom_needs_curve_linearize(geom))
 	{
 		LWGEOM *linearized = lwcurve_linearize(geom, 32, LW_LINEARIZE_TOLERANCE_TYPE_SEGS_PER_QUAD, 0);
 		if (linearized == NULL)

--- a/raster/rt_pg/rtpg_geometry.c
+++ b/raster/rt_pg/rtpg_geometry.c
@@ -59,34 +59,6 @@ Datum RASTER_getPolygon(PG_FUNCTION_ARGS);
 /* rasterize a geometry */
 Datum RASTER_asRaster(PG_FUNCTION_ARGS);
 
-static bool
-rtpg_lwgeom_is_curve_type(const LWGEOM *geom)
-{
-	uint32_t i;
-
-	switch (geom->type)
-	{
-	case CIRCSTRINGTYPE:
-	case COMPOUNDTYPE:
-	case CURVEPOLYTYPE:
-	case MULTICURVETYPE:
-	case MULTISURFACETYPE:
-	case NURBSCURVETYPE:
-		return true;
-	case COLLECTIONTYPE: {
-		const LWCOLLECTION *collection = (const LWCOLLECTION *)geom;
-		for (i = 0; i < collection->ngeoms; i++)
-		{
-			if (rtpg_lwgeom_is_curve_type(collection->geoms[i]))
-				return true;
-		}
-		return false;
-	}
-	default:
-		return false;
-	}
-}
-
 /* ---------------------------------------------------------------- */
 /*  Raster envelope                                                 */
 /* ---------------------------------------------------------------- */
@@ -1152,7 +1124,11 @@ Datum RASTER_asRaster(PG_FUNCTION_ARGS)
 		geom = geom2d;
 	}
 
-	if (lwgeom_has_arc(geom) || rtpg_lwgeom_is_curve_type(geom))
+	/*
+	 * Follow the same liblwgeom path as ST_CurveToLine. It returns a
+	 * cloned geometry for already-linear inputs, and recursively handles
+	 * curved members inside geometry collections before WKB serialization.
+	 */
 	{
 		LWGEOM *linearized = lwcurve_linearize(geom, 32, LW_LINEARIZE_TOLERANCE_TYPE_SEGS_PER_QUAD, 0);
 		if (linearized == NULL)

--- a/raster/test/regress/rt_asraster.sql
+++ b/raster/test/regress/rt_asraster.sql
@@ -544,6 +544,35 @@ WITH cases(label, geom) AS (
 )
 SELECT * FROM stats ORDER BY label;
 
+WITH lineal_curves(label, geom) AS (
+	VALUES
+	(
+		'#1168-CircularStringMatchesCurveToLine',
+		'CIRCULARSTRING(0 0, 5 5, 10 0)'::geometry
+	),
+	(
+		'#1168-CompoundCurveMatchesCurveToLine',
+		'COMPOUNDCURVE((0 0, 2 0), CIRCULARSTRING(2 0, 4 2, 6 0))'::geometry
+	),
+	(
+		'#1168-MultiCurveMatchesCurveToLine',
+		'MULTICURVE(CIRCULARSTRING(0 0, 5 5, 10 0))'::geometry
+	)
+), rasters AS (
+	SELECT
+		label,
+		ST_AsRaster(geom, 1.0, -1.0, '8BUI', 7, 0) AS curved_rast,
+		ST_AsRaster(ST_CurveToLine(geom), 1.0, -1.0, '8BUI', 7, 0) AS linear_rast
+	FROM lineal_curves
+)
+SELECT
+	label,
+	ST_SameAlignment(curved_rast, linear_rast) AS same_alignment,
+	(ST_MetaData(curved_rast)).width = (ST_MetaData(linear_rast)).width AS same_width,
+	(ST_MetaData(curved_rast)).height = (ST_MetaData(linear_rast)).height AS same_height
+FROM rasters
+ORDER BY label;
+
 WITH linearized_rasters(label, geom) AS (
 	VALUES
 	(

--- a/raster/test/regress/rt_asraster.sql
+++ b/raster/test/regress/rt_asraster.sql
@@ -523,6 +523,10 @@ WITH cases(label, geom) AS (
 	(
 		'#1168-CurvePolygonStraight',
 		'CURVEPOLYGON(COMPOUNDCURVE((0 0, 4 0, 4 4, 0 4, 0 0)))'::geometry
+	),
+	(
+		'#1168-NURBSCurve',
+		ST_MakeNurbsCurve(2, 'LINESTRING(0 0, 5 10, 10 0)'::geometry)
 	)
 ), rasters AS (
 	SELECT
@@ -540,19 +544,31 @@ WITH cases(label, geom) AS (
 )
 SELECT * FROM stats ORDER BY label;
 
-WITH collection_rasters AS (
+WITH linearized_rasters(label, geom) AS (
+	VALUES
+	(
+		'#1168-GeometryCollectionCurveStraight',
+		'GEOMETRYCOLLECTION(COMPOUNDCURVE((0 0, 4 0, 4 4)))'::geometry
+	),
+	(
+		'#1168-NURBSCurveMatchesCurveToLine',
+		ST_MakeNurbsCurve(2, 'LINESTRING(0 0, 5 10, 10 0)'::geometry)
+	)
+), rasters AS (
 	SELECT
+		label,
 		ST_AsRaster(geom, 1.0, -1.0, '8BUI', 7, 0) AS curved_rast,
 		ST_AsRaster(ST_CurveToLine(geom), 1.0, -1.0, '8BUI', 7, 0) AS linear_rast
-	FROM (SELECT 'GEOMETRYCOLLECTION(COMPOUNDCURVE((0 0, 4 0, 4 4)))'::geometry AS geom) g
+	FROM linearized_rasters
 )
 SELECT
-	'#1168-GeometryCollectionCurveStraight',
+	label,
 	ST_SameAlignment(curved_rast, linear_rast) AS same_alignment,
 	(ST_MetaData(curved_rast)).width = (ST_MetaData(linear_rast)).width AS same_width,
 	(ST_MetaData(curved_rast)).height = (ST_MetaData(linear_rast)).height AS same_height,
 	(ST_SummaryStats(curved_rast)).count IS NOT DISTINCT FROM (ST_SummaryStats(linear_rast)).count AS same_count
-FROM collection_rasters;
+FROM rasters
+ORDER BY label;
 
 DELETE FROM "spatial_ref_sys" WHERE srid = 992163;
 DELETE FROM "spatial_ref_sys" WHERE srid = 993309;

--- a/raster/test/regress/rt_asraster.sql
+++ b/raster/test/regress/rt_asraster.sql
@@ -523,28 +523,36 @@ WITH cases(label, geom) AS (
 	(
 		'#1168-CurvePolygonStraight',
 		'CURVEPOLYGON(COMPOUNDCURVE((0 0, 4 0, 4 4, 0 4, 0 0)))'::geometry
-	),
-	(
-		'#1168-GeometryCollectionCurveStraight',
-		'GEOMETRYCOLLECTION(COMPOUNDCURVE((0 0, 4 0, 4 4)))'::geometry
 	)
 ), rasters AS (
 	SELECT
 		label,
-		ST_AsRaster(geom, 1.0, -1.0, '8BUI', 7, 0) AS curved_rast,
-		ST_AsRaster(ST_CurveToLine(geom), 1.0, -1.0, '8BUI', 7, 0) AS linear_rast
+		ST_AsRaster(geom, 1.0, -1.0, '8BUI', 7, 0) AS rast
 	FROM cases
 ), stats AS (
 	SELECT
 		label,
-		ST_SameAlignment(curved_rast, linear_rast) AS same_alignment,
-		(ST_MetaData(curved_rast)).width = (ST_MetaData(linear_rast)).width AS same_width,
-		(ST_MetaData(curved_rast)).height = (ST_MetaData(linear_rast)).height AS same_height,
-		(ST_SummaryStats(curved_rast)).count IS NOT DISTINCT FROM (ST_SummaryStats(linear_rast)).count AS same_count,
-		(ST_SummaryStats(curved_rast)).sum IS NOT DISTINCT FROM (ST_SummaryStats(linear_rast)).sum AS same_sum
+		(ST_MetaData(rast)).width > 0 AS has_width,
+		(ST_MetaData(rast)).height > 0 AS has_height,
+		(ST_SummaryStats(rast)).count > 0 AS has_pixels,
+		(ST_SummaryStats(rast)).sum > 0 AS has_burned_pixels
 	FROM rasters
 )
 SELECT * FROM stats ORDER BY label;
+
+WITH collection_rasters AS (
+	SELECT
+		ST_AsRaster(geom, 1.0, -1.0, '8BUI', 7, 0) AS curved_rast,
+		ST_AsRaster(ST_CurveToLine(geom), 1.0, -1.0, '8BUI', 7, 0) AS linear_rast
+	FROM (SELECT 'GEOMETRYCOLLECTION(COMPOUNDCURVE((0 0, 4 0, 4 4)))'::geometry AS geom) g
+)
+SELECT
+	'#1168-GeometryCollectionCurveStraight',
+	ST_SameAlignment(curved_rast, linear_rast) AS same_alignment,
+	(ST_MetaData(curved_rast)).width = (ST_MetaData(linear_rast)).width AS same_width,
+	(ST_MetaData(curved_rast)).height = (ST_MetaData(linear_rast)).height AS same_height,
+	(ST_SummaryStats(curved_rast)).count IS NOT DISTINCT FROM (ST_SummaryStats(linear_rast)).count AS same_count
+FROM collection_rasters;
 
 DELETE FROM "spatial_ref_sys" WHERE srid = 992163;
 DELETE FROM "spatial_ref_sys" WHERE srid = 993309;

--- a/raster/test/regress/rt_asraster.sql
+++ b/raster/test/regress/rt_asraster.sql
@@ -502,6 +502,50 @@ FROM (
 SELECT '#5084' As ticket, count(dp.geom)
 FROM ST_DumpAsPolygons(ST_AsRaster('LINESTRING(986015.7 6720291.2,986024.3 6720347,986028 6720417.4,986025.6 6720474.3)'::geometry, 2::double precision, 2, 0, 0)) AS dp;
 
+WITH cases(label, geom) AS (
+	VALUES
+	(
+		'#1168-CircularString',
+		'CIRCULARSTRING(0 0, 5 5, 10 0)'::geometry
+	),
+	(
+		'#1168-CompoundCurve',
+		'COMPOUNDCURVE((0 0, 2 0), CIRCULARSTRING(2 0, 4 2, 6 0))'::geometry
+	),
+	(
+		'#1168-CompoundCurveStraight',
+		'COMPOUNDCURVE((0 0, 4 0, 4 4))'::geometry
+	),
+	(
+		'#1168-CurvePolygon',
+		'CURVEPOLYGON(CIRCULARSTRING(0 0, 5 5, 10 0, 5 -5, 0 0))'::geometry
+	),
+	(
+		'#1168-CurvePolygonStraight',
+		'CURVEPOLYGON(COMPOUNDCURVE((0 0, 4 0, 4 4, 0 4, 0 0)))'::geometry
+	),
+	(
+		'#1168-GeometryCollectionCurveStraight',
+		'GEOMETRYCOLLECTION(COMPOUNDCURVE((0 0, 4 0, 4 4)))'::geometry
+	)
+), rasters AS (
+	SELECT
+		label,
+		ST_AsRaster(geom, 1.0, -1.0, '8BUI', 7, 0) AS curved_rast,
+		ST_AsRaster(ST_CurveToLine(geom), 1.0, -1.0, '8BUI', 7, 0) AS linear_rast
+	FROM cases
+), stats AS (
+	SELECT
+		label,
+		ST_SameAlignment(curved_rast, linear_rast) AS same_alignment,
+		(ST_MetaData(curved_rast)).width = (ST_MetaData(linear_rast)).width AS same_width,
+		(ST_MetaData(curved_rast)).height = (ST_MetaData(linear_rast)).height AS same_height,
+		(ST_SummaryStats(curved_rast)).count IS NOT DISTINCT FROM (ST_SummaryStats(linear_rast)).count AS same_count,
+		(ST_SummaryStats(curved_rast)).sum IS NOT DISTINCT FROM (ST_SummaryStats(linear_rast)).sum AS same_sum
+	FROM rasters
+)
+SELECT * FROM stats ORDER BY label;
+
 DELETE FROM "spatial_ref_sys" WHERE srid = 992163;
 DELETE FROM "spatial_ref_sys" WHERE srid = 993309;
 DELETE FROM "spatial_ref_sys" WHERE srid = 993310;

--- a/raster/test/regress/rt_asraster_expected
+++ b/raster/test/regress/rt_asraster_expected
@@ -63,9 +63,9 @@ NOTICE:  The rasters have different scales on the X axis
 4.8|993310|142|88|1|1000.000|-1000.000|0.000|0.000|-176000.000|115000.000|16BUI|0.000|t|13.000|13.000|f
 4.9|993310|142|88|1|1000.000|-1000.000|0.000|0.000|-176453.000|115987.000|16BUI|0.000|t|13.000|13.000|f
 #5084|10
-#1168-CircularString|t|t|t|t|t
-#1168-CompoundCurve|t|t|t|t|t
-#1168-CompoundCurveStraight|t|t|t|t|t
-#1168-CurvePolygon|t|t|t|t|t
-#1168-CurvePolygonStraight|t|t|t|t|t
-#1168-GeometryCollectionCurveStraight|t|t|t|t|t
+#1168-CircularString|t|t|t|t
+#1168-CompoundCurve|t|t|t|t
+#1168-CompoundCurveStraight|t|t|t|t
+#1168-CurvePolygon|t|t|t|t
+#1168-CurvePolygonStraight|t|t|t|t
+#1168-GeometryCollectionCurveStraight|t|t|t|t

--- a/raster/test/regress/rt_asraster_expected
+++ b/raster/test/regress/rt_asraster_expected
@@ -69,5 +69,8 @@ NOTICE:  The rasters have different scales on the X axis
 #1168-CurvePolygon|t|t|t|t
 #1168-CurvePolygonStraight|t|t|t|t
 #1168-NURBSCurve|t|t|t|t
+#1168-CircularStringMatchesCurveToLine|t|t|t
+#1168-CompoundCurveMatchesCurveToLine|t|t|t
+#1168-MultiCurveMatchesCurveToLine|t|t|t
 #1168-GeometryCollectionCurveStraight|t|t|t|t
 #1168-NURBSCurveMatchesCurveToLine|t|t|t|t

--- a/raster/test/regress/rt_asraster_expected
+++ b/raster/test/regress/rt_asraster_expected
@@ -68,4 +68,6 @@ NOTICE:  The rasters have different scales on the X axis
 #1168-CompoundCurveStraight|t|t|t|t
 #1168-CurvePolygon|t|t|t|t
 #1168-CurvePolygonStraight|t|t|t|t
+#1168-NURBSCurve|t|t|t|t
 #1168-GeometryCollectionCurveStraight|t|t|t|t
+#1168-NURBSCurveMatchesCurveToLine|t|t|t|t

--- a/raster/test/regress/rt_asraster_expected
+++ b/raster/test/regress/rt_asraster_expected
@@ -63,3 +63,9 @@ NOTICE:  The rasters have different scales on the X axis
 4.8|993310|142|88|1|1000.000|-1000.000|0.000|0.000|-176000.000|115000.000|16BUI|0.000|t|13.000|13.000|f
 4.9|993310|142|88|1|1000.000|-1000.000|0.000|0.000|-176453.000|115987.000|16BUI|0.000|t|13.000|13.000|f
 #5084|10
+#1168-CircularString|t|t|t|t|t
+#1168-CompoundCurve|t|t|t|t|t
+#1168-CompoundCurveStraight|t|t|t|t|t
+#1168-CurvePolygon|t|t|t|t|t
+#1168-CurvePolygonStraight|t|t|t|t|t
+#1168-GeometryCollectionCurveStraight|t|t|t|t|t


### PR DESCRIPTION
## Summary

This is a bounded slice of https://trac.osgeo.org/postgis/ticket/1168.

`ST_AsRaster` now supports curved geometry inputs while using the curve handling available in the linked GDAL version:

- with GDAL versions before 3.14, PostGIS linearizes curved inputs before serializing them to WKB for rasterization
- with GDAL 3.14 and newer, standard OGR curve types use the native curve linearization added to `GDALRasterizeGeometries()` by https://github.com/OSGeo/gdal/pull/14509
- `NURBSCurve` inputs continue to use the PostGIS curve linearizer on every GDAL version because OGR has no corresponding geometry type

TIN and PolyhedralSurface rasterization remain unsupported, so this PR intentionally references rather than closes the broader Trac ticket.

## Review Follow-Up

- preserve the PostGIS fallback through GDAL 3.13
- defer standard OGR curve handling to GDAL 3.14 and newer
- keep direct and nested `NURBSCurve` inputs on the PostGIS linearizer path
- avoid cloning already-linear inputs
- test curved inputs, straight curve containers, nested collections, and `NURBSCurve` parity with `ST_CurveToLine`

References https://trac.osgeo.org/postgis/ticket/1168

## Validation

- `make -C raster/rt_pg -j32`
- `make staged-install`
- `make -C raster/test/regress check TESTS=rt_asraster RUNTESTFLAGS='--raster --verbose'`
- `make check-news`
- `make -C doc check`
- `git diff --check`
