### PR TITLE
doc: fix localized EPUB help target

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -487,7 +487,7 @@ epub-uninstall:
 	rm -f $(DESTDIR)$(docdir)/postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).epub
 
 epub: postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).epub ## Generate postgis-<version>-en.epub
-pdf-localized: ## Generate a postgis-<version>-<lang>.epub for supported languages
+epub-localized: ## Generate a postgis-<version>-<lang>.epub for supported languages
 
 pdf: postgis-${POSTGIS_MAJOR_VERSION}.${POSTGIS_MINOR_VERSION}.${POSTGIS_MICRO_VERSION}$(DOCSUFFIX).pdf ## Generate postgis-<version>-en.pdf
 pdf-localized: ## Generate a postgis-<version>-<lang>.pdf for supported languages


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: Non-security Makefile help typo for localized EPUB.
- Corrects the localized EPUB help text so it documents the EPUB target instead of repeating the PDF target name.

## Backpatch notes
- Documentation-only one-liner; safe to cherry-pick or omit from security-only backpatch queues.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C doc help; git diff --check