### PR TITLE
ci: make contributor credit audit explicit

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -23,7 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Cache ccache

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Cache ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
 
     - name: 'Check Out'
       uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
 
     - name: 'Prepare Image'
       run: |

--- a/.github/workflows/contributor-credits.yml
+++ b/.github/workflows/contributor-credits.yml
@@ -1,0 +1,24 @@
+name: Contributor Credits
+
+on:
+  push:
+    branches-ignore:
+      - 'main'
+  pull_request: ~
+
+permissions:
+  contents: read
+
+jobs:
+  contributor-credits:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check Contributor Credits
+        run: make check-contributor-credits

--- a/.github/workflows/msys.yml
+++ b/.github/workflows/msys.yml
@@ -23,8 +23,6 @@ jobs:
       # see https://github.com/msys2/setup-msys2
     - name: checkout
       uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
     - name: '${{ matrix.icon }} Setup MSYS2'
       uses: msys2/setup-msys2@v2
       with:

--- a/.woodpecker/contributor-credits.yml
+++ b/.woodpecker/contributor-credits.yml
@@ -2,9 +2,17 @@ labels:
   platform: linux/amd64
 when:
   event: [push, pull_request, tag]
+
+clone:
+  - name: git
+    image: woodpeckerci/plugin-git
+    settings:
+      depth: 0
+      partial: false
+
 steps:
-  build:
+  check:
     image: repo.osgeo.org/postgis/build-test:debian13
     pull: true
     commands:
-      - sh ci/dronie/postgis_tools.sh
+      - make check-contributor-credits

--- a/.woodpecker/regress.yml
+++ b/.woodpecker/regress.yml
@@ -49,10 +49,10 @@ variables:
     - egrep '(PASS|FAIL|SKIP|INFO|ERROR)' check.log
 
 clone:
-  - name: git
+  git:
     image: woodpeckerci/plugin-git
     settings:
-      depth: 0
+      depth: 50
       partial: false
 
 steps:

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -89,8 +89,7 @@ endif
 
 # The "lint" tests do not depend on specific code configurations
 # but solely on the source code state
-check-lint: check-no-trailing-blanks check-news check-contributor-credits \
-	check-tests-enabled check-lang-enabled
+check-lint: check-no-trailing-blanks check-news check-tests-enabled check-lang-enabled
 
 staged-install: all
 	$(MAKE) -C regress staged-install
@@ -98,6 +97,7 @@ staged-install: all
 check-news:
 	$(top_srcdir)/utils/check_news.sh $(top_srcdir)
 
+.PHONY: check-contributor-credits
 check-contributor-credits:
 	@if test ! -e "$(top_srcdir)/.git"; then \
 		echo "SKIP: contributor credits require a Git worktree"; \

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,14 @@ all install uninstall staged-install clean distclean maintainer-clean test check
 	   echo "You must use GNU make to build PostGIS." ; \
 	   false; \
 	 fi
+
+# This target must also work before configure, so dedicated CI can audit
+# contributor credits from a clean checkout with full Git history.
+.PHONY: check-contributor-credits
+check-contributor-credits:
+	@if test ! -e ".git"; then \
+		echo "SKIP: contributor credits require a Git worktree"; \
+	else \
+		python3 -B utils/test_check_contributor_credits.py && \
+		python3 -B utils/check_contributor_credits.py --repo .; \
+	fi

--- a/doc/development/testing.md
+++ b/doc/development/testing.md
@@ -120,11 +120,13 @@ Other useful targets:
   extension upgrade paths after `sudo make install`.
 * `make installcheck` runs tests against an installed copy after
   `sudo make install`.
-* `make check` includes the contributor-credit validator in its source-state
-  checks. It checks that every non-merge Git author, `Co-authored-by` trailer,
-  and contributor named in an unreleased `NEWS` section is present in
-  `doc/credits.xml`; `make check-contributor-credits` runs only this check.
-  A Git worktree must have full, non-shallow history; release trees without
+* `make check-contributor-credits` runs an optional maintainer audit that checks
+  that every non-merge Git author, `Co-authored-by` trailer, and contributor
+  named in an unreleased `NEWS` section is present in `doc/credits.xml`. It is
+  not part of `make check` because it needs Python and a Git worktree with
+  full, non-shallow history. GitHub Actions and Woodpecker each run a dedicated
+  contributor-credit job with full history, keeping the audit in CI without
+  making ordinary build or packaging checks depend on it. Release trees without
   `.git` skip the check. Add aliases to `.mailmap` instead of duplicating a
   person under multiple names in the manual. If only a public handle can be
   verified, use a linked `@handle (GitHub user)` credit. If only a partial name

--- a/doc/development/testing/ci.md
+++ b/doc/development/testing/ci.md
@@ -27,7 +27,7 @@ service that owns the behavior:
 | FreeBSD GitHub Actions job | `.github/workflows/ci-freebsd.yml`; see [FreeBSD development environment](../environment/freebsd.md) |
 | macOS GitHub Actions job | `.github/workflows/ci-macos.yml`; see [macOS development environment](../environment/macos.md) |
 | MSYS2/MinGW GitHub Actions job | `.github/workflows/msys.yml` |
-| GitHub CodeQL and codespell jobs | `.github/workflows/codeql.yml` and `.github/workflows/codespell.yml` |
+| GitHub CodeQL, codespell, and contributor-credit jobs | `.github/workflows/codeql.yml`, `.github/workflows/codespell.yml`, and `.github/workflows/contributor-credits.yml` |
 | Debbie build, docs, and release jobs | `ci/debbie/`, the Debbie Jenkins jobs, and release-process notes |
 | Winnie Windows jobs | `ci/winnie/` and the Winnie Jenkins jobs |
 | Bessie/Bessie32 and Berrie/Berrie64 jobs | `ci/bessie*`, `ci/berrie*`, and the corresponding Jenkins worker labels |

--- a/utils/ci-status.json
+++ b/utils/ci-status.json
@@ -85,6 +85,16 @@
       ]
     },
     {
+      "name": "GitHub Actions / Contributor Credits",
+      "provider": "github_actions",
+      "required": true,
+      "workflow": "contributor-credits.yml",
+      "url": "https://github.com/postgis/postgis/actions/workflows/contributor-credits.yml",
+      "branches": [
+        "master"
+      ]
+    },
+    {
       "name": "GitHub Actions / CodeQL",
       "provider": "github_actions",
       "required": true,


### PR DESCRIPTION
Mirror-side PR for GitHub Actions. Canonical review surface: https://gitea.osgeo.org/postgis/postgis/pulls/365

## Summary

- keep `make check` / `check-lint` from running the contributor-credit validator, so ordinary builds and packaging checks do not require Python or full Git history
- add a dedicated GitHub Actions workflow that checks contributor credits with `actions/checkout` full history
- add a dedicated Woodpecker/Gitea pipeline that checks contributor credits with full-history clone settings
- restore default/shallow checkout behavior for the regular GitHub and Woodpecker build/regress/tool lanes

Follow-up to https://gitea.osgeo.org/postgis/postgis/pulls/363.

## Validation

- `python3 -B utils/test_check_contributor_credits.py`
- `python3 -B utils/check_contributor_credits.py --repo .`
- `make check-contributor-credits`
- `make -n check-lint`
- `make check-lint`
- `make -C doc check-localized`
- `git diff --check`