### PR TITLE
Backport TWKB parser hardening to stable-3.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PostGIS 3.2.11
  - #5899, pg_upgrade issue for non-standard geography SRID (Paul Ramsey)
  - Flatgeobuf schema mismatch vulnerability (NeuroWinter)
  - #5989, CurvePolygon distance corner case (Paul Ramsey)
+ - OSSFuzz 525554772, avoid signed integer overflow (Even Rouault)
+ - OSSFuzz 525548201, avoid overly nested inputs (Darafei Praliaskouski)
 
 
 PostGIS 3.2.10
@@ -3207,4 +3209,3 @@ PostGIS 0.1
 - truely_inside()
 - rtree index support functions
 - gist index support functions
-

--- a/liblwgeom/cunit/cu_in_twkb.c
+++ b/liblwgeom/cunit/cu_in_twkb.c
@@ -224,6 +224,42 @@ static void test_twkb_in_precision(void)
 
 
 
+static void
+test_twkb_in_coordinate_delta_overflow(void)
+{
+	const uint8_t twkb[] = {0x02, /* LINESTRING with default precision. */
+				0x00,
+				0x02, /* Two points. */
+				0xfe,
+				0xff,
+				0xff,
+				0xff,
+				0xff,
+				0xff, /* X = INT64_MAX. */
+				0xff,
+				0xff,
+				0xff,
+				0x01,
+				0x00, /* Y = 0. */
+				0x02, /* X delta = 1. */
+				0x00};
+	LWGEOM *geom;
+
+	cu_error_msg_reset();
+
+	geom = lwgeom_from_twkb(twkb, sizeof(twkb), LW_PARSER_CHECK_NONE);
+
+	/* TWKB stores coordinate deltas as signed integers. Malformed or fuzzed
+	 * inputs can wrap the accumulated delta; the parser must make that wrap
+	 * explicit instead of relying on undefined signed-overflow behaviour.
+	 */
+	ASSERT_STRING_EQUAL(cu_error_msg, "");
+	CU_ASSERT_PTR_NOT_NULL(geom);
+	if (geom != NULL)
+		lwgeom_free(geom);
+	cu_error_msg_reset();
+}
+
 /*
 ** Used by test harness to register the tests in this file.
 */
@@ -239,4 +275,5 @@ void twkb_in_suite_setup(void)
 	PG_ADD_TEST(suite, test_twkb_in_multipolygon);
 	PG_ADD_TEST(suite, test_twkb_in_collection);
 	PG_ADD_TEST(suite, test_twkb_in_precision);
+	PG_ADD_TEST(suite, test_twkb_in_coordinate_delta_overflow);
 }

--- a/liblwgeom/cunit/cu_in_twkb.c
+++ b/liblwgeom/cunit/cu_in_twkb.c
@@ -255,9 +255,39 @@ test_twkb_in_coordinate_delta_overflow(void)
 	 */
 	ASSERT_STRING_EQUAL(cu_error_msg, "");
 	CU_ASSERT_PTR_NOT_NULL(geom);
-	if (geom != NULL)
-		lwgeom_free(geom);
+	lwgeom_free(geom);
+}
+
+
+static void
+test_twkb_in_deep_collection(void)
+{
+	const size_t ngeoms = 201;
+	const size_t twkb_size = ngeoms * 3 + 2;
+	uint8_t *twkb = lwalloc(twkb_size);
+	LWGEOM *geom;
+	size_t i;
+
+	for (i = 0; i < ngeoms; i++)
+	{
+		/* GEOMETRYCOLLECTION with default precision and one child. */
+		twkb[3 * i] = 0x07;
+		twkb[3 * i + 1] = 0x00;
+		twkb[3 * i + 2] = 0x01;
+	}
+	twkb[3 * ngeoms] = 0x01;     /* POINT with default precision. */
+	twkb[3 * ngeoms + 1] = 0x10; /* Empty geometry. */
+
 	cu_error_msg_reset();
+
+	geom = lwgeom_from_twkb(twkb, twkb_size, LW_PARSER_CHECK_NONE);
+
+	/* Recursive collection parsing must reject hostile nesting before the C
+	 * stack becomes the effective input validator.
+	 */
+	ASSERT_STRING_EQUAL(cu_error_msg, "Geometry has too many chained collections");
+	CU_ASSERT_PTR_NULL(geom);
+	lwfree(twkb);
 }
 
 /*
@@ -276,4 +306,5 @@ void twkb_in_suite_setup(void)
 	PG_ADD_TEST(suite, test_twkb_in_collection);
 	PG_ADD_TEST(suite, test_twkb_in_precision);
 	PG_ADD_TEST(suite, test_twkb_in_coordinate_delta_overflow);
+	PG_ADD_TEST(suite, test_twkb_in_deep_collection);
 }

--- a/liblwgeom/lwin_twkb.c
+++ b/liblwgeom/lwin_twkb.c
@@ -164,6 +164,19 @@ static uint8_t byte_from_twkb_state(twkb_parse_state *s)
 	return val;
 }
 
+/** Implements *pa += b in a sanitizer friendly way, using wrap around
+ * logic in case of overflow
+ */
+#if __clang_major__ >= 4
+__attribute__((no_sanitize("unsigned-integer-overflow")))
+#endif
+static inline void safe_add_int64(int64_t* pa, int64_t b)
+{
+	uint64_t u_a = (uint64_t)*pa;
+	uint64_t u_b = (uint64_t)b;
+	u_a += u_b;
+	memcpy(pa, &u_a, sizeof(int64_t));
+}
 
 /**
 * POINTARRAY
@@ -189,24 +202,24 @@ static POINTARRAY* ptarray_from_twkb_state(twkb_parse_state *s, uint32_t npoints
 	{
 		int j = 0;
 		/* X */
