### PR TITLE
liblwgeom: reject UINT32_MAX NURBS segments

### DIFF
--- a/liblwgeom/lwstroke.c
+++ b/liblwgeom/lwstroke.c
@@ -899,6 +899,7 @@ lwnurbscurve_linearize(const LWNURBSCURVE *curve, double tol,
                         int flags)
 {
 	uint32_t num_segments;
+	const double max_segments = (double)UINT32_MAX - 1.0;
 
 	LWDEBUG(2, "lwnurbscurve_linearize called.");
 
@@ -946,7 +947,7 @@ lwnurbscurve_linearize(const LWNURBSCURVE *curve, double tol,
 			diagonal = sqrt(width * width + height * height + depth * depth);
 		}
 
-		if (diagonal > tol * UINT32_MAX)
+		if (diagonal > tol * max_segments)
 		{
 			lwerror("%s: max deviation is too small, got %.15g", __func__, tol);
 			return NULL;
@@ -955,7 +956,7 @@ lwnurbscurve_linearize(const LWNURBSCURVE *curve, double tol,
 		break;
 	}
 	case LW_LINEARIZE_TOLERANCE_TYPE_MAX_ANGLE:
-		if (tol < (2.0 * M_PI) / UINT32_MAX)
+		if (tol < (2.0 * M_PI) / max_segments)
 		{
 			lwerror("%s: max angle is too small, got %.15g", __func__, tol);
 			return NULL;

--- a/liblwgeom/lwstroke.c
+++ b/liblwgeom/lwstroke.c
@@ -927,13 +927,13 @@ lwnurbscurve_linearize(const LWNURBSCURVE *curve, double tol,
 		}
 		num_segments = (uint32_t)(tol * 4);
 		break;
-	case LW_LINEARIZE_TOLERANCE_TYPE_MAX_DEVIATION:
-	{
+	case LW_LINEARIZE_TOLERANCE_TYPE_MAX_DEVIATION: {
 		GBOX box;
 		double width = 0.0;
 		double height = 0.0;
 		double depth = 0.0;
 		double diagonal = 0.0;
+		double segments_required;
 
 		if (!curve->points || curve->points->npoints == 0)
 			return lwnurbscurve_to_linestring(curve, NURBS_MIN_LINEARIZE_SEGMENTS);
@@ -947,12 +947,13 @@ lwnurbscurve_linearize(const LWNURBSCURVE *curve, double tol,
 			diagonal = sqrt(width * width + height * height + depth * depth);
 		}
 
-		if (diagonal > tol * max_segments)
+		segments_required = diagonal / tol;
+		if (!isfinite(segments_required) || segments_required > max_segments)
 		{
 			lwerror("%s: max deviation is too small, got %.15g", __func__, tol);
 			return NULL;
 		}
-		num_segments = diagonal > 0.0 ? (uint32_t)ceil(diagonal / tol) : NURBS_MIN_LINEARIZE_SEGMENTS;
+		num_segments = diagonal > 0.0 ? (uint32_t)ceil(segments_required) : NURBS_MIN_LINEARIZE_SEGMENTS;
 		break;
 	}
 	case LW_LINEARIZE_TOLERANCE_TYPE_MAX_ANGLE:


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: NURBS CurveToLine can request UINT32_MAX segments.
- Tightens NURBS linearization boundary checks so UINT32_MAX is rejected instead of reaching segment generation.

## Backpatch notes
- Small boundary-condition change in liblwgeom; applies cleanly where the same tolerance checks exist.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C liblwgeom -j32; git diff --check