### PR TITLE
Stabilize GEOS main linework handling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - GH-1160, [topology] Preserve overlay intersection boundaries when
+          noding lines with GEOS main (Darafei Praliaskouski)
  - #6093, Fix SQL generation on ppc64el when NURBS comments are
           preprocessed with AltiVec vector macros (Darafei Praliaskouski)
  - #6094, [upgrade] Avoid legacy string literal warnings in downgrade checks

--- a/doc/reference_overlay.xml
+++ b/doc/reference_overlay.xml
@@ -1056,9 +1056,9 @@ FROM (
 <para>This example unions an array of linestrings.</para>
 <programlisting>SELECT ST_AsText(ST_Union(ARRAY[
     ST_GeomFromText('LINESTRING(1 2, 3 4)'),
-    ST_GeomFromText('LINESTRING(3 4, 4 5)')
+    ST_GeomFromText('LINESTRING(4 5, 5 6)')
 ])) As wktunion;</programlisting>
-<screen>MULTILINESTRING((1 2,3 4),(3 4,4 5))</screen>
+<screen>MULTILINESTRING((1 2,3 4),(4 5,5 6))</screen>
       </refsection>
       <refsection>
         <title>See Also</title>

--- a/doc/reference_processing.xml
+++ b/doc/reference_processing.xml
@@ -2596,6 +2596,8 @@ FROM (SELECT ST_Polygonize(geom_4269) AS polycoll
       </refsection>
       <refsection>
         <title>Examples: Finding shared paths</title>
+        <para>Adjacent shared path segments may be returned as separate or merged LineStrings
+          depending on the GEOS version.</para>
         <informaltable>
           <tgroup cols="1">
             <tbody>
@@ -2622,11 +2624,11 @@ FROM (SELECT ST_Polygonize(geom_4269) AS polycoll
                   <programlisting>
  SELECT ST_AsText(ST_SharedPaths(ST_GeomFromText('MULTILINESTRING((26 125,26 200,126 200,126 125,26 125),
        (51 150,101 150,76 175,51 150))'),
-    ST_GeomFromText('LINESTRING(151 100,126 156.25,126 125,90 161, 76 175)')
+    ST_GeomFromText('LINESTRING(151 100,126 156.25,126 125,101 150, 76 175)')
     )
   )</programlisting>
 <screen>GEOMETRYCOLLECTION(MULTILINESTRING((126 156.25,126 125),
- (101 150,90 161),(90 161,76 175)),MULTILINESTRING EMPTY)</screen>
+ (101 150,76 175)),MULTILINESTRING EMPTY)</screen>
             </para>
             </entry>
         </row>
@@ -2636,13 +2638,13 @@ FROM (SELECT ST_Polygonize(geom_4269) AS polycoll
 <lineannotation>
 same example but linestring orientation flipped
 </lineannotation>
-SELECT ST_AsText(ST_SharedPaths(ST_GeomFromText('LINESTRING(76 175,90 161,126 125,126 156.25,151 100)'),
+SELECT ST_AsText(ST_SharedPaths(ST_GeomFromText('LINESTRING(76 175,101 150,126 125,126 156.25,151 100)'),
    ST_GeomFromText('MULTILINESTRING((26 125,26 200,126 200,126 125,26 125),
        (51 150,101 150,76 175,51 150))')
     )
   )</programlisting>
 <screen>GEOMETRYCOLLECTION(MULTILINESTRING EMPTY,
-MULTILINESTRING((76 175,90 161),(90 161,101 150),(126 125,126 156.25)))</screen>
+MULTILINESTRING((76 175,101 150),(126 125,126 156.25)))</screen>
             </para>
             </entry>
         </row>

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7379,6 +7379,57 @@ _lwt_split_by_nodes(const LWGEOM *g, const LWGEOM *nodes)
   return bg;
 }
 
+/*
+ * Compute the junction points between the overlay intersection linework
+ * (shared paths and crossings between the noded line and nearby edges)
+ * and the rest of the noded line: the 0-dimensional intersection
+ * components plus the mod-2 boundary of the 1-dimensional ones.
+ *
+ * These junctions must become topology nodes. GEOS >= 3.15 returns
+ * overlay output line-merged, which would otherwise hide them inside
+ * line interiors. Older GEOS keeps them as boundaries of the overlay
+ * output components, making a split at them a no-op.
+ *
+ * Returns a MULTIPOINT.
+ */
+static LWGEOM *
+_lwt_overlay_split_points(const LWGEOM *xset)
+{
+  LWGEOM *multi = lwgeom_as_multi(xset);
+  LWCOLLECTION *xcol = lwgeom_as_lwcollection(multi);
+  LWCOLLECTION *epoints = lwcollection_extract(xcol, POINTTYPE);
+  LWCOLLECTION *points = lwcollection_construct_empty(MULTIPOINTTYPE, xset->srid,
+    FLAGS_GET_Z(xset->flags), FLAGS_GET_M(xset->flags));
+  LWCOLLECTION *lines = lwcollection_extract(xcol, LINETYPE);
+  LWGEOM *bnd = lwgeom_boundary(lwcollection_as_lwgeom(lines));
+  uint32_t i;
+
+  for (i = 0; i < epoints->ngeoms; i++)
+    lwcollection_add_lwgeom(points, lwgeom_clone_deep(epoints->geoms[i]));
+
+  if (bnd)
+  {
+    LWCOLLECTION *bcol = lwgeom_as_lwcollection(bnd);
+    if (bcol)
+    {
+      for (i = 0; i < bcol->ngeoms; i++)
+        lwcollection_add_lwgeom(points, lwgeom_clone_deep(bcol->geoms[i]));
+    }
+    else if (!lwgeom_is_empty(bnd))
+    {
+      lwcollection_add_lwgeom(points, lwgeom_clone_deep(bnd));
+    }
+    lwgeom_free(bnd);
+  }
+
+  lwcollection_release(epoints);
+  lwcollection_release(lines);
+  lwgeom_release(multi);
+
+  points->srid = xset->srid;
+  return lwcollection_as_lwgeom(points);
+}
+
 static LWT_ELEMID*
 _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
             int handleFaceSplit, int maxNewEdges)
@@ -7386,7 +7437,7 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
   LWGEOM *geomsbuf[1];
   LWGEOM **geoms;
   uint32_t ngeoms;
-  LWGEOM *noded, *tmp;
+  LWGEOM *noded, *tmp, *xsplit = NULL;
   LWCOLLECTION *col;
   LWT_ELEMID *ids;
   LWT_ISO_EDGE *edges;
@@ -7601,6 +7652,9 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     xset = lwgeom_intersection(noded, iedges);
     LWDEBUGG(1, xset, "Intersected");
     lwgeom_free(noded);
+    /* Collect the junctions between shared and non-shared linework
+     * before line merging can hide them (see step 2.5) */
+    xsplit = _lwt_overlay_split_points(xset);
 
     /* We linemerge here because INTERSECTION, as of GEOS 3.8,
      * will result in shared segments being output as multiple
@@ -7689,6 +7743,25 @@ _lwt_AddLine(LWT_TOPOLOGY* topo, LWLINE* line, double tol, int* nedges,
     LWDEBUGG(1, noded, "Node-split");
     /* will not release the geoms array */
     lwcollection_release(col);
+  }
+
+  /* 2.5. Split by overlay junctions
+   *
+   * GEOS >= 3.15 returns line-merged overlay output, hiding the
+   * junctions between shared and non-shared linework inside line
+   * interiors. Splitting restores them; older GEOS keeps them as
+   * component boundaries and the split is a no-op.
+   */
+  if ( xsplit )
+  {
+    if ( !lwgeom_is_empty(xsplit) )
+    {
+      tmp = _lwt_split_by_nodes(noded, xsplit);
+      lwgeom_free(noded);
+      noded = tmp;
+      LWDEBUGG(1, noded, "Overlay-junction-split");
+    }
+    lwgeom_free(xsplit);
   }
 
 

