### PR TITLE
topology: free overlay split helper inputs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ To take advantage of all postgis_sfcgal extension features SFCGAL 2.3+ is needed
 
 * Bug Fixes *
 
+ - GH-1162, [topology] Free overlay split helper inputs
+          (Darafei Praliaskouski)
  - GH-1160, Adapt topology, regression expectations, and manual examples
           to GEOS 3.15 overlay line merging (Paul Ramsey, Darafei Praliaskouski)
  - #6093, Fix SQL generation on ppc64el when NURBS comments are

--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -7422,9 +7422,9 @@ _lwt_overlay_split_points(const LWGEOM *xset)
     lwgeom_free(bnd);
   }
 
-  lwcollection_release(epoints);
-  lwcollection_release(lines);
-  lwgeom_release(multi);
+  lwcollection_free(epoints);
+  lwcollection_free(lines);
+  lwgeom_free(multi);
 
   points->srid = xset->srid;
   return lwcollection_as_lwgeom(points);


### PR DESCRIPTION
## Summary

Free the owning geometries built by `_lwt_overlay_split_points()` with the normal liblwgeom destructors.

The helper creates:

- `multi` via `lwgeom_as_multi()`
- `epoints` and `lines` via `lwcollection_extract()`

Those objects own collection wrappers, child geometry wrappers, and geometry arrays. Releasing only the outer wrapper leaves the nested allocations behind for the lifetime of the caller context.

## Validation

- `git diff --check upstream/master..HEAD`
- `git clang-format --diff upstream/master`
- `./autogen.sh`
- `./configure`
- `make -j32`
- `make check RUNTESTFLAGS=topogeo_addlinestring`
- `utils/check_news.sh .`
