### PR TITLE
sfcgal: pass roof height before slope

### DIFF
--- a/sfcgal/lwgeom_sfcgal.c
+++ b/sfcgal/lwgeom_sfcgal.c
@@ -2148,7 +2148,7 @@ sfcgal_generate_roof(PG_FUNCTION_ARGS)
 	geom = POSTGIS2SFCGALGeometry(input);
 	PG_FREE_IF_COPY(input, 0);
 
-	result = sfcgal_geometry_generate_roof(geom, roof_type, slope_angle, height, (size_t)primary_edge_index);
+	result = sfcgal_geometry_generate_roof(geom, roof_type, height, slope_angle, (size_t)primary_edge_index);
 	sfcgal_geometry_delete(geom);
 
 	output = SFCGALGeometry2POSTGIS(result, 1, srid);


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: CG_GenerateRoof swaps height and slope arguments.
- Pass the SQL height argument into SFCGAL before the slope angle so roof generation keeps the advertised API order.

## Backpatch notes
- Backpatch is a one-line argument order fix in the SFCGAL wrapper; older branches need the same call-site check if the wrapper is present.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C sfcgal -j32; git diff --check