### PR TITLE
regress: fix fixedoverlay GEOS version helper

### DIFF
--- a/regress/core/fixedoverlay.sql
+++ b/regress/core/fixedoverlay.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION geos_version()
 RETURNS integer AS $$
     SELECT (matches[1]::integer * 100) + matches[2]::integer
-    FROM regexp_match(postgis_geos_version(), E'^([0-9]+)]\\.([0-9]+)') AS matches;
+    FROM regexp_match(postgis_geos_version(), E'^([0-9]+)\\.([0-9]+)') AS matches;
 $$ LANGUAGE 'sql' IMMUTABLE;
 
 SELECT 'intersection', ST_AsText(ST_Intersection(


### PR DESCRIPTION
## Summary

Fix the GEOS version helper in `fixedoverlay.sql` so it matches normal `postgis_geos_version()` strings such as `3.15.0-CAPI-...`.

`wrapx.sql` already used the correct pattern; this makes the duplicate helper consistent. This is a regression-test-only fix, not a security fix.

## Validation

- `git diff --check upstream/master..HEAD`
- `./autogen.sh`
- `./configure`
- `make -j32`
- `make check RUNTESTFLAGS=fixedoverlay`
