### PR TITLE
Guard against NULL in lwgeom_wrapx point clone

### DIFF
--- a/liblwgeom/lwgeom_wrapx.c
+++ b/liblwgeom/lwgeom_wrapx.c
@@ -193,6 +193,7 @@ lwgeom_wrapx(const LWGEOM* lwgeom_in, double cutx, double amount)
 	{
 		const LWPOINT *pt = lwgeom_as_lwpoint(lwgeom_clone_deep(lwgeom_in));
 		POINT4D pt4d;
+		if ( ! pt ) return NULL;
 		getPoint4d_p(pt->point, 0, &pt4d);
 
 		LWDEBUGF(2, "POINT X is %g, cutx:%g, amount:%g", pt4d.x, cutx, amount);


### PR DESCRIPTION
lwgeom_clone_deep can return NULL when the underlying allocator (default_allocator -> malloc) fails, which propagates through lwgeom_as_lwpoint and is dereferenced at pt->point. Add a NULL check before the dereference.
Found by PostgresPro