### PR TITLE
postgis: reset interrupt callbacks when clear

### DIFF
--- a/postgis/postgis_module.c
+++ b/postgis/postgis_module.c
@@ -70,6 +70,10 @@ static void interrupt_geos_callback(void)
 	{
 		GEOS_interruptRequest();
 	}
+	else
+	{
+		GEOS_interruptCancel();
+	}
 }
 
 static void interrupt_liblwgeom_callback(void)
@@ -88,6 +92,10 @@ static void interrupt_liblwgeom_callback(void)
 	if (QueryCancelPending || ProcDiePending)
 	{
 		lwgeom_request_interrupt();
+	}
+	else
+	{
+		lwgeom_cancel_interrupt();
 	}
 }
 
@@ -139,5 +147,3 @@ _PG_fini(void)
 {
 	elog(NOTICE, "Goodbye from PostGIS %s", POSTGIS_VERSION);
 }
-
-

--- a/raster/rt_pg/rtpostgis.c
+++ b/raster/rt_pg/rtpostgis.c
@@ -159,6 +159,8 @@ rtpg_interrupt_liblwgeom_callback(void)
 #endif
 	if (QueryCancelPending || ProcDiePending)
 		lwgeom_request_interrupt();
+	else
+		lwgeom_cancel_interrupt();
 }
 
 static lwinterrupt_callback *prev_liblwgeom_interrupt_callback = NULL;


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: Interrupt rework breaks cancellation for PostGIS operations.
- Cancels previously requested GEOS/liblwgeom interrupt state when PostgreSQL clears the interrupt flag, including raster callbacks.

## Backpatch notes
- Small callback reset change; backpatch to branches carrying the interrupt callback rework, including raster if present.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C postgis -j32; raster-enabled ./configure && make -C raster/rt_pg -j32; git diff --check