### PR TITLE
raster: check array_range allocation and free on the error branch

### DIFF
--- a/raster/loader/raster2pgsql.c
+++ b/raster/loader/raster2pgsql.c
@@ -142,6 +142,12 @@ array_range(int min, int max, int step, int **range, uint32_t *len) {
 	*len = (uint32_t) ((abs(max - min) + 1 + (step / 2)) / step);
 	*range = rtalloc(sizeof(int) * *len);
 
+	if (!*range)
+	{
+		*len = 0;
+		return 0;
+	}
+
 	if (min < max) {
 		for (i = min, j = 0; i <= max; i += step, j++)
 			(*range)[j] = i;
@@ -156,6 +162,7 @@ array_range(int min, int max, int step, int **range, uint32_t *len) {
 	}
 	else {
 		*len = 0;
+		rtdealloc(*range);
 		*range = NULL;
 		return 0;
 	}


### PR DESCRIPTION
rtalloc in array_range could return NULL and be dereferenced when filling the range array; check the result and return the existing error code (0) instead. Also rtdealloc the already-allocated range in the (currently unreachable) else branch before nulling the pointer, so no allocation leaks on the error path.