### PR TITLE
topology: clean up TopoRingIsCCW early returns

### DIFF
--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -5917,7 +5917,9 @@ Datum TopoRingIsCCW(PG_FUNCTION_ARGS)
 
   if ( lwgeom_is_empty(lwgeom) )
   {
-    PG_RETURN_BOOL(false);
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 0);
+	  PG_RETURN_BOOL(false);
   }
 
   if (lwgeom->type == POLYGONTYPE)
@@ -5930,8 +5932,10 @@ Datum TopoRingIsCCW(PG_FUNCTION_ARGS)
   }
   else
   {
-    lwpgerror("Unsupported geometry type passed to TopoRingIsCCW");
-    PG_RETURN_NULL();
+	  lwgeom_free(lwgeom);
+	  PG_FREE_IF_COPY(geom, 0);
+	  lwpgerror("Unsupported geometry type passed to TopoRingIsCCW");
+	  PG_RETURN_NULL();
   }
 
   isCCW = lwt_IsTopoRingCCW(pa);


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: Memory leak on empty TopoRingIsCCW input.
- Frees deserialized geometry and copied varlena input before empty and unsupported-type exits.

## Backpatch notes
- Small cleanup in one topology C function; should cherry-pick directly to branches with the same early returns.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C topology -j32; git diff --check