-		s->coords[j] += twkb_parse_state_varint(s);
+		safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 		dlist[ndims*i + j] = s->coords[j] / s->factor;
 		j++;
 		/* Y */
-		s->coords[j] += twkb_parse_state_varint(s);
+		safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 		dlist[ndims*i + j] = s->coords[j] / s->factor;
 		j++;
 		/* Z */
 		if ( s->has_z )
 		{
-			s->coords[j] += twkb_parse_state_varint(s);
+			safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 			dlist[ndims*i + j] = s->coords[j] / s->factor_z;
 			j++;
 		}
 		/* M */
 		if ( s->has_m )
 		{
-			s->coords[j] += twkb_parse_state_varint(s);
+			safe_add_int64(&(s->coords[j]), twkb_parse_state_varint(s));
 			dlist[ndims*i + j] = s->coords[j] / s->factor_m;
 			j++;
 		}

--- a/liblwgeom/lwin_twkb.c
+++ b/liblwgeom/lwin_twkb.c
@@ -29,6 +29,8 @@
 #include "varint.h"
 
 #define TWKB_IN_MAXCOORDS 4
+/** Max depth in a geometry. Matches the WKB parser recursion limit. */
+#define LW_PARSER_MAX_DEPTH 200
 
 /**
 * Used for passing the parse state between the parsing functions.
@@ -42,6 +44,7 @@ typedef struct
 
 	uint32_t check; /* Simple validity checks on geometries */
 	uint32_t lwtype; /* Current type we are handling */
+	uint8_t depth;   /* Current recursion level, to prevent stack overflows */
 
 	uint8_t has_bbox;
 	uint8_t has_size;
@@ -467,6 +470,7 @@ static LWCOLLECTION* lwcollection_from_twkb_state(twkb_parse_state *s)
 	int ngeoms, i;
 	LWGEOM *geom = NULL;
 	LWCOLLECTION *col = lwcollection_construct_empty(s->lwtype, SRID_UNKNOWN, s->has_z, s->has_m);
+	uint8_t start_depth = s->depth;
 
 	LWDEBUG(2,"Entering lwcollection_from_twkb_state");
 
@@ -485,16 +489,28 @@ static LWCOLLECTION* lwcollection_from_twkb_state(twkb_parse_state *s)
 			twkb_parse_state_varint_skip(s);
 	}
 
+	s->depth++;
+	if (s->depth >= LW_PARSER_MAX_DEPTH)
+	{
+		lwcollection_free(col);
+		lwerror("Geometry has too many chained collections");
+		s->depth = start_depth;
+		return NULL;
+	}
+
 	for ( i = 0; i < ngeoms; i++ )
 	{
 		geom = lwgeom_from_twkb_state(s);
-		if ( lwcollection_add_lwgeom(col, geom) == NULL )
+		if (!geom || lwcollection_add_lwgeom(col, geom) == NULL)
 		{
-			lwerror("Unable to add geometry (%p) to collection (%p)", geom, col);
+			lwgeom_free(geom);
+			lwcollection_free(col);
+			s->depth = start_depth;
 			return NULL;
 		}
 	}
 
+	s->depth--;
 
 	return col;
 }
@@ -648,7 +664,7 @@ LWGEOM* lwgeom_from_twkb_state(twkb_parse_state *s)
 			break;
 	}
 
-	if ( has_bbox )
+	if (has_bbox && geom)
 		geom->bbox = gbox_clone(&bbox);
 
 	return geom;


### PR DESCRIPTION
## Summary

Backport the TWKB malformed-input hardening from `stable-3.3` to `stable-3.2`, where the same parser code still exists and was missing the June OSSFuzz fixes.

This also adds the 3.2.11 NEWS entries for those TWKB OSSFuzz fixes.

## Provenance

Clean cherry-picks from OSGeo Gitea:

- https://gitea.osgeo.org/postgis/postgis/commit/042033350e03984901fa39514a18e4db945cb4cc
- https://gitea.osgeo.org/postgis/postgis/commit/25fba64468a5fb8b5a99a040f6e3bcb2026360bd

NEWS mirrors the related stable-line NEWS commits:

- https://gitea.osgeo.org/postgis/postgis/commit/ebb7fa94dcf04b5f4f0609b49a72e87bb6d4cc70
- https://gitea.osgeo.org/postgis/postgis/commit/5802fccea0ba20af837e376ca3c80326c87b6c7f

## Target branch

`stable-3.2`, for PostGIS 3.2.11.

## Validation

- `git diff --check upstream/stable-3.2...HEAD`
- `PATH=/usr/lib/postgresql/15/bin:$PATH ./configure --with-raster --without-protobuf`
- `PATH=/usr/lib/postgresql/15/bin:$PATH make -C liblwgeom -j8`
- `PATH=/usr/lib/postgresql/15/bin:$PATH make -C liblwgeom/cunit cu_tester -j8`
- `./liblwgeom/cunit/cu_tester` (335 tests, 0 failures)

## Trac follow-up

No Trac ticket is attached to these TWKB OSSFuzz fixes, so there is no fixed-version update to make after merge.
