### PR TITLE
raster: make rtstrdup return NULL on allocation failure like strdup

### DIFF
--- a/raster/rt_core/rt_context.c
+++ b/raster/rt_core/rt_context.c
@@ -265,6 +265,8 @@ rtstrdup(const char *str) {
 	if (!str) return NULL;
 	sz = strlen(str) + 1;
 	dup = rtalloc(sz);
-	memcpy(dup, str, sz);
+	if (dup) {
+		memcpy(dup, str, sz);
+	}
 	return dup;
 }


### PR DESCRIPTION
Standard strdup returns NULL when it cannot allocate memory for the copy; rtstrdup instead unconditionally memcpy'd into the rtalloc result, writing through a NULL pointer when the allocation failed. Guard the copy behind the allocation check so rtstrdup returns NULL on out of memory, mirroring the standard library semantics its name implies.