### PR TITLE
topology: preserve zero tolerance semantics

### DIFF
--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7119,7 +7119,7 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
     lwnotice("Empty component of noded line");
     return 0; /* must be empty */
   }
-  endpoint_tol = tol == 0 ? 0 : _lwt_minTolerance(lwpoint_as_lwgeom(start_point));
+  endpoint_tol = _lwt_minTolerance(lwpoint_as_lwgeom(start_point));
   nid[0] = _lwt_AddPoint( topo, start_point,
                           endpoint_tol,
                           handleFaceSplit, &mm, &pointSplitEdges );
@@ -7137,7 +7137,7 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
             "after successfully getting first point !?");
     return -1;
   }
-  endpoint_tol = tol == 0 ? 0 : _lwt_minTolerance(lwpoint_as_lwgeom(end_point));
+  endpoint_tol = _lwt_minTolerance(lwpoint_as_lwgeom(end_point));
   nid[1] = _lwt_AddPoint( topo, end_point,
                           endpoint_tol,
                           handleFaceSplit, &mm, &pointSplitEdges );

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7119,10 +7119,8 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
     lwnotice("Empty component of noded line");
     return 0; /* must be empty */
   }
-  endpoint_tol = _lwt_minTolerance(lwpoint_as_lwgeom(start_point));
-  nid[0] = _lwt_AddPoint( topo, start_point,
-                          endpoint_tol,
-                          handleFaceSplit, &mm, &pointSplitEdges );
+  endpoint_tol = tol == 0.0 ? 0.0 : _lwt_minTolerance(lwpoint_as_lwgeom(start_point));
+  nid[0] = _lwt_AddPoint(topo, start_point, endpoint_tol, handleFaceSplit, &mm, &pointSplitEdges);
   lwpoint_free(start_point); /* too late if lwt_AddPoint calls lwerror */
   if ( nid[0] == -1 ) return -1; /* lwerror should have been called */
   if ( numNewEdges ) *numNewEdges += pointSplitEdges;
@@ -7137,10 +7135,8 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
             "after successfully getting first point !?");
     return -1;
   }
-  endpoint_tol = _lwt_minTolerance(lwpoint_as_lwgeom(end_point));
-  nid[1] = _lwt_AddPoint( topo, end_point,
-                          endpoint_tol,
-                          handleFaceSplit, &mm, &pointSplitEdges );
+  endpoint_tol = tol == 0.0 ? 0.0 : _lwt_minTolerance(lwpoint_as_lwgeom(end_point));
+  nid[1] = _lwt_AddPoint(topo, end_point, endpoint_tol, handleFaceSplit, &mm, &pointSplitEdges);
   lwpoint_free(end_point); /* too late if lwt_AddPoint calls lwerror */
   if ( nid[1] == -1 ) return -1; /* lwerror should have been called */
   if ( numNewEdges ) *numNewEdges += pointSplitEdges;

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7106,6 +7106,7 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
   uint64_t nn, i;
   int moved=0, mm;
   int pointSplitEdges = -666;
+  double endpoint_tol;
 
   if ( numNewEdges ) *numNewEdges = 0;
 
@@ -7118,8 +7119,9 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
     lwnotice("Empty component of noded line");
     return 0; /* must be empty */
   }
+  endpoint_tol = tol == 0 ? 0 : _lwt_minTolerance(lwpoint_as_lwgeom(start_point));
   nid[0] = _lwt_AddPoint( topo, start_point,
-                          _lwt_minTolerance(lwpoint_as_lwgeom(start_point)),
+                          endpoint_tol,
                           handleFaceSplit, &mm, &pointSplitEdges );
   lwpoint_free(start_point); /* too late if lwt_AddPoint calls lwerror */
   if ( nid[0] == -1 ) return -1; /* lwerror should have been called */
@@ -7135,8 +7137,9 @@ _lwt_AddLineEdge( LWT_TOPOLOGY* topo, LWLINE* edge, double tol,
             "after successfully getting first point !?");
     return -1;
   }
+  endpoint_tol = tol == 0 ? 0 : _lwt_minTolerance(lwpoint_as_lwgeom(end_point));
   nid[1] = _lwt_AddPoint( topo, end_point,
-                          _lwt_minTolerance(lwpoint_as_lwgeom(end_point)),
+                          endpoint_tol,
                           handleFaceSplit, &mm, &pointSplitEdges );
   lwpoint_free(end_point); /* too late if lwt_AddPoint calls lwerror */
   if ( nid[1] == -1 ) return -1; /* lwerror should have been called */

--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -4965,7 +4965,7 @@ Datum GetNodeByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if (tol < -1 || (tol < 0 && tol != -1))
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5035,7 +5035,7 @@ Datum GetEdgeByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if (tol < -1 || (tol < 0 && tol != -1))
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5107,7 +5107,7 @@ Datum GetFaceByPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if (tol < -1 || (tol < 0 && tol != -1))
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5188,7 +5188,7 @@ Datum TopoGeo_AddPoint(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if (tol < -1 || (tol < 0 && tol != -1))
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5299,7 +5299,7 @@ Datum TopoGeo_AddLinestring(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < -1 )
+    if (tol < -1 || (tol < 0 && tol != -1))
     {
       lwgeom_free(lwgeom);
       PG_FREE_IF_COPY(geom, 1);
@@ -5419,7 +5419,7 @@ Datum TopoGeo_AddLinestringNoFace(PG_FUNCTION_ARGS)
   }
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if (tol < -1 || (tol < 0 && tol != -1))
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5510,7 +5510,7 @@ Datum TopoGeo_AddPolygon(PG_FUNCTION_ARGS)
     }
 
     tol = PG_GETARG_FLOAT8(2);
-    if ( tol < -1 )
+    if (tol < -1 || (tol < 0 && tol != -1))
     {
       PG_FREE_IF_COPY(geom, 1);
       lwpgerror("Tolerance must be -1 or >=0 ");
@@ -5860,7 +5860,7 @@ Datum TopoGeo_LoadGeometry(PG_FUNCTION_ARGS)
   geom = PG_GETARG_GSERIALIZED_P(1);
 
   tol = PG_GETARG_FLOAT8(2);
-  if ( tol < -1 )
+  if (tol < -1 || (tol < 0 && tol != -1))
   {
     PG_FREE_IF_COPY(geom, 1);
     lwpgerror("Tolerance must be -1 or >=0 ");

--- a/topology/sql/topogeometry/totopogeom.sql.in
+++ b/topology/sql/topogeometry/totopogeom.sql.in
@@ -156,8 +156,8 @@ BEGIN
   alayer := layer_id(tg);
   atopology := topology_info.name;
 
-  -- Get tolerance, if 0 was given
-  tolerance := COALESCE( NULLIF(atolerance, 0), topology._st_mintolerance(topology_info.name, ageom) );
+  -- Preserve exact and automatic tolerance semantics for each dumped component.
+  tolerance := atolerance;
 
   -- Get layer information
   BEGIN


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: No security issue; tolerance semantics regressions found.
- Keeps zero tolerance distinct from automatic tolerance while still rejecting invalid negative values.

## Backpatch notes
- SQL/C semantic correction split only across the existing topology entry points; suitable as one backpatch commit.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C topology -j32; git diff --check