### PR TITLE
Avoid ppc64el vector macro in NURBS SQL comments

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - #6093, Fix SQL generation on ppc64el when NURBS comments are
+          preprocessed with AltiVec vector macros (Darafei Praliaskouski)
  - #6094, [upgrade] Avoid legacy string literal warnings in downgrade checks
           with standard_conforming_strings off (Darafei Praliaskouski)
  - GH-898, Fix ST_DFullyWithin indexed plans and large-coordinate

--- a/postgis/postgis_nurbs.sql.in
+++ b/postgis/postgis_nurbs.sql.in
@@ -4,9 +4,9 @@
 --   degree: Polynomial degree (1-10), higher = smoother
 --   control_points: LINESTRING geometry defining curve shape
 --   weights: Optional array of positive weights, one per control point (NULL for uniform weights)
---   knots: Optional knot vector defining parameter space (NULL for uniform clamped spacing)
+--   knots: Optional knot sequence defining parameter space (NULL for uniform clamped spacing)
 -- Returns: NURBS curve geometry
--- Note: Knot vector must have (npoints + degree + 1) elements and be non-decreasing
+-- Note: Knot sequence must have (npoints + degree + 1) elements and be non-decreasing
 -- Examples:
 --   SELECT ST_MakeNurbsCurve(2, 'LINESTRING(0 0, 5 10, 10 0)'::geometry);
 --   SELECT ST_MakeNurbsCurve(2, 'LINESTRING(0 0, 5 10, 10 0)'::geometry, ARRAY[1.0, 2.0, 1.0]);
@@ -58,7 +58,7 @@ CREATE OR REPLACE FUNCTION ST_Weights(nurbscurve geometry)
     COST 25;
 
 -- ST_Knots(nurbscurve)
--- Extracts the knot vector defining parameter space
+-- Extracts the knot sequence defining parameter space
 -- Parameters:
 --   nurbscurve: Input NURBS curve geometry
 -- Returns: Array of knot values, NULL for uniform parameterization


### PR DESCRIPTION
## Summary

Fixes the ppc64el SQL generation failure reported in https://trac.osgeo.org/postgis/ticket/6093.

The ppc64el toolchain can provide an AltiVec `vector` macro, and PostGIS runs the SQL templates through `cpp` while building `postgis.sql`. The NURBS SQL template had bare `vector` tokens in comments, so preprocessing could recurse before the SQL file was generated.

This rewords those NURBS comments to use `knot sequence` instead and adds the release note entry for PostGIS 3.7.0.

## Testing

- `./utils/check_news.sh .`
- `make -C postgis postgis.sql`
- `/usr/bin/cpp -traditional-cpp -w -P -Upixel -Ubool -Dvector=vector postgis/postgis_nurbs.sql.in >/tmp/postgis-6093-nurbs-cpp-final.out`
