### PR TITLE
regress: relax ST_Buffer interrupt tolerance on 3.4

### DIFF
--- a/regress/core/interrupt_buffer.sql
+++ b/regress/core/interrupt_buffer.sql
@@ -21,7 +21,7 @@ SET statement_timeout TO 100;
 select ST_Buffer(g,100) from _inputs WHERE id = 1;
 --( select (st_dumppoints(st_buffer(st_makepoint(0,0),10000,100000))).geom g) foo;
 -- it may take some more to interrupt st_buffer, see
-SELECT _timecheck('buffer', '250ms');
+SELECT _timecheck('buffer', '350ms');
 
 -- Not affected by old timeout
 SELECT '1', ST_NPoints(ST_Buffer('POINT(4 0)'::geometry, 2, 1));


### PR DESCRIPTION
## Summary

The stable-3.4 Debbie PG15 regression job failed in `regress/core/interrupt_buffer` because `ST_Buffer` was interrupted after 285ms while the branch still tolerated only 250ms:

https://debbie.postgis.net/view/PostGIS/job/PostGIS_Regress/38702/

Master, stable-3.6, and stable-3.5 already allow 350ms for this check. This applies the same tolerance on stable-3.4 so the test still proves `ST_Buffer` is interruptible without failing on scheduler noise.

## Validation

- `git diff --check`
- compared `regress/core/interrupt_buffer.sql` against master, stable-3.6, and stable-3.5
