### PR TITLE
topology: avoid rebuilding unsafe repair indexes

### DIFF
--- a/doc/extras_topology.xml
+++ b/doc/extras_topology.xml
@@ -563,6 +563,7 @@ Rename a topology from <varname>topo_stage</varname> to <varname>topo_prod</varn
 When upgrading from PostGIS topology &lt;3.6.0 to version &gt;3.6.0+, the topogeometry column definition was changed.
 This caused corruption in topogeometries created before the upgrade. This function fixes this corruption in affected tables.
                 </para>
+                <para>The function refuses to process tables with expression or partial indexes; drop or rebuild those indexes manually around the repair.</para>
 
                 <!-- use this format if new function -->
                 <para role="availability" conformance="3.6.1">Availability: 3.6.1</para>

--- a/topology/sql/manage/FixCorruptTopoGeometryColumn.sql.in
+++ b/topology/sql/manage/FixCorruptTopoGeometryColumn.sql.in
@@ -21,6 +21,33 @@ $$
 DECLARE var_sql text; var_row_count bigint; result text; var_create_index_sql text; var_drop_index_sql text;
 BEGIN
     result = '';
+    EXECUTE format('LOCK TABLE %1$I.%2$I IN SHARE ROW EXCLUSIVE MODE', layerSchema, layerTable);
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_inherits inherited
+        JOIN pg_catalog.pg_class tbl ON tbl.oid = inherited.inhparent
+        JOIN pg_catalog.pg_namespace nsp ON nsp.oid = tbl.relnamespace
+        WHERE nsp.nspname = layerSchema
+          AND tbl.relname = layerTable
+    ) THEN
+        RAISE EXCEPTION 'Cannot safely repair %.% while inheritance or partition child tables exist; repair each table separately',
+            layerSchema, layerTable;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_index i
+        JOIN pg_catalog.pg_class tbl ON tbl.oid = i.indrelid
+        JOIN pg_catalog.pg_namespace nsp ON nsp.oid = tbl.relnamespace
+        WHERE nsp.nspname = layerSchema
+          AND tbl.relname = layerTable
+          AND (i.indexprs IS NOT NULL OR i.indpred IS NOT NULL)
+    ) THEN
+        RAISE EXCEPTION 'Cannot safely repair %.% while expression or partial indexes exist; drop or rebuild those indexes manually',
+            layerSchema, layerTable;
+    END IF;
+
 	-- if topogeometry is bigint, then fix damaged integer, need to upgrade to bigint
 	IF EXISTS ( SELECT 1
 		FROM  pg_catalog.pg_type AS pg_type
@@ -31,12 +58,27 @@ WHERE pg_type.typname = 'topogeometry' AND pga.attname = 'id'
 			AND
 		pg_type.typnamespace::regnamespace::text = 'topology' AND  pga.atttypid::regtype::text = 'bigint' ) THEN
 
-    -- generate index scripts to create and drop indexes that are based on the column
-    IF EXISTS( SELECT 1 FROM pg_indexes WHERE schemaname = layerSchema AND tablename = layerTable AND indexdef LIKE '%(' || layerColumn || ')%' ) THEN
-        SELECT string_agg(indexdef, ';'),  string_agg('DROP INDEX ' || quote_ident(schemaname) || '.' || quote_ident(indexname), ';')  INTO var_create_index_sql, var_drop_index_sql
-            FROM pg_indexes
-             WHERE schemaname = layerSchema
-                AND tablename = layerTable AND indexdef LIKE ('%(' || layerColumn || ')%');
+    -- generate scripts for plain indexes that directly include the column
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_index i
+        JOIN pg_catalog.pg_class tbl ON tbl.oid = i.indrelid
+        JOIN pg_catalog.pg_namespace nsp ON nsp.oid = tbl.relnamespace
+        JOIN pg_catalog.pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = ANY(string_to_array(i.indkey::text, ' ')::int2[])
+        WHERE nsp.nspname = layerSchema
+          AND tbl.relname = layerTable
+          AND att.attname = layerColumn
+    ) THEN
+        SELECT string_agg(pg_catalog.pg_get_indexdef(i.indexrelid), ';'),
+               string_agg('DROP INDEX ' || i.indexrelid::regclass::text, ';')
+        INTO var_create_index_sql, var_drop_index_sql
+        FROM pg_catalog.pg_index i
+        JOIN pg_catalog.pg_class tbl ON tbl.oid = i.indrelid
+        JOIN pg_catalog.pg_namespace nsp ON nsp.oid = tbl.relnamespace
+        JOIN pg_catalog.pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = ANY(string_to_array(i.indkey::text, ' ')::int2[])
+        WHERE nsp.nspname = layerSchema
+          AND tbl.relname = layerTable
+          AND att.attname = layerColumn;
     END IF;
 
     IF var_drop_index_sql > '' THEN
