### PR TITLE
loader: handle shp2pgsql allocation failures

### DIFF
--- a/loader/shp2pgsql-cli.c
+++ b/loader/shp2pgsql-cli.c
@@ -571,6 +571,11 @@ main (int argc, char **argv)
 
 	/* Create the shapefile state object */
 	state = ShpLoaderCreate(config);
+	if (!state)
+	{
+		fprintf(stderr, "Unable to allocate memory for loader state\n");
+		exit(1);
+	}
 
 	/* Open the shapefile */
 	ret = ShpLoaderOpenShape(state);

--- a/loader/shp2pgsql-core.c
+++ b/loader/shp2pgsql-core.c
@@ -16,6 +16,7 @@
 #include "../postgis_config.h"
 
 #include <math.h> /* for isnan */
+#include <limits.h>
 #include <strings.h>
 
 #include "shp2pgsql-core.h"
@@ -170,6 +171,8 @@ escape_copy_string(char *str)
 
 	size = ptr - str + toescape + 1;
 	result = calloc(1, size);
+	if (!result)
+		return NULL;
 	optr = result;
 	ptr = str;
 
@@ -223,6 +226,8 @@ escape_insert_string(char *str)
 
 	size = ptr - str + toescape + 1;
 	result = calloc(1, size);
+	if (!result)
+		return NULL;
 	optr = result;
 	ptr = str;
 
