### PR TITLE
_lwt_RemEdge: report the correct value the backend returned

### DIFF
--- a/liblwgeom/topo/lwgeom_topo.c
+++ b/liblwgeom/topo/lwgeom_topo.c
@@ -4396,7 +4396,7 @@ _lwt_RemEdge( LWT_TOPOLOGY* topo, LWT_ELEMID edge_id, int modFace )
   if (result != 1)
   {
     _lwt_release_edges(edge, 1);
-    lwerror("Unexpected error: %" PRIu64 " faces updated when expecting 1", i);
+    lwerror("Unexpected error: %d faces updated when expecting 1", result);
     return -1;
   }
       }


### PR DESCRIPTION
The unexpected-result branch printed the loop variable i, which at that point holds an unrelated edge/face id, instead of the number of faces lwt_be_updateFacesById() reported as updated.  The sibling insertFaces branch a few lines below already reports result with %d.