@@ -44,7 +86,7 @@ WHERE pg_type.typname = 'topogeometry' AND pga.attname = 'id'
     END IF;
 
     -- correct any corrupt topogeometries and fix
-	 var_sql =  format('UPDATE %1$I.%2$I
+	 var_sql =  format('UPDATE ONLY %1$I.%2$I
 	 	SET
 	   %3$I = (
 	     (%3$I).topology_id,
@@ -63,7 +105,7 @@ WHERE pg_type.typname = 'topogeometry' AND pga.attname = 'id'
     END IF;
 	result = result || E'\n' || format('%s rows updated for %s.%s.%s column to bigint id type', var_row_count, layerSchema, layerTable, layerColumn);
   ELSE --we are coming from bigint and going back to integer
-  	var_sql =  format('UPDATE %1$I.%2$I
+	var_sql =  format('UPDATE ONLY %1$I.%2$I
 	 	SET
 	   %3$I = (
 	     (%3$I).topology_id,

--- a/topology/test/regress/hooks/hook-after-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-after-upgrade-topology.sql
@@ -1,6 +1,7 @@
 SELECT * FROM topology.layer;
 \d upgrade_test.feature
 -- https://trac.osgeo.org/postgis/ticket/5983
+DROP INDEX upgrade_test.upgrade_test_feature_tg_id_idx;
 SELECT topology.FixCorruptTopoGeometryColumn(schema_name, table_name, feature_column)
     FROM topology.layer;
 
@@ -22,4 +23,3 @@ INSERT INTO upgrade_test.domain_test values (
 
 SELECT topology.DropTopology('upgrade_test');
 SELECT topology.DropTopology('upgrade_test_copy');
-

--- a/topology/test/regress/hooks/hook-before-upgrade-topology.sql
+++ b/topology/test/regress/hooks/hook-before-upgrade-topology.sql
@@ -4,7 +4,7 @@ SELECT topology.createTopology('upgrade_test');
 CREATE TABLE upgrade_test.feature(id serial primary key);
 SELECT topology.AddTopoGeometryColumn('upgrade_test', 'upgrade_test', 'feature', 'tg', 'linear');
 INSERT INTO upgrade_test.feature(tg) SELECT topology.toTopoGeom('LINESTRING(0 0, 10 0)', 'upgrade_test', 1);
-CREATE INDEX ON upgrade_test.feature ( id(tg) );
+CREATE INDEX upgrade_test_feature_tg_id_idx ON upgrade_test.feature ( id(tg) );
 
 -- Create some TopoGeometry data
 CREATE TABLE upgrade_test.domain_test(a topology.topoelement, b topology.topoelementarray);
@@ -12,4 +12,3 @@ INSERT INTO upgrade_test.domain_test values (
   '{1,2}'::topology.topoelement,
   '{{2,3}}'::topology.topoelementarray
 );
-


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: Privileged repair can execute attacker index expressions.
- Refuses expression/partial indexes during repair and only rebuilds plain indexes directly covering the repaired column.

## Backpatch notes
- Intentionally conservative SQL change in FixCorruptTopoGeometryColumn; backpatch with the catalog query/doc note together.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C topology -j32; git diff --check