### PR TITLE
Make selectivity NULL-argument guard NULL-safe

### DIFF
--- a/postgis/gserialized_estimate.c
+++ b/postgis/gserialized_estimate.c
@@ -2052,6 +2052,13 @@ gserialized_sel_internal(PlannerInfo *root, List *args, int varRelid, int mode)
 		return DEFAULT_ND_SEL;
 	}
 
+	if (other == NULL)
+	{
+		ReleaseVariableStats(vardata);
+		POSTGIS_DEBUGF(2, "%s: no other argument, returning default selectivity %g", __func__, DEFAULT_ND_SEL);
+		return DEFAULT_ND_SEL;
+	}
+
 	if (!IsA(other, Const))
 	{
 		ReleaseVariableStats(vardata);
@@ -2060,7 +2067,7 @@ gserialized_sel_internal(PlannerInfo *root, List *args, int varRelid, int mode)
 	}
 
 	otherConst = (Const*)other;
-	if ((!otherConst) || otherConst->constisnull)
+	if (otherConst->constisnull)
 	{
 		ReleaseVariableStats(vardata);
 		POSTGIS_DEBUGF(2, "%s: constant argument is NULL", __func__);


### PR DESCRIPTION
get_restriction_variable() can return true with *other NULL when estimate_expression_value() folds an expression to NULL (e.g. NULLIF or a NULL Const). The existing guard relied on IsA(other, Const), which dereferences other; a NULL other would hit nodeTag(NULL) and crash before the check ever ran.

Fixes: c84b3f996e2eaea3ba3afeecb783113ab16f0982