### PR TITLE
topology: preserve large ids from edge wrappers

### DIFF
--- a/topology/postgis_topology.c
+++ b/topology/postgis_topology.c
@@ -4726,7 +4726,7 @@ Datum ST_RemEdgeModFace(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID node_id;
   LWT_TOPOLOGY *topo;
 
@@ -4781,7 +4781,7 @@ Datum ST_RemEdgeNewFace(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID node_id;
   LWT_TOPOLOGY *topo;
 
@@ -4834,7 +4834,7 @@ Datum ST_ModEdgeHeal(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID eid1, eid2;
   LWT_TOPOLOGY *topo;
 
@@ -4888,7 +4888,7 @@ Datum ST_NewEdgeHeal(PG_FUNCTION_ARGS)
 {
   text* toponame_text;
   char* toponame;
-  int ret;
+  LWT_ELEMID ret;
   LWT_ELEMID eid1, eid2;
   LWT_TOPOLOGY *topo;
 


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: Bigint topology support has truncation and metadata bugs.
- Uses LWT_ELEMID for topology wrapper return values so large edge ids are not narrowed through int.

## Backpatch notes
- C-only type widening in four wrappers; backpatch to branches carrying bigint topology support.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C topology -j32; git diff --check