### PR TITLE
topology: return large edge ids from proximity helper

### DIFF
--- a/topology/sql/query/FindVertexSegmentPairsBelowDistance.sql.in
+++ b/topology/sql/query/FindVertexSegmentPairsBelowDistance.sql.in
@@ -9,16 +9,16 @@
 -- WHERE edge_id = v.vert_edge;
 --
 CREATE OR REPLACE FUNCTION topology.findVertexSegmentPairsBelowDistance(toponame varchar, tolerance float8)
-RETURNS TABLE (seg_edge int, segno int, vert_edge int, vertno int, vert_geom geometry)
+RETURNS TABLE (seg_edge bigint, segno int, vert_edge bigint, vertno int, vert_geom geometry)
 AS $BODY$
 DECLARE
   sql text;
 BEGIN
   sql := format($$
     SELECT
-      e1.edge_id seg_edge,
+      e1.edge_id::bigint seg_edge,
       s.path[1] segno,
-      e2.edge_id vert_edge,
+      e2.edge_id::bigint vert_edge,
       p.path[1] vertno,
       p.geom vert_geom
     FROM

--- a/topology/topology_before_upgrade.sql.in
+++ b/topology/topology_before_upgrade.sql.in
@@ -48,4 +48,16 @@ SELECT _postgis_add_column_to_table('topology.topology', 'useslargeids', 'BOOLEA
 
 -- 3.7.0
 -- Return edge identifiers as bigint instead of integer
-SELECT _postgis_drop_function_by_signature('topology.findVertexSegmentPairsBelowDistance(varchar, float8)', '3.7.0');
+DO $postgis_upgrade$
+DECLARE
+	old_result text;
+BEGIN
+	old_result := pg_get_function_result('topology.findVertexSegmentPairsBelowDistance(varchar, float8)'::regprocedure);
+	IF old_result LIKE '%seg_edge integer%' AND old_result LIKE '%vert_edge integer%' THEN
+		PERFORM _postgis_drop_function_by_signature('topology.findVertexSegmentPairsBelowDistance(varchar, float8)', '3.7.0');
+	END IF;
+EXCEPTION
+	WHEN undefined_function THEN
+		NULL;
+END
+$postgis_upgrade$;

--- a/topology/topology_before_upgrade.sql.in
+++ b/topology/topology_before_upgrade.sql.in
@@ -46,3 +46,6 @@ SELECT _postgis_topology_upgrade_domain_type('topoelement','integer[]','bigint[]
 SELECT _postgis_topology_upgrade_domain_type('topoelementarray','integer[][]','bigint[][]','3.6.0');
 SELECT _postgis_add_column_to_table('topology.topology', 'useslargeids', 'BOOLEAN', true, 'false','3.6.0');
 
+-- 3.7.0
+-- Return edge identifiers as bigint instead of integer
+SELECT _postgis_drop_function_by_signature('topology.findVertexSegmentPairsBelowDistance(varchar, float8)', '3.7.0');


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: New topology helper uses int for bigint edge IDs.
- Updates the helper return signature so edge ids stay bigint-sized instead of narrowing through int.

## Backpatch notes
- SQL-only signature correction; backpatch by applying the return type change where FindVertexSegmentPairsBelowDistance exists.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C topology -j32; git diff --check