### PR TITLE
utils: reject duplicate NEWS release headings

### DIFF
--- a/utils/check_news.sh
+++ b/utils/check_news.sh
@@ -38,6 +38,15 @@ fi
 
 cd ${RD}
 
+# Check that release headings are unique. Rebase mistakes can otherwise
+# turn the previous release section into a second copy of the current one.
+duplicate_release=$(grep '^PostGIS [0-9]' NEWS | sort | uniq -d | head -1)
+if test -n "${duplicate_release}"; then
+  echo "FAIL: NEWS file has duplicate release heading: ${duplicate_release}"
+  exit 1
+fi
+echo "PASS: NEWS file release headings are unique"
+
 # Extract dates from NEWS file and check they
 # are sorted correctly
 pdate=$(date '+%Y/%m/%d') # most recent timestamp


### PR DESCRIPTION
Adds a small guard to `utils/check_news.sh` so rebases cannot silently turn an older NEWS section into a duplicate of the current release heading.

This catches mistakes like changing `PostGIS 3.7.0alpha1` to `PostGIS 3.7.0beta1` while adding the new entry under the old section, leaving two `PostGIS 3.7.0beta1` sections in the file.

Validation:
- `utils/check_news.sh .`
- synthetic duplicate `PostGIS 3.7.0beta1` heading exits with failure