### PR TITLE
Prevent NULL deref when shrinking raster file list fails

### DIFF
--- a/raster/loader/raster2pgsql.c
+++ b/raster/loader/raster2pgsql.c
@@ -2943,6 +2943,7 @@ main(int argc, char **argv) {
 			config->rt_file_count++;
 			config->rt_file = (char **) rtrealloc(config->rt_file, sizeof(char *) * config->rt_file_count);
 			if (config->rt_file == NULL) {
+				config->rt_file_count = 0;
 				rterror(_("Could not allocate memory for storing raster files"));
 				rtdealloc_config(config);
 				exit(1);
@@ -3027,6 +3028,7 @@ main(int argc, char **argv) {
 			rtdealloc(config->rt_file[--(config->rt_file_count)]);
 			config->rt_file = (char **) rtrealloc(config->rt_file, sizeof(char *) * config->rt_file_count);
 			if (config->rt_file == NULL) {
+				config->rt_file_count = 0;
 				rterror(_("Could not reallocate the memory holding raster names"));
 				rtdealloc_config(config);
 				exit(1);


### PR DESCRIPTION
When rtrealloc fails on the in-memory raster file list, config->rt_file becomes NULL while config->rt_file_count is left non-zero. The subsequent rtdealloc_config() then iterates count..0 dereferencing config->rt_file[i] on a NULL array, crashing in the OOM cleanup path.

Reset rt_file_count to 0 before running the error cleanup so the partial state is not dereferenced. Applies to both the append path (grow) and the schema.table-parse path (shrink).

Fixes: 8b8ce38f5dd2b30f8d8bac3a09bc60213688f48d