### PR TITLE
Fix typo doc ref overlay

### DIFF
--- a/doc/po/be/postgis-manual.po
+++ b/doc/po/be/postgis-manual.po
@@ -18978,7 +18978,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/da/postgis-manual.po
+++ b/doc/po/da/postgis-manual.po
@@ -18829,7 +18829,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/de/postgis-manual.po
+++ b/doc/po/de/postgis-manual.po
@@ -24060,7 +24060,7 @@ msgstr ""
 #. Tag: para
 #, fuzzy, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/es/postgis-manual.po
+++ b/doc/po/es/postgis-manual.po
@@ -20878,7 +20878,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/fr/postgis-manual.po
+++ b/doc/po/fr/postgis-manual.po
@@ -24005,7 +24005,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/it_IT/postgis-manual.po
+++ b/doc/po/it_IT/postgis-manual.po
@@ -20483,7 +20483,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/ja/postgis-manual.po
+++ b/doc/po/ja/postgis-manual.po
@@ -23347,7 +23347,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/ka/postgis-manual.po
+++ b/doc/po/ka/postgis-manual.po
@@ -18819,7 +18819,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/ko_KR/postgis-manual.po
+++ b/doc/po/ko_KR/postgis-manual.po
@@ -20802,7 +20802,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/pl/postgis-manual.po
+++ b/doc/po/pl/postgis-manual.po
@@ -19009,7 +19009,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/pt_BR/postgis-manual.po
+++ b/doc/po/pt_BR/postgis-manual.po
@@ -20978,7 +20978,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/ro/postgis-manual.po
+++ b/doc/po/ro/postgis-manual.po
@@ -18838,7 +18838,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/ru/postgis-manual.po
+++ b/doc/po/ru/postgis-manual.po
@@ -18857,7 +18857,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/sv/postgis-manual.po
+++ b/doc/po/sv/postgis-manual.po
@@ -23476,7 +23476,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/templates/postgis-manual.pot
+++ b/doc/po/templates/postgis-manual.pot
@@ -18808,7 +18808,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - ST_Intersection(A,"
 "B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/uk/postgis-manual.po
+++ b/doc/po/uk/postgis-manual.po
@@ -23771,7 +23771,7 @@ msgstr ""
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/po/zh_Hans/postgis-manual.po
+++ b/doc/po/zh_Hans/postgis-manual.po
@@ -21935,7 +21935,7 @@ msgstr "计算表示几何图形 A 和 B 不相交部分的几何图形。"
 #. Tag: para
 #, no-c-format
 msgid ""
-"Returns a geometry representing the portions of geonetries A and B that do "
+"Returns a geometry representing the portions of geometries A and B that do "
 "not intersect. This is equivalent to <code>ST_Union(A,B) - "
 "ST_Intersection(A,B)</code>. It is called a symmetric difference because "
 "<code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>."

--- a/doc/reference_overlay.xml
+++ b/doc/reference_overlay.xml
@@ -803,7 +803,7 @@ CREATE TABLE subdivided_geoms AS
       <refsection>
         <title>Description</title>
 
-        <para>Returns a geometry representing the portions of geonetries A and B
+        <para>Returns a geometry representing the portions of geometries A and B
             that do not intersect.
             This is equivalent to <code>ST_Union(A,B) - ST_Intersection(A,B)</code>.
             It is called a symmetric difference because <code>ST_SymDifference(A,B) = ST_SymDifference(B,A)</code>.


### PR DESCRIPTION
In the page of [`ST_SymDifference`](https://postgis.net/docs/ST_SymDifference.html), there is a typo :

> Returns a geometry representing the portions of geonetries A and B that do not intersect.

This PR fixes the typo (geometries instead of geonetries) in 2 commits:
- One for the XML : reference_overlay.xml
- an other one for `.po` files.