@@ -271,6 +276,11 @@ GeneratePointGeometry(SHPLOADERSTATE *state, SHPObject *obj, char **geometry, in
 	{
 		/* Allocate memory for our array of LWPOINTs and our dynptarrays */
 		lwmultipoints = malloc(sizeof(LWPOINT *) * obj->nVertices);
+		if (!lwmultipoints)
+		{
+			snprintf(state->message, SHPLOADERMSGLEN, "unable to allocate memory for point geometry");
+			return SHPLOADERERR;
+		}
 
 		/* We need an array of pointers to each of our sub-geometries */
 		for (u = 0; u < obj->nVertices; u++)
@@ -361,6 +371,11 @@ GenerateLineStringGeometry(SHPLOADERSTATE *state, SHPObject *obj, char **geometr
 
 	/* Allocate memory for our array of LWLINEs and our dynptarrays */
 	lwmultilinestrings = malloc(sizeof(LWPOINT *) * obj->nParts);
+	if (!lwmultilinestrings)
+	{
+		snprintf(state->message, SHPLOADERMSGLEN, "unable to allocate memory for linestring geometry");
+		return SHPLOADERERR;
+	}
 
 	/* We need an array of pointers to each of our sub-geometries */
 	for (u = 0; u < obj->nParts; u++)
@@ -474,6 +489,12 @@ FindPolygons(SHPObject *obj, Ring ***Out)
 	/* Allocate initial memory */
 	Outer = (Ring **)malloc(sizeof(Ring *) * obj->nParts);
 	Inner = (Ring **)malloc(sizeof(Ring *) * obj->nParts);
+	if (!Outer || !Inner)
+	{
+		free(Outer);
+		free(Inner);
+		return -1;
+	}
 
 	/* Iterate over rings dividing in Outers and Inners */
 	for (pi=0; pi < obj->nParts; pi++)
@@ -495,10 +516,46 @@ FindPolygons(SHPObject *obj, Ring ***Out)
 
 		/* Compute number of vertices */
 		nv = ve - vs;
+		assert(nv >= 0 && nv < INT_MAX / sizeof(Point));
 
 		/* Allocate memory for a ring */
 		ring = (Ring *)malloc(sizeof(Ring));
-		ring->list = (Point *)malloc(sizeof(Point) * nv);
+		if (!ring)
+		{
+			/* Free rings allocated so far (stored in Outer/Inner) */
+			for (pi = 0; pi < out_index; pi++)
+			{
+				free(Outer[pi]->list);
+				free(Outer[pi]);
+			}
+			for (pi = 0; pi < in_index; pi++)
+			{
+				free(Inner[pi]->list);
+				free(Inner[pi]);
+			}
+			free(Outer);
+			free(Inner);
+			return -1;
+		}
+		ring->list = (Point *)malloc(sizeof(Point) * (size_t)nv);
+		if (!ring->list)
+		{
+			free(ring);
+			/* Free rings allocated so far (stored in Outer/Inner) */
+			for (pi = 0; pi < out_index; pi++)
+			{
+				free(Outer[pi]->list);
+				free(Outer[pi]);
+			}
+			for (pi = 0; pi < in_index; pi++)
+			{
+				free(Inner[pi]->list);
+				free(Inner[pi]);
+			}
+			free(Outer);
+			free(Inner);
+			return -1;
+		}
 		ring->n = nv;
 		ring->next = NULL;
 		ring->linked = 0;
@@ -660,6 +717,12 @@ GeneratePolygonGeometry(SHPLOADERSTATE *state, SHPObject *obj, char **geometry)
 
 	polygon_total = FindPolygons(obj, &Outer);
 
+	if (polygon_total < 0)
+	{
+		snprintf(state->message, SHPLOADERMSGLEN, "unable to allocate memory for polygon rings");
+		return SHPLOADERERR;
+	}
+
 	if (state->config->simple_geometries == 1 && polygon_total != 1) /* We write Non-MULTI geometries, but have several parts: */
 	{
 		snprintf(state->message, SHPLOADERMSGLEN, _("We have a Multipolygon with %d parts, can't use -S switch!"), polygon_total);
@@ -669,6 +732,12 @@ GeneratePolygonGeometry(SHPLOADERSTATE *state, SHPObject *obj, char **geometry)
 
 	/* Allocate memory for our array of LWPOLYs */
 	lwpolygons = malloc(sizeof(LWPOLY *) * polygon_total);
+	if (!lwpolygons)
+	{
+		ReleasePolygons(Outer, polygon_total);
+		snprintf(state->message, SHPLOADERMSGLEN, "unable to allocate memory for polygon geometry");
+		return SHPLOADERERR;
+	}
 
 	/* Cycle through each individual polygon */
 	for (pi = 0; pi < polygon_total; pi++)
@@ -1000,6 +1069,8 @@ ShpLoaderCreate(SHPLOADERCONFIG *config)
 
 	/* Create a new state object and assign the config to it */
 	state = malloc(sizeof(SHPLOADERSTATE));
+	if (!state)
+		return NULL;
 	state->config = config;
 
 	/* Set any state defaults */
@@ -1316,17 +1387,27 @@ ShpLoaderOpenShape(SHPLOADERSTATE *state)
 
 	state->num_records = DBFGetRecordCount(state->hDBFHandle);
 
-	/* Allocate storage for field information */
-	state->field_names = malloc(state->num_fields * sizeof(char*));
+	/* Allocate storage for field information.
+	 * field_names and pgfieldtypes hold per-field strings that are freed
+	 * individually; use calloc so any slot never assigned stays NULL and
+	 * free(NULL) is safe on the allocation-failure cleanup path. */
+	state->field_names = calloc(state->num_fields, sizeof(char*));
 	state->types = (DBFFieldType *)malloc(state->num_fields * sizeof(int));
 	state->widths = malloc(state->num_fields * sizeof(int));
 	state->precisions = malloc(state->num_fields * sizeof(int));
-	state->pgfieldtypes = malloc(state->num_fields * sizeof(char *));
+	state->pgfieldtypes = calloc(state->num_fields, sizeof(char *));
 	state->col_names = calloc(
 		(size_t)state->num_fields * (MAXFIELDNAMELEN + 2) +
 			(state->config->readshape ? strlen(state->geo_col) : 0) + 1,
 		sizeof(char)
 	);
+	if (!state->col_names ||
+		(state->num_fields && (!state->field_names || !state->types ||
+			!state->widths || !state->precisions || !state->pgfieldtypes)))
+	{
+		state->num_fields = 0;
+		goto open_shape_field_alloc_failure;
+	}
 
 	/* Generate a string of comma separated column names of the form "col1, col2 ... colN" for the SQL
 	   insertion string */
@@ -1414,6 +1495,8 @@ ShpLoaderOpenShape(SHPLOADERSTATE *state)
 		}
 
 		state->field_names[j] = strdup(name);
+		if (!state->field_names[j])
+			goto open_shape_field_alloc_failure;
 
 		/* Now generate the PostgreSQL type name string and width based upon the shapefile type */
 		switch (state->types[j])
@@ -1469,6 +1552,9 @@ ShpLoaderOpenShape(SHPLOADERSTATE *state)
 			return SHPLOADERERR;
 		}
 
+		if (!state->pgfieldtypes[j])
+			goto open_shape_field_alloc_failure;
+
 		strcat(state->col_names, "\"");
 		strcat(state->col_names, name);
 
@@ -1489,6 +1575,31 @@ ShpLoaderOpenShape(SHPLOADERSTATE *state)
 
 	/* Return status */
 	return ret;
+
+open_shape_field_alloc_failure:
+	/* Release the per-field strings populated so far; free(NULL) is safe for
+	 * the slots that were never assigned. */
+	for (int j = 0; j < state->num_fields; j++)
+	{
+		free(state->field_names[j]);
+		free(state->pgfieldtypes[j]);
+	}
+	free(state->field_names);
+	state->field_names = NULL;
+	free(state->types);
+	state->types = NULL;
+	free(state->widths);
+	state->widths = NULL;
+	free(state->precisions);
+	state->precisions = NULL;
+	free(state->pgfieldtypes);
+	state->pgfieldtypes = NULL;
+	free(state->col_names);
+	state->col_names = NULL;
+	state->num_fields = 0;
+	state->num_records = 0;
+	snprintf(state->message, SHPLOADERMSGLEN, "unable to allocate memory for field information");
+	return SHPLOADERERR;
 }
 
 /* Return a pointer to an allocated string containing the header for the specified loader state */
@@ -1864,13 +1975,25 @@ ShpLoaderGenerateSQLRowStatement(SHPLOADERSTATE *state, int item, char **strreco
 			if (state->config->dump_format)
 			{
 				escval = escape_copy_string(val);
-				stringbuffer_aprintf(sb, "%s", escval);
 			}
 			else
 			{
 				escval = escape_insert_string(val);
-				stringbuffer_aprintf(sb, "'%s'", escval);
 			}
+
+			if (!escval)
+			{
+				snprintf(state->message, SHPLOADERMSGLEN, "unable to allocate memory for escaped attribute value");
+				SHPDestroyObject(obj);
+				stringbuffer_destroy(sbwarn);
+				stringbuffer_destroy(sb);
+				return SHPLOADERERR;
+			}
+
+			if (state->config->dump_format)
+				stringbuffer_aprintf(sb, "%s", escval);
+			else
+				stringbuffer_aprintf(sb, "'%s'", escval);
 
 			/* Free the escaped version if required */
 			if (val != escval)

--- a/loader/shp2pgsql-gui.c
+++ b/loader/shp2pgsql-gui.c
@@ -1219,6 +1219,11 @@ validate_remote_loader_columns(SHPLOADERCONFIG *config, PGresult *result)
 				{
 					/* If we have a row then lets do some simple column validation... */
 					state = ShpLoaderCreate(config);
+					if (!state)
+					{
+						pgui_logf(_("Warning: Could not load shapefile %s"), config->shp_file);
+						return SHPLOADERERR;
+					}
 					ret = ShpLoaderOpenShape(state);
 					if (ret != SHPLOADEROK)
 					{
@@ -1571,6 +1576,11 @@ pgui_action_import(GtkWidget *widget, gpointer data)
 
 		/* Create the shapefile state object */
 		state = ShpLoaderCreate(loader_file_config);
+		if (!state)
+		{
+			pgui_logf(_("Warning: Could not load shapefile %s"), loader_file_config->shp_file);
+			goto import_cleanup;
+		}
 
 		/* Open the shapefile */
 		ret = ShpLoaderOpenShape(state);
@@ -1768,7 +1778,9 @@ import_cleanup:
 		pg_connection = NULL;
 
 		/* If we didn't finish inserting all of the items (and we expected to), an error occurred */
-		if ((state->config->plan.load_data && i != ShpLoaderGetRecordCount(state)) || !ret)
+		if (state && ((state->config->plan.load_data && i != ShpLoaderGetRecordCount(state)) || !ret))
+			pgui_logf(_("Shapefile import failed."));
+		else if (!state)
 			pgui_logf(_("Shapefile import failed."));
 		else
 			pgui_logf(_("Shapefile import completed."));


### PR DESCRIPTION
Check the return of malloc/calloc in the shp2pgsql loader paths and bail out cleanly instead of dereferencing NULL. Escaped-value and field-info allocation failures now error out before the value is written, so no unescaped attribute reaches the output buffer. The partial-allocation paths in FindPolygons and ShpLoaderOpenShape release what was already allocated and null the owning pointers so ShpLoaderDestroy stays safe.

Found by PostgresPro with Svace Static Analyzer.