### PR TITLE
Fix NULL deref in raster colormap arg cleanup

### DIFF
--- a/raster/rt_core/rt_mapalgebra.c
+++ b/raster/rt_core/rt_mapalgebra.c
@@ -1504,10 +1504,11 @@ _rti_colormap_arg_destroy(_rti_colormap_arg arg) {
 		rt_raster_destroy(arg->raster);
 	}
 
-	if (arg->nexpr) {
+	if (arg->expr != NULL) {
 		for (i = 0; i < arg->nexpr; i++) {
-			if (arg->expr[i] != NULL)
-				rtdealloc(arg->expr[i]);
+			if (arg->expr[i] == NULL)
+				break;
+			rtdealloc(arg->expr[i]);
 		}
 		rtdealloc(arg->expr);
 	}


### PR DESCRIPTION
__rti_colormap_arg_destroy dereferenced arg->expr[i] without first checking that the array itself was allocated. When rtalloc fails (arg->expr == NULL) the destroy path reads from a NULL array and crashes. Guard the loop on arg->expr != NULL and stop at the first NULL element, which also avoids freeing uninitialized entries when a partial allocation (rtalloc of individual expressions) fails.

Fixes: 46a76d3b39bb36c2b896e2a67dc88dac13be1fce
Found by PostgresPro.