### PR TITLE
Group contributor aliases in mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,92 @@
-Sandro Santilli <strk@kbt.io> <strk@keybit.net>
-Bborie Park <dustymugs@gmail.com> <dustymugs at gmail.com>
+Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com> kalenikaliaksandr <45686940+kalenikaliaksandr@users.noreply.github.com>
+Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com> kalenikaliaksandr <kalenik.aliaksandr@gmail.com>
+
+Arthur Lesuisse <alesuiss@ulb.ac.be> <root@cs.ulb.ac.be>
+
+Bas Couwenberg <sebastic@debian.org> <sebastic@xs4all.nl>
+
 Bborie Park <dustymugs@gmail.com> <bkpark at ucdavis.edu>
+Bborie Park <dustymugs@gmail.com> <dustymugs at gmail.com>
+
+Björn Harrtell <bjorn@wololo.org> <bjorn@septima.dk>
+Björn Harrtell <bjorn@wololo.org> <bjornharrtell@users.noreply.github.com>
+Björn Harrtell <bjorn@wololo.org> bjornharrtell <bjorn@wololo.org>
+
+Dan Baston <dbaston@gmail.com> <dbaston@isciences.com>
+Dan Baston <dbaston@gmail.com> Daniel Baston <dbaston@gmail.com>
+Dan Baston <dbaston@gmail.com> dbaston <dbaston@gmail.com>
+Dan Baston <dbaston@gmail.com> dbaston <dbaston@maponics.com>
+
+Dapeng Wang <wangdapeng20191008@gmail.com> Wang Dapeng <wangdapeng20191008@gmail.com>
+Dapeng Wang <wangdapeng20191008@gmail.com> Wangdapeng <wangdapeng20191008@gmail.com>
+Dapeng Wang <wangdapeng20191008@gmail.com> wangdapeng <345731923@qq.com>
+
+Darafei Praliaskouski <me@komzpa.net> <komzpa@gojuno.com>
+Darafei Praliaskouski <me@komzpa.net> Darafei <komzpa@gmail.com>
+
+Edouard Choinière <echoix@users.noreply.weblate.osgeo.org> Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>
+
+Esteban Zimányi <estebanzimanyi@gmail.com> Esteban ZIMANYI <ezimanyi@xinu8.ulb.ac.be>
+Esteban Zimányi <estebanzimanyi@gmail.com> Esteban Zimanyi <esteban.zimanyi@ulb.be>
+Esteban Zimányi <estebanzimanyi@gmail.com> Esteban Zimanyi <estebanzimanyi@gmail.com>
+Esteban Zimányi <estebanzimanyi@gmail.com> estebanzimanyi <ezimanyi@ulb.ac.be>
+
+Even Rouault <even.rouault@spatialys.com> <even.rouault@mines-paris.org>
+
+George Silva <georger.silva@gmail.com> george-silva <georger.silva@gmail.com>
+
+Kashif Rasul <kashif.rasul@gmail.com> <kashif@nomad-labs.com>
+Kashif Rasul <kashif.rasul@gmail.com> <kashif@spacialdb.com>
+
+Loïc Bartoletti <loic.bartoletti@oslandia.com> <l.bartoletti@free.fr>
+Loïc Bartoletti <loic.bartoletti@oslandia.com> <lbartoletti@noreply.gitea.osgeo.org>
+Loïc Bartoletti <loic.bartoletti@oslandia.com> <lbartoletti@tuxfamily.org>
+Loïc Bartoletti <loic.bartoletti@oslandia.com> <lbartoletti@users.noreply.github.com>
+Loïc Bartoletti <loic.bartoletti@oslandia.com> <lituus@free.fr>
+Loïc Bartoletti <loic.bartoletti@oslandia.com> bartoletti <lbartoletti@tuxfamily.org>
+Loïc Bartoletti <loic.bartoletti@oslandia.com> lbartoletti <l.bartoletti@free.fr>
+Loïc Bartoletti <loic.bartoletti@oslandia.com> lbartoletti <loic.bartoletti@oslandia.com>
+
+Mateusz Loskot <mateusz@loskot.net> Mateusz Łoskot <mateusz@loskot.net>
+Mateusz Loskot <mateusz@loskot.net> unknown <MateuszL@DEV596.cadcorp.net>
+
+Mike Toews <mwtoews@gmail.com> Mike Taves <mwtoews@gmail.com>
+Mike Toews <mwtoews@gmail.com> mwtoews <mwtoews@gmail.com>
+
+Mohit Kumar <mohitkharb@gmail.com> Mohit Kumar <Mohitkharb@gmail.com>
+Mohit Kumar <mohitkharb@gmail.com> lsi <Mohitkharb@gmail.com>
+
+Paul Ramsey <pramsey@cleverelephant.ca> <paul.ramsey@snowflake.com>
+Paul Ramsey <pramsey@cleverelephant.ca> <pramsey+github@cleverelephant.ca>
+Paul Ramsey <pramsey@cleverelephant.ca> pramsey <pramsey@cleverelephant.ca>
+
+Raúl Marín <git@rmr.ninja> <rmrodriguez@carto.com>
+Raúl Marín <git@rmr.ninja> <rmrodriguez@cartodb.com>
+Raúl Marín <git@rmr.ninja> Raul Marin <git@rmr.ninja>
+
+Regina Obe <lr@pcorp.us> <regina.obe@appsassociates.com>
+Regina Obe <lr@pcorp.us> <regina@arrival3d.com>
+Regina Obe <lr@pcorp.us> <robe@postgis.net>
+Regina Obe <lr@pcorp.us> leoregina <lr@pcorp.us>
+Regina Obe <lr@pcorp.us> robe <regina@arrival3d.com>
+Regina Obe <lr@pcorp.us> robe2 <lr@pcorp.us>
+
+Rémi Cura <remi.cura@gmail.com> <Remi-C@fake.fake>
+Rémi Cura <remi.cura@gmail.com> <Remi-C@users.noreply.github.com>
+Rémi Cura <remi.cura@gmail.com> Remi-C <remi.cura@gmail.com>
+Rémi Cura <remi.cura@gmail.com> Rémi-C <remi.cura@gmail.com>
+
+Sandro Santilli <strk@kbt.io> <strk@keybit.net>
+Sandro Santilli <strk@kbt.io> strk <strk@kbt.io>
+
+Sergei Shoulbakov <managerzf168@gmail.com> <sshoulbakov@kontur.io>
+Sergei Shoulbakov <managerzf168@gmail.com> Sergei <managerzf168@gmail.com>
+Sergei Shoulbakov <managerzf168@gmail.com> sergei sh <managerzf168@gmail.com>
+Sergei Shoulbakov <managerzf168@gmail.com> sergei sh <sshoulbakov@kontur.io>
+
+Teramoto Ikuhiro <yellow@affrc.go.jp> <teramoto.ikuhiro576@naro.go.jp>
+Teramoto Ikuhiro <yellow@affrc.go.jp> yellow73 <yellow73.github@gmail.com>
+
+Weblate <noreply@weblate.org> <noreply-mt-weblate@weblate.org>
+
+Wouter Geraedts <wouter@tweedegolf.com> <git@woutergeraedts.nl>


### PR DESCRIPTION
## Summary

Add `.mailmap` entries for common contributor name and email aliases visible in the repository history.

This groups repeated identities in `git shortlog`, including aliases for Regina Obe, Darafei Praliaskouski, Raúl Marín Rodríguez, Dan Baston, Loïc Bartoletti, Björn Harrtell, Teramoto Ikuhiro, Paul Ramsey, Weblate, and other clear same-person variants.

## Validation

- `git check-mailmap` for representative aliases
- `git shortlog -sne --all --no-merges | head -100`
- `git diff --check`
