### PR TITLE
topology: quote TotalTopologySize regclasses safely

### DIFF
--- a/topology/sql/manage/TotalTopologySize.sql.in
+++ b/topology/sql/manage/TotalTopologySize.sql.in
@@ -24,12 +24,15 @@ BEGIN
   sql := format(
     $$
 SELECT
-pg_catalog.pg_total_relation_size('%1$I.edge_data') +
-pg_catalog.pg_total_relation_size('%1$I.node') +
-pg_catalog.pg_total_relation_size('%1$I.face') +
-pg_catalog.pg_total_relation_size('%1$I.relation')
+pg_catalog.pg_total_relation_size(%1$L) +
+pg_catalog.pg_total_relation_size(%2$L) +
+pg_catalog.pg_total_relation_size(%3$L) +
+pg_catalog.pg_total_relation_size(%4$L)
     $$,
-    toponame
+    format('%I.edge_data', toponame),
+    format('%I.node', toponame),
+    format('%I.face', toponame),
+    format('%I.relation', toponame)
   );
 
   EXECUTE sql INTO total_size;


### PR DESCRIPTION
## Summary
- Addresses security scanner finding: TotalTopologySize misquotes apostrophe topology names.
- Builds regclass text with identifier formatting first, then SQL-literal quoting, so apostrophes in topology names remain safe.

## Backpatch notes
- SQL-only quoting fix; should cherry-pick directly to branches with TotalTopologySize.
- Kept as a single focused commit on top of master for straightforward cherry-pick/backpatch review.

## Validation
- make -C topology -j32; git diff --check