### PR TITLE
fuzzers: pass supported sanitizer flags to smoke links

### DIFF
--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -10,8 +10,9 @@ SEED_CORPORA := $(wildcard $(FUZZER_SRC_DIR)/*_seed_corpus.zip)
 # Makefile, so it must inherit the configured dependency include paths.
 POSTGIS_CONFIGURED_CPPFLAGS := $(shell sed -n 's/^CPPFLAGS = //p' $(POSTGIS_BUILD_DIR)/liblwgeom/Makefile 2>/dev/null | sed 's/$$(RYU_INCLUDE)//g; s/-I$$(builddir)//g; s/-I$$(srcdir)//g' | sed 1q)
 POSTGIS_CONFIGURED_LDFLAGS := $(shell sed -n 's/^LDFLAGS = //p' $(POSTGIS_BUILD_DIR)/liblwgeom/Makefile 2>/dev/null | sed 1q)
+POSTGIS_CONFIGURED_SANITIZE_FLAGS := $(shell cxx="$(CXX)"; set -- $$cxx; test "$$#" -gt 0 || set -- c++; sed -n 's/^CFLAGS = //p' $(POSTGIS_BUILD_DIR)/liblwgeom/Makefile 2>/dev/null | tr ' ' '\n' | awk '/^-fsanitize/ { print }' | while read flag; do printf 'int main(void){return 0;}\n' | "$$@" "$$flag" -x c++ -fsyntax-only - >/dev/null 2>&1 && printf "%s " "$$flag"; done)
 POSTGIS_FUZZER_CPPFLAGS = $(POSTGIS_CONFIGURED_CPPFLAGS) $(CPPFLAGS)
-POSTGIS_FUZZER_LDFLAGS = $(POSTGIS_CONFIGURED_LDFLAGS) $(LDFLAGS)
+POSTGIS_FUZZER_LDFLAGS = $(POSTGIS_CONFIGURED_SANITIZE_FLAGS) $(POSTGIS_CONFIGURED_LDFLAGS) $(LDFLAGS)
 
 .PHONY: clean dummyfuzzers check check-corpus
 


### PR DESCRIPTION
## Summary

Master-only fuzzer smoke-link repair.

This PR now only carries the fuzzer Makefile fix: standalone fuzzer smoke links inherit the supported sanitizer flags from the configured `liblwgeom` build, while filtering out sanitizer flags unsupported by the active C++ compiler.

## Scope cleanup

The previous branch revision also carried leftover #896 geometry/accessor follow-ups. Those were removed from this PR after re-checking Paul Ramsey's #896 split: the accepted #896 scope already present on `master` is not extended here.

Stable branch backpatch PRs in the same maintenance round are #1127, #1128, #1129, #1130, and #1131. This master PR is no longer a common #896 follow-up PR for those branches.

Current head: `4b683f393f65f232a90047c5c6f59a3ad98e479a`.

## Validation

- `git diff --check`
- `./utils/check_news.sh .`
- `make -C fuzzers -n dummyfuzzers POSTGIS_BUILD_DIR=<fake configured build> FUZZER_OUT=<tmp> CXX=c++` with fake configured `CFLAGS` containing one supported sanitizer and one unsupported sanitizer; the dry-run link command kept `-fsanitize=undefined` and filtered out the unsupported flag.

GitHub Actions restarted for the current head after the branch update.
