### PR TITLE
Add standard-conforming strings GitHub Actions job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         #- { tag: pg14-clang-geos39-gdal31-proj71, mode: usan_clang }
         # Run tests with different dependency combinations
         - { tag: latest, mode: tests }
+        - { tag: pg18-geosmain-gdal311-proj96, mode: standard_conforming_strings_off }
         - { tag: latest, mode: garden }
 
     runs-on: ubuntu-latest
@@ -66,5 +67,3 @@ jobs:
       if: ${{ success() }}
       run: |
         docker rm pgtest-${GITHUB_RUN_NUMBER}
-
-

--- a/ci/github/run_standard_conforming_strings_off.sh
+++ b/ci/github/run_standard_conforming_strings_off.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+WARNINGS="-Werror -Wall -Wextra -Wformat -Werror=format-security"
+WARNINGS_DISABLED="-Wno-unused-parameter -Wno-implicit-fallthrough -Wno-cast-function-type"
+
+CFLAGS_STD="-g -O2 -mtune=generic -fno-omit-frame-pointer ${WARNINGS} ${WARNINGS_DISABLED}"
+LDFLAGS_STD="-Wl,-Bsymbolic-functions -Wl,-z,relro"
+
+/usr/local/pgsql/bin/pg_ctl -c -l /tmp/logfile -o '-F' start
+./autogen.sh
+./configure CFLAGS="${CFLAGS_STD}" LDFLAGS="${LDFLAGS_STD}"
+make -j
+make check RUNTESTFLAGS="--verbose --after-create-db-script ${PWD}/regress/hooks/standard-conforming-strings-off.sql"


### PR DESCRIPTION
## Summary
- add a GitHub Actions matrix entry for `standard_conforming_strings_off` on the stable PG18 build image
- run the normal build/test path with the `standard-conforming-strings-off.sql` after-create hook
- mirror the coverage Woodie already gives for string-literal regressions like #2808/#5633 on GitHub PRs

## Validation
- `bash -n ci/github/run_standard_conforming_strings_off.sh`
- parsed `.github/workflows/ci.yml` with PyYAML
- `git diff --check`

Draft because I did not run the full Docker Actions image locally. GitHub `latest` currently rejects `standard_conforming_strings=off`, and GitHub build images do not ship `pgextwlist.so`, so this job uses the stable PG18 image and intentionally does not use the Woodie-only `configure-pgextwlist.sql` hook.



