### PR TITLE
utils: create upgrade-check tempdir safely

### DIFF
--- a/utils/check_create_upgrade_replaced_function_errors.sh
+++ b/utils/check_create_upgrade_replaced_function_errors.sh
@@ -2,10 +2,8 @@
 
 set -e
 
-TMPDIR="${TMPDIR:-/tmp}/check_create_upgrade_replaced_function_errors.$$"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/check_create_upgrade_replaced_function_errors.XXXXXX")"
 trap 'rm -rf "${TMPDIR}"' EXIT
-
-mkdir -p "${TMPDIR}"
 
 cat > "${TMPDIR}/postgis.sql" <<'SQL'
 -- INSTALL VERSION: 3.7.0dev


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: Predictable temporary directory in new check script.
- Uses mktemp -d for the upgrade-check script temporary directory instead of a predictable PID-based path.

## Backpatch notes
- Script-only fix; backpatch by applying the tempdir creation change and keeping the existing trap cleanup.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- sh -n utils/check_create_upgrade_replaced_function_errors.sh; git diff --check