--- a/regress/core/wrapx.sql
+++ b/regress/core/wrapx.sql
@@ -15,7 +15,7 @@ $$ LANGUAGE 'plpgsql';
 CREATE OR REPLACE FUNCTION geos_version()
 RETURNS integer AS $$
     SELECT (matches[1]::integer * 100) + matches[2]::integer
-    FROM regexp_match(postgis_geos_version(), E'^([0-9]+)]\\.([0-9]+)') AS matches;
+    FROM regexp_match(postgis_geos_version(), E'^([0-9]+)\\.([0-9]+)') AS matches;
 $$ LANGUAGE 'sql' IMMUTABLE;
 
 

--- a/topology/test/regress/topogeo_addlinestring.sql
+++ b/topology/test/regress/topogeo_addlinestring.sql
@@ -99,9 +99,9 @@ SELECT 'cross', TopoGeo_addLineString('city_data', 'SRID=4326;LINESTRING(49 18, 
 SELECT check_changes('cross');
 
 -- Snapping (and splitting a face)
-SELECT 'snap', TopoGeo_addLineString('city_data', 'SRID=4326;LINESTRING(18 22.2, 22.5 22.2, 21.2 20.5)', 1) ORDER BY 2;
+SELECT 'snap', COUNT(*) FROM TopoGeo_addLineString('city_data', 'SRID=4326;LINESTRING(18 22.2, 22.5 22.2, 21.2 20.5)', 1);
 SELECT check_changes('snap');
-SELECT 'snap_again', TopoGeo_addLineString('city_data', 'SRID=4326;LINESTRING(18 22.2, 22.5 22.2, 21.2 20.5)', 1) ORDER BY 2;
+SELECT 'snap_again', COUNT(*) FROM TopoGeo_addLineString('city_data', 'SRID=4326;LINESTRING(18 22.2, 22.5 22.2, 21.2 20.5)', 1);
 SELECT check_changes('snap_again');
 
 -- A mix of crossing and overlapping, splitting another face

--- a/topology/test/regress/topogeo_addlinestring_expected
+++ b/topology/test/regress/topogeo_addlinestring_expected
@@ -38,9 +38,7 @@ cross|E|LINESTRING(47 14,47 17.6)
 cross|E|LINESTRING(47 17.6,47 22)
 cross|E|LINESTRING(47 17.6,44 17)
 cross|E|LINESTRING(49 18,47 17.6)
-snap|7
-snap|36
-snap|38
+snap|3
 snap|N||POINT(21.2 20.5)
 snap|N||POINT(22.35 22)
 snap|N||POINT(18 22.2)
@@ -48,9 +46,7 @@ snap|E|LINESTRING(22.35 22,35 22)
 snap|E|LINESTRING(22.35 22,21.2 20.5)
 snap|E|LINESTRING(21 22,22.35 22)
 snap|E|LINESTRING(18 22.2,21 22)
-snap_again|7
-snap_again|36
-snap_again|38
+snap_again|3
 crossover|4
 crossover|N||POINT(21 10)
 crossover|N||POINT(16.2 14)


### PR DESCRIPTION
## Summary
- Preserve topology overlay junctions under GEOS >= 3.15 overlay line-merging: collect the 0-dimensional intersection components plus the mod-2 boundary (`lwgeom_boundary`) of the 1-dimensional ones from the noded-line/nearby-edges intersection, and re-split the noded line at them in a new step 2.5 of `_lwt_AddLine`. With older GEOS these points are already component boundaries of the overlay output, so the extra split is a no-op.
- Assert edge count instead of edge ids in the `topogeo_addlinestring` snap case: the final topology state is unchanged (still verified by `check_changes`), but edge id assignment depends on GEOS overlay output ordering.
- Fix the wrapx GEOS-version parser: a stray `]` made the regexp never match, so the GEOS >= 3.15 expected outputs were never selected.
- Make the `ST_Union` array example and both `ST_SharedPaths` examples GEOS-version-stable by using linework whose shared stretches are single straight segments, and document that `ST_SharedPaths` segmentation may vary with the GEOS version. The example outputs are byte-identical on GEOS 3.14 and GEOS main, so no example-tester changes are needed.

## Validation
- GEOS 3.14.1: `make -j`, `sudo make install`, full topology suite `make -C topology/test check RUNTESTFLAGS="--extension --topology"` — 84 tests, 0 failed, including upgrade rerun
- GEOS 3.14.1: `make -C regress check RUNTESTFLAGS="--extension" TESTS="$PWD/regress/core/wrapx"` — 0 failed, including upgrade rerun
- GEOS 3.14.1: `make -C regress exampletest` — 610 manual example tests passed; `make -C regress exampletest-unit`; `make -C doc check-xml`
- GEOS main (3.15.0dev-CAPI-1.21.0, PostgreSQL 18 docker): `-Werror`-clean build; full topology suite — 84 tests, 0 failed, including upgrade rerun; wrapx — 0 failed
- `ST_SharedPaths` example outputs verified byte-identical between GEOS 3.14.1 and GEOS main
- `./utils/check_news.sh`, `git diff --check`

## Notes
- This replaces the previous, more invasive approach on this branch (hand-rolled split-point parity tracking in topology code plus alternate-output matching machinery in the manual example tester). Previous head for reference: 17dac4fccca076f01835f0f2a4a7ac134842ba0e.
- `utils/postgis_exampletest.py` is intentionally untouched: stabilizing the documented examples removed the need for alternate expected outputs.

References https://github.com/postgis/postgis/commit/63de00830dc7afb6102a095cb1a41514e9064c1f
