### PR TITLE
ci: mark outdated failed runs as stale

### DIFF
--- a/utils/ci-status.py
+++ b/utils/ci-status.py
@@ -793,8 +793,10 @@ def stale_after_hours(config, check):
 
 def apply_staleness(result, config, check):
     threshold = stale_after_hours(config, check)
-    distance_count, distance_ref = result_revision_distance(config, result)
-    if result["status"] != IN_PROGRESS and distance_count and distance_count > 0:
+    distance_count, distance_ref = None, None
+    if result["status"] != IN_PROGRESS:
+        distance_count, distance_ref = result_revision_distance(config, result)
+    if result["status"] not in (IN_PROGRESS, SUCCESS) and distance_count and distance_count > 0:
         stale = dict(result)
         stale["revision_commits_behind"] = distance_count
         stale["revision_compare_ref"] = distance_ref

--- a/utils/ci-status.py
+++ b/utils/ci-status.py
@@ -608,6 +608,11 @@ def jenkins_revision(build):
         sha1 = revision.get("SHA1")
         if sha1:
             return sha1
+    params = jenkins_parameters(build)
+    for name in ("after", "BRANCH", "commit", "GIT_COMMIT"):
+        value = params.get(name)
+        if value and len(value) == 40 and all(ch in "0123456789abcdefABCDEF" for ch in value):
+            return value
     return None
 
 
@@ -787,16 +792,24 @@ def stale_after_hours(config, check):
 
 
 def apply_staleness(result, config, check):
+    threshold = stale_after_hours(config, check)
+    distance_count, distance_ref = result_revision_distance(config, result)
+    if result["status"] != IN_PROGRESS and distance_count and distance_count > 0:
+        stale = dict(result)
+        stale["revision_commits_behind"] = distance_count
+        stale["revision_compare_ref"] = distance_ref
+        stale["revision_distance"] = revision_distance_text(distance_count, distance_ref)
+        stale["status"] = STALE
+        stale["message"] = f"{result.get('message', 'CI run')} ({stale['revision_distance']})"
+        return stale
     if result["status"] != SUCCESS:
         return result
-    threshold = stale_after_hours(config, check)
     completed_at = parse_time(result.get("completed_at"))
     if threshold is None or completed_at is None:
         return result
     age = utc_now() - completed_at
     if age.total_seconds() <= threshold * 3600:
         return result
-    distance_count, distance_ref = result_revision_distance(config, result)
     if distance_count == 0:
         return result
     stale = dict(result)


### PR DESCRIPTION
Treat completed CI runs on older revisions as stale instead of current failures.

The dashboard already kept old successful runs green when the branch had not changed. This extends the same revision-aware logic to failed and unknown completed runs: if the recorded CI revision is behind the tracked branch, the row becomes stale/yellow instead of failure/red.

This also teaches Jenkins matrix children to report their revision from the `after`/`BRANCH` parameters, because those jobs do not always expose `lastBuiltRevision` in the JSON API.

Validation:
- `GITHUB_TOKEN=$(gh auth token) python3 utils/ci-status.py --format json --timeout 25 --output-dir /tmp/postgis-ci-status-stale-patch2 > /tmp/postgis-ci-status-stale-patch2.json || true`
