### PR TITLE
ci: test macOS with PostgreSQL 18

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -13,7 +13,7 @@ jobs:
     name: "macOS"
     runs-on: macos-latest
     env:
-      PG: "17"
+      PG: "18"
       HOMEBREW_PREFIX: "/opt/homebrew"
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       CCACHE_MAXSIZE: "1G"


### PR DESCRIPTION
The macOS CI job currently installs Homebrew `postgresql@17`. Multiple unrelated PR runs are failing before build/test during dependency installation with:

```
initdb: error: file "/opt/homebrew/share/postgresql@17/postgres.bki" does not exist
```

Homebrew currently provides `postgresql@18`, with macOS bottles available, so move the macOS job to PostgreSQL 18 to avoid the broken 17 install path and keep this CI lane useful.

This is intentionally CI-only and separate from the security-finding fixes so those branches stay easy to backpatch.