### PR TITLE
upgrade: escape version regex literals

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,8 @@ PostGIS 3.6.5
   cancellation state (Darafei Praliaskouski)
 - #5948, [topology] Prevent MakeTopologyPrecise from erasing edges when
           grid size exceeds their extent (Darafei Praliaskouski)
+- #6094, [upgrade] Avoid legacy string literal warnings in downgrade checks
+  with standard_conforming_strings off (Darafei Praliaskouski)
 
 
 PostGIS 3.6.4

--- a/utils/create_upgrade.pl
+++ b/utils/create_upgrade.pl
@@ -1022,11 +1022,11 @@ BEGIN
     ) SELECT
       upgraded as scripts_upgraded,
       installed as scripts_installed,
-      pg_catalog.substring(upgraded, '([0-9]+)\.')::int * 100 +
-      pg_catalog.substring(upgraded, '[0-9]+\.([0-9]+)(\.|$)')::int
+      pg_catalog.substring(upgraded, E'([0-9]+)\\.')::int * 100 +
+      pg_catalog.substring(upgraded, E'[0-9]+\\.([0-9]+)(\\.|$)')::int
         as version_to_num,
-      pg_catalog.substring(installed, '([0-9]+)\.')::int * 100 +
-      pg_catalog.substring(installed, '[0-9]+\.([0-9]+)(\.|$)')::int
+      pg_catalog.substring(installed, E'([0-9]+)\\.')::int * 100 +
+      pg_catalog.substring(installed, E'[0-9]+\\.([0-9]+)(\\.|$)')::int
         as version_from_num,
       installed ~ 'dev|alpha|beta'
         as version_from_isdev
@@ -1061,5 +1061,4 @@ BEGIN
 END
 $$
 LANGUAGE 'plpgsql';
-
 


### PR DESCRIPTION
## Summary
- escape the generated `_postgis_upgrade_info()` version regex literals with explicit `E''` syntax
- keep downgrade checks quiet and parser-stable when `standard_conforming_strings` is off
- add the #6094 release note for PostGIS 3.6.5

## Ticket
Closes https://trac.osgeo.org/postgis/ticket/6094

## Validation
- regenerated `topology/topology_upgrade.sql.in` and `postgis/postgis_upgrade.sql.in` locally to inspect the emitted SQL
- focused `psql` check: simulated `postgis_topology` downgrade `3.6.4dev` to `3.5.8dev` under `standard_conforming_strings=off` and verified it raises `Downgrade of postgis_topology ... forbidden`
- focused `psql` check: simulated helper creation under `standard_conforming_strings=off` and verified `_postgis_upgrade_info()` returns version metadata without legacy escape warnings
- `git diff --check`
- `./utils/check_news.sh .`
